### PR TITLE
Fix github issue templates and revise README.md / CATALOG.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_azure_mcp_onboard_request.yml
+++ b/.github/ISSUE_TEMPLATE/01_azure_mcp_onboard_request.yml
@@ -1,8 +1,8 @@
-name: Onboarding Request
+name: Azure MCP Onboarding Request
 description: Use this template to file an onboarding request for a new service / tool for the Azure MCP server.
 title: "[ONBOARD]"
-labels: ["onboarding","needs-triage"]
-projects: ["Azure/812"]
+labels: ["onboarding","needs-triage","Azure.Mcp.Server"]
+projects: ["Microsoft/1976"]
 
 body:
   - type: markdown
@@ -37,7 +37,7 @@ body:
     id: timeline
     attributes:
       label: Timeline
-      description: May 2025, November 2025, TBD, etc.
+      description: November 2025, February 2026, TBD, etc.
         Please provide your desired timeline
       placeholder: TBD
     validations:

--- a/.github/ISSUE_TEMPLATE/02_mcp_server_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_mcp_server_request.yml
@@ -1,0 +1,46 @@
+---
+name: "/microsoft/mcp Repository Onboarding Request"
+description: "Request to add a new Server to the repository"
+title: "[MCP Server Request] <Proposed Server Name>"
+labels: ["onboarding", "Template.Mcp.Server"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## MCP Server Addition Request
+        Thank you for your interest in contributing a new MCP Server!
+        Please fill out the following details to help us review your request.
+  - type: input
+    id: server_name
+    attributes:
+      label: "Server Name"
+      description: "What is the name of the MCP Server you want to add?"
+      placeholder: "e.g., Contoso Data MCP Server"
+    validations:
+      required: true
+  - type: input
+    id: contacts
+    attributes:
+      label: Contacts
+      description: List of contacts who own the Microsoft Server being onboarded
+      placeholder: ex. Alice Cooper (alcoop), Bob Dylan (bdylan)
+    validations:
+      required: true
+  - type: textarea
+    id: scenarios
+    attributes:
+      label: Intended Agent Scenarios
+      description: What customer scenarios are you trying to solve with this server or tool? Please provide a brief description of the scenarios and how they relate to MCP.
+      placeholder: Description
+    validations:
+      required: true
+  - type: textarea
+    id: timeline
+    attributes:
+      label: Timeline
+      description: November 2025, February 2026, TBD, etc.
+        Please provide your desired timeline
+      placeholder: TBD
+    validations:
+      required: true

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,0 +1,67 @@
+# 📂 Microsoft MCP Servers
+
+Below are Microsoft's official MCP server implementations:
+
+---
+
+## Official Microsoft MCP Servers
+
+### 📅 Azure DevOps MCP Server
+- **Repository**: [Azure DevOps MCP Server - Public Preview](https://github.com/microsoft/azure-devops-mcp)
+- **Description**: The MCP Server for Azure DevOps enables you to bring context into AI workflows and interact with Azure DevOps artifacts such as work items, test plans, builds, releases, and pull requests.
+
+### 🔷 Azure MCP Server
+- **Repository**: [microsoft/mcp](https://github.com/microsoft/mcp/tree/main/servers/Azure.Mcp.Server#readme)
+- **Description**: Implements the MCP standard to manage Azure resources, enabling declarative provisioning and integration with AI workflows.
+
+### ✨ Azure AI Foundry MCP Server
+- **Repository**: [azure-ai-foundry/mcp-foundry](https://github.com/azure-ai-foundry/mcp-foundry)
+- **Description**: An experimental MCP server implementation for Azure AI Foundry that exposes unified tools for models, knowledge, evaluation and deployment.
+
+### 📊 Clarity MCP Server
+- **Repository**: [@microsoft/clarity-mcp-server](https://www.npmjs.com/package/@microsoft/clarity-mcp-server)
+- **Description**: An MCP server for Microsoft Clarity analytics integration. Enables AI models to access web analytics data, heatmaps, and session recordings to understand user behavior and site performance.
+
+### 🗃️ Dataverse MCP Server
+- **Documentation**: [Microsoft Dataverse](https://go.microsoft.com/fwlink/?linkid=2320176)
+- **Description**: Chat over your business data using NL - Discover tables, run queries, retrieve data, insert or update records, and execute custom prompts grounded in business knowledge and context.
+
+### 📁 Files MCP Server
+- **Repository**: [microsoft/files-mcp-server](https://github.com/microsoft/files-mcp-server)
+- **Description**: Provides a declarative control plane for managing file-based resources, supporting AI workflows that involve static files and documentation synchronization.
+
+### 📝 Markitdown MCP Server
+- **Repository**: [microsoft/markitdown](https://github.com/microsoft/markitdown)
+- **Description**: A specialized MCP server for Markdown processing and manipulation. Enables AI models to read, write, and transform Markdown content with robust parsing and formatting capabilities.
+
+### 💻 Microsoft Dev Box MCP
+- **Package**: [@microsoft/devbox-mcp](https://www.npmjs.com/package/@microsoft/devbox-mcp)
+- **Description**: An MCP server for [Microsoft Dev Box](https://azure.microsoft.com/products/dev-box). Enables natural language interactions for developer-focused operations like managing Dev Boxes, configuring environments, and handling pools. Check out the [README](https://www.npmjs.com/package/@microsoft/devbox-mcp?activeTab=readme) for more details. Use this [one-click link](https://insiders.vscode.dev/redirect/mcp/install?name=Dev%20Box&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40microsoft%2Fdevbox-mcp%40latest%22%5D%7D) to install Dev Box MCP in your VS Code.
+
+### 🛢️ Microsoft Fabric Real-Time Intelligence MCP Server
+- **Repository**: [RTI MCP Server](https://aka.ms/rti.mcp.repo)
+- **Description**: Chat with your real-time data the new agentic way using natural language and AI. MCP server for [Fabric Real-Time Intelligence](https://aka.ms/fabricrti) supporting tools for [Eventhouse](https://aka.ms/eventhouse), [Azure Data Explorer](https://aka.ms/adx), and other RTI services (coming soon)
+
+### 📚 Microsoft Learn Docs MCP Server
+- **Repository**: [microsoftdocs/mcp](https://github.com/microsoftdocs/mcp)
+- **Description**: A remote MCP server that provides structured access to official Microsoft Learn documentation. Enables AI models to retrieve accurate, authoritative, and context-aware technical content for code generation, question answering, and workflow grounding.
+
+### 🛢️ Microsoft SQL MCP Server
+- **Repository**: [MSSQL MCP Server](https://aka.ms/MssqlMcp)
+- **Description**: Chat with your business data the new agentic way using natural language and AI. Connect to any SQL database—from ground (on-premises) to Azure cloud to Microsoft Fabric via a simple connection string. Discover and define table schemas, manage tables, and perform CRUD operations through conversational prompts.
+
+### 🎭 Playwright MCP
+- **Repository**: [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp)
+- **Description**: An MCP server for browsing the internet. Enables LLMs to interact with web pages through structured accessibility snapshots. Useful for web navigation and form-filling, data extraction from structured content, automated testing driven by LLMs, and general-purpose browser interaction for agents.
+
+### ☸️ Azure Kubernetes Service (AKS) MCP Server
+- **Repository**: [Azure/aks-mcp](https://github.com/Azure/aks-mcp)
+- **Description**: An MCP server that enables AI assistants to interact with Azure Kubernetes Service (AKS) clusters. It serves as a bridge between AI tools and AKS, translating natural language requests into AKS operations and returning the results in a format the AI tools can understand.
+
+### 📚 Microsoft 365 Agents Toolkit MCP
+- **Repository**: [M365 Agents Toolkit MCP](https://aka.ms/m365agentstoolkit-mcp)
+- **Description**: An MCP server that provides a seamless connection between AI agents and developers for building apps and agents for Microsoft 365 and Microsoft 365 Copilot.
+
+---
+
+For additions or corrections please open a pull request.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,31 @@
-# Microsoft Model Context Protocol (MCP) Servers
+# Microsoft MCP Servers
 
-This repository catalogs various Microsoft implementations of the Model Context Protocol (MCP), an open standard that facilitates seamless integration between AI applications and external data sources and tools. MCP enables AI models to access the context they need to perform tasks effectively.
+
+
+Welcome to the Microsoft MCP Servers repository! This repo catalogs official and community MCP Server implementations that enable AI agents to connect with external data, tools, and services.
+
+---
+
+## 📑 Table of Contents
+
+- [What is MCP?](#what-is-mcp)
+- [Featured MCP Servers](#featured-mcp-servers)
+  - [Azure MCP Server](#azure-mcp-server)
+  - [Microsoft Fabric MCP Server](#microsoft-fabric-mcp-server)
+  - [Request a New MCP Server](#request-a-new-mcp-server)
+- [Microsoft MCP Server Catalog](#mcp-server-catalog)
+- [Related Resources](#related-resources)
+- [Templates](#templates)
+- [Contributing](#contributing)
+- [Trademarks](#trademarks)
 
 ---
 
 ## 📘 What is MCP?
 
-**Model Context Protocol (MCP)** is an open protocol that standardizes how applications provide context to large language models (LLMs). It allows AI applications to connect with various data sources and tools in a consistent manner, enhancing their capabilities and flexibility. MCP follows a client-server architecture where:
+**Model Context Protocol (MCP)** is an open protocol that standardizes how applications provide context to large language models (LLMs). It allows AI applications to connect with various data sources and tools in a consistent manner, enhancing their capabilities and flexibility. MCP follows a client-server architecture:
 
-- **MCP Hosts**: Applications like AI assistants or integrated development environments (IDEs) that initiate connections.
+- **MCP Hosts**: Applications like AI assistants or IDEs that initiate connections.
 - **MCP Clients**: Connectors within the host application that maintain 1:1 connections with servers.
 - **MCP Servers**: Services that provide context and capabilities through the standardized MCP.
 
@@ -16,104 +33,27 @@ For more details, visit the [official MCP website](https://modelcontextprotocol.
 
 ---
 
-## 📂 Microsoft MCP Servers
+## 🌟 Featured MCP Servers
 
-Below are Microsoft's official MCP server implementations:
+### 🔷 [Azure MCP Server](servers/Azure.Mcp.Server/README.md)
 
-### 📅 Azure DevOps MCP Server
+Implements the MCP standard to manage Azure resources, enabling declarative provisioning and integration with AI workflows. See the [Azure MCP Server README](servers/Azure.Mcp.Server/README.md) for install instructions, usage, and troubleshooting.
 
-- **Repository**: [Azure DevOps MCP Server - Public Preview](https://github.com/microsoft/azure-devops-mcp)
-- **Description**: The MCP Server for Azure DevOps enables you to bring context into AI workflows and interact with Azure DevOps artifacts such as work items, test plans, builds, releases, and pull requests.
+### 🛢️ [Microsoft Fabric MCP Server](servers/Fabric.Mcp.Server/README.md)
 
----
-
-### 🔷 Azure MCP Server
-
-- **Repository**: [microsoft/mcp](https://github.com/microsoft/mcp/tree/main/servers/Azure.Mcp.Server#readme)
-- **Description**: Implements the MCP standard to manage Azure resources, enabling declarative provisioning and integration with AI workflows.
+Provides MCP-based access to Microsoft Fabric Real-Time Intelligence and related services. See the [Microsoft Fabric MCP Server README](servers/Fabric.Mcp.Server/README.md) for details.
 
 ---
 
-### ✨ Azure AI Foundry MCP Server
+## 📚 Microsoft MCP Server Catalog
 
-- **Repository**: [azure-ai-foundry/mcp-foundry](https://github.com/azure-ai-foundry/mcp-foundry)
-- **Description**: An experimental MCP server implementation for Azure AI Foundry that exposes unified tools for models, knowledge, evaluation and deployment.
-
----
-
-### 📊 Clarity MCP Server
-
-- **Repository**: [@microsoft/clarity-mcp-server](https://www.npmjs.com/package/@microsoft/clarity-mcp-server)
-- **Description**: An MCP server for Microsoft Clarity analytics integration. Enables AI models to access web analytics data, heatmaps, and session recordings to understand user behavior and site performance.
+Looking for the full list of MCP Servers? See the [Microsoft MCP Server Catalog](CATALOG.md) for all the latest MCP Servers from Microsoft, including public preview and experimental servers.
 
 ---
 
-### 🗃️ Dataverse MCP Server
+## 🆕 Request a New MCP Server
 
-- **Documentation**: [Microsoft Dataverse](https://go.microsoft.com/fwlink/?linkid=2320176)
-- **Description**: Chat over your business data using NL - Discover tables, run queries, retrieve data, insert or update records, and execute custom prompts grounded in business knowledge and context.
----
-
-### 📁 Files MCP Server
-
-- **Repository**: [microsoft/files-mcp-server](https://github.com/microsoft/files-mcp-server)
-- **Description**: Provides a declarative control plane for managing file-based resources, supporting AI workflows that involve static files and documentation synchronization.
-
----
-
-### 📝 Markitdown MCP Server
-
-- **Repository**: [microsoft/markitdown](https://github.com/microsoft/markitdown)
-- **Description**: A specialized MCP server for Markdown processing and manipulation. Enables AI models to read, write, and transform Markdown content with robust parsing and formatting capabilities.
-
----
-
-### 💻 Microsoft Dev Box MCP
-
-- **Package**: [@microsoft/devbox-mcp](https://www.npmjs.com/package/@microsoft/devbox-mcp)
-- **Description**: An MCP server for [Microsoft Dev Box](https://azure.microsoft.com/products/dev-box). Enables natural language interactions for developer-focused operations like managing Dev Boxes, configuring environments, and handling pools. Check out the [README](https://www.npmjs.com/package/@microsoft/devbox-mcp?activeTab=readme) for more details. Use this [one-click link](https://insiders.vscode.dev/redirect/mcp/install?name=Dev%20Box&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40microsoft%2Fdevbox-mcp%40latest%22%5D%7D) to install Dev Box MCP in your VS Code.
-
----
-
-### 🛢️Microsoft Fabric Real-Time Intelligence MCP Server
-
-- **Repository**: [RTI MCP Server](https://aka.ms/rti.mcp.repo)
-- **Description**: Chat with your real-time data the new agentic way using natural language and AI. MCP server for [Fabric Real-Time Intelligence](https://aka.ms/fabricrti) supporting tools for [Eventhouse](https://aka.ms/eventhouse), [Azure Data Explorer](https://aka.ms/adx), and other RTI services (coming soon)
-
----
-
-### 📚 Microsoft Learn Docs MCP Server
-
-- **Repository**: [microsoftdocs/mcp](https://github.com/microsoftdocs/mcp)
-- **Description**: A remote MCP server that provides structured access to official Microsoft Learn documentation. Enables AI models to retrieve accurate, authoritative, and context-aware technical content for code generation, question answering, and workflow grounding.
-
----
-
-### 🛢️Microsoft SQL MCP Server
-
-- **Repository**: [MSSQL MCP Server](https://aka.ms/MssqlMcp)
-- **Description**: Chat with your business data the new agentic way using natural language and AI. Connect to any SQL database—from ground (on-premises) to Azure cloud to Microsoft Fabric via a simple connection string. Discover and define table schemas, manage tables, and perform CRUD operations through conversational prompts.
-
----
-
-### 🎭 Playwright MCP
-
-- **Repository**: [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp)
-- **Description**: An MCP server for browsing the internet. Enables LLMs to interact with web pages through structured accessibility snapshots. Useful for web navigation and form-filling, data extraction from structured content, automated testing driven by LLMs, and general-purpose browser interaction for agents.
-
----
-
-### ☸️ Azure Kubernetes Service (AKS) MCP Server
-
-- **Repository**: [Azure/aks-mcp](https://github.com/Azure/aks-mcp)
-- **Description**: An MCP server that enables AI assistants to interact with Azure Kubernetes Service (AKS) clusters. It serves as a bridge between AI tools and AKS, translating natural language requests into AKS operations and returning the results in a format the AI tools can understand.
-
----
-
-### 📚 Microsoft 365 Agents Toolkit MCP
-
-- **Repository**: [M365 Agents Toolkit MCP](https://aka.ms/m365agentstoolkit-mcp)
-- **Description**: An MCP server that provides a seamless connection between AI agents and developers for building apps and agents for Microsoft 365 and Microsoft 365 Copilot.
+Want to add a new MCP Server to this repository? [Open an MCP Server Request](issues/new?template=02_mcp_server_request.yml) using our issue template.
 
 ---
 
@@ -122,7 +62,7 @@ Below are Microsoft's official MCP server implementations:
 - [Microsoft MCP Resources](https://github.com/microsoft/mcp/tree/main/Resources)
 - [MCP Pattern Overview](https://modelcontextprotocol.io/introduction)
 - [MCP SDKs and Building Blocks](https://modelcontextprotocol.io/sdk)
-- [MCP Specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/)
+- [MCP Specification](https://spec.modelcontextprotocol.io/specification/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,4 @@
-# Microsoft MCP Servers
-
-
-
-Welcome to the Microsoft MCP Servers repository! This repo catalogs official and community MCP Server implementations that enable AI agents to connect with external data, tools, and services.
-
----
-
-## 📑 Table of Contents
-
-- [What is MCP?](#what-is-mcp)
-- [Featured MCP Servers](#featured-mcp-servers)
-  - [Azure MCP Server](#azure-mcp-server)
-  - [Microsoft Fabric MCP Server](#microsoft-fabric-mcp-server)
-  - [Request a New MCP Server](#request-a-new-mcp-server)
-- [Microsoft MCP Server Catalog](#mcp-server-catalog)
-- [Related Resources](#related-resources)
-- [Templates](#templates)
-- [Contributing](#contributing)
-- [Trademarks](#trademarks)
-
----
+# 🌟 Microsoft MCP Servers
 
 ## 📘 What is MCP?
 
@@ -31,46 +10,34 @@ Welcome to the Microsoft MCP Servers repository! This repo catalogs official and
 
 For more details, visit the [official MCP website](https://modelcontextprotocol.io).
 
----
+## 📁 Which MCP Servers are built from this repository?
 
-## 🌟 Featured MCP Servers
+This repository contains core libraries, test frameworks, engineering systems, pipelines, and tooling for Microsoft MCP Server contributors to unify engineering investments; and reduce duplication and divergence:
 
-### 🔷 [Azure MCP Server](servers/Azure.Mcp.Server/README.md)
+| MCP Server           |  README              | Source Code             |    CHANGELOG          | Releases             | Documentation             | Troubleshooting             | Support             |
+|:---------------------|:--------------------:|:-----------------------:|:---------------------:|:--------------------:|:-------------------------:|:---------------------------:|:-------------------:|
+| Azure MCP            | [Azure MCP README]   | [Azure MCP Source Code] | [Azure MCP CHANGELOG] | [Azure MCP Releases] | [Azure MCP Documentation] | [Azure MCP Troubleshooting] | [Azure MCP Support] |
 
-Implements the MCP standard to manage Azure resources, enabling declarative provisioning and integration with AI workflows. See the [Azure MCP Server README](servers/Azure.Mcp.Server/README.md) for install instructions, usage, and troubleshooting.
+[Azure MCP README]: https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/README.md
+[Azure MCP CHANGELOG]: https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/CHANGELOG.md
+[Azure MCP Source Code]: https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server
+[Azure MCP Releases]: https://github.com/microsoft/mcp/releases?q=Azure
+[Azure MCP Documentation]: https://learn.microsoft.com/azure/developer/azure-mcp-server/
+[Azure MCP Troubleshooting]: https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/TROUBLESHOOTING.md
+[Azure MCP Support]: https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/SUPPORT.md
 
-### 🛢️ [Microsoft Fabric MCP Server](servers/Fabric.Mcp.Server/README.md)
 
-Provides MCP-based access to Microsoft Fabric Real-Time Intelligence and related services. See the [Microsoft Fabric MCP Server README](servers/Fabric.Mcp.Server/README.md) for details.
+## 📚 Looking for the full list of MCP Servers from Microsoft?
+See the [Microsoft MCP Server Catalog](https://github.com/microsoft/mcp/blob/main/CATALOG.md) for all the latest MCP Servers, including public preview and experimental servers.
 
----
-
-## 📚 Microsoft MCP Server Catalog
-
-Looking for the full list of MCP Servers? See the [Microsoft MCP Server Catalog](CATALOG.md) for all the latest MCP Servers from Microsoft, including public preview and experimental servers.
-
----
-
-## 🆕 Request a New MCP Server
-
-Want to add a new MCP Server to this repository? [Open an MCP Server Request](issues/new?template=02_mcp_server_request.yml) using our issue template.
-
----
+## 🏗️ Looking for starter templates that use MCP? 
+Check out the [Azure Developer CLI (azd) templates](https://azure.github.io/awesome-azd/?tags=mcp) tagged with MCP.
 
 ## 📎 Related Resources
-
 - [Microsoft MCP Resources](https://github.com/microsoft/mcp/tree/main/Resources)
 - [MCP Pattern Overview](https://modelcontextprotocol.io/introduction)
 - [MCP SDKs and Building Blocks](https://modelcontextprotocol.io/sdk)
 - [MCP Specification](https://spec.modelcontextprotocol.io/specification/)
-
----
-
-## 🏗️ Templates
-
-Looking for starter templates that use MCP? Check out the [Azure Developer CLI (azd) templates](https://azure.github.io/awesome-azd/?tags=mcp) tagged with MCP.
-
----
 
 ## Contributing
 


### PR DESCRIPTION
## What does this PR do?
1. Fix project reference in `Azure MCP Server onboarding` issue template
2. Add a new `MCP Server onboarding` issue template
3. Move list of Microsoft MCP Servers to a new `CATALOG.md`
4. Update `README.md` with direct links to Azure MCP Server key files, and establish a v0 pattern for more MCP Servers to follow

    
