### PR TITLE
update secret hint of cert create tool

### DIFF
--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateCreateCommand.cs
@@ -28,7 +28,7 @@ public sealed class CertificateCreateCommand(ILogger<CertificateCreateCommand> l
         OpenWorld = true,
         ReadOnly = false,
         LocalRequired = false,
-        Secret = true
+        Secret = false
     };
 
     public override string Description =>

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.LiveTests/KeyVaultCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.LiveTests/KeyVaultCommandTests.cs
@@ -154,6 +154,28 @@ public class KeyVaultCommandTests(ITestOutputHelper output) : CommandTestsBase(o
     }
 
     [Fact]
+    public async Task Should_create_certificate()
+    {
+        var certificateName = Settings.ResourceBaseName + Random.Shared.NextInt64();
+        var result = await CallToolAsync(
+            "azmcp_keyvault_certificate_create",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "vault", Settings.ResourceBaseName },
+                { "certificate", certificateName}
+            });
+
+        var createdCertificateName = result.AssertProperty("name");
+        Assert.Equal(JsonValueKind.String, createdCertificateName.ValueKind);
+        Assert.Equal(certificateName, createdCertificateName.GetString());
+
+        // Verify that the certificate has some expected properties
+        ValidateCertificate(result);
+    }
+
+
+    [Fact]
     public async Task Should_import_certificate()
     {
         // Generate a self-signed certificate and export to a temporary PFX file with a password


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

cert create does not return sensitive information. update secret hint of cert create tool

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
