### PR TITLE
add secret and local required hints

### DIFF
--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -184,6 +184,15 @@ public sealed class CommandFactoryToolLoader(
             Title = command.Title,
         };
 
+        // Add Secret metadata to tool.Meta if the property exists
+        if (metadata.Secret)
+        {
+            tool.Meta = new JsonObject
+            {
+                ["SecretHint"] = metadata.Secret
+            };
+        }
+
         var options = command.GetCommand().Options;
 
         var schema = new ToolInputSchema();

--- a/core/Azure.Mcp.Core/src/Commands/ToolMetadata.cs
+++ b/core/Azure.Mcp.Core/src/Commands/ToolMetadata.cs
@@ -71,6 +71,42 @@ public sealed class ToolMetadata
     public bool ReadOnly { get; init; } = false;
 
     /// <summary>
+    /// Gets or sets whether this tool deals with sensitive or secret information.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If <see langword="true"/>, the tool handles sensitive data such as secrets, credentials, keys, or other confidential information.
+    /// If <see langword="false"/>, the tool does not handle sensitive information.
+    /// </para>
+    /// <para>
+    /// This metadata helps MCP clients understand when a tool might expose or require access to sensitive data,
+    /// allowing for appropriate security measures and user confirmation flows.
+    /// </para>
+    /// <para>
+    /// The default is <see langword="false"/>.
+    /// </para>
+    /// </remarks>
+    public bool Secret { get; init; } = false;
+
+    /// <summary>
+    /// Gets or sets whether this tool requires local execution or resources.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If <see langword="true"/>, the tool requires local execution environment or local resources to function properly.
+    /// If <see langword="false"/>, the tool can operate without local dependencies.
+    /// </para>
+    /// <para>
+    /// This metadata helps MCP clients understand whether the tool needs to be executed locally
+    /// or can be delegated to remote execution environments.
+    /// </para>
+    /// <para>
+    /// The default is <see langword="false"/>.
+    /// </para>
+    /// </remarks>
+    public bool LocalRequired { get; init; } = false;
+
+    /// <summary>
     /// Creates a new instance of <see cref="ToolMetadata"/> with default values.
     /// All properties default to their MCP specification defaults.
     /// </summary>

--- a/docs/new-command.md
+++ b/docs/new-command.md
@@ -415,7 +415,9 @@ public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Co
     public override ToolMetadata Metadata => new()
     {
         Destructive = false,    // Set to true for commands that modify resources
-        ReadOnly = true         // Set to false for commands that modify resources
+        ReadOnly = true,         // Set to false for commands that modify resources
+        Secret = false,          // Set to true for commands that may return sensitive information
+        LocalRequired = false   // Set to true for tools requiring local execution/resources
     };
 
     protected override void RegisterOptions(Command command)


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

add secret and local required hints

secretHint will be added into tool.Meta while local required hint is for local use only.

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
