### PR TITLE
Adding Azure DevOps MCP Server to list of available in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Below are Microsoft's official MCP server implementations:
 - **Repository**: RTI MCP Server](https://aka.ms/rti.mcp.repo)  
 - **Description**: Chat with your real-time data the new agentic way using natural language and AI. MCP server for Fabric Real-Time Intelligence (https://aka.ms/fabricrti) supporting tools for Eventhouse (https://aka.ms/eventhouse), Azure Data Explorer (https://aka.ms/adx, and other RTI services (coming soon)
 
+---
+
+### 📅 Azure DevOps MCP Server
+
+- **Documentation**: [Azure DevOps MCP Server - Public Preview](https://github.com/microsoft/azure-devops-mcp)
+- **Description**: The MCP Server for Azure DevOps enables you to bring context into AI workflows and interact with Azure DevOps artifacts such as work items, test plans, builds, releases, and pull requests.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Below are Microsoft's official MCP server implementations:
 
 ### 📅 Azure DevOps MCP Server
 
-- **Documentation**: [Azure DevOps MCP Server - Public Preview](https://github.com/microsoft/azure-devops-mcp)
+- **Repository**: [Azure DevOps MCP Server - Public Preview](https://github.com/microsoft/azure-devops-mcp)
 - **Description**: The MCP Server for Azure DevOps enables you to bring context into AI workflows and interact with Azure DevOps artifacts such as work items, test plans, builds, releases, and pull requests.
 
 ---


### PR DESCRIPTION

This pull request updates the `README.md` file to include information about the Azure DevOps MCP Server. The change introduces a new section with documentation and a description of this server's capabilities.

Key addition:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R83-R88): Added a new section titled "Azure DevOps MCP Server" with documentation and a description explaining how the server integrates Azure DevOps artifacts into AI workflows.