### PR TITLE
Enhance AKS nodepool information with comprehensive properties

### DIFF
--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -6,6 +6,8 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 ### Features Added
 
+- Enhanced AKS nodepool information with comprehensive properties. [[#454](https://github.com/microsoft/mcp/issues/454)]
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/tools/Azure.Mcp.Tools.Aks/src/Commands/AksJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.Aks/src/Commands/AksJsonContext.cs
@@ -13,5 +13,6 @@ namespace Azure.Mcp.Tools.Aks.Commands;
 [JsonSerializable(typeof(NodepoolListCommand.NodepoolListCommandResult))]
 [JsonSerializable(typeof(NodepoolGetCommand.NodepoolGetCommandResult))]
 [JsonSerializable(typeof(Models.NodePool))]
+[JsonSerializable(typeof(Models.NodePoolPowerState))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class AksJsonContext : JsonSerializerContext;

--- a/tools/Azure.Mcp.Tools.Aks/src/Models/NodePool.cs
+++ b/tools/Azure.Mcp.Tools.Aks/src/Models/NodePool.cs
@@ -9,30 +9,81 @@ public class NodePool
     public string? Name { get; set; }
 
     /// <summary> Number of nodes in the pool. </summary>
-    public int? NodeCount { get; set; }
+    public int? Count { get; set; }
 
     /// <summary> VM size of the agent nodes. </summary>
-    public string? NodeVmSize { get; set; }
+    public string? VmSize { get; set; }
 
-    /// <summary> OS type of the node pool. </summary>
-    public string? OsType { get; set; }
+    /// <summary> OS Disk size in GB. </summary>
+    public int? OsDiskSizeGB { get; set; }
 
-    /// <summary> Pool mode (System/User). </summary>
-    public string? Mode { get; set; }
+    /// <summary> OS Disk type (Managed/Ephemeral). </summary>
+    public string? OsDiskType { get; set; }
 
-    /// <summary> Kubernetes/orchestrator version for the pool. </summary>
-    public string? OrchestratorVersion { get; set; }
+    /// <summary> Kubelet disk type (OS/Temp). </summary>
+    public string? KubeletDiskType { get; set; }
 
-    /// <summary> Whether cluster autoscaler is enabled for this pool. </summary>
-    public bool? EnableAutoScaling { get; set; }
+    /// <summary> Maximum pods per node. </summary>
+    public int? MaxPods { get; set; }
 
-    /// <summary> Minimum node count when autoscaling is enabled. </summary>
-    public int? MinCount { get; set; }
+    /// <summary> Pool type (e.g., VirtualMachineScaleSets). </summary>
+    public string? Type { get; set; }
 
     /// <summary> Maximum node count when autoscaling is enabled. </summary>
     public int? MaxCount { get; set; }
 
+    /// <summary> Minimum node count when autoscaling is enabled. </summary>
+    public int? MinCount { get; set; }
+
+    /// <summary> Whether cluster autoscaler is enabled for this pool. </summary>
+    public bool? EnableAutoScaling { get; set; }
+
+    /// <summary> Scale down mode (e.g., Delete, Deallocate). </summary>
+    public string? ScaleDownMode { get; set; }
+
     /// <summary> Provisioning state of the node pool resource. </summary>
     public string? ProvisioningState { get; set; }
+
+    /// <summary> Power state of the node pool. </summary>
+    public NodePoolPowerState? PowerState { get; set; }
+
+    /// <summary> Target orchestrator (Kubernetes) version. </summary>
+    public string? OrchestratorVersion { get; set; }
+
+    /// <summary> Current orchestrator (Kubernetes) version. </summary>
+    public string? CurrentOrchestratorVersion { get; set; }
+
+    /// <summary> Whether nodes have a public IP. </summary>
+    public bool? EnableNodePublicIP { get; set; }
+
+    /// <summary> VMSS priority (e.g., Regular, Spot). </summary>
+    public string? ScaleSetPriority { get; set; }
+
+    /// <summary> VMSS eviction policy (e.g., Delete, Deallocate). </summary>
+    public string? ScaleSetEvictionPolicy { get; set; }
+
+    /// <summary> Node labels. </summary>
+    public IDictionary<string, string>? NodeLabels { get; set; }
+
+    /// <summary> Node taints. </summary>
+    public IList<string>? NodeTaints { get; set; }
+
+    /// <summary> Pool mode (System/User). </summary>
+    public string? Mode { get; set; }
+
+    /// <summary> OS type of the node pool. </summary>
+    public string? OsType { get; set; }
+
+    /// <summary> OS SKU (e.g., Ubuntu, CBLMariner). </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("osSKU")]
+    public string? OsSKU { get; set; }
+
+    /// <summary> Node image version. </summary>
+    public string? NodeImageVersion { get; set; }
 }
 
+public sealed class NodePoolPowerState
+{
+    /// <summary> Power state code (e.g., Running, Stopped). </summary>
+    public string? Code { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.Aks/src/Services/AksService.cs
+++ b/tools/Azure.Mcp.Tools.Aks/src/Services/AksService.cs
@@ -283,15 +283,30 @@ public sealed class AksService(
         return new NodePool
         {
             Name = data.Name,
-            NodeCount = data.Count,
-            NodeVmSize = data.VmSize?.ToString(),
-            OsType = data.OSType?.ToString(),
+            Count = data.Count,
+            VmSize = data.VmSize?.ToString(),
+            OsDiskSizeGB = data.OSDiskSizeInGB,
+            OsDiskType = data.OSDiskType?.ToString(),
+            KubeletDiskType = data.KubeletDiskType?.ToString(),
+            MaxPods = data.MaxPods,
+            Type = data.TypePropertiesType?.ToString(),
+            MaxCount = data.MaxCount,
+            MinCount = data.MinCount,
+            EnableAutoScaling = data.EnableAutoScaling,
+            ScaleDownMode = data.ScaleDownMode?.ToString(),
+            ProvisioningState = data.ProvisioningState?.ToString(),
+            PowerState = data.PowerStateCode.HasValue ? new NodePoolPowerState { Code = data.PowerStateCode.Value.ToString() } : null,
             Mode = data.Mode?.ToString(),
             OrchestratorVersion = data.OrchestratorVersion,
-            EnableAutoScaling = data.EnableAutoScaling,
-            MinCount = data.MinCount,
-            MaxCount = data.MaxCount,
-            ProvisioningState = data.ProvisioningState?.ToString()
+            CurrentOrchestratorVersion = data.CurrentOrchestratorVersion,
+            EnableNodePublicIP = data.EnableNodePublicIP,
+            ScaleSetPriority = data.ScaleSetPriority?.ToString(),
+            ScaleSetEvictionPolicy = data.ScaleSetEvictionPolicy?.ToString(),
+            NodeLabels = data.NodeLabels?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
+            NodeTaints = data.NodeTaints?.ToList(),
+            OsType = data.OSType?.ToString(),
+            OsSKU = data.OSSku?.ToString(),
+            NodeImageVersion = data.NodeImageVersion
         };
     }
 }

--- a/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.LiveTests/NodepoolCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.LiveTests/NodepoolCommandTests.cs
@@ -43,7 +43,7 @@ public sealed class NodepoolCommandTests(ITestOutputHelper output)
         Assert.Equal(JsonValueKind.Array, nodePools.ValueKind);
         Assert.True(nodePools.GetArrayLength() > 0, "Expected at least one node pool in the cluster");
 
-        // Validate a few common properties exist on each node pool
+        // Validate properties exist on each node pool
         foreach (var pool in nodePools.EnumerateArray())
         {
             Assert.Equal(JsonValueKind.Object, pool.ValueKind);
@@ -58,6 +58,66 @@ public sealed class NodepoolCommandTests(ITestOutputHelper output)
             if (pool.TryGetProperty("provisioningState", out var stateProperty))
             {
                 Assert.False(string.IsNullOrEmpty(stateProperty.GetString()));
+            }
+
+            if (pool.TryGetProperty("osDiskSizeGB", out var osDiskSize))
+            {
+                Assert.True(osDiskSize.ValueKind is JsonValueKind.Number or JsonValueKind.Null);
+            }
+            if (pool.TryGetProperty("osDiskType", out var osDiskType))
+            {
+                Assert.True(osDiskType.ValueKind is JsonValueKind.String or JsonValueKind.Null);
+            }
+            if (pool.TryGetProperty("kubeletDiskType", out var kubeletDiskType))
+            {
+                Assert.True(kubeletDiskType.ValueKind is JsonValueKind.String or JsonValueKind.Null);
+            }
+            if (pool.TryGetProperty("maxPods", out var maxPods))
+            {
+                Assert.True(maxPods.ValueKind is JsonValueKind.Number or JsonValueKind.Null);
+            }
+            if (pool.TryGetProperty("type", out var typeProperty))
+            {
+                Assert.True(typeProperty.ValueKind is JsonValueKind.String or JsonValueKind.Null);
+            }
+            if (pool.TryGetProperty("enableAutoScaling", out var autoScale))
+            {
+                Assert.True(autoScale.ValueKind is JsonValueKind.True or JsonValueKind.False or JsonValueKind.Null);
+            }
+            if (pool.TryGetProperty("powerState", out var powerState) && powerState.ValueKind == JsonValueKind.Object)
+            {
+                if (powerState.TryGetProperty("code", out var code))
+                {
+                    Assert.True(code.ValueKind is JsonValueKind.String or JsonValueKind.Null);
+                }
+            }
+            if (pool.TryGetProperty("currentOrchestratorVersion", out var currVer))
+            {
+                Assert.True(currVer.ValueKind is JsonValueKind.String or JsonValueKind.Null);
+            }
+            if (pool.TryGetProperty("enableNodePublicIP", out var pubIP))
+            {
+                Assert.True(pubIP.ValueKind is JsonValueKind.True or JsonValueKind.False or JsonValueKind.Null);
+            }
+            if (pool.TryGetProperty("scaleSetPriority", out var priority))
+            {
+                Assert.True(priority.ValueKind is JsonValueKind.String or JsonValueKind.Null);
+            }
+            if (pool.TryGetProperty("nodeLabels", out var labels))
+            {
+                Assert.True(labels.ValueKind is JsonValueKind.Object or JsonValueKind.Null);
+            }
+            if (pool.TryGetProperty("nodeTaints", out var taints))
+            {
+                Assert.True(taints.ValueKind is JsonValueKind.Array or JsonValueKind.Null);
+            }
+            if (pool.TryGetProperty("osSKU", out var osSku))
+            {
+                Assert.True(osSku.ValueKind is JsonValueKind.String or JsonValueKind.Null);
+            }
+            if (pool.TryGetProperty("nodeImageVersion", out var imgVer))
+            {
+                Assert.True(imgVer.ValueKind is JsonValueKind.String or JsonValueKind.Null);
             }
         }
     }

--- a/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.LiveTests/NodepoolGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.LiveTests/NodepoolGetCommandTests.cs
@@ -69,6 +69,13 @@ public sealed class NodepoolGetCommandTests(ITestOutputHelper output)
         {
             Assert.False(string.IsNullOrEmpty(stateProperty.GetString()));
         }
+
+        Assert.True(nodePool.TryGetProperty("orchestratorVersion", out _));
+        Assert.True(nodePool.TryGetProperty("currentOrchestratorVersion", out _));
+        Assert.True(nodePool.TryGetProperty("enableAutoScaling", out _));
+        Assert.True(nodePool.TryGetProperty("maxPods", out _));
+        Assert.True(nodePool.TryGetProperty("osSKU", out _));
+        Assert.True(nodePool.TryGetProperty("nodeImageVersion", out _));
     }
 
     [Fact]
@@ -177,4 +184,3 @@ public sealed class NodepoolGetCommandTests(ITestOutputHelper output)
         Assert.False(result.HasValue);
     }
 }
-

--- a/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.UnitTests/Nodepool/NodepoolGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.UnitTests/Nodepool/NodepoolGetCommandTests.cs
@@ -58,8 +58,8 @@ public sealed class NodepoolGetCommandTests
             var testNodePool = new Models.NodePool
             {
                 Name = "np1",
-                NodeCount = 3,
-                NodeVmSize = "Standard_DS2_v2",
+                Count = 3,
+                VmSize = "Standard_DS2_v2",
                 Mode = "System"
             };
             _aksService.GetNodePool(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
@@ -91,9 +91,30 @@ public sealed class NodepoolGetCommandTests
         var expectedNodePool = new Models.NodePool
         {
             Name = "userpool",
-            NodeCount = 5,
-            NodeVmSize = "Standard_D4s_v5",
-            Mode = "User"
+            Count = 1,
+            VmSize = "Standard_NC24ads_A100_v4",
+            OsDiskSizeGB = 256,
+            OsDiskType = "Ephemeral",
+            KubeletDiskType = "OS",
+            MaxPods = 110,
+            Type = "VirtualMachineScaleSets",
+            MaxCount = 5,
+            MinCount = 1,
+            EnableAutoScaling = true,
+            ScaleDownMode = "Delete",
+            ProvisioningState = "Succeeded",
+            PowerState = new Models.NodePoolPowerState { Code = "Running" },
+            OrchestratorVersion = "1.33.2",
+            CurrentOrchestratorVersion = "1.33.2",
+            EnableNodePublicIP = false,
+            ScaleSetPriority = "Spot",
+            ScaleSetEvictionPolicy = "Delete",
+            NodeLabels = new Dictionary<string, string> { { "kubernetes.azure.com/scalesetpriority", "spot" } },
+            NodeTaints = new List<string> { "kubernetes.azure.com/scalesetpriority=spot:NoSchedule" },
+            Mode = "User",
+            OsType = "Linux",
+            OsSKU = "Ubuntu",
+            NodeImageVersion = "AKSUbuntu-2204gen2containerd-202508.20.1"
         };
         _aksService.GetNodePool(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
             .Returns(expectedNodePool);
@@ -115,8 +136,30 @@ public sealed class NodepoolGetCommandTests
 
         Assert.NotNull(result);
         Assert.Equal(expectedNodePool.Name, result.NodePool.Name);
-        Assert.Equal(expectedNodePool.NodeCount, result.NodePool.NodeCount);
-        Assert.Equal(expectedNodePool.NodeVmSize, result.NodePool.NodeVmSize);
+        Assert.Equal(expectedNodePool.Count, result.NodePool.Count);
+        Assert.Equal(expectedNodePool.VmSize, result.NodePool.VmSize);
+        Assert.Equal(expectedNodePool.OsDiskSizeGB, result.NodePool.OsDiskSizeGB);
+        Assert.Equal(expectedNodePool.OsDiskType, result.NodePool.OsDiskType);
+        Assert.Equal(expectedNodePool.KubeletDiskType, result.NodePool.KubeletDiskType);
+        Assert.Equal(expectedNodePool.MaxPods, result.NodePool.MaxPods);
+        Assert.Equal(expectedNodePool.Type, result.NodePool.Type);
+        Assert.Equal(expectedNodePool.MaxCount, result.NodePool.MaxCount);
+        Assert.Equal(expectedNodePool.MinCount, result.NodePool.MinCount);
+        Assert.Equal(expectedNodePool.EnableAutoScaling, result.NodePool.EnableAutoScaling);
+        Assert.Equal(expectedNodePool.ScaleDownMode, result.NodePool.ScaleDownMode);
+        Assert.Equal(expectedNodePool.ProvisioningState, result.NodePool.ProvisioningState);
+        Assert.Equal(expectedNodePool.PowerState?.Code, result.NodePool.PowerState?.Code);
+        Assert.Equal(expectedNodePool.OrchestratorVersion, result.NodePool.OrchestratorVersion);
+        Assert.Equal(expectedNodePool.CurrentOrchestratorVersion, result.NodePool.CurrentOrchestratorVersion);
+        Assert.Equal(expectedNodePool.EnableNodePublicIP, result.NodePool.EnableNodePublicIP);
+        Assert.Equal(expectedNodePool.ScaleSetPriority, result.NodePool.ScaleSetPriority);
+        Assert.Equal(expectedNodePool.ScaleSetEvictionPolicy, result.NodePool.ScaleSetEvictionPolicy);
+        Assert.Equal(expectedNodePool.NodeLabels!["kubernetes.azure.com/scalesetpriority"], result.NodePool.NodeLabels!["kubernetes.azure.com/scalesetpriority"]);
+        Assert.Equal(expectedNodePool.NodeTaints![0], result.NodePool.NodeTaints![0]);
+        Assert.Equal(expectedNodePool.Mode, result.NodePool.Mode);
+        Assert.Equal(expectedNodePool.OsType, result.NodePool.OsType);
+        Assert.Equal(expectedNodePool.OsSKU, result.NodePool.OsSKU);
+        Assert.Equal(expectedNodePool.NodeImageVersion, result.NodePool.NodeImageVersion);
     }
 
     [Fact]
@@ -156,4 +199,3 @@ public sealed class NodepoolGetCommandTests
         Assert.Contains("troubleshooting", response.Message);
     }
 }
-

--- a/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.UnitTests/Nodepool/NodepoolListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.UnitTests/Nodepool/NodepoolListCommandTests.cs
@@ -56,8 +56,8 @@ public sealed class NodepoolListCommandTests
         {
             var testNodePools = new List<Models.NodePool>
             {
-                new() { Name = "np1", NodeCount = 3, NodeVmSize = "Standard_DS2_v2" },
-                new() { Name = "np2", NodeCount = 5, NodeVmSize = "Standard_D4s_v5" }
+                new() { Name = "np1", Count = 3, VmSize = "Standard_DS2_v2" },
+                new() { Name = "np2", Count = 5, VmSize = "Standard_D4s_v5" }
             };
             _aksService.ListNodePools(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
                 .Returns(testNodePools);
@@ -88,8 +88,62 @@ public sealed class NodepoolListCommandTests
         // Arrange
         var expectedNodePools = new List<Models.NodePool>
         {
-            new() { Name = "systempool", NodeCount = 3, NodeVmSize = "Standard_DS2_v2", Mode = "System" },
-            new() { Name = "userpool", NodeCount = 5, NodeVmSize = "Standard_D4s_v5", Mode = "User" }
+            new()
+            {
+                Name = "systempool",
+                Count = 3,
+                VmSize = "Standard_DS2_v2",
+                OsDiskSizeGB = 128,
+                OsDiskType = "Managed",
+                KubeletDiskType = "OS",
+                MaxPods = 110,
+                Type = "VirtualMachineScaleSets",
+                MaxCount = 5,
+                MinCount = 1,
+                EnableAutoScaling = true,
+                ScaleDownMode = "Delete",
+                ProvisioningState = "Succeeded",
+                PowerState = new Models.NodePoolPowerState { Code = "Running" },
+                OrchestratorVersion = "1.33.1",
+                CurrentOrchestratorVersion = "1.33.1",
+                EnableNodePublicIP = false,
+                ScaleSetPriority = "Regular",
+                ScaleSetEvictionPolicy = null,
+                NodeLabels = new Dictionary<string, string> { { "pool", "system" } },
+                NodeTaints = new List<string>(),
+                Mode = "System",
+                OsType = "Linux",
+                OsSKU = "Ubuntu",
+                NodeImageVersion = "AKSUbuntu-2204gen2containerd-202508.20.1"
+            },
+            new()
+            {
+                Name = "userpool",
+                Count = 5,
+                VmSize = "Standard_D4s_v5",
+                OsDiskSizeGB = 256,
+                OsDiskType = "Ephemeral",
+                KubeletDiskType = "OS",
+                MaxPods = 110,
+                Type = "VirtualMachineScaleSets",
+                MaxCount = 10,
+                MinCount = 1,
+                EnableAutoScaling = true,
+                ScaleDownMode = "Delete",
+                ProvisioningState = "Succeeded",
+                PowerState = new Models.NodePoolPowerState { Code = "Running" },
+                OrchestratorVersion = "1.33.2",
+                CurrentOrchestratorVersion = "1.33.2",
+                EnableNodePublicIP = false,
+                ScaleSetPriority = "Spot",
+                ScaleSetEvictionPolicy = "Delete",
+                NodeLabels = new Dictionary<string, string> { { "kubernetes.azure.com/scalesetpriority", "spot" } },
+                NodeTaints = new List<string> { "kubernetes.azure.com/scalesetpriority=spot:NoSchedule" },
+                Mode = "User",
+                OsType = "Linux",
+                OsSKU = "Ubuntu",
+                NodeImageVersion = "AKSUbuntu-2204gen2containerd-202508.20.1"
+            }
         };
         _aksService.ListNodePools(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
             .Returns(expectedNodePools);
@@ -112,9 +166,33 @@ public sealed class NodepoolListCommandTests
 
         Assert.NotNull(result);
         Assert.Equal(expectedNodePools.Count, result.NodePools.Count);
+
+        // Validate enriched fields for first pool
         Assert.Equal(expectedNodePools[0].Name, result.NodePools[0].Name);
-        Assert.Equal(expectedNodePools[0].NodeCount, result.NodePools[0].NodeCount);
-        Assert.Equal(expectedNodePools[0].NodeVmSize, result.NodePools[0].NodeVmSize);
+        Assert.Equal(expectedNodePools[0].Count, result.NodePools[0].Count);
+        Assert.Equal(expectedNodePools[0].VmSize, result.NodePools[0].VmSize);
+        Assert.Equal(expectedNodePools[0].OsDiskSizeGB, result.NodePools[0].OsDiskSizeGB);
+        Assert.Equal(expectedNodePools[0].OsDiskType, result.NodePools[0].OsDiskType);
+        Assert.Equal(expectedNodePools[0].KubeletDiskType, result.NodePools[0].KubeletDiskType);
+        Assert.Equal(expectedNodePools[0].MaxPods, result.NodePools[0].MaxPods);
+        Assert.Equal(expectedNodePools[0].Type, result.NodePools[0].Type);
+        Assert.Equal(expectedNodePools[0].MaxCount, result.NodePools[0].MaxCount);
+        Assert.Equal(expectedNodePools[0].MinCount, result.NodePools[0].MinCount);
+        Assert.Equal(expectedNodePools[0].EnableAutoScaling, result.NodePools[0].EnableAutoScaling);
+        Assert.Equal(expectedNodePools[0].ScaleDownMode, result.NodePools[0].ScaleDownMode);
+        Assert.Equal(expectedNodePools[0].ProvisioningState, result.NodePools[0].ProvisioningState);
+        Assert.Equal(expectedNodePools[0].PowerState?.Code, result.NodePools[0].PowerState?.Code);
+        Assert.Equal(expectedNodePools[0].OrchestratorVersion, result.NodePools[0].OrchestratorVersion);
+        Assert.Equal(expectedNodePools[0].CurrentOrchestratorVersion, result.NodePools[0].CurrentOrchestratorVersion);
+        Assert.Equal(expectedNodePools[0].EnableNodePublicIP, result.NodePools[0].EnableNodePublicIP);
+        Assert.Equal(expectedNodePools[0].ScaleSetPriority, result.NodePools[0].ScaleSetPriority);
+        Assert.Equal(expectedNodePools[0].ScaleSetEvictionPolicy, result.NodePools[0].ScaleSetEvictionPolicy);
+        Assert.Equal(expectedNodePools[0].NodeLabels!["pool"], result.NodePools[0].NodeLabels!["pool"]);
+        Assert.Equal(expectedNodePools[0].NodeTaints!.Count, result.NodePools[0].NodeTaints!.Count);
+        Assert.Equal(expectedNodePools[0].Mode, result.NodePools[0].Mode);
+        Assert.Equal(expectedNodePools[0].OsType, result.NodePools[0].OsType);
+        Assert.Equal(expectedNodePools[0].OsSKU, result.NodePools[0].OsSKU);
+        Assert.Equal(expectedNodePools[0].NodeImageVersion, result.NodePools[0].NodeImageVersion);
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?

Enhance AKS nodepool information with comprehensive properties
- Add detailed nodepool properties including disk configuration, scaling settings, and node metadata
- Expand NodePool model with 20+ new properties for complete cluster visibility
- Enhance unit and live tests to validate new properties
- Improve property naming consistency (NodeCount -> Count, NodeVmSize -> VmSize)


## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
