### PR TITLE
Cleaned up Cloud Architect Unit Tests

### DIFF
--- a/tools/Azure.Mcp.Tools.CloudArchitect/tests/Azure.Mcp.Tools.CloudArchitect.UnitTests/Design/DesignCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.CloudArchitect/tests/Azure.Mcp.Tools.CloudArchitect.UnitTests/Design/DesignCommandTests.cs
@@ -83,10 +83,7 @@ public class DesignCommandTests
     [InlineData("--answer \"Web application\"")]
     [InlineData("--next-question-needed true")]
     [InlineData("--confidence-score 0.8")]
-    [InlineData("--architecture-component \"Frontend\"")]
-    [InlineData("--architecture-tier Infrastructure")]
     [InlineData("--question \"App type?\" --question-number 1 --total-questions 5")]
-    [InlineData("--architecture-tier Platform --architecture-component \"AKS Cluster\"")]
     public async Task ExecuteAsync_ReturnsArchitectureDesignText(string args)
     {
         // Arrange
@@ -611,22 +608,6 @@ public class DesignCommandTests
         Assert.Equal(2, responseObject.ResponseObject.State.Requirements.Explicit.Count);
         Assert.Single(responseObject.ResponseObject.State.Requirements.Implicit);
         Assert.Single(responseObject.ResponseObject.State.Requirements.Assumed);
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_WithInvalidStateJson_HandlesGracefully()
-    {
-        // Arrange
-        var invalidStateJson = "{ invalid json }";
-        var args = new[] { "--state", invalidStateJson };
-        var parseResult = _parser.Parse(args);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, parseResult);
-
-        // Assert - The command should handle the error gracefully and return an error response
-        Assert.NotEqual(200, response.Status);
-        Assert.NotEmpty(response.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?
Cleaned up Cloud Architect Unit tests by removing inputs/tests that corresponded to older implementation

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist

- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [ ] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
