### PR TITLE
Fix the null value assignment in GetValueOrDefault()

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Extensions/CommandResultExtensionsTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Extensions/CommandResultExtensionsTests.cs
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Azure.Mcp.Core.Extensions;
+using Xunit;
+
+namespace Azure.Mcp.Core.UnitTests.Extensions;
+
+public class CommandResultExtensionsTests
+{
+    [Fact]
+    public void GetValueOrDefault_WithExplicitStringValue_ReturnsValue()
+    {
+        // Arrange
+        var option = new Option<string?>("--name");
+        var command = new Command("test") { option };
+        var parseResult = command.Parse("--name test-value");
+
+        // Act
+        var result = parseResult.CommandResult.GetValueOrDefault(option);
+
+        // Assert
+        Assert.Equal("test-value", result);
+    }
+
+    [Fact]
+    public void GetValueOrDefault_WithMissingStringValue_ReturnsNull()
+    {
+        // Arrange
+        var option = new Option<string?>("--name");
+        var command = new Command("test") { option };
+        var parseResult = command.Parse("");
+
+        // Act
+        var result = parseResult.CommandResult.GetValueOrDefault(option);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetValueOrDefault_WithExplicitIntValue_ReturnsValue()
+    {
+        // Arrange
+        var option = new Option<int?>("--count");
+        var command = new Command("test") { option };
+        var parseResult = command.Parse("--count 42");
+
+        // Act
+        var result = parseResult.CommandResult.GetValueOrDefault(option);
+
+        // Assert
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void GetValueOrDefault_WithMissingIntValue_ReturnsNull()
+    {
+        // Arrange
+        var option = new Option<int?>("--count");
+        var command = new Command("test") { option };
+        var parseResult = command.Parse("");
+
+        // Act
+        var result = parseResult.CommandResult.GetValueOrDefault(option);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetValueOrDefault_WithExplicitLongValue_ReturnsValue()
+    {
+        // Arrange
+        var option = new Option<long?>("--max-size-bytes");
+        var command = new Command("test") { option };
+        var parseResult = command.Parse("--max-size-bytes 1073741824");
+
+        // Act
+        var result = parseResult.CommandResult.GetValueOrDefault(option);
+
+        // Assert
+        Assert.Equal(1073741824L, result);
+    }
+
+    [Fact]
+    public void GetValueOrDefault_WithMissingLongValue_ReturnsNull()
+    {
+        // Arrange
+        var option = new Option<long?>("--max-size-bytes");
+        var command = new Command("test") { option };
+        var parseResult = command.Parse("");
+
+        // Act
+        var result = parseResult.CommandResult.GetValueOrDefault(option);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetValueOrDefault_WithExplicitBoolValue_ReturnsValue()
+    {
+        // Arrange
+        var option = new Option<bool?>("--zone-redundant");
+        var command = new Command("test") { option };
+        var parseResult = command.Parse("--zone-redundant true");
+
+        // Act
+        var result = parseResult.CommandResult.GetValueOrDefault(option);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void GetValueOrDefault_WithMissingBoolValue_ReturnsNull()
+    {
+        // Arrange
+        var option = new Option<bool?>("--zone-redundant");
+        var command = new Command("test") { option };
+        var parseResult = command.Parse("");
+
+        // Act
+        var result = parseResult.CommandResult.GetValueOrDefault(option);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetValueOrDefault_WithExplicitZeroIntValue_ReturnsZero()
+    {
+        // Arrange
+        var option = new Option<int?>("--count");
+        var command = new Command("test") { option };
+        var parseResult = command.Parse("--count 0");
+
+        // Act
+        var result = parseResult.CommandResult.GetValueOrDefault(option);
+
+        // Assert
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void GetValueOrDefault_WithExplicitFalseBoolValue_ReturnsFalse()
+    {
+        // Arrange
+        var option = new Option<bool?>("--zone-redundant");
+        var command = new Command("test") { option };
+        var parseResult = command.Parse("--zone-redundant false");
+
+        // Act
+        var result = parseResult.CommandResult.GetValueOrDefault(option);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void GetValueOrDefault_WithBoolSwitch_ReturnsTrue()
+    {
+        // Arrange
+        var option = new Option<bool?>("--verbose");
+        var command = new Command("test") { option };
+        var parseResult = command.Parse("--verbose");
+
+        // Act
+        var result = parseResult.CommandResult.GetValueOrDefault(option);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void GetValueOrDefault_WithMissingBoolSwitch_ReturnsNull()
+    {
+        // Arrange
+        var option = new Option<bool?>("--verbose");
+        var command = new Command("test") { option };
+        var parseResult = command.Parse("");
+
+        // Act
+        var result = parseResult.CommandResult.GetValueOrDefault(option);
+
+        // Assert
+        Assert.Null(result);
+    }
+}


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
