### PR TITLE
Fix issues in Docker and Version Bump steps

### DIFF
--- a/eng/pipelines/templates/jobs/docker.yml
+++ b/eng/pipelines/templates/jobs/docker.yml
@@ -37,8 +37,8 @@ jobs:
         $properties = ./eng/scripts/Get-ProjectProperties.ps1 -ProjectName '${{parameters.ServerName}}.csproj'
         $imageName = $properties.DockerImageName
         $version = $properties.Version
-        Write-Host "##vso[task.setvariable variable=DockerImageName]$imageName"
-        Write-Host "##vso[task.setvariable variable=DockerImageVersion]$version$VersionSuffix"
+        Write-Host "##vso[task.setvariable variable=DockerImageName;isOutput=true]$imageName"
+        Write-Host "##vso[task.setvariable variable=DockerImageVersion;isOutput=true]$version$VersionSuffix"
     env:
       VERSION_SUFFIX: '$(VersionSuffix)'
 

--- a/eng/pipelines/templates/jobs/release.yml
+++ b/eng/pipelines/templates/jobs/release.yml
@@ -149,3 +149,4 @@ jobs:
       PRBranchName: increment-package-version-$(Build.BuildId)
       CommitMsg: "Increment package version after release"
       PRTitle: "Increment version after release"
+      RepoOwner: microsoft


### PR DESCRIPTION
## What does this PR do?
Docker's version variables weren't set as output, so following jobs couldn't use them
The version bump step wasn't overriding the default repo owner name of `Azure` to `microsoft` so it was producing the full PR target repo name `Azure/microsoft/mcp`

## Pre-merge Checklist

- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [ ] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
