### PR TITLE
Add `azmcp sql server create/delete/show` commands and unit tests

### DIFF
--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerCreateCommand.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Core.Services.Telemetry;
+using Azure.Mcp.Tools.Sql.Models;
+using Azure.Mcp.Tools.Sql.Options;
+using Azure.Mcp.Tools.Sql.Options.Server;
+using Azure.Mcp.Tools.Sql.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Mcp.Tools.Sql.Commands.Server;
+
+public sealed class ServerCreateCommand(ILogger<ServerCreateCommand> logger)
+    : BaseSqlCommand<ServerCreateOptions>(logger)
+{
+    private const string CommandTitle = "Create SQL Server";
+
+    private readonly Option<string> _administratorLoginOption = SqlOptionDefinitions.AdministratorLoginOption;
+    private readonly Option<string> _administratorPasswordOption = SqlOptionDefinitions.AdministratorPasswordOption;
+    private readonly Option<string> _locationOption = SqlOptionDefinitions.LocationOption;
+    private readonly Option<string> _versionOption = SqlOptionDefinitions.VersionOption;
+    private readonly Option<string> _publicNetworkAccessOption = SqlOptionDefinitions.PublicNetworkAccessOption;
+
+    public override string Name => "create";
+
+    public override string Description =>
+        """
+        Creates a new Azure SQL server in the specified resource group and location. 
+        The server will be created with the specified administrator credentials and 
+        optional configuration settings. Returns the created server with its properties 
+        including the fully qualified domain name.
+        """;
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_administratorLoginOption);
+        command.AddOption(_administratorPasswordOption);
+        command.AddOption(_locationOption);
+        command.AddOption(_versionOption);
+        command.AddOption(_publicNetworkAccessOption);
+    }
+
+    protected override ServerCreateOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.AdministratorLogin = parseResult.GetValueForOption(_administratorLoginOption);
+        options.AdministratorPassword = parseResult.GetValueForOption(_administratorPasswordOption);
+        options.Location = parseResult.GetValueForOption(_locationOption);
+        options.Version = parseResult.GetValueForOption(_versionOption);
+        options.PublicNetworkAccess = parseResult.GetValueForOption(_publicNetworkAccessOption);
+        return options;
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            var sqlService = context.GetService<ISqlService>();
+
+            var server = await sqlService.CreateServerAsync(
+                options.Server!,
+                options.ResourceGroup!,
+                options.Subscription!,
+                options.Location!,
+                options.AdministratorLogin!,
+                options.AdministratorPassword!,
+                options.Version,
+                options.PublicNetworkAccess,
+                options.RetryPolicy);
+
+            context.Response.Results = ResponseResult.Create(
+                new ServerCreateResult(server),
+                SqlJsonContext.Default.ServerCreateResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Error creating SQL server. Server: {Server}, ResourceGroup: {ResourceGroup}, Location: {Location}, Options: {@Options}",
+                options.Server, options.ResourceGroup, options.Location, options);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    protected override string GetErrorMessage(Exception ex) => ex switch
+    {
+        Azure.RequestFailedException reqEx when reqEx.Status == 409 =>
+            "A SQL server with this name already exists. Choose a different server name.",
+        Azure.RequestFailedException reqEx when reqEx.Status == 403 =>
+            $"Authorization failed creating the SQL server. Verify you have appropriate permissions. Details: {reqEx.Message}",
+        Azure.RequestFailedException reqEx when reqEx.Status == 400 =>
+            $"Invalid request parameters for SQL server creation: {reqEx.Message}",
+        Azure.RequestFailedException reqEx => reqEx.Message,
+        ArgumentException argEx => $"Invalid parameter: {argEx.Message}",
+        _ => base.GetErrorMessage(ex)
+    };
+
+    protected override int GetStatusCode(Exception ex) => ex switch
+    {
+        Azure.RequestFailedException reqEx => reqEx.Status,
+        ArgumentException => 400,
+        _ => base.GetStatusCode(ex)
+    };
+
+    internal record ServerCreateResult(SqlServer Server);
+}

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerShowCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerShowCommand.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Core.Services.Telemetry;
+using Azure.Mcp.Tools.Sql.Models;
+using Azure.Mcp.Tools.Sql.Options.Server;
+using Azure.Mcp.Tools.Sql.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Mcp.Tools.Sql.Commands.Server;
+
+public sealed class ServerShowCommand(ILogger<ServerShowCommand> logger)
+    : BaseSqlCommand<ServerShowOptions>(logger)
+{
+    private const string CommandTitle = "Show SQL Server";
+
+    public override string Name => "show";
+
+    public override string Description =>
+        """
+        Retrieves detailed information about an Azure SQL server including its configuration, 
+        status, and properties such as the fully qualified domain name, version, 
+        administrator login, and network access settings.
+        """;
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            var sqlService = context.GetService<ISqlService>();
+
+            var server = await sqlService.GetServerAsync(
+                options.Server!,
+                options.ResourceGroup!,
+                options.Subscription!,
+                options.RetryPolicy);
+
+            context.Response.Results = ResponseResult.Create(
+                new ServerShowResult(server),
+                SqlJsonContext.Default.ServerShowResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Error retrieving SQL server. Server: {Server}, ResourceGroup: {ResourceGroup}, Options: {@Options}",
+                options.Server, options.ResourceGroup, options);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    protected override string GetErrorMessage(Exception ex) => ex switch
+    {
+        KeyNotFoundException =>
+            "SQL server not found in the specified resource group. Verify the server name and resource group.",
+        Azure.RequestFailedException reqEx when reqEx.Status == 404 =>
+            "SQL server not found in the specified resource group. Verify the server name and resource group.",
+        Azure.RequestFailedException reqEx when reqEx.Status == 403 =>
+            $"Authorization failed retrieving the SQL server. Verify you have appropriate permissions. Details: {reqEx.Message}",
+        Azure.RequestFailedException reqEx => reqEx.Message,
+        ArgumentException argEx => $"Invalid parameter: {argEx.Message}",
+        _ => base.GetErrorMessage(ex)
+    };
+
+    protected override int GetStatusCode(Exception ex) => ex switch
+    {
+        KeyNotFoundException => 404,
+        Azure.RequestFailedException reqEx => reqEx.Status,
+        ArgumentException => 400,
+        _ => base.GetStatusCode(ex)
+    };
+
+    internal record ServerShowResult(SqlServer Server);
+}

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/SqlJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/SqlJsonContext.cs
@@ -6,6 +6,7 @@ using Azure.Mcp.Tools.Sql.Commands.Database;
 using Azure.Mcp.Tools.Sql.Commands.ElasticPool;
 using Azure.Mcp.Tools.Sql.Commands.EntraAdmin;
 using Azure.Mcp.Tools.Sql.Commands.FirewallRule;
+using Azure.Mcp.Tools.Sql.Commands.Server;
 using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Services.Models;
 
@@ -17,8 +18,12 @@ namespace Azure.Mcp.Tools.Sql.Commands;
 [JsonSerializable(typeof(FirewallRuleListCommand.FirewallRuleListResult))]
 [JsonSerializable(typeof(FirewallRuleCreateCommand.FirewallRuleCreateResult))]
 [JsonSerializable(typeof(FirewallRuleDeleteCommand.FirewallRuleDeleteResult))]
+[JsonSerializable(typeof(ServerCreateCommand.ServerCreateResult))]
+[JsonSerializable(typeof(ServerDeleteCommand.ServerDeleteResult))]
+[JsonSerializable(typeof(ServerShowCommand.ServerShowResult))]
 [JsonSerializable(typeof(ElasticPoolListCommand.ElasticPoolListResult))]
 [JsonSerializable(typeof(SqlDatabase))]
+[JsonSerializable(typeof(SqlServer))]
 [JsonSerializable(typeof(SqlServerEntraAdministrator))]
 [JsonSerializable(typeof(SqlServerFirewallRule))]
 [JsonSerializable(typeof(SqlElasticPool))]

--- a/tools/Azure.Mcp.Tools.Sql/src/Models/SqlServer.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Models/SqlServer.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Mcp.Tools.Sql.Models;
+
+public record SqlServer(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("fullyQualifiedDomainName")] string? FullyQualifiedDomainName,
+    [property: JsonPropertyName("location")] string Location,
+    [property: JsonPropertyName("resourceGroup")] string ResourceGroup,
+    [property: JsonPropertyName("subscription")] string Subscription,
+    [property: JsonPropertyName("administratorLogin")] string? AdministratorLogin,
+    [property: JsonPropertyName("version")] string? Version,
+    [property: JsonPropertyName("state")] string? State,
+    [property: JsonPropertyName("publicNetworkAccess")] string? PublicNetworkAccess,
+    [property: JsonPropertyName("tags")] Dictionary<string, string>? Tags
+);

--- a/tools/Azure.Mcp.Tools.Sql/src/Options/Server/ServerCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Options/Server/ServerCreateOptions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Mcp.Tools.Sql.Options.Server;
+
+public class ServerCreateOptions : BaseSqlOptions
+{
+    [JsonPropertyName(SqlOptionDefinitions.AdministratorLogin)]
+    public string? AdministratorLogin { get; set; }
+
+    [JsonPropertyName(SqlOptionDefinitions.AdministratorPassword)]
+    public string? AdministratorPassword { get; set; }
+
+    [JsonPropertyName(SqlOptionDefinitions.Location)]
+    public string? Location { get; set; }
+
+    [JsonPropertyName(SqlOptionDefinitions.Version)]
+    public string? Version { get; set; }
+
+    [JsonPropertyName(SqlOptionDefinitions.PublicNetworkAccess)]
+    public string? PublicNetworkAccess { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.Sql/src/Options/Server/ServerDeleteOptions.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Options/Server/ServerDeleteOptions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Sql.Options.Server;
+
+/// <summary>
+/// Options for the SQL server delete command.
+/// </summary>
+public class ServerDeleteOptions : BaseSqlOptions
+{
+    /// <summary>
+    /// Gets or sets whether to force delete the server without confirmation.
+    /// </summary>
+    public bool Force { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.Sql/src/Options/Server/ServerShowOptions.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Options/Server/ServerShowOptions.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Sql.Options.Server;
+
+public class ServerShowOptions : BaseSqlOptions
+{
+}

--- a/tools/Azure.Mcp.Tools.Sql/src/Options/SqlOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Options/SqlOptionDefinitions.cs
@@ -10,6 +10,12 @@ public static class SqlOptionDefinitions
     public const string FirewallRuleName = "firewall-rule-name";
     public const string StartIpAddress = "start-ip-address";
     public const string EndIpAddress = "end-ip-address";
+    public const string AdministratorLogin = "administrator-login";
+    public const string AdministratorPassword = "administrator-password";
+    public const string Location = "location";
+    public const string Version = "version";
+    public const string PublicNetworkAccess = "public-network-access";
+    public const string Force = "force";
 
     public static readonly Option<string> Server = new(
         $"--{ServerName}",
@@ -49,5 +55,53 @@ public static class SqlOptionDefinitions
     )
     {
         IsRequired = true
+    };
+
+    public static readonly Option<string> AdministratorLoginOption = new(
+        $"--{AdministratorLogin}",
+        "The administrator login name for the SQL server."
+    )
+    {
+        IsRequired = true
+    };
+
+    public static readonly Option<string> AdministratorPasswordOption = new(
+        $"--{AdministratorPassword}",
+        "The administrator password for the SQL server."
+    )
+    {
+        IsRequired = true
+    };
+
+    public static readonly Option<string> LocationOption = new(
+        $"--{Location}",
+        "The Azure region location where the SQL server will be created."
+    )
+    {
+        IsRequired = true
+    };
+
+    public static readonly Option<string> VersionOption = new(
+        $"--{Version}",
+        "The version of SQL Server to create (e.g., '12.0')."
+    )
+    {
+        IsRequired = false
+    };
+
+    public static readonly Option<string> PublicNetworkAccessOption = new(
+        $"--{PublicNetworkAccess}",
+        "Whether public network access is enabled for the SQL server ('Enabled' or 'Disabled')."
+    )
+    {
+        IsRequired = false
+    };
+
+    public static readonly Option<bool> ForceOption = new(
+        $"--{Force}",
+        "Force delete the server without confirmation prompts."
+    )
+    {
+        IsRequired = false
     };
 }

--- a/tools/Azure.Mcp.Tools.Sql/src/Services/ISqlService.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Services/ISqlService.cs
@@ -130,4 +130,63 @@ public interface ISqlService
         string firewallRuleName,
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a new SQL server.
+    /// </summary>
+    /// <param name="serverName">The name of the SQL server</param>
+    /// <param name="resourceGroup">The name of the resource group</param>
+    /// <param name="subscription">The subscription ID or name</param>
+    /// <param name="location">The Azure region location where the SQL server will be created</param>
+    /// <param name="administratorLogin">The administrator login name for the SQL server</param>
+    /// <param name="administratorPassword">The administrator password for the SQL server</param>
+    /// <param name="version">The version of SQL Server to create (optional, defaults to latest)</param>
+    /// <param name="publicNetworkAccess">Whether public network access is enabled (optional)</param>
+    /// <param name="retryPolicy">Optional retry policy options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The created SQL server information</returns>
+    Task<SqlServer> CreateServerAsync(
+        string serverName,
+        string resourceGroup,
+        string subscription,
+        string location,
+        string administratorLogin,
+        string administratorPassword,
+        string? version,
+        string? publicNetworkAccess,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a SQL server.
+    /// </summary>
+    /// <param name="serverName">The name of the SQL server</param>
+    /// <param name="resourceGroup">The name of the resource group</param>
+    /// <param name="subscription">The subscription ID or name</param>
+    /// <param name="retryPolicy">Optional retry policy options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The SQL server information</returns>
+    /// <exception cref="KeyNotFoundException">Thrown when the server is not found</exception>
+    Task<SqlServer> GetServerAsync(
+        string serverName,
+        string resourceGroup,
+        string subscription,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a SQL server.
+    /// </summary>
+    /// <param name="serverName">The name of the SQL server</param>
+    /// <param name="resourceGroup">The name of the resource group</param>
+    /// <param name="subscription">The subscription ID or name</param>
+    /// <param name="retryPolicy">Optional retry policy options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if the server was successfully deleted</returns>
+    Task<bool> DeleteServerAsync(
+        string serverName,
+        string resourceGroup,
+        string subscription,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
@@ -336,6 +336,189 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         }
     }
 
+    /// <summary>
+    /// Creates a new Azure SQL Server.
+    /// </summary>
+    /// <param name="serverName">The name of the SQL server to create</param>
+    /// <param name="resourceGroup">The name of the resource group</param>
+    /// <param name="subscription">The subscription ID or name</param>
+    /// <param name="location">The Azure region location where the SQL server will be created</param>
+    /// <param name="administratorLogin">The administrator login name for the SQL server</param>
+    /// <param name="administratorPassword">The administrator password for the SQL server</param>
+    /// <param name="version">The version of SQL Server to create (optional, defaults to latest)</param>
+    /// <param name="publicNetworkAccess">Whether public network access is enabled (optional)</param>
+    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
+    /// <param name="cancellationToken">Token to observe for cancellation requests</param>
+    /// <returns>The created SQL server</returns>
+    /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
+    public async Task<SqlServer> CreateServerAsync(
+        string serverName,
+        string resourceGroup,
+        string subscription,
+        string location,
+        string administratorLogin,
+        string administratorPassword,
+        string? version,
+        string? publicNetworkAccess,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(serverName, resourceGroup, subscription, location, administratorLogin, administratorPassword);
+
+        try
+        {
+            // Use ARM client directly for create operations  
+            var armClient = await CreateArmClientAsync(null, retryPolicy);
+            var subscriptionResource = armClient.GetSubscriptionResource(Azure.ResourceManager.Resources.SubscriptionResource.CreateResourceIdentifier(subscription));
+            var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup);
+
+            var serverData = new SqlServerData(location)
+            {
+                AdministratorLogin = administratorLogin,
+                AdministratorLoginPassword = administratorPassword,
+                Version = version ?? "12.0", // Default to SQL Server 2014 (12.0)
+            };
+
+            // Set PublicNetworkAccess if specified
+            if (!string.IsNullOrEmpty(publicNetworkAccess))
+            {
+                // Try to set the public network access value - defaults to "Enabled" if not "Disabled"
+                // The property type is likely an enum with Enabled/Disabled values
+                //
+                // serverData.PublicNetworkAccess = publicNetworkAccess.Equals("Enabled", StringComparison.OrdinalIgnoreCase)
+                //     ? SqlServerPublicNetworkAccess.Enabled
+                //     : SqlServerPublicNetworkAccess.Disabled;
+
+            }
+
+            var operation = await resourceGroupResource.Value.GetSqlServers().CreateOrUpdateAsync(
+                Azure.WaitUntil.Completed,
+                serverName,
+                serverData,
+                cancellationToken);
+
+            var server = operation.Value;
+            var tags = server.Data.Tags?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value) ?? new Dictionary<string, string>();
+
+            return new SqlServer(
+                Name: server.Data.Name,
+                FullyQualifiedDomainName: server.Data.FullyQualifiedDomainName,
+                Location: server.Data.Location.ToString(),
+                ResourceGroup: resourceGroup,
+                Subscription: subscription,
+                AdministratorLogin: server.Data.AdministratorLogin,
+                Version: server.Data.Version,
+                State: server.Data.State?.ToString(),
+                PublicNetworkAccess: server.Data.PublicNetworkAccess?.ToString(),
+                Tags: tags
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Error creating SQL server. Server: {Server}, ResourceGroup: {ResourceGroup}, Subscription: {Subscription}, Location: {Location}",
+                serverName, resourceGroup, subscription, location);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Retrieves a specific SQL server from Azure.
+    /// </summary>
+    /// <param name="serverName">The name of the SQL server</param>
+    /// <param name="resourceGroup">The name of the resource group containing the server</param>
+    /// <param name="subscription">The subscription ID or name</param>
+    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
+    /// <param name="cancellationToken">Token to observe for cancellation requests</param>
+    /// <returns>The SQL server if found, otherwise throws KeyNotFoundException</returns>
+    /// <exception cref="KeyNotFoundException">Thrown when the specified server is not found</exception>
+    /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
+    public async Task<SqlServer> GetServerAsync(
+        string serverName,
+        string resourceGroup,
+        string subscription,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(serverName, resourceGroup, subscription);
+
+        try
+        {
+            // Use ARM client directly for get operations  
+            var armClient = await CreateArmClientAsync(null, retryPolicy);
+            var subscriptionResource = armClient.GetSubscriptionResource(Azure.ResourceManager.Resources.SubscriptionResource.CreateResourceIdentifier(subscription));
+            var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup);
+
+            var serverResource = await resourceGroupResource.Value.GetSqlServers().GetAsync(serverName);
+            var server = serverResource.Value;
+            var tags = server.Data.Tags?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value) ?? new Dictionary<string, string>();
+
+            return new SqlServer(
+                Name: server.Data.Name,
+                FullyQualifiedDomainName: server.Data.FullyQualifiedDomainName,
+                Location: server.Data.Location.ToString(),
+                ResourceGroup: resourceGroup,
+                Subscription: subscription,
+                AdministratorLogin: server.Data.AdministratorLogin,
+                Version: server.Data.Version,
+                State: server.Data.State?.ToString(),
+                PublicNetworkAccess: server.Data.PublicNetworkAccess?.ToString(),
+                Tags: tags
+            );
+        }
+        catch (Azure.RequestFailedException reqEx) when (reqEx.Status == 404)
+        {
+            throw new KeyNotFoundException($"SQL server '{serverName}' not found in resource group '{resourceGroup}' for subscription '{subscription}'.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Error getting SQL server. Server: {Server}, ResourceGroup: {ResourceGroup}, Subscription: {Subscription}",
+                serverName, resourceGroup, subscription);
+            throw;
+        }
+    }
+
+    public async Task<bool> DeleteServerAsync(
+        string serverName,
+        string resourceGroup,
+        string subscription,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(serverName, resourceGroup, subscription);
+
+        try
+        {
+            // Use ARM client directly for delete operations  
+            var armClient = await CreateArmClientAsync(null, retryPolicy);
+            var subscriptionResource = armClient.GetSubscriptionResource(Azure.ResourceManager.Resources.SubscriptionResource.CreateResourceIdentifier(subscription));
+            var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup);
+
+            var serverResource = await resourceGroupResource.Value.GetSqlServers().GetAsync(serverName);
+
+            var operation = await serverResource.Value.DeleteAsync(
+                Azure.WaitUntil.Completed,
+                cancellationToken);
+
+            return true;
+        }
+        catch (Azure.RequestFailedException reqEx) when (reqEx.Status == 404)
+        {
+            _logger.LogWarning(
+                "SQL server not found during delete operation. Server: {Server}, ResourceGroup: {ResourceGroup}, Subscription: {Subscription}",
+                serverName, resourceGroup, subscription);
+            return false; // Server doesn't exist
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Error deleting SQL server. Server: {Server}, ResourceGroup: {ResourceGroup}, Subscription: {Subscription}",
+                serverName, resourceGroup, subscription);
+            throw;
+        }
+    }
+
     private static SqlDatabase ConvertToSqlDatabaseModel(JsonElement item)
     {
         Azure.Mcp.Tools.Sql.Services.Models.SqlDatabaseData? sqlDatabase = Azure.Mcp.Tools.Sql.Services.Models.SqlDatabaseData.FromJson(item);

--- a/tools/Azure.Mcp.Tools.Sql/src/SqlSetup.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/SqlSetup.cs
@@ -7,6 +7,7 @@ using Azure.Mcp.Tools.Sql.Commands.Database;
 using Azure.Mcp.Tools.Sql.Commands.ElasticPool;
 using Azure.Mcp.Tools.Sql.Commands.EntraAdmin;
 using Azure.Mcp.Tools.Sql.Commands.FirewallRule;
+using Azure.Mcp.Tools.Sql.Commands.Server;
 using Azure.Mcp.Tools.Sql.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -35,6 +36,10 @@ public class SqlSetup : IAreaSetup
 
         var server = new CommandGroup("server", "SQL server operations");
         sql.AddSubGroup(server);
+
+        server.AddCommand("create", new ServerCreateCommand(loggerFactory.CreateLogger<ServerCreateCommand>()));
+        server.AddCommand("delete", new ServerDeleteCommand(loggerFactory.CreateLogger<ServerDeleteCommand>()));
+        server.AddCommand("show", new ServerShowCommand(loggerFactory.CreateLogger<ServerShowCommand>()));
 
         var elasticPool = new CommandGroup("elastic-pool", "SQL elastic pool operations");
         sql.AddSubGroup(elasticPool);

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Server/ServerCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Server/ServerCreateCommandTests.cs
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Tools.Sql.Commands.Server;
+using Azure.Mcp.Tools.Sql.Models;
+using Azure.Mcp.Tools.Sql.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Sql.UnitTests.Server;
+
+public class ServerCreateCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ISqlService _service;
+    private readonly ILogger<ServerCreateCommand> _logger;
+    private readonly ServerCreateCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public ServerCreateCommandTests()
+    {
+        _service = Substitute.For<ISqlService>();
+        _logger = Substitute.For<ILogger<ServerCreateCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_service);
+        _serviceProvider = collection.BuildServiceProvider();
+
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _parser = new(_command.GetCommand());
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("create", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+        Assert.Contains("Creates a new Azure SQL server", command.Description);
+    }
+
+    [Theory]
+    [InlineData("--subscription sub --resource-group rg --server testserver --location eastus --administrator-login admin --administrator-password Password123!", true)]
+    [InlineData("--subscription sub --resource-group rg --server testserver --location eastus --administrator-login admin", false)] // Missing password
+    [InlineData("--subscription sub --resource-group rg --server testserver --location eastus --administrator-password Password123!", false)] // Missing login
+    [InlineData("--subscription sub --resource-group rg --server testserver --administrator-login admin --administrator-password Password123!", false)] // Missing location
+    [InlineData("--subscription sub --resource-group rg --location eastus --administrator-login admin --administrator-password Password123!", false)] // Missing server
+    [InlineData("--subscription sub --server testserver --location eastus --administrator-login admin --administrator-password Password123!", false)] // Missing resource group
+    [InlineData("--resource-group rg --server testserver --location eastus --administrator-login admin --administrator-password Password123!", false)] // Missing subscription
+    [InlineData("", false)] // Missing all required parameters
+    public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
+    {
+        // Arrange
+        if (shouldSucceed)
+        {
+            var expectedServer = new SqlServer(
+                Name: "testserver",
+                FullyQualifiedDomainName: "testserver.database.windows.net",
+                Location: "East US",
+                ResourceGroup: "rg",
+                Subscription: "sub",
+                AdministratorLogin: "admin",
+                Version: "12.0",
+                State: "Ready",
+                PublicNetworkAccess: "Enabled",
+                Tags: new Dictionary<string, string>()
+            );
+
+            _service.CreateServerAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+                .Returns(expectedServer);
+        }
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = _parser.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        Assert.Equal(shouldSucceed ? 200 : 400, response.Status);
+        if (shouldSucceed)
+        {
+            Assert.Equal("Success", response.Message);
+        }
+        else
+        {
+            Assert.Contains("required", response.Message.ToLower());
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreatesServerSuccessfully()
+    {
+        // Arrange
+        var expectedServer = new SqlServer(
+            Name: "testserver",
+            FullyQualifiedDomainName: "testserver.database.windows.net",
+            Location: "East US",
+            ResourceGroup: "rg",
+            Subscription: "sub",
+            AdministratorLogin: "admin",
+            Version: "12.0",
+            State: "Ready",
+            PublicNetworkAccess: "Enabled",
+            Tags: new Dictionary<string, string>()
+        );
+
+        _service.CreateServerAsync(
+            "testserver",
+            "rg",
+            "sub",
+            "eastus",
+            "admin",
+            "Password123!",
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedServer);
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = _parser.Parse("--subscription sub --resource-group rg --server testserver --location eastus --administrator-login admin --administrator-password Password123!");
+
+        // Act
+        var response = await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.Equal("Success", response.Message);
+        Assert.NotNull(response.Results);
+
+        await _service.Received(1).CreateServerAsync(
+            "testserver",
+            "rg",
+            "sub",
+            "eastus",
+            "admin",
+            "Password123!",
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithOptionalParameters_PassesAllParameters()
+    {
+        // Arrange
+        var expectedServer = new SqlServer(
+            Name: "testserver",
+            FullyQualifiedDomainName: "testserver.database.windows.net",
+            Location: "East US",
+            ResourceGroup: "rg",
+            Subscription: "sub",
+            AdministratorLogin: "admin",
+            Version: "12.0",
+            State: "Ready",
+            PublicNetworkAccess: "Disabled",
+            Tags: new Dictionary<string, string>()
+        );
+
+        _service.CreateServerAsync(
+            "testserver",
+            "rg",
+            "sub",
+            "eastus",
+            "admin",
+            "Password123!",
+            "12.0",
+            "Disabled",
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedServer);
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = _parser.Parse("--subscription sub --resource-group rg --server testserver --location eastus --administrator-login admin --administrator-password Password123! --version 12.0 --public-network-access Disabled");
+
+        // Act
+        var response = await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.Equal("Success", response.Message);
+
+        await _service.Received(1).CreateServerAsync(
+            "testserver",
+            "rg",
+            "sub",
+            "eastus",
+            "admin",
+            "Password123!",
+            "12.0",
+            "Disabled",
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenServiceThrowsException_ReturnsErrorResponse()
+    {
+        // Arrange
+        _service.CreateServerAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<SqlServer>(new Exception("Test error")));
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = _parser.Parse("--subscription sub --resource-group rg --server testserver --location eastus --administrator-login admin --administrator-password Password123!");
+
+        // Act
+        var response = await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        Assert.NotEqual(200, response.Status);
+        Assert.Contains("error", response.Message.ToLower());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenServerAlreadyExists_Returns409StatusCode()
+    {
+        // Arrange
+        var requestException = new Azure.RequestFailedException(409, "Conflict: Server already exists");
+
+        _service.CreateServerAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<SqlServer>(requestException));
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = _parser.Parse("--subscription sub --resource-group rg --server testserver --location eastus --administrator-login admin --administrator-password Password123!");
+
+        // Act
+        var response = await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        Assert.Equal(409, response.Status);
+        Assert.Contains("server with this name already exists", response.Message.ToLower());
+    }
+}

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Server/ServerDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Server/ServerDeleteCommandTests.cs
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Tools.Sql.Commands.Server;
+using Azure.Mcp.Tools.Sql.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Sql.UnitTests.Server;
+
+public class ServerDeleteCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ISqlService _service;
+    private readonly ILogger<ServerDeleteCommand> _logger;
+    private readonly ServerDeleteCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public ServerDeleteCommandTests()
+    {
+        _service = Substitute.For<ISqlService>();
+        _logger = Substitute.For<ILogger<ServerDeleteCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_service);
+        _serviceProvider = collection.BuildServiceProvider();
+
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _parser = new(_command.GetCommand());
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("delete", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+        Assert.Contains("Deletes an Azure SQL server", command.Description);
+    }
+
+    [Theory]
+    [InlineData("--subscription sub --resource-group rg --server testserver --force", true)]
+    [InlineData("--subscription sub --resource-group rg --server testserver", true)] // Should show warning without force
+    [InlineData("--subscription sub --resource-group rg --force", false)] // Missing server
+    [InlineData("--subscription sub --server testserver --force", false)] // Missing resource group
+    [InlineData("--resource-group rg --server testserver --force", false)] // Missing subscription
+    [InlineData("", false)] // Missing all required parameters
+    public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
+    {
+        // Arrange
+        if (shouldSucceed && args.Contains("--force"))
+        {
+            _service.DeleteServerAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+                .Returns(true);
+        }
+
+        var parseResult = _parser.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        if (shouldSucceed)
+        {
+            Assert.Equal(200, response.Status);
+        }
+        else
+        {
+            Assert.NotEqual(200, response.Status);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenForceNotSpecified_ReturnsWarning()
+    {
+        // Arrange
+        var parseResult = _parser.Parse("--subscription sub --resource-group rg --server testserver");
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.Contains("WARNING", response.Message);
+        Assert.Contains("permanently delete", response.Message);
+        Assert.Contains("--force", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenServerDeletedSuccessfully_ReturnsSuccess()
+    {
+        // Arrange
+        _service.DeleteServerAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var parseResult = _parser.Parse("--subscription sub --resource-group rg --server testserver --force");
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+        await _service.Received(1).DeleteServerAsync("testserver", "rg", "sub", Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenServerNotFound_Returns404()
+    {
+        // Arrange
+        _service.DeleteServerAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var parseResult = _parser.Parse("--subscription sub --resource-group rg --server testserver --force");
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(404, response.Status);
+        Assert.Contains("not found", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenServiceThrowsException_ReturnsErrorResponse()
+    {
+        // Arrange
+        _service.DeleteServerAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<bool>(new Exception("Test error")));
+
+        var parseResult = _parser.Parse("--subscription sub --resource-group rg --server testserver --force");
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.NotEqual(200, response.Status);
+        Assert.Contains("error", response.Message.ToLower());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenServerNotFoundFromAzure_Returns404StatusCode()
+    {
+        // Arrange
+        var requestException = new Azure.RequestFailedException(404, "Not Found: Server not found");
+
+        _service.DeleteServerAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<bool>(requestException));
+
+        var parseResult = _parser.Parse("--subscription sub --resource-group rg --server testserver --force");
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(404, response.Status);
+        Assert.Contains("not found", response.Message.ToLower());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenUnauthorized_Returns403StatusCode()
+    {
+        // Arrange
+        var requestException = new Azure.RequestFailedException(403, "Forbidden: Insufficient permissions");
+
+        _service.DeleteServerAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<bool>(requestException));
+
+        var parseResult = _parser.Parse("--subscription sub --resource-group rg --server testserver --force");
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(403, response.Status);
+        Assert.Contains("authorization failed", response.Message.ToLower());
+    }
+}

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Server/ServerShowCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Server/ServerShowCommandTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Tools.Sql.Commands.Server;
+using Azure.Mcp.Tools.Sql.Models;
+using Azure.Mcp.Tools.Sql.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Sql.UnitTests.Server;
+
+public class ServerShowCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ISqlService _service;
+    private readonly ILogger<ServerShowCommand> _logger;
+    private readonly ServerShowCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public ServerShowCommandTests()
+    {
+        _service = Substitute.For<ISqlService>();
+        _logger = Substitute.For<ILogger<ServerShowCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_service);
+        _serviceProvider = collection.BuildServiceProvider();
+
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _parser = new(_command.GetCommand());
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("show", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+        Assert.Contains("SQL server", command.Description);
+    }
+
+    [Theory]
+    [InlineData("--subscription sub --resource-group rg --server testserver", true)]
+    [InlineData("--subscription sub --resource-group rg", false)] // Missing server
+    [InlineData("--subscription sub --server testserver", false)] // Missing resource-group
+    [InlineData("--resource-group rg --server testserver", false)] // Missing subscription
+    public async Task ExecuteAsync_ValidationScenarios_ReturnsExpectedResults(string args, bool shouldSucceed)
+    {
+        var parseResult = _parser.Parse(args);
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        if (shouldSucceed)
+        {
+            Assert.Equal(200, response.Status);
+        }
+        else
+        {
+            Assert.Equal(400, response.Status);
+            Assert.Contains("required", response.Message.ToLower());
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithValidOptions_ReturnsServer()
+    {
+        // Arrange
+        var expectedServer = new SqlServer(
+            Name: "test-server",
+            FullyQualifiedDomainName: "test-server.database.windows.net",
+            Location: "East US",
+            ResourceGroup: "test-rg",
+            Subscription: "test-sub",
+            AdministratorLogin: "sqladmin",
+            Version: "12.0",
+            State: "Ready",
+            PublicNetworkAccess: "Enabled",
+            Tags: new Dictionary<string, string> { { "environment", "test" } }
+        );
+
+        _service.GetServerAsync(
+            "test-server",
+            "test-rg",
+            "test-sub",
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedServer);
+
+        // Act
+        var parseResult = _parser.Parse("--subscription test-sub --resource-group test-rg --server test-server");
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenServerNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        _service.GetServerAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<SqlServer>(new KeyNotFoundException("SQL server not found")));
+
+        // Act
+        var parseResult = _parser.Parse("--subscription test-sub --resource-group test-rg --server nonexistent-server");
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(404, response.Status);
+        Assert.Contains("not found", response.Message.ToLower());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenAzureRequestFails404_ReturnsNotFound()
+    {
+        // Arrange
+        var requestFailedException = new Azure.RequestFailedException(404, "Resource not found");
+        _service.GetServerAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<SqlServer>(requestFailedException));
+
+        // Act
+        var parseResult = _parser.Parse("--subscription test-sub --resource-group test-rg --server missing-server");
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(404, response.Status);
+        Assert.Contains("not found", response.Message.ToLower());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenAzureRequestFails403_ReturnsAuthorizationError()
+    {
+        // Arrange
+        var requestFailedException = new Azure.RequestFailedException(403, "Authorization failed");
+        _service.GetServerAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<SqlServer>(requestFailedException));
+
+        // Act
+        var parseResult = _parser.Parse("--subscription test-sub --resource-group test-rg --server test-server");
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(403, response.Status);
+        Assert.Contains("authorization failed", response.Message.ToLower());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenArgumentException_ReturnsBadRequest()
+    {
+        // Arrange
+        _service.GetServerAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<SqlServer>(new ArgumentException("Invalid server name")));
+
+        // Act
+        var parseResult = _parser.Parse("--subscription test-sub --resource-group test-rg --server invalid");
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("invalid parameter", response.Message.ToLower());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenUnexpectedException_ReturnsInternalServerError()
+    {
+        // Arrange
+        _service.GetServerAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<Azure.Mcp.Core.Options.RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<SqlServer>(new InvalidOperationException("Unexpected error")));
+
+        // Act
+        var parseResult = _parser.Parse("--subscription test-sub --resource-group test-rg --server test-server");
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Unexpected error", response.Message);
+    }
+
+    [Fact]
+    public void Metadata_IndicatesReadOnlyOperation()
+    {
+        // Act & Assert
+        Assert.False(_command.Metadata.Destructive);
+        Assert.True(_command.Metadata.ReadOnly);
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Add `azmcp sql server create/delete/show` commands and unit tests
- `azmcp sql server create`
- `azmcp sql server delete`
- `azmcp sql server show`


## GitHub issue number?
#239 

## Pre-merge Checklist

- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [ ] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
