### PR TITLE
Fixed how handling of status codes as exit codes

### DIFF
--- a/servers/Azure.Mcp.Server/src/Program.cs
+++ b/servers/Azure.Mcp.Server/src/Program.cs
@@ -37,7 +37,9 @@ internal class Program
             var commandFactory = serviceProvider.GetRequiredService<CommandFactory>();
             var rootCommand = commandFactory.RootCommand;
             var parseResult = rootCommand.Parse(args);
-            return await parseResult.InvokeAsync();
+            var status = await parseResult.InvokeAsync();
+
+            return (status >= 200 && status < 300) ? 0 : 1;
         }
         catch (Exception ex)
         {

--- a/servers/Fabric.Mcp.Server/src/Program.cs
+++ b/servers/Fabric.Mcp.Server/src/Program.cs
@@ -41,7 +41,9 @@ internal class Program
             var commandFactory = serviceProvider.GetRequiredService<CommandFactory>();
             var rootCommand = commandFactory.RootCommand;
             var parseResult = rootCommand.Parse(args);
-            return await parseResult.InvokeAsync();
+            var status = await parseResult.InvokeAsync();
+
+            return (status >= 200 && status < 300) ? 0 : 1;
         }
         catch (Exception ex)
         {

--- a/servers/Template.Mcp.Server/src/Program.cs
+++ b/servers/Template.Mcp.Server/src/Program.cs
@@ -38,7 +38,9 @@ internal class Program
             var commandFactory = serviceProvider.GetRequiredService<CommandFactory>();
             var rootCommand = commandFactory.RootCommand;
             var parseResult = rootCommand.Parse(args);
-            return await parseResult.InvokeAsync();
+            var status = await parseResult.InvokeAsync();
+
+            return (status >= 200 && status < 300) ? 0 : 1;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## What does this PR do?

Before [this PR](https://github.com/microsoft/mcp/pull/48), we used to create a `CommandLineBuilder` for validating commands and only changed the exit code in case of failure. I assume this class from **System.CommandLine** returned 0 when successful. In the case of an error, we'd update the exit value to the status code returned by the server:

<img width="1084" height="604" alt="image" src="https://github.com/user-attachments/assets/f472771e-7040-40d6-ac94-3e34f3a4a5c4" />

Now, we simply return the status code of the command we call:

<img width="2134" height="415" alt="image" src="https://github.com/user-attachments/assets/e92ce723-4bb8-4d9b-b9cc-457e095b5ff9" />

This PR returns the old functionality where an exit code of `0` means "Success" and `1` means there was an error to keep it consistent to what's done for most processes.

## GitHub issue number?
N/A

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
