### PR TITLE
Remove ContinueOnError from check-spelling step

### DIFF
--- a/eng/pipelines/templates/jobs/analyze.yml
+++ b/eng/pipelines/templates/jobs/analyze.yml
@@ -38,9 +38,7 @@ jobs:
       sourceDirectory: $(Build.SourcesDirectory)
 
   - template: /eng/common/pipelines/templates/steps/check-spelling.yml
-    parameters:
-      ContinueOnError: false
-
+  
   - template: /eng/common/pipelines/templates/steps/verify-links.yml
     parameters:
       Condition: succeededOrFailed()


### PR DESCRIPTION
Turn spelling errors into warnings instead of failing the build.