### PR TITLE
Use static artifact names and version suffix veriable

### DIFF
--- a/eng/pipelines/templates/common.yml
+++ b/eng/pipelines/templates/common.yml
@@ -13,19 +13,10 @@ parameters:
   default: false
 - name: ServerName
   type: string
-  default: none
+  default: ''
 - name: SkipDockerRelease
   type: string
   default: false
-- name: VsixTargets
-  type: object
-  default:
-    - linux-x64
-    - linux-arm64
-    - osx-x64
-    - osx-arm64
-    - win-x64
-    - win-arm64
 
 resources:
   repositories:
@@ -50,7 +41,6 @@ extends:
       jobs:
       - template: /eng/pipelines/templates/jobs/initialize.yml
         parameters:
-          DynamicPrereleaseVersion: ${{ not(parameters.ReleaseRun) }}
           ServerName: ${{ parameters.ServerName }}
 
     - stage: Build
@@ -63,8 +53,6 @@ extends:
       variables:
       - template: /eng/pipelines/templates/variables/image.yml
       - template: /eng/pipelines/templates/variables/globals.yml
-      - name: VersionSuffix
-        value: $[ stageDependencies.Initialize.Initialize.outputs['GetVersion.VersionSuffix'] ]
       jobs:
       - template: /eng/pipelines/templates/jobs/analyze.yml
       - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
@@ -73,8 +61,7 @@ extends:
           JobTemplatePath: /eng/pipelines/templates/jobs/build.yml
           AdditionalParameters:
             TestTimeoutInMinutes: 10
-            ${{ if ne(parameters.ServerName, 'none') }}:
-              ServerName: ${{ parameters.ServerName }}
+            ServerName: ${{ parameters.ServerName }}
           MatrixConfigs:
             - Name: build_matrix
               Path: eng/pipelines/build-matrix.json
@@ -100,7 +87,6 @@ extends:
       - stage: SignAndPack
         displayName: 'Sign and Pack'
         dependsOn:
-        - Initialize
         - Build
         pool:
           name: $(LINUXPOOL)
@@ -109,8 +95,6 @@ extends:
         variables:
         - template: /eng/pipelines/templates/variables/image.yml
         - template: /eng/pipelines/templates/variables/globals.yml
-        - name: VersionSuffix
-          value: $[ stageDependencies.Initialize.Initialize.outputs['GetVersion.VersionSuffix'] ]
         jobs:
         - template: /eng/pipelines/templates/jobs/sign-and-pack.yml
           parameters:
@@ -119,7 +103,6 @@ extends:
       - ${{ if eq(parameters.ReleaseRun, 'true') }}:
         - stage: Release
           dependsOn:
-          - Initialize
           - SignAndPack
           pool:
             name: $(LINUXPOOL)
@@ -131,7 +114,6 @@ extends:
           jobs:
           - template: /eng/pipelines/templates/jobs/release.yml
             parameters:
-              VsixTargets: ${{ parameters.VsixTargets }}
               ServerName: ${{ parameters.ServerName }}
               IncludeNative: false
               SkipDockerRelease: ${{ parameters.SkipDockerRelease }}
@@ -139,7 +121,6 @@ extends:
       - ${{ else }}:
         - stage: Integration
           dependsOn:
-          - Initialize
           - SignAndPack
           pool:
             name: $(LINUXPOOL)
@@ -148,8 +129,6 @@ extends:
           variables:
           - template: /eng/pipelines/templates/variables/image.yml
           - template: /eng/pipelines/templates/variables/globals.yml
-          - name: VersionSuffix
-            value: $[ stageDependencies.Initialize.Initialize.outputs['GetVersion.VersionSuffix'] ]
           jobs:
           - template: /eng/pipelines/templates/jobs/integration.yml
             parameters:

--- a/eng/pipelines/templates/common.yml
+++ b/eng/pipelines/templates/common.yml
@@ -41,6 +41,7 @@ extends:
       jobs:
       - template: /eng/pipelines/templates/jobs/initialize.yml
         parameters:
+          DynamicPrereleaseVersion: ${{ not(parameters.ReleaseRun) }}
           ServerName: ${{ parameters.ServerName }}
 
     - stage: Build

--- a/eng/pipelines/templates/common.yml
+++ b/eng/pipelines/templates/common.yml
@@ -53,6 +53,8 @@ extends:
       variables:
       - template: /eng/pipelines/templates/variables/image.yml
       - template: /eng/pipelines/templates/variables/globals.yml
+      - name: VersionSuffix
+        value: $[ stageDependencies.Initialize.Initialize.outputs['GetVersion.VersionSuffix'] ]
       jobs:
       - template: /eng/pipelines/templates/jobs/analyze.yml
       - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
@@ -87,6 +89,7 @@ extends:
       - stage: SignAndPack
         displayName: 'Sign and Pack'
         dependsOn:
+        - Initialize
         - Build
         pool:
           name: $(LINUXPOOL)
@@ -95,6 +98,8 @@ extends:
         variables:
         - template: /eng/pipelines/templates/variables/image.yml
         - template: /eng/pipelines/templates/variables/globals.yml
+        - name: VersionSuffix
+          value: $[ stageDependencies.Initialize.Initialize.outputs['GetVersion.VersionSuffix'] ]
         jobs:
         - template: /eng/pipelines/templates/jobs/sign-and-pack.yml
           parameters:
@@ -103,6 +108,7 @@ extends:
       - ${{ if eq(parameters.ReleaseRun, 'true') }}:
         - stage: Release
           dependsOn:
+          - Initialize
           - SignAndPack
           pool:
             name: $(LINUXPOOL)
@@ -111,6 +117,8 @@ extends:
           variables:
           - template: /eng/pipelines/templates/variables/image.yml
           - template: /eng/pipelines/templates/variables/globals.yml
+          - name: VersionSuffix
+            value: $[ stageDependencies.Initialize.Initialize.outputs['GetVersion.VersionSuffix'] ]
           jobs:
           - template: /eng/pipelines/templates/jobs/release.yml
             parameters:
@@ -121,6 +129,7 @@ extends:
       - ${{ else }}:
         - stage: Integration
           dependsOn:
+          - Initialize
           - SignAndPack
           pool:
             name: $(LINUXPOOL)
@@ -129,6 +138,8 @@ extends:
           variables:
           - template: /eng/pipelines/templates/variables/image.yml
           - template: /eng/pipelines/templates/variables/globals.yml
+          - name: VersionSuffix
+            value: $[ stageDependencies.Initialize.Initialize.outputs['GetVersion.VersionSuffix'] ]
           jobs:
           - template: /eng/pipelines/templates/jobs/integration.yml
             parameters:

--- a/eng/pipelines/templates/jobs/build.yml
+++ b/eng/pipelines/templates/jobs/build.yml
@@ -14,7 +14,6 @@ parameters:
   type: number
 - name: ServerName
   type: string
-  default: ''
 
 jobs:
 - job: Build_${{ parameters.OSName }}
@@ -142,5 +141,5 @@ jobs:
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:
       ArtifactPath: $(Build.ArtifactStagingDirectory)
-      ArtifactName: $(PipelineArtifactName)_$(System.JobName)
+      ArtifactName: build_$(System.JobName)
       SbomEnabled: ${{ ne(variables['Build.Reason'], 'PullRequest') }}

--- a/eng/pipelines/templates/jobs/docker/release-docker.yml
+++ b/eng/pipelines/templates/jobs/docker/release-docker.yml
@@ -48,7 +48,7 @@ jobs:
   - task: 1ES.PublishPipelineArtifact@1
     inputs:
       path: $(Build.ArtifactStagingDirectory)
-      artifact: docker_drops
+      artifact: docker_staged
 
 - job: PublishACR
   displayName: "Publish to ACR"
@@ -61,8 +61,8 @@ jobs:
   templateContext:
     inputs:
     - input: pipelineArtifact
-      artifactName: docker_drops
-      targetPath: $(Pipeline.Workspace)/docker_drops
+      artifactName: docker_staged
+      targetPath: $(Pipeline.Workspace)/docker_staged
 
     outputs:
     - output: containerImage
@@ -91,7 +91,7 @@ jobs:
   - task: 1ES.BuildContainerImage@1
     displayName: Build Docker Image
     inputs:
-      path: '$(Pipeline.Workspace)/docker_drops'
+      path: '$(Pipeline.Workspace)/docker_staged'
       image: image:tag
       buildArguments: |
         --build-arg PUBLISH_DIR="Azure.Mcp.Server/linux-x64/dist"

--- a/eng/pipelines/templates/jobs/docker/release-docker.yml
+++ b/eng/pipelines/templates/jobs/docker/release-docker.yml
@@ -22,7 +22,7 @@ jobs:
     displayName: 'Download signed packages'
     inputs:
       buildType: 'current'
-      artifactName: $(PipelineArtifactName)_signed
+      artifactName: binaries_signed
       targetPath: $(Build.ArtifactStagingDirectory)
 
   - task: CopyFiles@2

--- a/eng/pipelines/templates/jobs/initialize.yml
+++ b/eng/pipelines/templates/jobs/initialize.yml
@@ -1,6 +1,4 @@
 parameters:
-- name: DynamicPrereleaseVersion
-  type: boolean
 - name: ServerName
   type: string
 
@@ -27,26 +25,7 @@ jobs:
       ./eng/scripts/Get-ToolsToTest.ps1
       -SetDevOpsVariables
       -TestType 'Live'
-      -ServerName '${{ iif(eq(parameters.ServerName, 'none'), '', parameters.ServerName) }}'
+      -ServerName '${{ parameters.ServerName }}'
     name: GetTestPathsLive
     displayName: "Get paths to test (Live)"
     workingDirectory: $(Build.SourcesDirectory)
-
-  - pwsh: |
-      $buildId = $env:BUILD_BUILDID
-      $buildReason = $env:BUILD_REASON
-      $sourceBranch = $env:BUILD_SOURCEBRANCH
-      $setDevVersion = $env:SETDEVVERSION -eq 'true'
-      $dynamicPrereleaseVersion = $env:DYNAMIC -eq 'true'
-
-      $shouldSetSuffix = $setDevVersion -or $dynamicPrereleaseVersion
-
-      $label = $buildReason -eq 'IndividualCI' -and $sourceBranch -eq 'refs/heads/main' ? 'beta' : 'alpha'
-      $suffix = $shouldSetSuffix ? "-$label.$buildId" : ''
-
-      Write-Host "Setting version suffix to '$suffix'"
-      Write-Host "##vso[task.setvariable variable=VersionSuffix;isOutput=true]$suffix"
-    name: GetVersion
-    displayName: "Get version suffix"
-    env:
-      DYNAMIC: ${{ parameters.DynamicPrereleaseVersion }}

--- a/eng/pipelines/templates/jobs/initialize.yml
+++ b/eng/pipelines/templates/jobs/initialize.yml
@@ -38,9 +38,12 @@ jobs:
       $sourceBranch = $env:BUILD_SOURCEBRANCH
       $setDevVersion = $env:SETDEVVERSION -eq 'true'
       $dynamicPrereleaseVersion = $env:DYNAMIC -eq 'true'
+
       $shouldSetSuffix = $setDevVersion -or $dynamicPrereleaseVersion
+
       $label = $buildReason -eq 'IndividualCI' -and $sourceBranch -eq 'refs/heads/main' ? 'beta' : 'alpha'
       $suffix = $shouldSetSuffix ? "-$label.$buildId" : ''
+
       Write-Host "Setting version suffix to '$suffix'"
       Write-Host "##vso[task.setvariable variable=VersionSuffix;isOutput=true]$suffix"
     name: GetVersion

--- a/eng/pipelines/templates/jobs/initialize.yml
+++ b/eng/pipelines/templates/jobs/initialize.yml
@@ -1,4 +1,6 @@
 parameters:
+- name: DynamicPrereleaseVersion
+  type: boolean
 - name: ServerName
   type: string
 
@@ -29,3 +31,19 @@ jobs:
     name: GetTestPathsLive
     displayName: "Get paths to test (Live)"
     workingDirectory: $(Build.SourcesDirectory)
+
+  - pwsh: |
+      $buildId = $env:BUILD_BUILDID
+      $buildReason = $env:BUILD_REASON
+      $sourceBranch = $env:BUILD_SOURCEBRANCH
+      $setDevVersion = $env:SETDEVVERSION -eq 'true'
+      $dynamicPrereleaseVersion = $env:DYNAMIC -eq 'true'
+      $shouldSetSuffix = $setDevVersion -or $dynamicPrereleaseVersion
+      $label = $buildReason -eq 'IndividualCI' -and $sourceBranch -eq 'refs/heads/main' ? 'beta' : 'alpha'
+      $suffix = $shouldSetSuffix ? "-$label.$buildId" : ''
+      Write-Host "Setting version suffix to '$suffix'"
+      Write-Host "##vso[task.setvariable variable=VersionSuffix;isOutput=true]$suffix"
+    name: GetVersion
+    displayName: "Get version suffix"
+    env:
+      DYNAMIC: ${{ parameters.DynamicPrereleaseVersion }}

--- a/eng/pipelines/templates/jobs/integration.yml
+++ b/eng/pipelines/templates/jobs/integration.yml
@@ -13,12 +13,12 @@ jobs:
   - checkout: self
 
   - download: current
-    displayName: Download npm_$(PipelineArtifactName)_packed
-    artifact: npm_$(PipelineArtifactName)_packed
+    displayName: Download packages_npm
+    artifact: packages_npm
 
   - template: /eng/pipelines/templates/steps/publish-to-dev-feed.yml
     parameters:
-      PathToArtifacts: $(Pipeline.Workspace)/npm_$(PipelineArtifactName)_packed
+      PathToArtifacts: $(Pipeline.Workspace)/packages_npm
       Registry: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/
       ${{ if and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'IndividualCI')) }}:
         Tag: dev
@@ -32,21 +32,21 @@ jobs:
   - checkout: self
 
   - download: current
-    displayName: Download nuget_$(PipelineArtifactName)_packed
-    artifact: nuget_$(PipelineArtifactName)_packed
+    displayName: Download packages_nuget_signed
+    artifact: packages_nuget_signed
 
   - task: 1ES.PublishNuget@1
     displayName: Publish platform-specific Nugets
     inputs:
       packageParentPath: '$(Pipeline.Workspace)'
-      packagesToPush: '$(Pipeline.Workspace)/nuget_$(PipelineArtifactName)_packed/${{ parameters.ServerName }}/platform/*.nupkg;!$(Pipeline.Workspace)/nuget_$(PipelineArtifactName)_packed/${{ parameters.ServerName }}/platform/*.symbols.nupkg'
+      packagesToPush: '$(Pipeline.Workspace)/packages_nuget_signed/${{ parameters.ServerName }}/platform/*.nupkg;!$(Pipeline.Workspace)/packages_nuget_signed/${{ parameters.ServerName }}/platform/*.symbols.nupkg'
       publishVstsFeed: ${{ parameters.NugetDevFeed }}
 
   - task: 1ES.PublishNuget@1
     displayName: Publish wrapper Nuget
     inputs:
       packageParentPath: '$(Pipeline.Workspace)'
-      packagesToPush: '$(Pipeline.Workspace)/nuget_$(PipelineArtifactName)_packed/${{ parameters.ServerName }}/wrapper/*.nupkg;!$(Pipeline.Workspace)/nuget_$(PipelineArtifactName)_packed/${{ parameters.ServerName }}/wrapper/*.symbols.nupkg'
+      packagesToPush: '$(Pipeline.Workspace)/packages_nuget_signed/${{ parameters.ServerName }}/wrapper/*.nupkg;!$(Pipeline.Workspace)/packages_nuget_signed/${{ parameters.ServerName }}/wrapper/*.symbols.nupkg'
       publishVstsFeed: ${{ parameters.NugetDevFeed }}
 
 # - job: PublishDocsToNightly

--- a/eng/pipelines/templates/jobs/npm/pack-npm.yml
+++ b/eng/pipelines/templates/jobs/npm/pack-npm.yml
@@ -11,8 +11,8 @@ jobs:
   - checkout: self
 
   - download: current
-    displayName: Download $(PipelineArtifactName)_signed
-    artifact: $(PipelineArtifactName)_signed
+    displayName: Download binaries_signed
+    artifact: binaries_signed
 
   - task: Powershell@2
     displayName: "Pack modules for Npm"
@@ -20,11 +20,11 @@ jobs:
       pwsh: true
       filePath: $(Build.SourcesDirectory)/eng/scripts/Pack-Npm.ps1
       arguments: >
-        -ArtifactsPath '$(Pipeline.Workspace)/$(PipelineArtifactName)_signed'
+        -ArtifactsPath '$(Pipeline.Workspace)/binaries_signed'
         -OutputPath '$(Build.ArtifactStagingDirectory)/packed'
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:
       ArtifactPath: $(Build.ArtifactStagingDirectory)/packed/npm
-      ArtifactName: npm_$(PipelineArtifactName)_packed
+      ArtifactName: packages_npm
       SbomEnabled: ${{ ne(variables['Build.Reason'], 'PullRequest') }}

--- a/eng/pipelines/templates/jobs/npm/release-npm.yml
+++ b/eng/pipelines/templates/jobs/npm/release-npm.yml
@@ -16,7 +16,7 @@ jobs:
     isProduction: true
     inputs:
     - input: pipelineArtifact
-      artifactName: npm_$(PipelineArtifactName)_packed
+      artifactName: packages_npm
       targetPath: $(Pipeline.Workspace)/drop
   environment: package-publish
   timeoutInMinutes: 120

--- a/eng/pipelines/templates/jobs/nuget/pack-and-sign-nuget.yml
+++ b/eng/pipelines/templates/jobs/nuget/pack-and-sign-nuget.yml
@@ -11,8 +11,8 @@ jobs:
   - checkout: self
 
   - download: current
-    displayName: Download $(PipelineArtifactName)_signed
-    artifact: $(PipelineArtifactName)_signed
+    displayName: Download binaries_signed
+    artifact: binaries_signed
 
   - script: |
       brew update
@@ -29,7 +29,7 @@ jobs:
       pwsh: true
       filePath: $(Build.SourcesDirectory)/eng/scripts/Pack-Nuget.ps1
       arguments: >
-        -ArtifactsPath '$(Pipeline.Workspace)/$(PipelineArtifactName)_signed'
+        -ArtifactsPath '$(Pipeline.Workspace)/binaries_signed'
         -OutputPath '$(Build.ArtifactStagingDirectory)/packed'
         -VersionSuffix '$(VersionSuffix)'
         -RepoUrl '$(Build.Repository.Uri)'
@@ -70,5 +70,5 @@ jobs:
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:
       ArtifactPath: $(Build.ArtifactStagingDirectory)/packed/nuget
-      ArtifactName: nuget_$(PipelineArtifactName)_packed
+      ArtifactName: packages_nuget_signed
       SbomEnabled: ${{ ne(variables['Build.Reason'], 'PullRequest') }}

--- a/eng/pipelines/templates/jobs/nuget/release-nuget.yml
+++ b/eng/pipelines/templates/jobs/nuget/release-nuget.yml
@@ -17,7 +17,7 @@ jobs:
     isProduction: true
     inputs:
     - input: pipelineArtifact
-      artifactName: 'nuget_$(PipelineArtifactName)_packed'
+      artifactName: 'packages_nuget_signed'
       targetPath: $(Pipeline.Workspace)/drop
   environment: package-publish
   timeoutInMinutes: 120

--- a/eng/pipelines/templates/jobs/release.yml
+++ b/eng/pipelines/templates/jobs/release.yml
@@ -1,6 +1,4 @@
 parameters:
-- name: VsixTargets
-  type: object
 - name: ServerName
   type: string
 - name: IncludeNative
@@ -16,8 +14,8 @@ jobs:
   - checkout: self
 
   - download: current
-    displayName: Download npm_$(PipelineArtifactName)_packed
-    artifact: npm_$(PipelineArtifactName)_packed
+    displayName: Download packages_npm
+    artifact: packages_npm
 
   - template: /eng/common/pipelines/templates/steps/retain-run.yml
 
@@ -28,7 +26,7 @@ jobs:
       $tag = "$serverName-$version$versionSuffix"
 
       gh release create $tag --title "$serverName $version$versionSuffix"
-      gh release upload $tag $(Pipeline.Workspace)/npm_$(PipelineArtifactName)_packed/*/*/*.tgz
+      gh release upload $tag $(Pipeline.Workspace)/packages_npm/*/*/*.tgz
     displayName: Create GitHub Release and upload artifacts
     env:
       GH_TOKEN: $(azuresdk-github-pat)
@@ -47,9 +45,7 @@ jobs:
 - template: /eng/pipelines/templates/jobs/vsix/release-vsix.yml
   parameters:
     ServerName: ${{ parameters.ServerName }}
-    VsixTargets: ${{ parameters.VsixTargets }}
     DependsOn: TagRepository
-
 
 - ${{ if ne(parameters.SkipDockerRelease, 'true') }}:
   - template: /eng/pipelines/templates/jobs/docker/release-docker.yml

--- a/eng/pipelines/templates/jobs/sign-and-pack.yml
+++ b/eng/pipelines/templates/jobs/sign-and-pack.yml
@@ -25,7 +25,7 @@ jobs:
       filePath: $(Build.SourcesDirectory)/eng/scripts/Compress-ForSigning.ps1
       arguments: >
         -ArtifactsPath '$(Pipeline.Workspace)'
-        -ArtifactPrefix '$(PipelineArtifactName)_'
+        -ArtifactPrefix 'build_'
         -OutputPath '$(Build.ArtifactStagingDirectory)/signed'
 
   - template: pipelines/steps/binary-signing.yml@azure-sdk-build-tools
@@ -67,7 +67,7 @@ jobs:
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:
       ArtifactPath: $(Build.ArtifactStagingDirectory)/signed
-      ArtifactName: $(PipelineArtifactName)_signed
+      ArtifactName: binaries_signed
       SbomEnabled: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
 
 - job: Verify_Signing
@@ -84,13 +84,13 @@ jobs:
   - checkout: none
 
   - download: current
-    artifact: $(PipelineArtifactName)_signed
+    artifact: binaries_signed
     displayName: "Download signed MCP server binaries"
 
   - pwsh: |
       Write-Host "Verifying binary signing for win-x64 and win-arm64 binaries..."
       $allSigned = $true
-      $signedBinaries = Get-ChildItem -Path '$(Pipeline.Workspace)/$(PipelineArtifactName)_signed/**/win-*' -Recurse -Include @("*.dll", "*.exe")
+      $signedBinaries = Get-ChildItem -Path '$(Pipeline.Workspace)/binaries_signed/**/win-*' -Recurse -Include @("*.dll", "*.exe")
       foreach ($binary in $signedBinaries) {
           if ((Get-AuthenticodeSignature -FilePath $binary.FullName).Status -ne 'Valid') {
               Write-Host "Binary $($binary.FullName) is NOT signed correctly."

--- a/eng/pipelines/templates/jobs/vsix/pack-and-sign-vsix.yml
+++ b/eng/pipelines/templates/jobs/vsix/pack-and-sign-vsix.yml
@@ -55,12 +55,12 @@ jobs:
   steps:
   - checkout: none
   - download: current
-    artifact: vsix_binaries_signed
+    artifact: packages_vsix_signed
     displayName: "Download signed MCP server VSIX files"
   - pwsh: |
       Write-Host "Verifying VSIX signing by parsing CodeSignSummary markdown files..."
 
-      $root = "$(Pipeline.Workspace)/vsix_binaries_signed"
+      $root = "$(Pipeline.Workspace)/packages_vsix_signed"
       $summaries = Get-ChildItem -Path $root -Recurse -Filter 'CodeSignSummary-*.md'
 
       if (-not $summaries) {

--- a/eng/pipelines/templates/jobs/vsix/pack-and-sign-vsix.yml
+++ b/eng/pipelines/templates/jobs/vsix/pack-and-sign-vsix.yml
@@ -15,7 +15,7 @@ jobs:
 
   # Download the signed MCP server binaries for this OS
   - download: current
-    artifact: $(PipelineArtifactName)_signed
+    artifact: binaries_signed
     displayName: "Download signed MCP server binaries"
 
   - task: NodeTool@0
@@ -28,7 +28,7 @@ jobs:
   - pwsh: >
       eng/scripts/Pack-Vsix.ps1
       -ServerName '${{ parameters.ServerName }}'
-      -ArtifactsPath '$(Pipeline.Workspace)/$(PipelineArtifactName)_signed'
+      -ArtifactsPath '$(Pipeline.Workspace)/binaries_signed'
       -OutputPath '$(Build.ArtifactStagingDirectory)'
     displayName: "Copy signed MCP server binaries to VSIX"
 
@@ -40,7 +40,7 @@ jobs:
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:
       ArtifactPath: $(Build.ArtifactStagingDirectory)
-      ArtifactName: vsix_packages_signed
+      ArtifactName: packages_vsix_signed
 
 - job: VerifyVSIXSigning
   displayName: "Verify VSIX Signing"
@@ -55,12 +55,12 @@ jobs:
   steps:
   - checkout: none
   - download: current
-    artifact: vsix_$(PipelineArtifactName)_signed
+    artifact: vsix_binaries_signed
     displayName: "Download signed MCP server VSIX files"
   - pwsh: |
       Write-Host "Verifying VSIX signing by parsing CodeSignSummary markdown files..."
 
-      $root = "$(Pipeline.Workspace)/vsix_$(PipelineArtifactName)_signed"
+      $root = "$(Pipeline.Workspace)/vsix_binaries_signed"
       $summaries = Get-ChildItem -Path $root -Recurse -Filter 'CodeSignSummary-*.md'
 
       if (-not $summaries) {

--- a/eng/pipelines/templates/jobs/vsix/release-vsix.yml
+++ b/eng/pipelines/templates/jobs/vsix/release-vsix.yml
@@ -1,10 +1,18 @@
 parameters:
 - name: ServerName
   type: string
-- name: VsixTargets
-  type: object
 - name: DependsOn
   type: object
+- name: VsixTargets
+  type: object
+  default:
+    - linux-x64
+    - linux-arm64
+    - osx-x64
+    - osx-arm64
+    - win-x64
+    - win-arm64
+
 
 jobs:
 # Deployment Jobs: Publish VSIX artifacts to Marketplace for each vsix target
@@ -18,7 +26,7 @@ jobs:
       isProduction: true
       inputs:
       - input: pipelineArtifact
-        artifactName: vsix_packages_signed
+        artifactName: packages_vsix_signed
         targetPath: $(Pipeline.Workspace)/drop
     environment: package-publish
     pool:

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,6 +1,15 @@
 variables:
   OfficialBuildId: $(Build.BuildNumber)
   skipComponentGovernanceDetection: true
-  PipelineArtifactName: packages
   nugetMultiFeedWarnLevel: 'none'
   GDN_SUPPRESS_FORKED_BUILD_WARNING: true
+
+  # Manual builds of main or hotfix/* are "release builds" and get no dynamic version suffix.
+  ${{ if and(or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/')), eq(variables['Build.Reason'], 'Manual')) }}:
+    VersionSuffix: ''
+  # CI builds of main are "beta"
+  ${{ elseif and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+    VersionSuffix: '-beta.$(Build.BuildId)'
+  # Everything else is an "alpha".
+  ${{ else }}:
+    VersionSuffix: '-alpha.$(Build.BuildId)'

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -3,13 +3,3 @@ variables:
   skipComponentGovernanceDetection: true
   nugetMultiFeedWarnLevel: 'none'
   GDN_SUPPRESS_FORKED_BUILD_WARNING: true
-
-  # Manual builds of main or hotfix/* are "release builds" and get no dynamic version suffix.
-  ${{ if and(or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/')), eq(variables['Build.Reason'], 'Manual')) }}:
-    VersionSuffix: ''
-  # CI builds of main are "beta"
-  ${{ elseif and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-    VersionSuffix: '-beta.$(Build.BuildId)'
-  # Everything else is an "alpha".
-  ${{ else }}:
-    VersionSuffix: '-alpha.$(Build.BuildId)'


### PR DESCRIPTION
## What does this PR do?
Removes the complexity of using an output variable for the version suffix by creating a global variable.
Replaces $(PipelineArtifactName) based artifact names with consistent static names:
- build_{platform}
- binaries_signed
- packages_npm
- packages_vsix_signed
- packages_nuget_signed
- docker_staged

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
