### PR TITLE
Removing Newtonsoft.Json package reference

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -71,7 +71,6 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
     <PackageVersion Include="MySqlConnector" Version="2.4.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Npgsql" Version="9.0.3" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta7.25380.108" />

--- a/core/Azure.Mcp.Core/src/Azure.Mcp.Core.csproj
+++ b/core/Azure.Mcp.Core/src/Azure.Mcp.Core.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Azure.ResourceManager.ResourceGraph" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" />
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
 </Project>

--- a/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.UnitTests/GetSchemaTests.cs
+++ b/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.UnitTests/GetSchemaTests.cs
@@ -8,7 +8,6 @@ using Azure.Mcp.Tools.BicepSchema.Services;
 using Azure.Mcp.Tools.BicepSchema.Services.ResourceProperties;
 using Azure.Mcp.Tools.BicepSchema.Services.ResourceProperties.Entities;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Azure.Mcp.Tools.BicepSchema.UnitTests;
@@ -239,9 +238,10 @@ public class GetSchemaTests
         // Verify
         Assert.Contains($"{resourceType}@{apiVersion}", response);
 
-        JArray root = JArray.Parse(response);
-        Assert.Equal("Resource", root.SelectToken("[0].$type")!.ToString());
-        Assert.Equal($"{resourceType}@{apiVersion}", root.SelectToken("[0].name")!.ToString());
+        using JsonDocument document = JsonDocument.Parse(response);
+        JsonElement root = document.RootElement;
+        Assert.Equal("Resource", root[0].GetProperty("$type").GetString());
+        Assert.Equal($"{resourceType}@{apiVersion}", root[0].GetProperty("name").GetString());
 
         //TODO: Consider more checks after optimizing output
     }


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

The Newtonsoft package was referenced but only used by a Bicep test. Its broader usage was implicitly removed when we switched to the AOT-safe Cosmos earlier. This PR removes the package reference and updates the test to use the equivalent STJ APIs.

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
