### PR TITLE
Add more unit tests for Azure.Mcp.Tools.Cosmos

### DIFF
--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ContainerListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ContainerListCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Core.Commands;
-using Azure.Mcp.Core.Services.Telemetry;
 using Azure.Mcp.Tools.Cosmos.Options;
 using Azure.Mcp.Tools.Cosmos.Services;
 using Microsoft.Extensions.Logging;

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/ContainerListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/ContainerListCommandTests.cs
@@ -30,12 +30,12 @@ public class ContainerListCommandTests
     {
         _cosmosService = Substitute.For<ICosmosService>();
         _logger = Substitute.For<ILogger<ContainerListCommand>>();
-        _command = new (_logger);
-        _parser = new (_command.GetCommand());
+        _command = new(_logger);
+        _parser = new(_command.GetCommand());
         _serviceProvider = new ServiceCollection()
             .AddSingleton(_cosmosService)
             .BuildServiceProvider();
-        _context = new (_serviceProvider);
+        _context = new(_serviceProvider);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/ContainerListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/ContainerListCommandTests.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using Azure.Mcp.Core.Models;
+using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Tools.Cosmos.Commands;
+using Azure.Mcp.Tools.Cosmos.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+using static Azure.Mcp.Tools.Cosmos.Commands.ContainerListCommand;
+
+namespace Azure.Mcp.Tools.Cosmos.UnitTests;
+
+public class ContainerListCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ICosmosService _cosmosService;
+    private readonly ILogger<ContainerListCommand> _logger;
+    private readonly ContainerListCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public ContainerListCommandTests()
+    {
+        _cosmosService = Substitute.For<ICosmosService>();
+        _logger = Substitute.For<ILogger<ContainerListCommand>>();
+        _command = new (_logger);
+        _parser = new (_command.GetCommand());
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_cosmosService)
+            .BuildServiceProvider();
+        _context = new (_serviceProvider);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsContainers_WhenContainersExist()
+    {
+        // Arrange
+        var expectedContainers = new List<string> { "container1", "container2" };
+        _cosmosService.ListContainers(
+            Arg.Is("account123"),
+            Arg.Is("database123"),
+            Arg.Is("sub123"),
+            Arg.Any<AuthMethod>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(expectedContainers);
+
+        var args = _parser.Parse([
+            "--account", "account123",
+            "--database", "database123",
+            "--subscription", "sub123"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<ContainerListCommandResult>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+        Assert.NotNull(result);
+        Assert.Equal(expectedContainers.Count, result.Containers.Count);
+        Assert.Equal(expectedContainers, result.Containers);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsNull_WhenNoContainersExist()
+    {
+        // Arrange
+        _cosmosService.ListContainers(
+            Arg.Is("account123"),
+            Arg.Is("database123"),
+            Arg.Is("sub123"),
+            Arg.Any<AuthMethod>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(new List<string>());
+
+        var args = _parser.Parse([
+            "--account", "account123",
+            "--database", "database123",
+            "--subscription", "sub123"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Null(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns500_WhenServiceThrowsException()
+    {
+        // Arrange
+        var expectedError = "Test error";
+
+        _cosmosService.ListContainers(
+            Arg.Is("account123"),
+            Arg.Is("database123"),
+            Arg.Is("sub123"),
+            Arg.Any<AuthMethod>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>())
+            .ThrowsAsync(new Exception(expectedError));
+
+        var args = _parser.Parse([
+            "--account", "account123",
+            "--database", "database123",
+            "--subscription", "sub123"
+        ]);
+
+        // Act 
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(500, response.Status);
+        Assert.StartsWith(expectedError, response.Message);
+    }
+
+    [Theory]
+    [InlineData("--account", "account123", "--database", "database123")] // Missing subscription
+    [InlineData("--subscription", "sub123", "--database", "database123")] // Missing account-name
+    [InlineData("--subscription", "sub123", "--account", "account123")] // Missing database-name
+    public async Task ExecuteAsync_Returns400_WhenRequiredParametersAreMissing(params string[] args)
+    {
+        // Arrange & Act 
+        var response = await _command.ExecuteAsync(_context, _parser.Parse(args));
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/DatabaseListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/DatabaseListCommandTests.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using Azure.Mcp.Core.Models;
+using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Tools.Cosmos.Commands;
+using Azure.Mcp.Tools.Cosmos.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+using static Azure.Mcp.Tools.Cosmos.Commands.DatabaseListCommand;
+
+namespace Azure.Mcp.Tools.Cosmos.UnitTests;
+
+public class DatabaseListCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ICosmosService _cosmosService;
+    private readonly ILogger<DatabaseListCommand> _logger;
+    private readonly DatabaseListCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public DatabaseListCommandTests()
+    {
+        _cosmosService = Substitute.For<ICosmosService>();
+        _logger = Substitute.For<ILogger<DatabaseListCommand>>();
+        _command = new (_logger);
+        _parser = new (_command.GetCommand());
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_cosmosService)
+            .BuildServiceProvider();
+        _context = new (_serviceProvider);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsDatabases_WhenDatabasesExist()
+    {
+        // Arrange
+        var expectedDatabases = new List<string> { "database1", "database2" };
+        _cosmosService.ListDatabases(
+            Arg.Is("account123"),
+            Arg.Is("sub123"),
+            Arg.Any<AuthMethod>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(expectedDatabases);
+
+        var args = _parser.Parse([
+            "--account", "account123",
+            "--subscription", "sub123"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<DatabaseListCommandResult>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+        Assert.NotNull(result);
+        Assert.Equal(expectedDatabases.Count, result.Databases.Count);
+        Assert.Equal(expectedDatabases, result.Databases);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsNull_WhenNoDataBaseExists()
+    {
+        // Arrange
+        _cosmosService.ListDatabases(
+            Arg.Is("account123"),
+            Arg.Is("sub123"),
+            Arg.Any<AuthMethod>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(new List<string>());
+
+        var args = _parser.Parse([
+            "--account", "account123",
+            "--subscription", "sub123"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Null(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns500_WhenServiceThrowsException()
+    {
+        // Arrange
+        var expectedError = "Test error";
+
+        _cosmosService.ListDatabases(
+            Arg.Is("account123"),
+            Arg.Is("sub123"),
+            Arg.Any<AuthMethod>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>())
+            .ThrowsAsync(new Exception(expectedError));
+
+        var args = _parser.Parse([
+            "--account", "account123",
+            "--subscription", "sub123"
+        ]);
+
+        // Act 
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(500, response.Status);
+        Assert.StartsWith(expectedError, response.Message);
+    }
+
+
+    [Theory]
+    [InlineData("--account", "account123")]
+    [InlineData("--subscription", "sub123")]
+    public async Task ExecuteAsync_Returns400_WhenRequiredParametersAreMissing(params string[] args)
+    {
+        // Arrange & Act 
+        var response = await _command.ExecuteAsync(_context, _parser.Parse(args));
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/DatabaseListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/DatabaseListCommandTests.cs
@@ -30,12 +30,12 @@ public class DatabaseListCommandTests
     {
         _cosmosService = Substitute.For<ICosmosService>();
         _logger = Substitute.For<ILogger<DatabaseListCommand>>();
-        _command = new (_logger);
-        _parser = new (_command.GetCommand());
+        _command = new(_logger);
+        _parser = new(_command.GetCommand());
         _serviceProvider = new ServiceCollection()
             .AddSingleton(_cosmosService)
             .BuildServiceProvider();
-        _context = new (_serviceProvider);
+        _context = new(_serviceProvider);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/ItemQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/ItemQueryCommandTests.cs
@@ -1,0 +1,204 @@
+﻿using System.CommandLine.Parsing;
+using System.Text.Json;
+using Azure.Mcp.Core.Models;
+using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Tools.Cosmos.Commands;
+using Azure.Mcp.Tools.Cosmos.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.Core;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+using static Azure.Mcp.Tools.Cosmos.Commands.ItemQueryCommand;
+
+namespace Azure.Mcp.Tools.Cosmos.UnitTests;
+
+public class ItemQueryCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ICosmosService _cosmosService;
+    private readonly ILogger<ItemQueryCommand> _logger;
+    private readonly ItemQueryCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public ItemQueryCommandTests()
+    {
+        _cosmosService = Substitute.For<ICosmosService>();
+        _logger = Substitute.For<ILogger<ItemQueryCommand>>();
+        _command = new (_logger);
+        _parser = new (_command.GetCommand());
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_cosmosService)
+            .BuildServiceProvider();
+        _context = new (_serviceProvider);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsItems_WhenQueryIsProvided()
+    {
+        // Arrange
+        var query = "SELECT * FROM c WHERE c.type = 'test'";
+        var expectedItems = new List<JsonElement>
+        {
+            JsonDocument.Parse("{\"id\":\"item1\"}").RootElement.Clone()!,
+            JsonDocument.Parse("{\"id\":\"item2\"}").RootElement.Clone()!
+        };
+
+        _cosmosService.QueryItems(
+            Arg.Is("account123"),
+            Arg.Is("database123"),
+            Arg.Is("container123"),
+            Arg.Is(query),
+            Arg.Is("sub123"),
+            Arg.Any<AuthMethod>(), null, Arg.Any<RetryPolicyOptions>())
+            .Returns(Task.FromResult(expectedItems));
+
+        var args = _parser.Parse([
+            "--account", "account123",
+            "--database", "database123",
+            "--container", "container123",
+            "--subscription", "sub123",
+            "--query", query
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<ItemQueryCommandResult>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Items.Count);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsItems_WhenNoQueryProvided()
+    {
+        // Arrange
+        var query = "SELECT * FROM c";
+        var expectedItems = new List<JsonElement>
+        {
+            JsonDocument.Parse("{\"id\":\"item1\"}").RootElement.Clone()!,
+            JsonDocument.Parse("{\"id\":\"item2\"}").RootElement.Clone()!
+        };
+
+        _cosmosService.QueryItems(
+            Arg.Is("account123"),
+            Arg.Is("database123"),
+            Arg.Is("container123"),
+            Arg.Is(query),
+            Arg.Is("sub123"),
+            Arg.Any<AuthMethod>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns(Task.FromResult(expectedItems));
+
+        var args = _parser.Parse([
+            "--account", "account123",
+            "--database", "database123",
+            "--container", "container123",
+            "--subscription", "sub123"
+            // No --query option
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<ItemQueryCommandResult>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Items.Count);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsNull_WhenNoItemsExist()
+    {
+        // Arrange
+        _cosmosService.QueryItems(
+            Arg.Is<string>(s => s == "account123"),
+            Arg.Is<string>(d => d == "database123"),
+            Arg.Is<string>(c => c == "container123"),
+            Arg.Is<string?>(q => q == null),
+            Arg.Is<string>(s => s == "sub123"),
+            Arg.Is<AuthMethod>(a => a == AuthMethod.Credential),
+            Arg.Is<string?>(t => t == null),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns(new List<JsonElement>());
+
+        var args = _parser.Parse([
+            "--account", "account123",
+            "--database", "database123",
+            "--container", "container123",
+            "--subscription", "sub123"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Null(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns500_WhenServiceThrowsException()
+    {
+        // Arrange
+        var expectedError = "Test error";
+        var query = "SELECT * FROM c";
+
+        _cosmosService.QueryItems(
+            Arg.Is("account123"),
+            Arg.Is("database123"),
+            Arg.Is("container123"),
+            Arg.Is(query),
+            Arg.Is("sub123"),
+            Arg.Any<AuthMethod>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .ThrowsAsync(new Exception(expectedError));
+
+        var args = _parser.Parse([
+            "--account", "account123",
+            "--database", "database123",
+            "--container", "container123",
+            "--subscription", "sub123"
+        ]);
+
+        // Act 
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(500, response.Status);
+        Assert.StartsWith(expectedError, response.Message);
+    }
+
+    [Theory]
+    [InlineData("--account", "account123", "--database", "database123", "--container", "container123")] // Missing subscription
+    [InlineData("--subscription", "sub123", "--database", "database123", "--container", "container123")] // Missing account-name
+    [InlineData("--subscription", "sub123", "--account", "account123", "--container", "container123")] // Missing database-name
+    [InlineData("--subscription", "sub123", "--account", "account123", "--database", "database123")] // Missing container-name
+    public async Task ExecuteAsync_Returns400_WhenRequiredParametersAreMissing(params string[] args)
+    {
+        // Arrange & Act 
+        var response = await _command.ExecuteAsync(_context, _parser.Parse(args));
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/ItemQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/ItemQueryCommandTests.cs
@@ -28,12 +28,12 @@ public class ItemQueryCommandTests
     {
         _cosmosService = Substitute.For<ICosmosService>();
         _logger = Substitute.For<ILogger<ItemQueryCommand>>();
-        _command = new (_logger);
-        _parser = new (_command.GetCommand());
+        _command = new(_logger);
+        _parser = new(_command.GetCommand());
         _serviceProvider = new ServiceCollection()
             .AddSingleton(_cosmosService)
             .BuildServiceProvider();
-        _context = new (_serviceProvider);
+        _context = new(_serviceProvider);
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?
Completes https://github.com/Azure/azure-mcp-pr/issues/298
Adds more unit tests for `Azure.Mcp.Tools.Cosmos`

## GitHub issue number?
https://github.com/Azure/azure-mcp-pr/issues/298

- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [x] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
