### PR TITLE
Add `azmcp sql db update` command and unit test

### DIFF
--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -975,6 +975,20 @@ azmcp sql db create --subscription <subscription> \
                     [--zone-redundant <true/false>] \
                     [--read-scale <Enabled|Disabled>]
 
+# Update an existing SQL database (applies only the provided configuration changes)
+azmcp sql db update --subscription <subscription> \
+                    --resource-group <resource-group> \
+                    --server <server-name> \
+                    --database <database-name> \
+                    [--sku-name <sku-name>] \
+                    [--sku-tier <sku-tier>] \
+                    [--sku-capacity <capacity>] \
+                    [--collation <collation>] \
+                    [--max-size-bytes <bytes>] \
+                    [--elastic-pool-name <elastic-pool-name>] \
+                    [--zone-redundant <true/false>] \
+                    [--read-scale <Enabled|Disabled>]
+
 # Delete a SQL database (idempotent – succeeds even if the database does not exist)
 azmcp sql db delete --subscription <subscription> \
                     --resource-group <resource-group> \

--- a/docs/e2eTestPrompts.md
+++ b/docs/e2eTestPrompts.md
@@ -372,6 +372,8 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | azmcp_sql_db_list | Show me all the databases configuration details in the Azure SQL server <server_name> |
 | azmcp_sql_db_show | Get the configuration details for the SQL database <database_name> on server <server_name> |
 | azmcp_sql_db_show | Show me the details of SQL database <database_name> in server <server_name> |
+| azmcp_sql_db_update | Update the performance tier of SQL database <database_name> on server <server_name> |
+| azmcp_sql_db_update | Scale SQL database <database_name> on server <server_name> to use <sku_name> SKU |
 
 ## Azure SQL Elastic Pool Operations
 

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -7,6 +7,7 @@ The Azure MCP Server updates automatically by default whenever a new release com
 ### Features Added
 
 - Enhanced AKS nodepool information with comprehensive properties. [[#454](https://github.com/microsoft/mcp/issues/454)]
+- Added support for updating Azure SQL databases via the command `azmcp_sql_db_update`.
 
 ### Breaking Changes
 

--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -123,6 +123,7 @@ The Azure MCP Server supercharges your agents with Azure context. Here are some 
 
 * "Show me details about my Azure SQL database 'mydb'"
 * "List all databases in my Azure SQL server 'myserver'"
+* "Update the performance tier of my Azure SQL database 'mydb'"
 * "List all firewall rules for my Azure SQL server 'myserver'"
 * "Create a firewall rule for my Azure SQL server 'myserver'"
 * "Delete a firewall rule from my Azure SQL server 'myserver'"
@@ -323,6 +324,7 @@ The Azure MCP Server supercharges your agents with Azure context. Here are some 
 * Show database details and properties
 * List the details and properties of all databases
 * Create a SQL database
+* Update a SQL database configuration
 * Delete a SQL database
 * List SQL server firewall rules
 * Create SQL server firewall rules

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseUpdateCommand.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Core.Extensions;
+using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Tools.Sql.Commands;
+using Azure.Mcp.Tools.Sql.Models;
+using Azure.Mcp.Tools.Sql.Options;
+using Azure.Mcp.Tools.Sql.Options.Database;
+using Azure.Mcp.Tools.Sql.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Mcp.Tools.Sql.Commands.Database;
+
+public sealed class DatabaseUpdateCommand(ILogger<DatabaseUpdateCommand> logger)
+    : BaseDatabaseCommand<DatabaseUpdateOptions>(logger)
+{
+    private const string CommandTitle = "Update SQL Database";
+
+    public override string Name => "update";
+
+    public override string Description =>
+        """
+        Update configuration settings for an existing Azure SQL Database. This command modifies an existing database's
+        compute tier, performance characteristics, redundancy, or other settings. Equivalent to 'az sql db update'.
+        Returns the updated database information including applied configuration changes.
+        """;
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new()
+    {
+        Destructive = false,
+        Idempotent = true,
+        OpenWorld = true,
+        ReadOnly = false,
+        LocalRequired = false,
+        Secret = false
+    };
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(SqlOptionDefinitions.SkuNameOption);
+        command.Options.Add(SqlOptionDefinitions.SkuTierOption);
+        command.Options.Add(SqlOptionDefinitions.SkuCapacityOption);
+        command.Options.Add(SqlOptionDefinitions.CollationOption);
+        command.Options.Add(SqlOptionDefinitions.MaxSizeBytesOption);
+        command.Options.Add(SqlOptionDefinitions.ElasticPoolNameOption);
+        command.Options.Add(SqlOptionDefinitions.ZoneRedundantOption);
+        command.Options.Add(SqlOptionDefinitions.ReadScaleOption);
+    }
+
+    protected override DatabaseUpdateOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.SkuName = parseResult.GetValueOrDefault<string>(SqlOptionDefinitions.SkuName);
+        options.SkuTier = parseResult.GetValueOrDefault<string>(SqlOptionDefinitions.SkuTier);
+        options.SkuCapacity = parseResult.GetValueOrDefault<int?>(SqlOptionDefinitions.SkuCapacity);
+        options.Collation = parseResult.GetValueOrDefault<string>(SqlOptionDefinitions.Collation);
+        options.MaxSizeBytes = parseResult.GetValueOrDefault<long?>(SqlOptionDefinitions.MaxSizeBytes);
+        options.ElasticPoolName = parseResult.GetValueOrDefault<string>(SqlOptionDefinitions.ElasticPoolName);
+        options.ZoneRedundant = parseResult.GetValueOrDefault<bool?>(SqlOptionDefinitions.ZoneRedundant);
+        options.ReadScale = parseResult.GetValueOrDefault<string>(SqlOptionDefinitions.ReadScale);
+        return options;
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            var sqlService = context.GetService<ISqlService>();
+
+            var database = await sqlService.UpdateDatabaseAsync(
+                options.Server!,
+                options.Database!,
+                options.ResourceGroup!,
+                options.Subscription!,
+                options.SkuName,
+                options.SkuTier,
+                options.SkuCapacity,
+                options.Collation,
+                options.MaxSizeBytes,
+                options.ElasticPoolName,
+                options.ZoneRedundant,
+                options.ReadScale,
+                options.RetryPolicy);
+
+            context.Response.Results = ResponseResult.Create(
+                new DatabaseUpdateResult(database),
+                SqlJsonContext.Default.DatabaseUpdateResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Error updating SQL database. Server: {Server}, Database: {Database}, ResourceGroup: {ResourceGroup}, Options: {@Options}",
+                options.Server, options.Database, options.ResourceGroup, options);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    protected override string GetErrorMessage(Exception ex) => ex switch
+    {
+        RequestFailedException reqEx when reqEx.Status == 404 =>
+            "SQL database or server not found. Verify the database name, server name, resource group, and that you have access.",
+        RequestFailedException reqEx when reqEx.Status == 403 =>
+            $"Authorization failed updating the SQL database. Verify you have appropriate permissions. Details: {reqEx.Message}",
+        RequestFailedException reqEx when reqEx.Status == 400 =>
+            $"Invalid database configuration. Check your update parameters. Details: {reqEx.Message}",
+        RequestFailedException reqEx => reqEx.Message,
+        _ => base.GetErrorMessage(ex)
+    };
+
+    internal record DatabaseUpdateResult(SqlDatabase Database);
+}

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/SqlJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/SqlJsonContext.cs
@@ -15,6 +15,7 @@ namespace Azure.Mcp.Tools.Sql.Commands;
 [JsonSerializable(typeof(DatabaseShowCommand.DatabaseShowResult))]
 [JsonSerializable(typeof(DatabaseListCommand.DatabaseListResult))]
 [JsonSerializable(typeof(DatabaseCreateCommand.DatabaseCreateResult))]
+[JsonSerializable(typeof(DatabaseUpdateCommand.DatabaseUpdateResult))]
 [JsonSerializable(typeof(DatabaseDeleteCommand.DatabaseDeleteResult))]
 [JsonSerializable(typeof(EntraAdminListCommand.EntraAdminListResult))]
 [JsonSerializable(typeof(FirewallRuleListCommand.FirewallRuleListResult))]

--- a/tools/Azure.Mcp.Tools.Sql/src/Options/Database/DatabaseUpdateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Options/Database/DatabaseUpdateOptions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Mcp.Tools.Sql.Options.Database;
+
+public class DatabaseUpdateOptions : BaseDatabaseOptions
+{
+    [JsonPropertyName(SqlOptionDefinitions.SkuName)]
+    public string? SkuName { get; set; }
+
+    [JsonPropertyName(SqlOptionDefinitions.SkuTier)]
+    public string? SkuTier { get; set; }
+
+    [JsonPropertyName(SqlOptionDefinitions.SkuCapacity)]
+    public int? SkuCapacity { get; set; }
+
+    [JsonPropertyName(SqlOptionDefinitions.Collation)]
+    public string? Collation { get; set; }
+
+    [JsonPropertyName(SqlOptionDefinitions.MaxSizeBytes)]
+    public long? MaxSizeBytes { get; set; }
+
+    [JsonPropertyName(SqlOptionDefinitions.ElasticPoolName)]
+    public string? ElasticPoolName { get; set; }
+
+    [JsonPropertyName(SqlOptionDefinitions.ZoneRedundant)]
+    public bool? ZoneRedundant { get; set; }
+
+    [JsonPropertyName(SqlOptionDefinitions.ReadScale)]
+    public string? ReadScale { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.Sql/src/Services/ISqlService.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Services/ISqlService.cs
@@ -62,6 +62,40 @@ public interface ISqlService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Updates configuration settings for an existing SQL database.
+    /// </summary>
+    /// <param name="serverName">The name of the SQL server</param>
+    /// <param name="databaseName">The name of the database to update</param>
+    /// <param name="resourceGroup">The resource group name</param>
+    /// <param name="subscription">The subscription ID or name</param>
+    /// <param name="skuName">Optional SKU name for the database</param>
+    /// <param name="skuTier">Optional SKU tier for the database</param>
+    /// <param name="skuCapacity">Optional SKU capacity for the database</param>
+    /// <param name="collation">Optional collation for the database</param>
+    /// <param name="maxSizeBytes">Optional maximum size in bytes for the database</param>
+    /// <param name="elasticPoolName">Optional elastic pool name to assign the database to</param>
+    /// <param name="zoneRedundant">Optional zone redundancy setting</param>
+    /// <param name="readScale">Optional read scale setting</param>
+    /// <param name="retryPolicy">Optional retry policy options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The updated SQL database information</returns>
+    Task<SqlDatabase> UpdateDatabaseAsync(
+        string serverName,
+        string databaseName,
+        string resourceGroup,
+        string subscription,
+        string? skuName = null,
+        string? skuTier = null,
+        int? skuCapacity = null,
+        string? collation = null,
+        long? maxSizeBytes = null,
+        string? elasticPoolName = null,
+        bool? zoneRedundant = null,
+        string? readScale = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets a list of databases for a SQL server.
     /// </summary>
     /// <param name="serverName">The name of the SQL server</param>

--- a/tools/Azure.Mcp.Tools.Sql/src/SqlSetup.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/SqlSetup.cs
@@ -34,6 +34,7 @@ public class SqlSetup : IAreaSetup
         database.AddCommand("show", new DatabaseShowCommand(loggerFactory.CreateLogger<DatabaseShowCommand>()));
         database.AddCommand("list", new DatabaseListCommand(loggerFactory.CreateLogger<DatabaseListCommand>()));
         database.AddCommand("create", new DatabaseCreateCommand(loggerFactory.CreateLogger<DatabaseCreateCommand>()));
+        database.AddCommand("update", new DatabaseUpdateCommand(loggerFactory.CreateLogger<DatabaseUpdateCommand>()));
         database.AddCommand("delete", new DatabaseDeleteCommand(loggerFactory.CreateLogger<DatabaseDeleteCommand>()));
 
         var server = new CommandGroup("server", "SQL server operations");

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Database/DatabaseUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Database/DatabaseUpdateCommandTests.cs
@@ -1,0 +1,291 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Tools.Sql.Commands.Database;
+using Azure.Mcp.Tools.Sql.Models;
+using Azure.Mcp.Tools.Sql.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Sql.UnitTests.Database;
+
+public class DatabaseUpdateCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ISqlService _sqlService;
+    private readonly ILogger<DatabaseUpdateCommand> _logger;
+    private readonly DatabaseUpdateCommand _command;
+    private readonly CommandContext _context;
+    private readonly Command _commandDefinition;
+
+    public DatabaseUpdateCommandTests()
+    {
+        _sqlService = Substitute.For<ISqlService>();
+        _logger = Substitute.For<ILogger<DatabaseUpdateCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_sqlService);
+        _serviceProvider = collection.BuildServiceProvider();
+
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _commandDefinition = _command.GetCommand();
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("update", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+        Assert.Contains("Update configuration settings", command.Description);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithValidParameters_UpdatesDatabase()
+    {
+        // Arrange
+        var mockDatabase = new SqlDatabase(
+            Name: "testdb",
+            Id: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/servers/server1/databases/testdb",
+            Type: "Microsoft.Sql/servers/databases",
+            Location: "East US",
+            Sku: new DatabaseSku("S0", "Standard", 10, null, null),
+            Status: "Online",
+            Collation: "SQL_Latin1_General_CP1_CI_AS",
+            CreationDate: DateTimeOffset.UtcNow,
+            MaxSizeBytes: 2147483648,
+            ServiceLevelObjective: "S0",
+            Edition: "Standard",
+            ElasticPoolName: null,
+            EarliestRestoreDate: DateTimeOffset.UtcNow,
+            ReadScale: "Disabled",
+            ZoneRedundant: true
+        );
+
+        _sqlService.UpdateDatabaseAsync(
+            Arg.Is("server1"),
+            Arg.Is("testdb"),
+            Arg.Is("rg"),
+            Arg.Is("sub"),
+            Arg.Is("S0"),
+            Arg.Is("Standard"),
+            Arg.Is(10),
+            Arg.Is("SQL_Latin1_General_CP1_CI_AS"),
+            Arg.Is(2147483648L),
+            Arg.Any<string?>(),
+            Arg.Is(true),
+            Arg.Is("Disabled"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(mockDatabase);
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub",
+            "--resource-group", "rg",
+            "--server", "server1",
+            "--database", "testdb",
+            "--sku-name", "S0",
+            "--sku-tier", "Standard",
+            "--sku-capacity", "10",
+            "--collation", "SQL_Latin1_General_CP1_CI_AS",
+            "--max-size-bytes", "2147483648",
+            "--zone-redundant", "true",
+            "--read-scale", "Disabled"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+        Assert.Equal("Success", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesServiceErrors()
+    {
+        // Arrange
+        _sqlService.UpdateDatabaseAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<int?>(),
+                Arg.Any<string?>(),
+                Arg.Any<long?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Test error"));
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub",
+            "--resource-group", "rg",
+            "--server", "server1",
+            "--database", "testdb"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Test error", response.Message);
+        Assert.Contains("troubleshooting", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesDatabaseNotFound()
+    {
+        // Arrange
+        var notFoundException = new RequestFailedException(404, "Database not found");
+        _sqlService.UpdateDatabaseAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<int?>(),
+                Arg.Any<string?>(),
+                Arg.Any<long?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(notFoundException);
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub",
+            "--resource-group", "rg",
+            "--server", "server1",
+            "--database", "missing"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(404, response.Status);
+        Assert.Contains("not found", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesInvalidConfiguration()
+    {
+        // Arrange
+        var badRequestException = new RequestFailedException(400, "Invalid configuration");
+        _sqlService.UpdateDatabaseAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<int?>(),
+                Arg.Any<string?>(),
+                Arg.Any<long?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(badRequestException);
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub",
+            "--resource-group", "rg",
+            "--server", "server1",
+            "--database", "testdb"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("Invalid database configuration", response.Message);
+    }
+
+    [Theory]
+    [InlineData("", false, "Missing required options")]
+    [InlineData("--subscription sub", false, "Missing required options")]
+    [InlineData("--subscription sub --resource-group rg", false, "Missing required options")]
+    [InlineData("--subscription sub --resource-group rg --server server1", false, "Missing required options")]
+    [InlineData("--subscription sub --resource-group rg --server server1 --database testdb", true, null)]
+    public async Task ExecuteAsync_ValidatesRequiredParameters(string commandArgs, bool shouldSucceed, string? expectedError)
+    {
+        // Arrange
+        if (shouldSucceed)
+        {
+            var mockDatabase = new SqlDatabase(
+                Name: "testdb",
+                Id: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/servers/server1/databases/testdb",
+                Type: "Microsoft.Sql/servers/databases",
+                Location: "East US",
+                Sku: null,
+                Status: "Online",
+                Collation: "SQL_Latin1_General_CP1_CI_AS",
+                CreationDate: DateTimeOffset.UtcNow,
+                MaxSizeBytes: 1073741824,
+                ServiceLevelObjective: "Basic",
+                Edition: "Basic",
+                ElasticPoolName: null,
+                EarliestRestoreDate: DateTimeOffset.UtcNow,
+                ReadScale: "Disabled",
+                ZoneRedundant: false
+            );
+
+            _sqlService.UpdateDatabaseAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<int?>(),
+                Arg.Any<string?>(),
+                Arg.Any<long?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
+                .Returns(mockDatabase);
+        }
+
+        var args = _commandDefinition.Parse(commandArgs.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        if (shouldSucceed)
+        {
+            Assert.Equal(200, response.Status);
+        }
+        else
+        {
+            Assert.NotEqual(200, response.Status);
+            if (expectedError != null)
+            {
+                Assert.Contains(expectedError, response.Message, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Add `azmcp sql db update` command and unit test

## GitHub issue number?
#126 

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
