### PR TITLE
Remove System.Text.Json package reference from project

### DIFF
--- a/tools/Fabric.Mcp.Tools.PublicApi/src/Fabric.Mcp.Tools.PublicApi.csproj
+++ b/tools/Fabric.Mcp.Tools.PublicApi/src/Fabric.Mcp.Tools.PublicApi.csproj
@@ -20,6 +20,5 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="System.CommandLine" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #107

This was left over from when we added Fabric.  VS wasn't building, so removing it.  It now builds and tests pass.