### PR TITLE
Add Path and Tool parameters to DeployTestResources

### DIFF
--- a/eng/pipelines/templates/jobs/initialize.yml
+++ b/eng/pipelines/templates/jobs/initialize.yml
@@ -28,8 +28,8 @@ jobs:
       -SetDevOpsVariables
       -TestType 'Live'
       -ServerName '${{ iif(eq(parameters.ServerName, 'none'), '', parameters.ServerName) }}'
-    name: GetTestAreasLive
-    displayName: "Get areas to test (Live)"
+    name: GetTestPathsLive
+    displayName: "Get paths to test (Live)"
     workingDirectory: $(Build.SourcesDirectory)
 
   - pwsh: |

--- a/eng/pipelines/templates/jobs/live-test.yml
+++ b/eng/pipelines/templates/jobs/live-test.yml
@@ -59,7 +59,7 @@ jobs:
       Inline: |
         ./eng/scripts/Test-Code.ps1 `
           -TestType 'Live' `
-          -Area $(Area) `
+          -Path $(Area) `
           -TestResultsPath '$(Build.ArtifactStagingDirectory)/testResults'
 
         exit $LastExitCode

--- a/eng/pipelines/templates/jobs/live-test.yml
+++ b/eng/pipelines/templates/jobs/live-test.yml
@@ -7,9 +7,9 @@ jobs:
 - job: LiveTest
   displayName: "Live tests -"
   timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
-  condition: and(succeeded(), eq(stageDependencies.Initialize.Initialize.outputs['GetTestAreasLive.HasTestAreas'], 'true'))
+  condition: and(succeeded(), eq(stageDependencies.Initialize.Initialize.outputs['GetTestPathsLive.HasTestPaths'], 'true'))
   strategy:
-    matrix: $[ stageDependencies.Initialize.Initialize.outputs['GetTestAreasLive.TestMatrix'] ]
+    matrix: $[ stageDependencies.Initialize.Initialize.outputs['GetTestPathsLive.TestMatrix'] ]
   steps:
   - checkout: self
 
@@ -59,7 +59,7 @@ jobs:
       Inline: |
         ./eng/scripts/Test-Code.ps1 `
           -TestType 'Live' `
-          -Path $(Area) `
+          -Path $(Path) `
           -TestResultsPath '$(Build.ArtifactStagingDirectory)/testResults'
 
         exit $LastExitCode
@@ -71,7 +71,7 @@ jobs:
     displayName: "Publish Results"
     inputs:
       testResultsFiles: "$(Build.ArtifactStagingDirectory)/testResults/*.trx"
-      testRunTitle: "live-$(Area)"
+      testRunTitle: "live-$(Path)"
       testResultsFormat: "VSTest"
       mergeTestResults: true
 

--- a/eng/pipelines/templates/jobs/live-test.yml
+++ b/eng/pipelines/templates/jobs/live-test.yml
@@ -59,7 +59,7 @@ jobs:
       Inline: |
         ./eng/scripts/Test-Code.ps1 `
           -TestType 'Live' `
-          -Path $(Path) `
+          -Path $(PathToTest) `
           -TestResultsPath '$(Build.ArtifactStagingDirectory)/testResults'
 
         exit $LastExitCode
@@ -71,7 +71,7 @@ jobs:
     displayName: "Publish Results"
     inputs:
       testResultsFiles: "$(Build.ArtifactStagingDirectory)/testResults/*.trx"
-      testRunTitle: "live-$(Path)"
+      testRunTitle: "live - $(PathToTest)"
       testResultsFormat: "VSTest"
       mergeTestResults: true
 

--- a/eng/scripts/Deploy-TestResources.ps1
+++ b/eng/scripts/Deploy-TestResources.ps1
@@ -45,7 +45,7 @@ switch ($PSCmdlet.ParameterSetName) {
                 Write-Error "Multiple tools match '$Tool':`n  $($matchNames -join "`n  ")`nPlease specify a more specific tool name."
                 exit 1
             } else {
-                Write-Error "No tool matches '$Tool'. Available tools: $($tools -join ', ')"
+                Write-Error "No tool matches '*$Tool*'."
                 exit 1
             }
         }

--- a/eng/scripts/Deploy-TestResources.ps1
+++ b/eng/scripts/Deploy-TestResources.ps1
@@ -19,21 +19,21 @@ function New-StringHash([string[]]$strings) {
     return [BitConverter]::ToString($hashBytes) -replace '-', ''
 }
 
-$toolPaths = Get-ChildItem -Path "$RepoRoot/tools" -Directory
-| Where-Object { Test-Path "$_/tests/test-resources.bicep" }
+$toolDirectories = Get-ChildItem -Path "$RepoRoot/tools" -Directory
+$serverDirectories = Get-ChildItem -Path "$RepoRoot/servers" -Directory
+$coreDirectories = Get-ChildItem -Path "$RepoRoot/core" -Directory
 
-$serverPaths = Get-ChildItem -Path "$RepoRoot/servers" -Directory
+$testablePaths = @($toolDirectories + $serverDirectories + $coreDirectories)
 | Where-Object { Test-Path "$_/tests/test-resources.bicep" }
-
-$corePaths = Get-ChildItem -Path "$RepoRoot/core" -Directory
-| Where-Object { Test-Path "$_/tests/test-resources.bicep" }
-
-$allPaths = $toolPaths + $serverPaths + $corePaths
+| ForEach-Object {
+    $relative = Resolve-Path -Path $_ -Relative -RelativeBasePath $RepoRoot
+    $relative.Replace('\', '/').TrimStart('./')
+ }
 
 $filteredPaths = @()
-foreach ($path in $allPaths) {
+foreach ($path in $testablePaths) {
     foreach ($filter in $Paths) {
-        if ($path -like $filter) {
+        if ($path -like $filter.Replace('\', '/')) {
             $filteredPaths += $path
             break
         }
@@ -41,56 +41,62 @@ foreach ($path in $allPaths) {
 }
 
 if ($filteredPaths.Count -eq 0) {
-    Write-Error "No paths with test resources match the specified filters: $($Areas -join ', ')"
+    Write-Error "No paths with test resources match the specified filters: $($Paths -join ', ')"
     exit 1
 }
 
-foreach ($area in $filteredAreas) {
-    $testResourcesDirectory = Resolve-Path -Path  "$Path/tests" -ErrorAction SilentlyContinue
-    $bicepPath = "$testResourcesDirectory/test-resources.bicep"
+if($SubscriptionId) {
+    Select-AzSubscription -Subscription $SubscriptionId | Out-Null
+    $context = Get-AzContext
+} else {
+    # We don't want New-TestResources to conditionally pick a subscription for us
+    # If the user didn't specify a subscription, we explicitly use the current context's subscription
+    $context = Get-AzContext
+    $SubscriptionId = $context.Subscription.Id
+}
 
-    if($SubscriptionId) {
-        Select-AzSubscription -Subscription $SubscriptionId | Out-Null
-        $context = Get-AzContext
-    } else {
-        # We don't want New-TestResources to conditionally pick a subscription for us
-        # If the user didn't specify a subscription, we explicitly use the current context's subscription
-        $context = Get-AzContext
-        $SubscriptionId = $context.Subscription.Id
-    }
-    $subscriptionName = $context.Subscription.Name
-    $account = $context.Account
+$subscriptionName = $context.Subscription.Name
+$account = $context.Account
+$accountName = $account.Id.Split('@')[0].ToLower()
 
-    # Base the user hash on the user's account ID and subscription being deployed to
-    if($Unique) {
-        $hash = [guid]::NewGuid().ToString()
-    } else {
-        $hash = (New-StringHash $account.Id, $SubscriptionId, $Path)
-    }
+function Deploy-TestResources
+{
+    param(
+        [string]$Path,
+        [string]$SubscriptionId,
+        [string]$SubscriptionName,
+        [string]$ResourceGroupName,
+        [string]$BaseName,
+        [int]$DeleteAfterHours,
+        [string]$TestResourcesDirectory,
+        [switch]$AsJob
+    )
 
-    $suffix = $hash.ToLower().Substring(0, 8)
-
-    if(!$BaseName) {
-        $BaseName = "mcp$($suffix)"
-    }
-
-    if(!$ResourceGroupName) {
-        $username = $account.Id.Split('@')[0].ToLower()
-        $ResourceGroupName = "$username-mcp$($suffix)"
-    }
-
-    Push-Location $RepoRoot
-    try {
-        Write-Host @"
+    Write-Host @"
 Deploying:
+    Path: '$Path'
     SubscriptionId: '$SubscriptionId'
-    SubscriptionName: '$subscriptionName'
+    SubscriptionName: '$SubscriptionName'
     ResourceGroupName: '$ResourceGroupName'
     BaseName: '$BaseName'
     DeleteAfterHours: $DeleteAfterHours
-    TestResourcesDirectory: '$testResourcesDirectory'
-"@
-        ./eng/common/TestResources/New-TestResources.ps1 `
+    TestResourcesDirectory: '$TestResourcesDirectory'`n
+"@ -ForegroundColor Yellow
+    if($AsJob) {
+       Start-ThreadJob -ScriptBlock {
+            param($RepoRoot, $SubscriptionId, $ResourceGroupName, $BaseName, $testResourcesDirectory, $DeleteAfterHours)
+
+            & "$RepoRoot/eng/common/TestResources/New-TestResources.ps1" `
+                -SubscriptionId $SubscriptionId `
+                -ResourceGroupName $ResourceGroupName `
+                -BaseName $BaseName `
+                -TestResourcesDirectory $testResourcesDirectory `
+                -DeleteAfterHours $DeleteAfterHours `
+                -Force
+
+        } -ArgumentList $RepoRoot, $SubscriptionId, $ResourceGroupName, $BaseName, $TestResourcesDirectory, $DeleteAfterHours
+    } else {
+        & "$RepoRoot/eng/common/TestResources/New-TestResources.ps1" `
             -SubscriptionId $SubscriptionId `
             -ResourceGroupName $ResourceGroupName `
             -BaseName $BaseName `
@@ -98,7 +104,68 @@ Deploying:
             -DeleteAfterHours $DeleteAfterHours `
             -Force
     }
-    finally {
-        Pop-Location
+}
+
+$jobInputs = $filteredPaths | ForEach-Object {
+    # the suffix is a unique-looking string appended to the resource group and resource base name
+    if($Unique) {
+        # actually unique suffix
+        $hash = [guid]::NewGuid().ToString()
+    } else {
+        # Base the suffix on the path being deployed, the user's account ID, and the subscription being deployed to
+        $hash = (New-StringHash $account.Id, $SubscriptionId, $_)
+    }
+
+    $suffix = $hash.ToLower().Substring(0, 8)
+
+    return @{
+        Path = $_
+        SubscriptionId = $SubscriptionId
+        SubscriptionName = $subscriptionName
+        ResourceGroupName = $ResourceGroupName ? $ResourceGroupName : "$accountName-mcp$($suffix)"
+        BaseName = $BaseName ? $BaseName : "mcp$($suffix)"
+        DeleteAfterHours = $DeleteAfterHours
+        TestResourcesDirectory = Resolve-Path -Path "$RepoRoot/$_/tests"
+    }
+}
+
+if ($jobInputs.Count -eq 1) {
+    $jobInput = $jobInputs[0]
+    Deploy-TestResources @jobInput
+} else {
+    $jobs = @()
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    foreach ($jobInput in $jobInputs) {
+        $job = Deploy-TestResources @jobInput -AsJob
+        $jobs += @{ Id = $job.Id; Path = $jobInput.Path }
+    }
+
+    $ErrorActionPreference = 'Continue'
+    while($true) {
+        $elapsed = $stopwatch.Elapsed
+        Write-Host "`n($($elapsed)) Checking status of deployment jobs..." -ForegroundColor Cyan
+
+        foreach ($job in $jobs) {
+            $jobState = Get-Job -Id $job.Id | Select-Object -ExpandProperty State
+            if ($jobState -in 'Failed', 'Stopped') {
+                Write-Warning "  Deployment job $($job.Path) $jobState. Job ID: $($job.Id)"
+                Receive-Job -Id $job.Id
+                Remove-Job -Id $job.Id
+                $jobs = @($jobs | Where-Object { $_.Id -ne $job.Id })
+            } elseif ($jobState -eq 'Completed') {
+                Write-Host "  Deployment job $($job.Path) completed. Job ID: $($job.Id)"
+                Receive-Job -Id $job.Id
+                Remove-Job -Id $job.Id
+                $jobs = @($jobs | Where-Object { $_.Id -ne $job.Id })
+            } else {
+                Write-Host "  Deployment job $($job.Path) $jobState. Job ID: $($job.Id)"
+            }
+        }
+
+        if ($jobs.Count -eq 0) {
+            break
+        }
+
+        Start-Sleep -Seconds 15
     }
 }

--- a/eng/scripts/Get-ProjectProperties.ps1
+++ b/eng/scripts/Get-ProjectProperties.ps1
@@ -3,22 +3,33 @@
 
 [CmdletBinding()]
 param(
-    [string] $ProjectName
+    [Parameter(Mandatory=$true, ParameterSetName='ByProjectName')]
+    [string] $ProjectName,
+    [Parameter(Mandatory=$true, ParameterSetName='ByPath')]
+    [string] $Path
 )
 
 . "$PSScriptRoot/../common/scripts/common.ps1"
 $RepoRoot = $RepoRoot.Path.Replace('\', '/')
 
-$projectFiles = Get-ChildItem $RepoRoot -Filter $ProjectName -Recurse
+if ($ProjectName) {
+    $projectFiles = Get-ChildItem $RepoRoot -Filter "$ProjectName" -Recurse
 
-if ($projectFiles.Count -eq 0) {
-    Write-Error "No project files found matching '$ProjectName'."
-    exit 1
-}
+    if ($projectFiles.Count -eq 0) {
+        Write-Error "No project files found matching '$ProjectName'."
+        exit 1
+    }
 
-if ($projectFiles.Count -gt 1) {
-    Write-Error "Multiple project files found matching '$ProjectName'."
-    exit 1
+    if ($projectFiles.Count -gt 1) {
+        Write-Error "Multiple project files found matching '$ProjectName'."
+        exit 1
+    }
+} elseif ($Path) {
+    $projectFiles = @(Get-Item $Path -ErrorAction SilentlyContinue)
+    if (-not $projectFiles) {
+        Write-Error "No project file found at path '$Path'."
+        exit 1
+    }
 }
 
 $project = [xml](Get-Content $projectFiles[0])

--- a/eng/scripts/Get-ToolsToTest.ps1
+++ b/eng/scripts/Get-ToolsToTest.ps1
@@ -129,7 +129,8 @@ try {
         }
 
         $testMatrix[$path] = [ordered]@{
-            Path = $path
+            # We can't use the name 'Path' here because it would override the Path environment variable in matrix based jobs
+            PathToTest = $path
             UnitTests = $hasUnitTests
             LiveTests = $hasLiveTests
             TestResources = $hasTestResources

--- a/eng/scripts/Get-ToolsToTest.ps1
+++ b/eng/scripts/Get-ToolsToTest.ps1
@@ -13,18 +13,18 @@ param(
 $RepoRoot = $RepoRoot.Path.Replace('\', '/')
 
 # When "core" is modified, include storage and keyVault as the canary service tools.
-$canaryAreas = @{
+$canaryPaths = @{
     "core/Azure.Mcp.Core"= @('tools/Azure.Mcp.Tools.Storage', 'tools/Azure.Mcp.Tools.KeyVault')
     "core/Microsoft.Mcp.Core"= @('tools/Azure.Mcp.Tools.Storage', 'tools/Azure.Mcp.Tools.KeyVault')
 }
 
-# While there is a "core" directory at the repo root, we consider the "core" area to be all of the repo outside of the
+# While there is a "core" directory at the repo root, we consider the "core" path to be all of the repo outside of the
 # "tools" directory.
 # This lets us make simple statements like:
 # - Changes in eng/ are "core" changes
 # - Changes in core/ are "core" changes
 # - Changes to tools/Azure.Mcp.Tools.Redis are "Azure.Mcp.Tools.Redis" changes
-# - If you change any "core" files, we need to test all of the "core" area as well as a few canary tools
+# - If you change any "core" files, we need to test all of the "core" path as well as a few canary tools
 # - If you change just tool files, we need to test the tools you changed
 
 # If the caller passed in a ServiceName, then only the tools that the server depends on are in scope to test
@@ -41,12 +41,12 @@ $paths = if ($ServerName) {
     Get-ChildItem $RepoRoot -Directory -Recurse
 }
 
-# Reduce the paths down to areas like:
+# Reduce down to paths like:
 #   tools/Azure.Mcp.Tools.Storage
 #   core/Fabric.Mcp.Core
 #   servers/Azure.Mcp.Server
 
-$areas = $paths
+$paths = $paths
     | Resolve-Path -Relative -RelativeBasePath $RepoRoot
     | Where-Object { ($_.Replace('\', '/') -replace '^./', '') -match '^((tools|servers|core)/[^/]+)/' }
     | ForEach-Object { $Matches[1] }
@@ -57,7 +57,7 @@ try {
     $isPullRequestBuild = $env:BUILD_REASON -eq 'PullRequest'
 
     if($isPullRequestBuild) {
-        # If we're in a pull request, use the set of changed files to narrow down the set of areas to test.
+        # If we're in a pull request, use the set of changed files to narrow down the set of paths to test.
         $changedFiles = Get-ChangedFiles
         # $changedFiles = [
         #   tools/Azure.Mcp.Tools.Storage/src/someFile.cs    <- "Azure.Mcp.Tools.Storage"
@@ -68,68 +68,68 @@ try {
         Write-Host ''
 
         # Currently, we don't exclude non-code files from the changed files list.
-        # For example, updating a markdown file in a service area will still trigger tests for that area.
-        # Updating a file outside of the defined "areas" will be seen as a change to the core area.
-        $changedAreas = @($changedFiles
-        | ForEach-Object { $_ -match '^((tools|core|servers)/.*?)/' -and $areas -contains $Matches[1] ? $Matches[1] : 'core/Microsoft.Mcp.Core' }
+        # For example, updating a markdown file in a service path will still trigger tests for that path.
+        # Updating a file outside of the defined paths will be seen as a change to the core path.
+        $changedPaths = @($changedFiles
+        | ForEach-Object { $_ -match '^((tools|core|servers)/.*?)/' -and $paths -contains $Matches[1] ? $Matches[1] : 'core/Microsoft.Mcp.Core' }
         | Sort-Object -Unique)
 
-        <# Making $changedAreas = @(
+        <# Making $changedPaths = @(
             'tools/Azure.Mcp.Tools.Storage',
             'tools/Azure.Mcp.Tools.Monitoring',
             'core/Microsoft.Mcp.Core'
         ) #>
 
-        if($changedAreas.Count -eq 0) {
-            Write-Host "No changed areas detected. Defaulting to core." -ForegroundColor Yellow
-            $changedAreas = @('core/Microsoft.Mcp.Core')
+        if($changedPaths.Count -eq 0) {
+            Write-Host "No changed, testable paths detected. Defaulting to core." -ForegroundColor Yellow
+            $changedPaths = @('core/Microsoft.Mcp.Core')
         } else {
-            Write-Host "Changed areas detected: $($changedAreas -join ', ')"
+            Write-Host "Changed paths detected: $($changedPaths -join ', ')"
         }
 
-        $areasToTest = $changedAreas
-        # If any affected area has "canaries", add them to the areas to test
-        foreach ($canaryKey in $canaryAreas.Keys) {
-            if($changedAreas -contains $canaryKey) {
-                $canaries = $canaryAreas[$canaryKey]
-                Write-Host "$canaryKey changes detected. Including canary areas: $($canaries -join ', ')" -ForegroundColor Cyan
-                $areasToTest += $canaries
+        $pathsToTest = $changedPaths
+        # If any affected path has "canaries", add them to the paths to test
+        foreach ($canaryKey in $canaryPaths.Keys) {
+            if($changedPaths -contains $canaryKey) {
+                $canaries = $canaryPaths[$canaryKey]
+                Write-Host "$canaryKey changes detected. Including canary paths: $($canaries -join ', ')" -ForegroundColor Cyan
+                $pathsToTest += $canaries
             }
         }
 
-        $areasToTest = @($areasToTest | Sort-Object -Unique)
+        $pathsToTest = @($pathsToTest | Sort-Object -Unique)
 
-        <# Making $areasToTest = @(
+        <# Making $pathsToTest = @(
             'tools/Azure.Mcp.Tools.Storage',
             'tools/Azure.Mcp.Tools.Monitoring',
             'core/Microsoft.Mcp.Core',
             'tools/Azure.Mcp.Tools.KeyVault'  <-- from Microsoft.Mcp.Core's canary list
         ) #>
     } else {
-        # If we're not in a pull request, test all areas
-        $areasToTest = $areas
+        # If we're not in a pull request, test all paths
+        $pathsToTest = $paths
     }
 
-    Write-Host "Forming area test matrix"
-    $areaMatrix = [ordered]@{}
-    foreach ($area in $areasToTest) {
-        $testResourcesPath = "$area/tests"
+    Write-Host "Forming test matrix"
+    $testMatrix = [ordered]@{}
+    foreach ($path in $pathsToTest) {
+        $testResourcesPath = "$path/tests"
         $hasTestResources = Test-Path "$RepoRoot/$testResourcesPath/test-resources.bicep"
         $hasLiveTests = (Get-ChildItem $testResourcesPath -Filter '*.LiveTests.csproj' -Recurse).Count -gt 0
         $hasUnitTests = (Get-ChildItem $testResourcesPath -Filter '*.UnitTests.csproj' -Recurse).Count -gt 0
 
         if ($TestType -eq 'Live' -and (!$hasLiveTests -or !$hasTestResources)) {
-            Write-Host "$area has changes, but no live tests or test resources found. Skipping." -ForegroundColor Yellow
+            Write-Host "$path has changes, but no live tests or test resources found. Skipping." -ForegroundColor Yellow
             continue
         }
 
         if ($TestType -eq 'Unit' -and !$hasUnitTests) {
-            Write-Host "$area has changes, but no unit tests found. Skipping." -ForegroundColor Yellow
+            Write-Host "$path has changes, but no unit tests found. Skipping." -ForegroundColor Yellow
             continue
         }
 
-        $areaMatrix[$area] = [ordered]@{
-            Area = $area
+        $testMatrix[$path] = [ordered]@{
+            Path = $path
             UnitTests = $hasUnitTests
             LiveTests = $hasLiveTests
             TestResources = $hasTestResources
@@ -137,21 +137,21 @@ try {
         }
     }
 
-    $hasTestAreas = $areaMatrix.Count -gt 0
+    $hasTestPaths = $testMatrix.Count -gt 0
 
     if($SetDevOpsVariables) {
-        # Set DevOps variables for changed areas
-        $json = ConvertTo-Json $areaMatrix -Compress
+        # Set DevOps variables for changed paths
+        $json = ConvertTo-Json $testMatrix -Compress
         Write-Host "##vso[task.setvariable variable=TestMatrix;isOutput=true]$json"
-        # Set a variable indicating if any areas changed
-        Write-Host "##vso[task.setvariable variable=HasTestAreas;isOutput=true]$hasTestAreas"
+        # Set a variable indicating if any paths changed
+        Write-Host "##vso[task.setvariable variable=HasTestPaths;isOutput=true]$hasTestPaths"
     }
 
     Write-Host ""
     Write-Host "TestMatrix:"
-    $areaMatrix | ConvertTo-Json | Out-Host
+    $testMatrix | ConvertTo-Json | Out-Host
 
-    Write-Host "HasTestAreas: $hasTestAreas"
+    Write-Host "HasTestPaths: $hasTestPaths"
 }
 finally {
     Pop-Location

--- a/eng/scripts/Test-Code.ps1
+++ b/eng/scripts/Test-Code.ps1
@@ -31,7 +31,7 @@ if (!$TestResultsPath) {
 # Clean previous results
 Remove-Item -Recurse -Force $TestResultsPath -ErrorAction SilentlyContinue
 
-# Finds all test projects, then filters them based on the specified path and area filters.
+# Finds all test projects, then filters them based on the specified path filters.
 function FilterTestProjects {
     $fileNameFilters = switch ($testType) {
         'Live' { '*.LiveTests.csproj' }

--- a/eng/scripts/Test-Code.ps1
+++ b/eng/scripts/Test-Code.ps1
@@ -90,11 +90,6 @@ function CreateTestSolution {
 }
 
 function Create-CoverageReport {
-    param(
-        [Parameter(Mandatory=$true)]
-        [string]$TestResultsPath
-    )
-
     # Find the coverage file
     $coverageFile = Get-ChildItem -Path $TestResultsPath -Recurse -Filter "coverage.cobertura.xml"
     | Where-Object { $_.FullName.Replace('\','/') -notlike "*/in/*" }
@@ -281,7 +276,7 @@ $testExitCode = $LastExitCode
 
 # Coverage Report Generation - only if coverage collection was enabled
 if ($CollectCoverage) {
-    Create-CoverageReport -TestResultsPath $TestResultsPath -OpenReport:$OpenReport
+    Create-CoverageReport
 }
 
 exit $testExitCode


### PR DESCRIPTION
## What does this PR do?
Deploy-TestResources wasn't updated to support the new tools/ paths.
This changes the parameter from 'Area' to 'Tool' and 'Path'.

```
Deploy-TestResources.ps1 -Path Azure.Mcp.Tools.*
Deploy-TestResources.ps1 -Path storage
Deploy-TestResources.ps1 -Path core/Azure.Mcp.Core
```

## GitHub issue number?
fixes #38

## Pre-merge Checklist

- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [ ] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
