### PR TITLE
Patch `create github release`

### DIFF
--- a/eng/pipelines/templates/jobs/docker.yml
+++ b/eng/pipelines/templates/jobs/docker.yml
@@ -91,6 +91,6 @@ jobs:
       path: '$(Pipeline.Workspace)/docker_drops'
       image: image:tag
       buildArguments: |
-        --build-arg PUBLISH_DIR="linux-x64/dist"
+        --build-arg PUBLISH_DIR="Azure.Mcp.Server/linux-x64/dist"
       enableNetwork: true
       useBuildKit: true

--- a/eng/pipelines/templates/jobs/release.yml
+++ b/eng/pipelines/templates/jobs/release.yml
@@ -25,7 +25,7 @@ jobs:
       $tag = "$serverName-$version$versionSuffix"
 
       gh release create $tag --title "$serverName $version$versionSuffix"
-      gh release upload $tag $(Pipeline.Workspace)/$(PipelineArtifactName)_packed/**/*.tgz
+      gh release upload $tag $(Pipeline.Workspace)/$(PipelineArtifactName)_packed/*/*.tgz
     displayName: Create GitHub Release and upload artifacts
     env:
       GH_TOKEN: $(azuresdk-github-pat)

--- a/eng/pipelines/templates/jobs/release.yml
+++ b/eng/pipelines/templates/jobs/release.yml
@@ -25,7 +25,7 @@ jobs:
       $tag = "$serverName-$version$versionSuffix"
 
       gh release create $tag --title "$serverName $version$versionSuffix"
-      gh release upload $tag $(Pipeline.Workspace)/$(PipelineArtifactName)_packed/*/*.tgz
+      gh release upload $tag $(Pipeline.Workspace)/$(PipelineArtifactName)_packed/*/*/*.tgz
     displayName: Create GitHub Release and upload artifacts
     env:
       GH_TOKEN: $(azuresdk-github-pat)


### PR DESCRIPTION
We are using `gh api`. The `gh api` does not support `**` pattern matching.

Therefore, we need to update the upload to more align with the actual artifact at rest.

<img width="242" height="317" alt="image" src="https://github.com/user-attachments/assets/4dd8586b-ac97-4253-9758-93ba27b425f6" />
