### PR TITLE
Replaced bicep tool dependency on Azure.Bicep.Types.Az package with Microsoft.Azure.Mcp.AzTypes.Internal.Compact package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,6 @@
     <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.2.0" />
     <PackageVersion Include="Azure.AI.Projects" Version="1.0.0-beta.9" />
     <PackageVersion Include="Azure.Bicep.Types" Version="0.6.1" />
-    <PackageVersion Include="Azure.Bicep.Types.Az" Version="0.2.792" />
     <PackageVersion Include="Azure.Core" Version="1.48.0" />
     <PackageVersion Include="Azure.Data.AppConfiguration" Version="1.6.1" />
     <PackageVersion Include="Azure.Identity" Version="1.16.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,6 +68,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
     <PackageVersion Include="Microsoft.HybridRow" Version="1.1.0-preview3" />
     <PackageVersion Include="Microsoft.Azure.Cosmos.Aot" Version="0.1.2-preview.2" />
+    <PackageVersion Include="Microsoft.Azure.Mcp.AzTypes.Internal.Compact" Version="0.2.802" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
     <PackageVersion Include="MySqlConnector" Version="2.4.0" />

--- a/tools/Azure.Mcp.Tools.BicepSchema/src/Azure.Mcp.Tools.BicepSchema.csproj
+++ b/tools/Azure.Mcp.Tools.BicepSchema/src/Azure.Mcp.Tools.BicepSchema.csproj
@@ -17,4 +17,9 @@
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Azure.Mcp.AzTypes.Internal.Compact">
+      <HintPath>C:\Users\masalama\bicep-types-az-compact\src\Bicep.Types.Az\bin\Debug\netstandard2.0\Microsoft.Azure.Mcp.AzTypes.Internal.Compact.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/tools/Azure.Mcp.Tools.BicepSchema/src/Azure.Mcp.Tools.BicepSchema.csproj
+++ b/tools/Azure.Mcp.Tools.BicepSchema/src/Azure.Mcp.Tools.BicepSchema.csproj
@@ -12,7 +12,6 @@
   <ItemGroup />
   <ItemGroup>
     <PackageReference Include="Azure.Bicep.Types" />
-    <PackageReference Include="Azure.Bicep.Types.Az" />
     <PackageReference Include="Microsoft.Azure.Mcp.AzTypes.Internal.Compact" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="ModelContextProtocol" />

--- a/tools/Azure.Mcp.Tools.BicepSchema/src/Azure.Mcp.Tools.BicepSchema.csproj
+++ b/tools/Azure.Mcp.Tools.BicepSchema/src/Azure.Mcp.Tools.BicepSchema.csproj
@@ -13,13 +13,9 @@
   <ItemGroup>
     <PackageReference Include="Azure.Bicep.Types" />
     <PackageReference Include="Azure.Bicep.Types.Az" />
+    <PackageReference Include="Microsoft.Azure.Mcp.AzTypes.Internal.Compact" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="System.CommandLine" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.Azure.Mcp.AzTypes.Internal.Compact">
-      <HintPath>C:\Users\masalama\bicep-types-az-compact\src\Bicep.Types.Az\bin\Debug\netstandard2.0\Microsoft.Azure.Mcp.AzTypes.Internal.Compact.dll</HintPath>
-    </Reference>
   </ItemGroup>
 </Project>

--- a/tools/Azure.Mcp.Tools.BicepSchema/src/Services/SchemaGenerator.cs
+++ b/tools/Azure.Mcp.Tools.BicepSchema/src/Services/SchemaGenerator.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 using Azure.Bicep.Types;
-using Azure.Bicep.Types.Az;
 using Azure.Mcp.Tools.BicepSchema.Services.ResourceProperties;
 using Azure.Mcp.Tools.BicepSchema.Services.ResourceProperties.Entities;
 using Azure.Mcp.Tools.BicepSchema.Services.Support;
+using Microsoft.Azure.Mcp.AzTypes.Internal.Compact;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Azure.Mcp.Tools.BicepSchema.Services;

--- a/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.UnitTests/GetSchemaTests.cs
+++ b/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.UnitTests/GetSchemaTests.cs
@@ -288,7 +288,7 @@ public class GetSchemaTests
                 "name": "Microsoft.ApiManagement/service/diagnostics/loggers"
               },
               "writableScopes": "ResourceGroup",
-              "readableScopes": "ResourceGroup",
+              "readableScopes": "None",
               "name": "Microsoft.ApiManagement/service/diagnostics/loggers@2018-01-01"
             }
           ]


### PR DESCRIPTION
## What does this PR do?
Replaced bicep tool dependency on Azure.Bicep.Types.Az package with Microsoft.Azure.Mcp.AzTypes.Internal.Compact package.
Microsoft.Azure.Mcp.AzTypes.Internal.Compact is identical to Azure.Bicep.Types.Az except that it provides bicep schemas for a smaller number of resource types. This was done to reduce overall size of mcp server
 
## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
