### PR TITLE
Support character-limit in list_sub tool

### DIFF
--- a/core/Azure.Mcp.Core/src/Areas/Subscription/Options/SubscriptionListOptions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Subscription/Options/SubscriptionListOptions.cs
@@ -1,8 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Core.Options;
+using System.Text.Json.Serialization;
 
 namespace Azure.Mcp.Core.Areas.Subscription.Options;
 
-public class SubscriptionListOptions : GlobalOptions;
+public class SubscriptionListOptions : GlobalOptions
+{
+    /// <summary>
+    /// The maximum number of characters to return in the response. Defaults to 10000.
+    /// </summary>
+    [JsonPropertyName(OptionDefinitions.Common.CharacterLimitName)]
+    public int CharacterLimit { get; set; } = 10000;
+}

--- a/core/Azure.Mcp.Core/src/Models/Option/OptionDefinitions.cs
+++ b/core/Azure.Mcp.Core/src/Models/Option/OptionDefinitions.cs
@@ -46,6 +46,17 @@ public static partial class OptionDefinitions
             Description = "The name of the Azure resource group. This is a logical container for Azure resources.",
             Required = false
         };
+
+        public const string CharacterLimitName = "character-limit";
+
+        public static readonly Option<int> CharacterLimit = new(
+            $"--{CharacterLimitName}"
+        )
+        {
+            Description = "The maximum number of characters to return in the response. If the response exceeds this limit, it will be truncated with a status message.",
+            Required = false,
+            DefaultValueFactory = _ => 10000
+        };
     }
 
     public static class RetryPolicy

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -7,6 +7,7 @@ The Azure MCP Server updates automatically by default whenever a new release com
 ### Features Added
 
 - Enhanced AKS nodepool information with comprehensive properties. [[#454](https://github.com/microsoft/mcp/issues/454)]
+- Added `--character-limit` parameter to `azmcp_subscription_list` command to control response size. This parameter allows users to limit the number of characters returned in the response, with automatic truncation and informative status messages when the limit is exceeded. Default limit is 10,000 characters.
 
 ### Breaking Changes
 


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

Support character-limit in list_sub tool

#428

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
