### PR TITLE
Add Azure Managed Lustre Filesystem Check Subnet Size

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -541,6 +541,7 @@
         "storageaccounts",
         "streamable",
         "submode",
+        "subnetsize",
         "subresource",
         "swedencentral",
         "swedensouth",

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -1063,15 +1063,22 @@ azmcp monitor metrics query --subscription <subscription> \
 ```bash
 # List Azure Managed Lustre Filesystems available in a subscription or resource group
 azmcp azuremanagedlustre filesystem list --subscription <subscription> \
-                                      --resource-group <resource-group>
-
-# Returns the required number of IP addresses for a specific Azure Managed Lustre SKU and filesystem size
-azmcp azuremanagedlustre filesystem required-subnet-size --subscription <subscription> \
-                                      --sku <azure-managed-lustre-sku> \
-                                      --size <filesystem-size-in-tib>
+                                         --resource-group <resource-group> 
 
 azmcp azuremanagedlustre filesystem sku get --subscription <subscription> \
                                             --location <location>
+
+# Returns the required number of IP addresses for a specific Azure Managed Lustre SKU and filesystem size
+azmcp azuremanagedlustre filesystem subnetsize ask --subscription <subscription> \
+                                                   --sku <azure-managed-lustre-sku> \
+                                                   --size <filesystem-size-in-tib>
+
+# Checks if a subnet has enough available IP addresses for the specified Azure Managed Lustre SKU and filesystem size
+azmcp azuremanagedlustre filesystem subnetsize validate --subscription <subscription> \
+                                                        --subnet-id <subnet-resource-id> \
+                                                        --sku <azure-managed-lustre-sku> \
+                                                        --size <filesystem-size-in-tib> \
+                                                        --location <filesystem-location>
 ```
 
 ### Azure Native ISV Operations

--- a/docs/e2eTestPrompts.md
+++ b/docs/e2eTestPrompts.md
@@ -340,8 +340,9 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 |:----------|:----------|
 | azmcp_azuremanagedlustre_filesystem_list | List the Azure Managed Lustre filesystems in my subscription <subscription_name> |
 | azmcp_azuremanagedlustre_filesystem_list | List the Azure Managed Lustre filesystems in my resource group <resource_group_name> |
-| azmcp_azuremanagedlustre_filesystem_required-subnet-size | Tell me how many IP addresses I need for <filesystem_size> of <amlfs_sku> |
 | azmcp_azuremanagedlustre_filesystem_sku_get | List the Azure Managed Lustre SKUs available in <location> |
+| azmcp_azuremanagedlustre_filesystem_subnetsize_ask | Tell me how many IP addresses I need for <filesystem_size> of <amlfs_sku> |
+| azmcp_azuremanagedlustre_filesystem_subnetsize_validate | Validate if <subnet_id> can host <filesystem_size> of <amlfs_sku> |
 
 ## Azure Marketplace
 

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -7,6 +7,8 @@ The Azure MCP Server updates automatically by default whenever a new release com
 ### Features Added
 
 - Added support for sending SMS messages via Azure Communication Services with the command `azmcp_communication_sms_send`. Supports single and multiple recipients, delivery reporting, and custom message tracking tags. [[#473](https://github.com/microsoft/mcp/pull/473)]
+- Added the following Azure Managed Lustre commands:
+  - `azmcp_azuremanagedlustre_filesystem_subnetsize_validate`: Check if the subnet can host the target Azure Managed Lustre SKU and size [[#110](https://github.com/microsoft/mcp/issues/110)].
 
 ### Breaking Changes
 
@@ -17,6 +19,8 @@ The Azure MCP Server updates automatically by default whenever a new release com
 - Fixed the construction of Azure Resource Graph queries for App Configuration in the `FindAppConfigStore` method. The name filter is now correctly passed via the `additionalFilter` parameter instead of `tableName`, resolving "ExactlyOneStartingOperatorRequired" and "BadRequest" errors when setting key-value pairs. [[#670](https://github.com/microsoft/mcp/pull/670)]
 
 ### Other Changes
+
+- Renamed `azmcp_azuremanagedlustre_filesystem_required-subnet-size` to `azmcp_azuremanagedlustre_filesystem_subnetsize_ask`
 
 #### Dependency updates
 

--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -330,6 +330,7 @@ To use Azure Entra ID, review the [troubleshooting guide](https://github.com/mic
 
 * "List the Azure Managed Lustre clusters in resource group 'my-resource-group'"
 * "How many IP Addresses I need to create a 128 TiB cluster of AMLFS 500?"
+* "Check if 'my-subnet-id' can host an Azure Managed Lustre with 'my-size' TiB and 'my-sku' in 'my-region'
 
 ### 📊 Azure Monitor
 

--- a/tools/Azure.Mcp.Tools.AzureManagedLustre/src/AzureManagedLustreSetup.cs
+++ b/tools/Azure.Mcp.Tools.AzureManagedLustre/src/AzureManagedLustreSetup.cs
@@ -18,7 +18,8 @@ public class AzureManagedLustreSetup : IAreaSetup
         services.AddSingleton<IAzureManagedLustreService, AzureManagedLustreService>();
 
         services.AddSingleton<FileSystemListCommand>();
-        services.AddSingleton<FileSystemSubnetSizeCommand>();
+        services.AddSingleton<SubnetSizeAskCommand>();
+        services.AddSingleton<SubnetSizeValidateCommand>();
         services.AddSingleton<SkuGetCommand>();
     }
 
@@ -33,8 +34,14 @@ public class AzureManagedLustreSetup : IAreaSetup
         var list = serviceProvider.GetRequiredService<FileSystemListCommand>();
         fileSystem.AddCommand(list.Name, list);
 
-        var subnetSize = serviceProvider.GetRequiredService<FileSystemSubnetSizeCommand>();
-        fileSystem.AddCommand(subnetSize.Name, subnetSize);
+        var subnetSize = new CommandGroup("subnetsize", "Subnet size planning and validation operations for Azure Managed Lustre.");
+        fileSystem.AddSubGroup(subnetSize);
+
+        var subnetSizeAsk = serviceProvider.GetRequiredService<SubnetSizeAskCommand>();
+        subnetSize.AddCommand(subnetSizeAsk.Name, subnetSizeAsk);
+
+        var subnetSizeValidate = serviceProvider.GetRequiredService<SubnetSizeValidateCommand>();
+        subnetSize.AddCommand(subnetSizeValidate.Name, subnetSizeValidate);
 
         var sku = new CommandGroup("sku", "This group provides commands to discover and retrieve information about available Azure Managed Lustre SKUs, including supported tiers, performance characteristics, and regional availability. Use these commands to validate SKU options prior to provisioning or updating a filesystem.");
         fileSystem.AddSubGroup(sku);

--- a/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Commands/AzureManagedLustreJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Commands/AzureManagedLustreJsonContext.cs
@@ -7,7 +7,8 @@ using Azure.Mcp.Tools.AzureManagedLustre.Models;
 
 namespace Azure.Mcp.Tools.AzureManagedLustre.Commands;
 
-[JsonSerializable(typeof(FileSystemSubnetSizeCommand.FileSystemSubnetSizeResult))]
+[JsonSerializable(typeof(SubnetSizeAskCommand.FileSystemSubnetSizeResult))]
+[JsonSerializable(typeof(SubnetSizeValidateCommand.FileSystemCheckSubnetResult))]
 [JsonSerializable(typeof(FileSystemListCommand.FileSystemListResult))]
 [JsonSerializable(typeof(SkuGetCommand.SkuGetResult))]
 [JsonSerializable(typeof(LustreFileSystem))]

--- a/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Commands/FileSystem/SubnetSize/SubnetSizeAskCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Commands/FileSystem/SubnetSize/SubnetSizeAskCommand.cs
@@ -10,12 +10,12 @@ using Microsoft.Extensions.Logging;
 
 namespace Azure.Mcp.Tools.AzureManagedLustre.Commands.FileSystem;
 
-public sealed class FileSystemSubnetSizeCommand(ILogger<FileSystemSubnetSizeCommand> logger)
-    : BaseAzureManagedLustreCommand<FileSystemSubnetSizeOptions>(logger)
+public sealed class SubnetSizeAskCommand(ILogger<SubnetSizeAskCommand> logger)
+    : BaseAzureManagedLustreCommand<SubnetSizeAskOptions>(logger)
 {
     private const string CommandTitle = "Calculate AMLFS Subnet Size required number of IP Addresses";
 
-    public override string Name => "required-subnet-size";
+    public override string Name => "ask";
 
     public override string Description =>
         """
@@ -57,7 +57,7 @@ public sealed class FileSystemSubnetSizeCommand(ILogger<FileSystemSubnetSizeComm
         });
     }
 
-    protected override FileSystemSubnetSizeOptions BindOptions(ParseResult parseResult)
+    protected override SubnetSizeAskOptions BindOptions(ParseResult parseResult)
     {
         var options = base.BindOptions(parseResult);
         options.Sku = parseResult.GetValueOrDefault<string>(AzureManagedLustreOptionDefinitions.SkuOption.Name);

--- a/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Commands/FileSystem/SubnetSize/SubnetSizeValidateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Commands/FileSystem/SubnetSize/SubnetSizeValidateCommand.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Net;
+using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Core.Extensions;
+using Azure.Mcp.Tools.AzureManagedLustre.Options;
+using Azure.Mcp.Tools.AzureManagedLustre.Options.FileSystem;
+using Azure.Mcp.Tools.AzureManagedLustre.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Mcp.Tools.AzureManagedLustre.Commands.FileSystem;
+
+public sealed class SubnetSizeValidateCommand(ILogger<SubnetSizeValidateCommand> logger)
+    : BaseAzureManagedLustreCommand<SubnetSizeValidateOptions>(logger)
+{
+    private const string CommandTitle = "Validate AMLFS subnet against SKU and size";
+
+    public override string Name => "validate";
+
+    public override string Description =>
+        "Validates that the provided subnet can host an Azure Managed Lustre filesystem for the given SKU and size.";
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new()
+    {
+        Destructive = false,
+        Idempotent = true,
+        OpenWorld = false,
+        ReadOnly = true,
+        LocalRequired = false,
+        Secret = false
+    };
+
+    private static readonly string[] AllowedSkus = [
+        "AMLFS-Durable-Premium-40",
+        "AMLFS-Durable-Premium-125",
+        "AMLFS-Durable-Premium-250",
+        "AMLFS-Durable-Premium-500"
+    ];
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(AzureManagedLustreOptionDefinitions.SkuOption);
+        command.Options.Add(AzureManagedLustreOptionDefinitions.SizeOption);
+        command.Options.Add(AzureManagedLustreOptionDefinitions.SubnetIdOption);
+        command.Options.Add(AzureManagedLustreOptionDefinitions.LocationOption);
+        command.Validators.Add(commandResult =>
+            {
+                var sku = commandResult.GetValueOrDefault<string>(AzureManagedLustreOptionDefinitions.SkuOption);
+                if (!string.IsNullOrWhiteSpace(sku) && !AllowedSkus.Contains(sku))
+                {
+                    commandResult.AddError($"Invalid SKU '{sku}'. Allowed values: {string.Join(", ", AllowedSkus)}");
+                }
+            }
+        );
+    }
+
+    protected override SubnetSizeValidateOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.Sku = parseResult.GetValueOrDefault<string>(AzureManagedLustreOptionDefinitions.SkuOption.Name);
+        options.Size = parseResult.GetValueOrDefault<int>(AzureManagedLustreOptionDefinitions.SizeOption.Name);
+        options.SubnetId = parseResult.GetValueOrDefault<string>(AzureManagedLustreOptionDefinitions.SubnetIdOption.Name);
+        options.Location = parseResult.GetValueOrDefault<string>(AzureManagedLustreOptionDefinitions.LocationOption.Name);
+        return options;
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        try
+        {
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+                return context.Response;
+
+            var options = BindOptions(parseResult);
+            var svc = context.GetService<IAzureManagedLustreService>();
+            var subnetIsValid = await svc.CheckAmlFSSubnetAsync(
+                                options.Subscription!,
+                                options.Sku!,
+                                options.Size,
+                                options.SubnetId!,
+                                options.Location!,
+                                options.Tenant,
+                                options.RetryPolicy);
+
+            context.Response.Results = ResponseResult.Create(new FileSystemCheckSubnetResult(subnetIsValid), AzureManagedLustreJsonContext.Default.FileSystemCheckSubnetResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error validating AMLFS subnet.");
+            HandleException(context, ex);
+        }
+        return context.Response;
+    }
+
+    internal record FileSystemCheckSubnetResult(bool Valid);
+}

--- a/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Options/AzureManagedLustreOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Options/AzureManagedLustreOptionDefinitions.cs
@@ -7,6 +7,7 @@ public static class AzureManagedLustreOptionDefinitions
 {
     public const string sku = "sku";
     public const string size = "size";
+    public const string subnetId = "subnet-id";
     public const string location = "location";
     public static readonly Option<string> SkuOption = new(
         $"--{sku}"
@@ -21,6 +22,14 @@ public static class AzureManagedLustreOptionDefinitions
     )
     {
         Description = "The AMLFS size (TiB).",
+        Required = true
+    };
+
+    public static readonly Option<string> SubnetIdOption = new(
+        $"--{subnetId}"
+    )
+    {
+        Description = "The subnet resource ID to validate for AMLFS.",
         Required = true
     };
 

--- a/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Options/FileSystem/SubnetSize/SubnetSizeAskOptions.cs
+++ b/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Options/FileSystem/SubnetSize/SubnetSizeAskOptions.cs
@@ -4,11 +4,11 @@ using System.Text.Json.Serialization;
 
 namespace Azure.Mcp.Tools.AzureManagedLustre.Options.FileSystem;
 
-public sealed class FileSystemSubnetSizeOptions : BaseAzureManagedLustreOptions
+public sealed class SubnetSizeAskOptions : BaseAzureManagedLustreOptions
 {
-    [property: JsonPropertyName("sku")]
+    [JsonPropertyName(AzureManagedLustreOptionDefinitions.sku)]
     public string? Sku { get; set; }
 
-    [property: JsonPropertyName("size")]
+    [JsonPropertyName(AzureManagedLustreOptionDefinitions.size)]
     public int Size { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Options/FileSystem/SubnetSize/SubnetSizeValidateOptions.cs
+++ b/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Options/FileSystem/SubnetSize/SubnetSizeValidateOptions.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Mcp.Tools.AzureManagedLustre.Options.FileSystem;
+
+public sealed class SubnetSizeValidateOptions : BaseAzureManagedLustreOptions
+{
+    [JsonPropertyName(AzureManagedLustreOptionDefinitions.sku)]
+    public string? Sku { get; set; }
+
+    [JsonPropertyName(AzureManagedLustreOptionDefinitions.size)]
+    public int Size { get; set; }
+
+    [JsonPropertyName(AzureManagedLustreOptionDefinitions.subnetId)]
+    public string? SubnetId { get; set; }
+
+    [JsonPropertyName(AzureManagedLustreOptionDefinitions.location)]
+    public string? Location { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Services/IAzureManagedLustreService.cs
+++ b/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Services/IAzureManagedLustreService.cs
@@ -19,6 +19,15 @@ public interface IAzureManagedLustreService
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null);
 
+    Task<bool> CheckAmlFSSubnetAsync(
+        string subscription,
+        string sku,
+        int size,
+        string subnetId,
+        string location,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null);
+
     Task<List<AzureManagedLustreSkuInfo>> SkuGetInfoAsync(
         string subscription,
         string? tenant = null,

--- a/tools/Azure.Mcp.Tools.AzureManagedLustre/tests/Azure.Mcp.Tools.AzureManagedLustre.LiveTests/AzureManagedLustreCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureManagedLustre/tests/Azure.Mcp.Tools.AzureManagedLustre.LiveTests/AzureManagedLustreCommandTests.cs
@@ -28,7 +28,7 @@ namespace Azure.Mcp.Tools.AzureManagedLustre.LiveTests
         public async Task Should_calculate_required_subnet_size()
         {
             var result = await CallToolAsync(
-                "azmcp_azuremanagedlustre_filesystem_required-subnet-size",
+                "azmcp_azuremanagedlustre_filesystem_subnetsize_ask",
                 new()
                 {
                     { "subscription", Settings.SubscriptionId },
@@ -91,6 +91,45 @@ namespace Azure.Mcp.Tools.AzureManagedLustre.LiveTests
                 var supportsZones = sku.AssertProperty("supportsZones");
                 Assert.False(supportsZones.GetBoolean(), "'supportsZones' must be false.");
             }
+        }
+
+
+        [Fact]
+        public async Task Should_check_subnet_size_and_succeed()
+        {
+            var result = await CallToolAsync(
+                "azmcp_azuremanagedlustre_filesystem_subnetsize_validate",
+                new()
+                {
+                    { "subscription", Settings.SubscriptionId },
+                    { "sku", "AMLFS-Durable-Premium-40" },
+                    { "size", 480 },
+                    { "location", Environment.GetEnvironmentVariable("LOCATION") },
+                    { "subnet-id", Environment.GetEnvironmentVariable("AMLFS_SUBNET_ID") }
+                });
+
+            var valid = result.AssertProperty("valid");
+            Assert.Equal(JsonValueKind.True, valid.ValueKind);
+            Assert.True(valid.GetBoolean());
+        }
+
+        [Fact]
+        public async Task Should_check_subnet_size_and_fail()
+        {
+            var result = await CallToolAsync(
+                "azmcp_azuremanagedlustre_filesystem_subnetsize_validate",
+                new()
+                {
+                    { "subscription", Settings.SubscriptionId },
+                    { "sku", "AMLFS-Durable-Premium-40" },
+                    { "size", 1008 },
+                    { "location", Environment.GetEnvironmentVariable("LOCATION") },
+                    { "subnet-id", Environment.GetEnvironmentVariable("AMLFS_SUBNET_SMALL_ID") }
+                });
+
+            var valid = result.AssertProperty("valid");
+            Assert.Equal(JsonValueKind.False, valid.ValueKind);
+            Assert.False(valid.GetBoolean());
         }
     }
 }

--- a/tools/Azure.Mcp.Tools.AzureManagedLustre/tests/Azure.Mcp.Tools.AzureManagedLustre.UnitTests/FileSystem/SubnetSize/SubnetSizeAskCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureManagedLustre/tests/Azure.Mcp.Tools.AzureManagedLustre.UnitTests/FileSystem/SubnetSize/SubnetSizeAskCommandTests.cs
@@ -20,8 +20,8 @@ public class FileSystemSubnetSizeCommandTests
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly IAzureManagedLustreService _amlfsService;
-    private readonly ILogger<FileSystemSubnetSizeCommand> _logger;
-    private readonly FileSystemSubnetSizeCommand _command;
+    private readonly ILogger<SubnetSizeAskCommand> _logger;
+    private readonly SubnetSizeAskCommand _command;
     private readonly CommandContext _context;
     private readonly Command _commandDefinition;
     private readonly string _knownSubscriptionId = "sub123";
@@ -29,7 +29,7 @@ public class FileSystemSubnetSizeCommandTests
     public FileSystemSubnetSizeCommandTests()
     {
         _amlfsService = Substitute.For<IAzureManagedLustreService>();
-        _logger = Substitute.For<ILogger<FileSystemSubnetSizeCommand>>();
+        _logger = Substitute.For<ILogger<SubnetSizeAskCommand>>();
 
         var services = new ServiceCollection().AddSingleton(_amlfsService);
         _serviceProvider = services.BuildServiceProvider();
@@ -43,7 +43,7 @@ public class FileSystemSubnetSizeCommandTests
     public void Constructor_InitializesCommandCorrectly()
     {
         var command = _command.GetCommand();
-        Assert.Equal("required-subnet-size", command.Name);
+        Assert.Equal("ask", command.Name);
         Assert.NotNull(command.Description);
         Assert.NotEmpty(command.Description);
     }

--- a/tools/Azure.Mcp.Tools.AzureManagedLustre/tests/Azure.Mcp.Tools.AzureManagedLustre.UnitTests/FileSystem/SubnetSize/SubnetSizeValidateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureManagedLustre/tests/Azure.Mcp.Tools.AzureManagedLustre.UnitTests/FileSystem/SubnetSize/SubnetSizeValidateCommandTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Tools.AzureManagedLustre.Commands.FileSystem;
+using Azure.Mcp.Tools.AzureManagedLustre.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace Azure.Mcp.Tools.AzureManagedLustre.UnitTests.FileSystem;
+
+public class FileSystemCheckSubnetCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAzureManagedLustreService _amlfsService;
+    private readonly ILogger<SubnetSizeValidateCommand> _logger;
+    private readonly SubnetSizeValidateCommand _command;
+    private readonly Command _commandDefinition;
+    private readonly CommandContext _context;
+    private readonly string _knownSubscriptionId = "sub123";
+
+    public FileSystemCheckSubnetCommandTests()
+    {
+        _amlfsService = Substitute.For<IAzureManagedLustreService>();
+        _logger = Substitute.For<ILogger<SubnetSizeValidateCommand>>();
+
+        var services = new ServiceCollection().AddSingleton(_amlfsService);
+        _serviceProvider = services.BuildServiceProvider();
+
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _commandDefinition = _command.GetCommand();
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("validate", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Succeeds_ForValidInput()
+    {
+        // Arrange
+        _amlfsService.CheckAmlFSSubnetAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions?>())
+            .Returns(Task.FromResult(true));
+
+        // Arrange
+        var args = _commandDefinition.Parse([
+            "--sku", "AMLFS-Durable-Premium-40",
+            "--size", "48",
+            "--location", "eastus",
+            "--subnet-id", "/subscriptions/sub123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/sn1",
+            "--subscription", _knownSubscriptionId
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<ResultJson>(json);
+        Assert.NotNull(result);
+        Assert.True(result!.Valid);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidSku_Returns400()
+    {
+        // Arrange
+        var args = _commandDefinition.Parse([
+            "--sku", "INVALID-SKU",
+            "--size", "48",
+            "--location", "eastus",
+            "--subnet-id", "/subscriptions/sub123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/sn1",
+            "--subscription", _knownSubscriptionId
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.True(response.Status >= HttpStatusCode.BadRequest);
+        Assert.Contains("invalid sku", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrows_IsHandled()
+    {
+        // Arrange
+        _amlfsService.CheckAmlFSSubnetAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions?>())
+            .ThrowsAsync(new Exception("error"));
+
+        var args = _commandDefinition.Parse([
+            "--sku", "AMLFS-Durable-Premium-40",
+            "--size", "48",
+            "--location", "eastus",
+            "--subnet-id", "/subscriptions/sub123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/sn1",
+            "--subscription", _knownSubscriptionId
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.True(response.Status >= HttpStatusCode.InternalServerError);
+        Assert.Contains("error", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private class ResultJson
+    {
+        [JsonPropertyName("valid")]
+        public bool Valid { get; set; }
+    }
+}

--- a/tools/Azure.Mcp.Tools.AzureManagedLustre/tests/test-resources.bicep
+++ b/tools/Azure.Mcp.Tools.AzureManagedLustre/tests/test-resources.bicep
@@ -14,6 +14,9 @@ param vnetAddressPrefix string = '10.20.0.0/16'
 @description('Subnet prefix for AMLFS (must be at least /24 per RP requirement)')
 param amlfsSubnetPrefix string = '10.20.1.0/24'
 
+@description('Subnet prefix for AMLFS small, for subnet validation live tests.')
+param amlfsSubnetSmallPrefix string = '10.20.2.0/28'
+
 @description('The client OID to grant access to test resources.')
 param testApplicationOid string = deployer().objectId
 
@@ -43,6 +46,17 @@ resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
         name: 'amlfs'
         properties: {
           addressPrefix: amlfsSubnetPrefix
+          natGateway: {
+            id: natGateway.id
+          }
+          privateEndpointNetworkPolicies: 'Disabled'
+          privateLinkServiceNetworkPolicies: 'Disabled'
+        }
+      }
+      {
+        name: 'amlfs-small'
+        properties: {
+          addressPrefix: amlfsSubnetSmallPrefix
           natGateway: {
             id: natGateway.id
           }
@@ -82,6 +96,7 @@ resource natPublicIp 'Microsoft.Network/publicIPAddresses@2024-07-01' = {
 }
 
 var filesystemSubnetId = resourceId('Microsoft.Network/virtualNetworks/subnets', vnet.name, 'amlfs')
+var filesystemSmallSubnetId = resourceId('Microsoft.Network/virtualNetworks/subnets', vnet.name, 'amlfs-small')
 
 resource amlfs 'Microsoft.StorageCache/amlFilesystems@2024-07-01' = {
   name: baseName
@@ -99,5 +114,7 @@ resource amlfs 'Microsoft.StorageCache/amlFilesystems@2024-07-01' = {
   }
 }
 
-output amlfsId string = amlfs.id
-output amlfsSubnetId string = filesystemSubnetId
+output AMLFS_ID string = amlfs.id
+output AMLFS_SUBNET_ID string = filesystemSubnetId
+output AMLFS_SUBNET_SMALL_ID string = filesystemSmallSubnetId
+output LOCATION string = location


### PR DESCRIPTION
## What does this PR do?
Adds the following Azure Managed Lustre commands:
  - `azmcp-azuremanagedlustre-filesystem-check-subnet-size`: Get information about Azure Managed Lustre SKU [[#110](https://github.com/microsoft/mcp/issues/110)]

## GitHub issue number?
Relates to:
 - [Add `azmcp azuremanagedlustre filesystem check-subnet-size`](https://github.com/microsoft/mcp/issues/110)

## Pre-merge Checklist

- [X] Required for All PRs
    - [X] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [X] PR title clearly describes the change
    - [X] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [X] Added comprehensive tests for new/modified functionality
    - [X] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [X] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [X] For MCP tool changes:
    - [X] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [X] Updated `README.md` documentation
    - [X] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [X] For new or modified tool descriptions, ran the `eng/tools/ToolDescriptionEvaluator` tool and obtained a result >= 0.4

