### PR TITLE
Update Azure.ResourceManager.StorageCache to 1.3.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,7 @@
     <PackageVersion Include="Azure.Storage.Files.DataLake" Version="12.22.0" />
     <PackageVersion Include="Azure.Storage.Files.Shares" Version="12.22.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.22.0" />
-    <PackageVersion Include="Azure.ResourceManager.StorageCache" Version="1.3.1" />
+    <PackageVersion Include="Azure.ResourceManager.StorageCache" Version="1.3.2" />
     <PackageVersion Include="Azure.ResourceManager.Datadog" Version="1.0.0-beta.6" />
     <PackageVersion Include="Azure.ResourceManager.CosmosDB" Version="1.4.0-beta.13" />
     <PackageVersion Include="Azure.ResourceManager.OperationalInsights" Version="1.3.1" />

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -22,6 +22,8 @@ The Azure MCP Server updates automatically by default whenever a new release com
 ### Other Changes
 
 - Updated `Azure.Identity` and `Azure.Identity.Broker` dependencies. [[#352](https://github.com/microsoft/mcp/pull/352)]
+- Updated the following dependencies to improve .NET Ahead-of-Time (AOT) compilation support: 
+  - Azure.ResourceManager.StorageCache: `1.3.1` → `1.3.2`
 
 ## 0.5.12 (2025-09-04)
 
@@ -34,7 +36,7 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 ### Other Changes
 
-- Added a verb to the namespace name for bestpractices [[#109](https://github.com/microsoft/mcp/pull/109)]
+AOT- Added a verb to the namespace name for bestpractices [[#109](https://github.com/microsoft/mcp/pull/109)]
 - Added instructions about consumption plan for azure functions deployment best practices [[#218](https://github.com/microsoft/mcp/pull/218)]
 
 ## 0.5.11 (2025-09-02)

--- a/servers/Azure.Mcp.Server/src/Azure.Mcp.Server.csproj
+++ b/servers/Azure.Mcp.Server/src/Azure.Mcp.Server.csproj
@@ -75,12 +75,4 @@
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
-  <!-- IMPORTANT: DO NOT ADD EXCLUSIONS HERE -->
-  <!-- If the "(Native AOT) Build module" stage fails in CI, follow the AOT compatibility guide:
-       https://github.com/Azure/azure-mcp/blob/main/docs/aot-compatibility.md
-       Do not add ProjectReference removals in this ItemGroup. -->
-  <ItemGroup Condition="'$(BuildNative)' == 'true'">
-    <ProjectReference
-      Remove="$(RepoRoot)\tools\azuremanagedlustre\src\AzureMcp.AzureManagedLustre\AzureMcp.AzureManagedLustre.csproj" />
-  </ItemGroup>
 </Project>

--- a/servers/Azure.Mcp.Server/src/Program.cs
+++ b/servers/Azure.Mcp.Server/src/Program.cs
@@ -66,6 +66,7 @@ internal class Program
             new Azure.Mcp.Tools.AppConfig.AppConfigSetup(),
             new Azure.Mcp.Tools.Authorization.AuthorizationSetup(),
             new Azure.Mcp.Tools.AzureIsv.AzureIsvSetup(),
+            new Azure.Mcp.Tools.AzureManagedLustre.AzureManagedLustreSetup(),
             new Azure.Mcp.Tools.AzureTerraformBestPractices.AzureTerraformBestPracticesSetup(),
             new Azure.Mcp.Tools.Deploy.DeploySetup(),
             new Azure.Mcp.Tools.EventGrid.EventGridSetup(),
@@ -98,7 +99,6 @@ internal class Program
             // follow the AOT compatibility guide instead of changing this list:
             // https://github.com/Azure/azure-mcp/blob/main/docs/aot-compatibility.md
             new Azure.Mcp.Tools.BicepSchema.BicepSchemaSetup(),
-            new Azure.Mcp.Tools.AzureManagedLustre.AzureManagedLustreSetup(),
 #endif
         ];
     }


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

Updated the following dependencies to improve .NET Ahead-of-Time (AOT) compilation support
- Azure.ResourceManager.StorageCache: `1.3.1` → `1.3.2`

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
