### PR TITLE
Update project paths for AOT analysis and tool description evaluator

### DIFF
--- a/eng/scripts/AOT-Config.ps1
+++ b/eng/scripts/AOT-Config.ps1
@@ -8,7 +8,7 @@ $RepoRoot = $RepoRoot.Path.Replace('\', '/')
 $script:AOTConfig = @{
     # Base paths
     RootPath = $RepoRoot
-    ProjectFile = "$RepoRoot/core/src/AzureMcp.Cli/AzureMcp.Cli.csproj"
+    ProjectFile = "$RepoRoot/servers/Azure.Mcp.Server/src/Azure.Mcp.Server.csproj"
 
     # AOT report directories and files
     ReportDirectory = "$RepoRoot/.work/aotCompactReport"

--- a/eng/tools/ToolDescriptionEvaluator/Program.cs
+++ b/eng/tools/ToolDescriptionEvaluator/Program.cs
@@ -356,7 +356,7 @@ class Program
         {
             // Try to find the azmcp executable in the CLI folder, relative to the executable location
             var exeDir = AppContext.BaseDirectory;
-            var azMcpPath = Path.GetFullPath(Path.Combine(FindRepoRoot(exeDir), "core", "src", "AzureMcp.Cli", "bin", "Debug", "net9.0"));
+            var azMcpPath = Path.GetFullPath(Path.Combine(FindRepoRoot(exeDir), "servers", "Azure.Mcp.Server", "src", "bin", "Debug", "net9.0"));
             var executablePath = Path.Combine(azMcpPath, "azmcp.exe");
 
             // Fallback to .dll if .exe doesn't exist

--- a/eng/tools/ToolDescriptionEvaluator/Run-ToolDescriptionEvaluator.ps1
+++ b/eng/tools/ToolDescriptionEvaluator/Run-ToolDescriptionEvaluator.ps1
@@ -43,7 +43,7 @@ try {
     }
 
     # Locate azmcp CLI artifact (platform & build-type agnostic)
-    $cliBinDir = Join-Path $repoRoot "core/src/AzureMcp.Cli/bin/Release"
+    $cliBinDir = Join-Path $repoRoot "servers/Azure.Mcp.Server/src/bin/Release"
     $platformIsWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
 
     # Acceptable artifact name candidates in precedence order


### PR DESCRIPTION
## Summary
Fixes broken AOT analysis and tool description evaluator scripts by updating project paths from non-existent CLI structure to actual server project location.

## Changes
- Update AOT-Config.ps1 to reference `servers/Azure.Mcp.Server/src/Azure.Mcp.Server.csproj`
- Fix ToolDescriptionEvaluator paths to use correct server executable location
- Replace `core/src/AzureMcp.Cli/` references with `servers/Azure.Mcp.Server/src/`

## Errors Fixed-

1. AOT 

<img width="1594" height="186" alt="Screenshot 2025-08-26 224024" src="https://github.com/user-attachments/assets/dc9b96e6-aaa2-42b9-be4d-e19eaa6472ee" />

2. Tool Evaluator

<img width="1416" height="56" alt="Screenshot 2025-08-26 224215" src="https://github.com/user-attachments/assets/a9713957-f3eb-48ac-8c13-5d8635520323" />
<img width="1550" height="477" alt="Screenshot 2025-08-26 225343" src="https://github.com/user-attachments/assets/e619e72d-a690-469e-af93-dd06cdddef76" />
