### PR TITLE
Update devcontainer configuration name and resources

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,6 +35,6 @@
             }
         }
     },
-    "remoteUser": "root",
+    "remoteUser": "vscode",
     "postCreateCommand": "dotnet --version && az --version && azd version && pwsh --version && npm --version"
 }


### PR DESCRIPTION
Change the devcontainer name to "Microsoft MCP Codespace" and increase memory allocation to 16GB. Additionally, set the remote user to root.