### PR TITLE
Add support for insecure-disable-elicitation

### DIFF
--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
@@ -46,6 +46,7 @@ public static class AzureMcpServiceCollectionExtensions
         {
             Namespace = serviceStartOptions.Namespace,
             ReadOnly = serviceStartOptions.ReadOnly ?? false,
+            InsecureDisableElicitation = serviceStartOptions.InsecureDisableElicitation,
         };
 
         if (serviceStartOptions.Mode == ModeTypes.NamespaceProxy)

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ServiceStartCommand.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ServiceStartCommand.cs
@@ -60,6 +60,7 @@ public sealed class ServiceStartCommand : BaseCommand
         command.Options.Add(ServiceOptionDefinitions.ReadOnly);
         command.Options.Add(ServiceOptionDefinitions.Debug);
         command.Options.Add(ServiceOptionDefinitions.EnableInsecureTransports);
+        command.Options.Add(ServiceOptionDefinitions.InsecureDisableElicitation);
     }
 
     /// <summary>
@@ -100,6 +101,7 @@ public sealed class ServiceStartCommand : BaseCommand
             ReadOnly = readOnly,
             Debug = debug,
             EnableInsecureTransports = enableInsecureTransports,
+            InsecureDisableElicitation = parseResult.GetValueOrDefault<bool>(ServiceOptionDefinitions.InsecureDisableElicitation.Name),
         };
 
         using var host = CreateHost(serverOptions);

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/ToolLoaderOptions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/ToolLoaderOptions.cs
@@ -9,4 +9,5 @@ namespace Azure.Mcp.Core.Areas.Server.Commands.ToolLoading;
 /// </summary>
 /// <param name="Namespace">The namespaces to filter commands by. If null or empty, all commands will be included.</param>
 /// <param name="ReadOnly">Whether the tool loader should operate in read-only mode. When true, only tools marked as read-only will be exposed.</param>
-public sealed record ToolLoaderOptions(string[]? Namespace = null, bool ReadOnly = false);
+/// <param name="InsecureDisableElicitation">Whether elicitation is disabled (insecure mode). When true, elicitation will always be treated as accepted.</param>
+public sealed record ToolLoaderOptions(string[]? Namespace = null, bool ReadOnly = false, bool InsecureDisableElicitation = false);

--- a/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceOptionDefinitions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceOptionDefinitions.cs
@@ -11,6 +11,7 @@ public static class ServiceOptionDefinitions
     public const string ReadOnlyName = "read-only";
     public const string DebugName = "debug";
     public const string EnableInsecureTransportsName = "enable-insecure-transports";
+    public const string InsecureDisableElicitationName = "insecure-disable-elicitation";
 
     public static readonly Option<string> Transport = new($"--{TransportName}")
     {
@@ -60,6 +61,15 @@ public static class ServiceOptionDefinitions
         Required = false,
         Hidden = true,
         Description = "Enable insecure transport",
+        DefaultValueFactory = _ => false
+    };
+
+    public static readonly Option<bool> InsecureDisableElicitation = new(
+        $"--{InsecureDisableElicitationName}")
+    {
+        Required = false,
+        Hidden = true,
+        Description = "Disable elicitation and always treat it as accepted (insecure)",
         DefaultValueFactory = _ => false
     };
 }

--- a/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceOptionDefinitions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceOptionDefinitions.cs
@@ -68,8 +68,7 @@ public static class ServiceOptionDefinitions
         $"--{InsecureDisableElicitationName}")
     {
         Required = false,
-        Hidden = true,
-        Description = "Disable elicitation and always treat it as accepted (insecure)",
+        Description = "Disable elicitation (user confirmation) before allowing high risk commands to run, such as returning Secrets (passwords) from KeyVault.",
         DefaultValueFactory = _ => false
     };
 }

--- a/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceStartOptions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceStartOptions.cs
@@ -52,8 +52,8 @@ public class ServiceStartOptions
     public bool EnableInsecureTransports { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets whether elicitation is disabled (insecure mode).
-    /// When true, elicitation will always be treated as accepted.
+    /// Gets or sets whether elicitation (user confirmation for high-risk operations like accessing secrets) is disabled (insecure mode).
+    /// When true, elicitation will always be treated as accepted without user confirmation.
     /// </summary>
     [JsonPropertyName("insecureDisableElicitation")]
     public bool InsecureDisableElicitation { get; set; } = false;

--- a/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceStartOptions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceStartOptions.cs
@@ -50,4 +50,11 @@ public class ServiceStartOptions
     /// </summary>
     [JsonPropertyName("enableInsecureTransports")]
     public bool EnableInsecureTransports { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets whether elicitation is disabled (insecure mode).
+    /// When true, elicitation will always be treated as accepted.
+    /// </summary>
+    [JsonPropertyName("insecureDisableElicitation")]
+    public bool InsecureDisableElicitation { get; set; } = false;
 }

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/ServiceStartCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/ServiceStartCommandTests.cs
@@ -45,6 +45,46 @@ public class ServiceStartCommandTests
         Assert.Equal(expectedTransport, actualTransport);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void InsecureDisableElicitationOption_ParsesCorrectly(bool expectedValue)
+    {
+        // Arrange
+        var parseResult = CreateParseResultWithInsecureDisableElicitation(expectedValue);
+
+        // Act
+        var actualValue = parseResult.GetValue(ServiceOptionDefinitions.InsecureDisableElicitation);
+
+        // Assert
+        Assert.Equal(expectedValue, actualValue);
+    }
+
+    [Fact]
+    public void InsecureDisableElicitationOption_DefaultsToFalse()
+    {
+        // Arrange
+        var parseResult = CreateParseResult(null);
+
+        // Act
+        var actualValue = parseResult.GetValue(ServiceOptionDefinitions.InsecureDisableElicitation);
+
+        // Assert
+        Assert.False(actualValue);
+    }
+
+    [Fact]
+    public void AllOptionsRegistered_IncludesInsecureDisableElicitation()
+    {
+        // Arrange & Act
+        var command = _command.GetCommand();
+
+        // Assert
+        var hasInsecureDisableElicitationOption = command.Options.Any(o =>
+            o.Name == ServiceOptionDefinitions.InsecureDisableElicitation.Name);
+        Assert.True(hasInsecureDisableElicitationOption, "InsecureDisableElicitation option should be registered");
+    }
+
     private static ParseResult CreateParseResult(string? serviceValue)
     {
         var root = new RootCommand
@@ -61,6 +101,28 @@ public class ServiceStartCommandTests
         // Add required transport default for test
         args.Add("--transport");
         args.Add("stdio");
+
+        return root.Parse([.. args]);
+    }
+
+    private static ParseResult CreateParseResultWithInsecureDisableElicitation(bool insecureDisableElicitation)
+    {
+        var root = new RootCommand
+        {
+            ServiceOptionDefinitions.Namespace,
+            ServiceOptionDefinitions.Transport,
+            ServiceOptionDefinitions.InsecureDisableElicitation
+        };
+        var args = new List<string>
+        {
+            "--transport",
+            "stdio"
+        };
+
+        if (insecureDisableElicitation)
+        {
+            args.Add("--insecure-disable-elicitation");
+        }
 
         return root.Parse([.. args]);
     }

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -117,6 +117,33 @@ azmcp server start \
 > - Multiple `--namespace` parameters can be used together to expose tools for multiple specific namespaces.
 > - The `--namespace` and `--mode` parameters can also be combined to provide a unique running mode based on the desired scenario.
 
+#### Server Start Command Options
+
+The `azmcp server start` command supports the following options:
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `--transport` | No | `stdio` | Transport mechanism to use (currently only `stdio` is supported) |
+| `--mode` | No | `namespace` | Server mode: `namespace` (default), `all`, or `single` |
+| `--namespace` | No | All namespaces | Specific Azure service namespaces to expose (can be repeated) |
+| `--read-only` | No | `false` | Only expose read-only operations |
+| `--debug` | No | `false` | Enable verbose debug logging to stderr |
+| `--insecure-disable-elicitation` | No | `false` | **⚠️ INSECURE**: Disable user consent prompts for sensitive operations |
+
+> **⚠️ Security Warning for `--insecure-disable-elicitation`:**
+>
+> This option bypasses security prompts that normally protect sensitive operations. When enabled:
+> - Tools that handle secrets, credentials, or sensitive data will execute without user confirmation
+> - This removes an important security layer designed to prevent unauthorized access to sensitive information
+> - Only use this option in trusted, automated environments where user interaction is not possible
+> - Never use this option in production environments or when handling untrusted input
+>
+> **Example usage (use with caution):**
+> ```bash
+> # For automated scenarios only - bypasses security prompts
+> azmcp server start --insecure-disable-elicitation
+> ```
+
 ### Azure AI Foundry Operations
 
 ```bash
@@ -533,8 +560,20 @@ azmcp keyvault key list --subscription <subscription> \
 
 #### Secrets
 
+Tools that handle sensitive data such as secrets, credentials, or keys require user consent before execution through a security mechanism called **elicitation**. When you run commands that access sensitive information, the MCP client will prompt you to confirm the operation before proceeding.
+
+> **🛡️ Elicitation Security Feature:**
+> 
+> Elicitation prompts appear when tools may expose sensitive information like:
+> - Key Vault secrets and keys
+> - Connection strings and passwords
+> - Certificate private keys
+> - Other confidential data
+>
+> These prompts protect against unauthorized access to sensitive information. You can bypass elicitation in automated scenarios using the `--insecure-disable-elicitation` server start option, but this should only be used in trusted environments.
+
 ```bash
-# Creates a secret in a key vault
+# Creates a secret in a key vault (will prompt for user consent)
 azmcp keyvault secret create --subscription <subscription> \
                              --vault <vault-name> \
                              --name <secret-name> \

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -132,7 +132,7 @@ The `azmcp server start` command supports the following options:
 
 > **⚠️ Security Warning for `--insecure-disable-elicitation`:**
 >
-> This option bypasses security prompts that normally protect sensitive operations. When enabled:
+> This option disables user confirmations (elicitations) before running tools that read sensitive data. When enabled:
 > - Tools that handle secrets, credentials, or sensitive data will execute without user confirmation
 > - This removes an important security layer designed to prevent unauthorized access to sensitive information
 > - Only use this option in trusted, automated environments where user interaction is not possible
@@ -562,7 +562,7 @@ azmcp keyvault key list --subscription <subscription> \
 
 Tools that handle sensitive data such as secrets, credentials, or keys require user consent before execution through a security mechanism called **elicitation**. When you run commands that access sensitive information, the MCP client will prompt you to confirm the operation before proceeding.
 
-> **🛡️ Elicitation Security Feature:**
+> **🛡️ Elicitation (user confirmation) Security Feature:**
 > 
 > Elicitation prompts appear when tools may expose sensitive information like:
 > - Key Vault secrets and keys


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

Add support for insecure-disable-elicitation

@[xiangyan99](https://github.com/microsoft/mcp/commits?author=xiangyan99)
xiangyan99 committed

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
