### PR TITLE
Fix VSIX signing and add "Verify VSIX Signing" step

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -128,6 +128,7 @@
                 "entraid",
                 "existingaccount",
                 "filestorage",
+                "fname",
                 "funkyfoo",
                 "gdnbaselines",
                 "globaltool",

--- a/eng/pipelines/templates/common.yml
+++ b/eng/pipelines/templates/common.yml
@@ -167,7 +167,7 @@ extends:
           - pwsh: |
               Write-Host "Verifying signing for win-x64 and win-arm64 VSIX files..."
               $allSigned = $true
-              $signedVsixFiles = Get-ChildItem -Path '$(Pipeline.Workspace)/vsix_$(PipelineArtifactName)_signed/**/win-*' -Recurse -Include "*.vsix"
+              $signedVsixFiles = Get-ChildItem -Path '$(Pipeline.Workspace)/vsix_$(PipelineArtifactName)_signed/**/win-*' -Recurse -Include "*.signature.p7s"
               foreach ($vsix in $signedVsixFiles) {
                   if ((Get-AuthenticodeSignature -FilePath $vsix.FullName).Status -ne 'Valid') {
                       Write-Host "VSIX file $($vsix.FullName) is NOT signed correctly."

--- a/eng/pipelines/templates/common.yml
+++ b/eng/pipelines/templates/common.yml
@@ -149,40 +149,6 @@ extends:
               }
             displayName: "Verify Binary Signing"
 
-        - job: Verify_VSIX_Signing
-          displayName: "Verify VSIX Signing"
-          dependsOn: SignAndPackVSIX
-          pool:
-            name: $(WINDOWSPOOL) # Signing verification must happen on windows
-            image: $(WINDOWSVMIMAGE)
-            os: windows
-          variables:
-          - template: /eng/pipelines/templates/variables/image.yml
-          - template: /eng/pipelines/templates/variables/globals.yml
-          steps:
-          - checkout: none
-          - download: current
-            artifact: vsix_$(PipelineArtifactName)_signed
-            displayName: "Download signed MCP server VSIX files"
-          - pwsh: |
-              Write-Host "Verifying signing for win-x64 and win-arm64 VSIX files..."
-              $allSigned = $true
-              $signedVsixFiles = Get-ChildItem -Path '$(Pipeline.Workspace)/vsix_$(PipelineArtifactName)_signed/**/win-*' -Recurse -Include "*.signature.p7s"
-              foreach ($vsix in $signedVsixFiles) {
-                  if ((Get-AuthenticodeSignature -FilePath $vsix.FullName).Status -ne 'Valid') {
-                      Write-Host "VSIX file $($vsix.FullName) is NOT signed correctly."
-                      $allSigned = $false
-                  }
-                  else {
-                      Write-Host "VSIX file $($vsix.FullName) is signed correctly."
-                  }
-              }
-              if (-not $allSigned) {
-                  Write-Error "One or more VSIX files are not signed correctly."
-                  exit 1
-              }
-            displayName: "Verify VSIX Signing"
-
       - ${{ if eq(parameters.ReleaseRun, 'true') }}:
         - stage: Release
           dependsOn:

--- a/eng/pipelines/templates/common.yml
+++ b/eng/pipelines/templates/common.yml
@@ -149,6 +149,40 @@ extends:
               }
             displayName: "Verify Binary Signing"
 
+        - job: Verify_VSIX_Signing
+          displayName: "Verify VSIX Signing"
+          dependsOn: SignAndPackVSIX
+          pool:
+            name: $(WINDOWSPOOL) # Signing verification must happen on windows
+            image: $(WINDOWSVMIMAGE)
+            os: windows
+          variables:
+          - template: /eng/pipelines/templates/variables/image.yml
+          - template: /eng/pipelines/templates/variables/globals.yml
+          steps:
+          - checkout: none
+          - download: current
+            artifact: vsix_$(PipelineArtifactName)_signed
+            displayName: "Download signed MCP server VSIX files"
+          - pwsh: |
+              Write-Host "Verifying signing for win-x64 and win-arm64 VSIX files..."
+              $allSigned = $true
+              $signedVsixFiles = Get-ChildItem -Path '$(Pipeline.Workspace)/vsix_$(PipelineArtifactName)_signed/**/win-*' -Recurse -Include "*.vsix"
+              foreach ($vsix in $signedVsixFiles) {
+                  if ((Get-AuthenticodeSignature -FilePath $vsix.FullName).Status -ne 'Valid') {
+                      Write-Host "VSIX file $($vsix.FullName) is NOT signed correctly."
+                      $allSigned = $false
+                  }
+                  else {
+                      Write-Host "VSIX file $($vsix.FullName) is signed correctly."
+                  }
+              }
+              if (-not $allSigned) {
+                  Write-Error "One or more VSIX files are not signed correctly."
+                  exit 1
+              }
+            displayName: "Verify VSIX Signing"
+
       - ${{ if eq(parameters.ReleaseRun, 'true') }}:
         - stage: Release
           dependsOn:

--- a/eng/pipelines/templates/jobs/sign-and-pack-vsix.yml
+++ b/eng/pipelines/templates/jobs/sign-and-pack-vsix.yml
@@ -35,7 +35,7 @@ jobs:
   - template: pipelines/steps/azd-vscode-signing.yml@azure-sdk-build-tools
     parameters:
       Path: $(Build.ArtifactStagingDirectory)
-      Pattern: '*.signature.p7s'
+      Pattern: '**/*.signature.p7s'
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:

--- a/eng/pipelines/templates/jobs/sign-and-pack-vsix.yml
+++ b/eng/pipelines/templates/jobs/sign-and-pack-vsix.yml
@@ -41,3 +41,37 @@ jobs:
     parameters:
       ArtifactPath: $(Build.ArtifactStagingDirectory)
       ArtifactName: vsix_packages_signed
+
+- job: VerifyVSIXSigning
+  displayName: "Verify VSIX Signing"
+  dependsOn: SignAndPackVSIX
+  pool:
+    name: $(WINDOWSPOOL) # Signing verification must happen on windows
+    image: $(WINDOWSVMIMAGE)
+    os: windows
+  variables:
+  - template: /eng/pipelines/templates/variables/image.yml
+  - template: /eng/pipelines/templates/variables/globals.yml
+  steps:
+  - checkout: none
+  - download: current
+    artifact: vsix_$(PipelineArtifactName)_signed
+    displayName: "Download signed MCP server VSIX files"
+  - pwsh: |
+      Write-Host "Verifying signing for win-x64 and win-arm64 VSIX files..."
+      $allSigned = $true
+      $signedVsixFiles = Get-ChildItem -Path '$(Pipeline.Workspace)/vsix_$(PipelineArtifactName)_signed/**/win-*' -Recurse -Include "*.signature.p7s"
+      foreach ($vsix in $signedVsixFiles) {
+          if ((Get-AuthenticodeSignature -FilePath $vsix.FullName).Status -ne 'Valid') {
+              Write-Host "VSIX file $($vsix.FullName) is NOT signed correctly."
+              $allSigned = $false
+          }
+          else {
+              Write-Host "VSIX file $($vsix.FullName) is signed correctly."
+          }
+      }
+      if (-not $allSigned) {
+          Write-Error "One or more VSIX files are not signed correctly."
+          exit 1
+      }
+    displayName: "Verify VSIX Signing"

--- a/eng/pipelines/templates/jobs/sign-and-pack-vsix.yml
+++ b/eng/pipelines/templates/jobs/sign-and-pack-vsix.yml
@@ -58,20 +58,71 @@ jobs:
     artifact: vsix_$(PipelineArtifactName)_signed
     displayName: "Download signed MCP server VSIX files"
   - pwsh: |
-      Write-Host "Verifying signing for win-x64 and win-arm64 VSIX files..."
-      $allSigned = $true
-      $signedVsixFiles = Get-ChildItem -Path '$(Pipeline.Workspace)/vsix_$(PipelineArtifactName)_signed/**/win-*' -Recurse -Include "*.signature.p7s"
-      foreach ($vsix in $signedVsixFiles) {
-          if ((Get-AuthenticodeSignature -FilePath $vsix.FullName).Status -ne 'Valid') {
-              Write-Host "VSIX file $($vsix.FullName) is NOT signed correctly."
-              $allSigned = $false
-          }
-          else {
-              Write-Host "VSIX file $($vsix.FullName) is signed correctly."
-          }
+      Write-Host "Verifying VSIX signing by parsing CodeSignSummary markdown files..."
+
+      $root = "$(Pipeline.Workspace)/vsix_$(PipelineArtifactName)_signed"
+      $summaries = Get-ChildItem -Path $root -Recurse -Filter 'CodeSignSummary-*.md'
+
+      if (-not $summaries) {
+        Write-Error "No CodeSignSummary-*.md files found under $root. Cannot verify signing."
+
+        exit 1
       }
-      if (-not $allSigned) {
-          Write-Error "One or more VSIX files are not signed correctly."
-          exit 1
+
+      $allPassed = $true
+
+      foreach ($file in $summaries) {
+        Write-Host "Checking summary: $($file.FullName)"
+
+        $lines = Get-Content -Path $file.FullName
+
+        # Consider only table lines that start with '|'
+        $tableLines = $lines | Where-Object { $_ -match '^\s*\|' }
+
+        if (-not $tableLines) { continue }
+
+        # Header is the first non-separator table line
+        $headerLine = $tableLines | Where-Object { $_ -notmatch '^\s*\|[-\s]+\|\s*$' } | Select-Object -First 1
+
+        if (-not $headerLine) { continue }
+
+        $headers = ($headerLine -split '\|') | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }
+        $statusIdx = [Array]::IndexOf($headers, 'Status')
+        $componentIdx = [Array]::IndexOf($headers, 'Component')
+        $fileNameIdx = [Array]::IndexOf($headers, 'FileName')
+
+        if ($statusIdx -lt 0 -or $componentIdx -lt 0) {
+          Write-Host "Skipping file with unexpected header format: $($file.FullName)"
+
+          continue
+        }
+
+        # Data rows: all table lines except header and separator
+        $dataRows = $tableLines | Where-Object { $_ -notmatch '^\s*\|[-\s]+\|\s*$' -and $_ -ne $headerLine }
+
+        foreach ($row in $dataRows) {
+          $cols = ($row -split '\|') | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }
+
+          if ($cols.Count -lt $headers.Count) { continue }
+
+          $component = $cols[$componentIdx]
+          $status = $cols[$statusIdx]
+          $fname = if ($fileNameIdx -ge 0 -and $fileNameIdx -lt $cols.Count) { $cols[$fileNameIdx] } else { '' }
+
+          if ($component -eq 'Sign' -and $status -ne 'Pass') {
+            Write-Host "Signing failed: Status=$status Component=$component File=$fname (in $($file.Name))"
+
+            $allPassed = $false
+          }
+        }
+      }
+
+      if (-not $allPassed) {
+        Write-Error "One or more 'Sign' entries did not report 'Pass' in CodeSignSummary."
+
+        exit 1
+      }
+      else {
+        Write-Host "All 'Sign' entries report 'Pass'."
       }
     displayName: "Verify VSIX Signing"

--- a/eng/pipelines/templates/jobs/sign-and-pack-vsix.yml
+++ b/eng/pipelines/templates/jobs/sign-and-pack-vsix.yml
@@ -6,7 +6,7 @@ parameters:
   type: string
 
 jobs:
-- job:
+- job: SignAndPackVSIX
   displayName: "Sign and Pack VSIX"
   dependsOn: ${{ parameters.DependsOn }}
   condition: and(succeeded(), ne(variables['NoPackagesChanged'], 'true'))


### PR DESCRIPTION
## What does this PR do?
Fixed pattern matching for .p7s files for VSIX signing during release and added a verify step.

## GitHub issue number?
N/A

## Pre-merge Checklist

- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [x] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
