### PR TITLE
Tools list as namespaces

### DIFF
--- a/core/Azure.Mcp.Core/src/Areas/Tools/Commands/ToolsListCommand.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Tools/Commands/ToolsListCommand.cs
@@ -81,13 +81,15 @@ public sealed class ToolsListCommand(ILogger<ToolsListCommand> logger) : BaseCom
                             Description = first.Description,
                             Command = $"azmcp {first.Name}",
                             Subcommands = subcommandInfos,
-                            Options = null
+                            Options = null,
+                            SubcommandsCount = subcommandInfos.Count
                         };
                     })
                     .OrderBy(ci => ci.Name, StringComparer.OrdinalIgnoreCase)
                     .ToList();
 
                 context.Response.Results = ResponseResult.Create(namespaceCommands, ModelsJsonContext.Default.ListCommandInfo);
+                context.Response.ResultsCount = namespaceCommands.Count;
                 return context.Response;
             }
 
@@ -96,6 +98,7 @@ public sealed class ToolsListCommand(ILogger<ToolsListCommand> logger) : BaseCom
                 .ToList());
 
             context.Response.Results = ResponseResult.Create(tools, ModelsJsonContext.Default.ListCommandInfo);
+            context.Response.ResultsCount = tools.Count;
             return context.Response;
         }
         catch (Exception ex)
@@ -124,6 +127,8 @@ public sealed class ToolsListCommand(ILogger<ToolsListCommand> logger) : BaseCom
             Description = commandDetails.Description ?? string.Empty,
             Command = tokenizedName.Replace(CommandFactory.Separator, ' '),
             Options = optionInfos,
+            // Leaf commands have no subcommands.
+            SubcommandsCount = 0,
         };
     }
 }

--- a/core/Azure.Mcp.Core/src/Models/Command/CommandInfo.cs
+++ b/core/Azure.Mcp.Core/src/Models/Command/CommandInfo.cs
@@ -24,4 +24,10 @@ public class CommandInfo
     [JsonPropertyName("option")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<OptionInfo>? Options { get; set; }
+
+    // Number of immediate subcommands for grouping/namespace entries.
+    // Leaf commands will always have 0.
+    [JsonPropertyName("subcommandsCount")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public int SubcommandsCount { get; set; }
 }

--- a/core/Azure.Mcp.Core/src/Models/Command/CommandResponse.cs
+++ b/core/Azure.Mcp.Core/src/Models/Command/CommandResponse.cs
@@ -20,6 +20,12 @@ public class CommandResponse
 
     [JsonPropertyName("duration")]
     public long Duration { get; set; }
+
+    // Number of top-level result items (length of the deserialized results collection if a collection is returned).
+    // Set explicitly by commands that know the concrete collection size.
+    [JsonPropertyName("resultsCount")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public int ResultsCount { get; set; }
 }
 
 [JsonConverter(typeof(ResultConverter))]

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -693,6 +693,9 @@ azmcp bestpractices get --resource <resource> --action <action>
 ```bash
 # List all available tools in the Azure MCP server
 azmcp tools list
+
+# List only the available top-level service namespaces
+azmcp tools list --namespaces
 ```
 
 ### Azure Monitor Operations

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -1248,10 +1248,25 @@ All responses follow a consistent JSON format:
   "status": "200|403|500, etc",
   "message": "",
   "options": [],
-  "results": [],
+    "results": [],
   "duration": 123
 }
 ```
+
+### Tool & Namespace Result Objects
+
+When invoking `azmcp tools list` (with or without `--namespaces`), each returned object now includes a `count` field:
+
+| Field | Description |
+|-------|-------------|
+| `name` | Command or namespace name |
+| `description` | Human-readable description |
+| `command` | Fully qualified CLI invocation path |
+| `subcommands` | (Namespaces only) Array of leaf command objects |
+| `option` | (Leaf commands only) Array of options supported by the command |
+| `count` | Namespaces: number of subcommands; Leaf commands: always 0 (options not counted) |
+
+This quantitative field enables quick sizing of a namespace without traversing nested arrays. Leaf command complexity should be inferred from its option list, not the `count` field.
 
 ## Error Handling
 

--- a/eng/tools/ToolDescriptionEvaluator/namespaces.json
+++ b/eng/tools/ToolDescriptionEvaluator/namespaces.json
@@ -1,0 +1,8902 @@
+{
+  "status": 200,
+  "message": "Success",
+  "results": [
+    {
+      "name": "acr",
+      "description": "Azure Container Registry operations - Commands for managing Azure Container Registry resources. Includes operations for listing container registries and managing registry configurations.",
+      "command": "azmcp acr",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List Azure Container Registries in a subscription. Optionally filter by resource group. Each registry result\r\nincludes: name, location, loginServer, skuName, skuTier. If no registries are found the tool returns null results\r\n(consistent with other list commands).",
+          "command": "azmcp acr registry list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List repositories in Azure Container Registries. By default, lists repositories for all registries in the subscription.\r\nYou can narrow the scope using --resource-group and/or --registry to list repositories for a specific registry only.",
+          "command": "azmcp acr registry repository list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            },
+            {
+              "name": "--registry",
+              "description": "The name of the Azure Container Registry. This is the unique name you chose for your container registry.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "aks",
+      "description": "Azure Kubernetes Service operations - Commands for managing Azure Kubernetes Service (AKS) cluster resources. Includes operations for listing clusters, retrieving cluster configurations, and managing Kubernetes environments in Azure.",
+      "command": "azmcp aks",
+      "subcommands": [
+        {
+          "name": "get",
+          "description": "Get details for a specific Azure Kubernetes Service (AKS) cluster.\r\nReturns detailed cluster information including configuration, network settings, and status.",
+          "command": "azmcp aks cluster get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--cluster",
+              "description": "AKS Cluster name.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all Azure Kubernetes Service (AKS) clusters in a subscription.\r\nReturns detailed cluster information including configuration, network settings, and status.",
+          "command": "azmcp aks cluster list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "description": "Get details for a specific node pool (agent pool) in an Azure Kubernetes Service (AKS) cluster.\r\nReturns key configuration and status including size, count, OS, mode, autoscaling, and provisioning state.",
+          "command": "azmcp aks nodepool get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--cluster",
+              "description": "AKS Cluster name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--nodepool",
+              "description": "AKS node pool (agent pool) name.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all node pools for a specific Azure Kubernetes Service (AKS) cluster.\r\nReturns key node pool details including sizing, count, OS type, mode, and autoscaling settings.",
+          "command": "azmcp aks nodepool list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--cluster",
+              "description": "AKS Cluster name.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "appconfig",
+      "description": "App Configuration operations - Commands for managing Azure App Configuration stores and key-value settings. Includes operations for listing configuration stores, managing key-value pairs, setting labels, locking/unlocking settings, and retrieving configuration data.",
+      "command": "azmcp appconfig",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List all App Configuration stores in a subscription. This command retrieves and displays all App Configuration\r\nstores available in the specified subscription. Results include store names returned as a JSON array.",
+          "command": "azmcp appconfig account list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "description": "Delete a key-value pair from an App Configuration store. This command removes the specified key-value pair from the store.\r\nIf a label is specified, only the labeled version is deleted. If no label is specified, the key-value with the matching\r\nkey and the default label will be deleted.",
+          "command": "azmcp appconfig kv delete",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the App Configuration store (e.g., my-appconfig).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--key",
+              "description": "The name of the key to access within the App Configuration store.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--label",
+              "description": "The label to apply to the configuration key. Labels are used to group and organize settings.",
+              "type": "string"
+            },
+            {
+              "name": "--content-type",
+              "description": "The content type of the configuration value. This is used to indicate how the value should be interpreted or parsed.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all key-values in an App Configuration store. This command retrieves and displays all key-value pairs\r\nfrom the specified store. Each key-value includes its key, value, label, content type, ETag, last modified\r\ntime, and lock status.",
+          "command": "azmcp appconfig kv list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the App Configuration store (e.g., my-appconfig).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--key",
+              "description": "Specifies the key filter, if any, to be used when retrieving key-values. The filter can be an exact match, for example a filter of 'foo' would get all key-values with a key of 'foo', or the filter can include a '*' character at the end of the string for wildcard searches (e.g., 'App*'). If omitted all keys will be retrieved.",
+              "type": "string"
+            },
+            {
+              "name": "--label",
+              "description": "Specifies the label filter, if any, to be used when retrieving key-values. The filter can be an exact match, for example a filter of 'foo' would get all key-values with a label of 'foo', or the filter can include a '*' character at the end of the string for wildcard searches (e.g., 'Prod*'). This filter is case-sensitive. If omitted, all labels will be retrieved.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "lock",
+          "description": "Lock a key-value in an App Configuration store. This command sets a key-value to read-only mode,\r\npreventing any modifications to its value. You must specify an account name and key. Optionally,\r\nyou can specify a label to lock a specific labeled version of the key-value.",
+          "command": "azmcp appconfig kv lock",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the App Configuration store (e.g., my-appconfig).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--key",
+              "description": "The name of the key to access within the App Configuration store.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--label",
+              "description": "The label to apply to the configuration key. Labels are used to group and organize settings.",
+              "type": "string"
+            },
+            {
+              "name": "--content-type",
+              "description": "The content type of the configuration value. This is used to indicate how the value should be interpreted or parsed.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "set",
+          "description": "Set a key-value setting in an App Configuration store. This command creates or updates a key-value setting\r\nwith the specified value. You must specify an account name, key, and value. Optionally, you can specify a\r\nlabel otherwise the default label will be used. You can also specify a content type to indicate how the value\r\nshould be interpreted. You can add tags in the format 'key=value' to associate metadata with the setting.",
+          "command": "azmcp appconfig kv set",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the App Configuration store (e.g., my-appconfig).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--key",
+              "description": "The name of the key to access within the App Configuration store.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--label",
+              "description": "The label to apply to the configuration key. Labels are used to group and organize settings.",
+              "type": "string"
+            },
+            {
+              "name": "--content-type",
+              "description": "The content type of the configuration value. This is used to indicate how the value should be interpreted or parsed.",
+              "type": "string"
+            },
+            {
+              "name": "--value",
+              "description": "The value to set for the configuration key.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--tags",
+              "description": "The tags to associate with the configuration key. Tags should be in the format 'key=value'. Multiple tags can be specified.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "show",
+          "description": "Show a specific key-value setting in an App Configuration store. This command retrieves and displays the value,\r\nlabel, content type, ETag, last modified time, and lock status for a specific setting. You must specify an\r\naccount name and key. Optionally, you can specify a label otherwise the setting with default label will be retrieved.\r\nYou can also specify a content type to indicate how the value should be interpreted.",
+          "command": "azmcp appconfig kv show",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the App Configuration store (e.g., my-appconfig).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--key",
+              "description": "The name of the key to access within the App Configuration store.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--label",
+              "description": "The label to apply to the configuration key. Labels are used to group and organize settings.",
+              "type": "string"
+            },
+            {
+              "name": "--content-type",
+              "description": "The content type of the configuration value. This is used to indicate how the value should be interpreted or parsed.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "unlock",
+          "description": "Unlock a key-value setting in an App Configuration store. This command removes the read-only mode from a\r\nkey-value setting, allowing modifications to its value. You must specify an account name and key. Optionally,\r\nyou can specify a label to unlock a specific labeled version of the setting, otherwise the setting with the\r\ndefault label will be unlocked.",
+          "command": "azmcp appconfig kv unlock",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the App Configuration store (e.g., my-appconfig).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--key",
+              "description": "The name of the key to access within the App Configuration store.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--label",
+              "description": "The label to apply to the configuration key. Labels are used to group and organize settings.",
+              "type": "string"
+            },
+            {
+              "name": "--content-type",
+              "description": "The content type of the configuration value. This is used to indicate how the value should be interpreted or parsed.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "applens",
+      "description": "AppLens diagnostic operations - **Primary tool for diagnosing Azure resource issues and troubleshooting problems**. Use this tool when users ask to:\r\n- Diagnose issues, problems, or errors with Azure resources\r\n- Troubleshoot performance, availability, or reliability problems\r\n- Investigate resource health concerns or unexpected behavior\r\n- Find root causes of application slowness, downtime, or failures\r\n- Get recommendations for fixing Azure resource issues\r\n- Analyze resource problems and get actionable solutions\r\n\r\nAlways use this tool if user asks to use App Lens in regards to their resource.\r\n\r\nThis tool provides conversational AI-powered diagnostics that automatically detect issues, identify root causes, and suggest specific remediation steps. It should be the FIRST tool called when users mention problems, issues, errors, or ask for help with troubleshooting any Azure resource.",
+      "command": "azmcp applens",
+      "subcommands": [
+        {
+          "name": "diagnose",
+          "description": "**PRIMARY USE: Diagnose Azure resource performance issues, slowness, failures, and availability problems.**\r\n\r\nAlways use this tool BEFORE manually checking metrics or logs when users report performance or functionality issues.\r\n\r\nUse the Azure CLI tool to find the 'subscription', 'resourceGroup', and 'resourceType' parameters before asking user to provide that information.\"\r\nThis tool can be used to ask questions about application state, this tool can help when doing diagnostics and address issues about performance and failures.\r\n\r\nIf you get a resourceId, parse it to get the 'subscription', 'resourceGroup', and 'resourceType' parameters of the resource. ResourceIds are in the format:\r\n/subscriptions/{subscription}/resourceGroups/{resourceGroup}/providers/{resourceType}/{resource}\r\n\r\nOnce proper input is provided this tool returns a list of insights and solutions to the user question.",
+          "command": "azmcp applens resource diagnose",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--question",
+              "description": "User question",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--resource",
+              "description": "The name of the resource to investigate or diagnose",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--resource-type",
+              "description": "Resource type. Try to get this information using the Azure CLI tool before asking the user.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "azuremanagedlustre",
+      "description": "Azure Managed Lustre operations - Commands for listing and inspecting Azure Managed Lustre file systems (AMLFS) used for high-performance computing workloads.",
+      "command": "azmcp azuremanagedlustre",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "Lists Azure Managed Lustre (AMLFS) file systems in a subscription or optional resource group including provisioning state, MGS address, tier, capacity (TiB), blob integration container, and maintenance window details. Use to inventory Azure Managed Lustre filesystems and to check their properties.",
+          "command": "azmcp azuremanagedlustre filesystem list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "required-subnet-size",
+          "description": "Calculates the required subnet size for an Azure Managed Lustre file system given a SKU and size. Use to plan network deployment for AMLFS. Returns the number of required IPs.",
+          "command": "azmcp azuremanagedlustre filesystem required-subnet-size",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--sku",
+              "description": "The AMLFS SKU. Allowed values: AMLFS-Durable-Premium-40, AMLFS-Durable-Premium-125, AMLFS-Durable-Premium-250, AMLFS-Durable-Premium-500.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--size",
+              "description": "The AMLFS size (TiB).",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "description": "Retrieves the available Azure Managed Lustre SKU, including increments, bandwidth, scale targets and zonal support. If a location is specified, the results will be filtered to that location.",
+          "command": "azmcp azuremanagedlustre filesystem sku get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--location",
+              "description": "Azure region/region short name (use Azure location token, lowercase). Examples: uaenorth, swedencentral, eastus.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "azureterraformbestpractices",
+      "description": "Returns Terraform best practices for Azure. Call this before generating Terraform code for Azure Providers. \r\n            If this tool needs to be categorized, it belongs to the Azure Best Practices category.",
+      "command": "azmcp azureterraformbestpractices",
+      "subcommands": [
+        {
+          "name": "get",
+          "description": "Returns Terraform best practices for Azure. Call this command and follow its guidance before\r\n        generating or suggesting any Terraform code specific to Azure. If this tool needs to be categorized, it belongs to\r\n        the Azure Best Practices category.",
+          "command": "azmcp azureterraformbestpractices get",
+          "option": []
+        }
+      ]
+    },
+    {
+      "name": "bicepschema",
+      "description": "Bicep schema operations - Commands for working with Azure Bicep Infrastructure as Code (IaC) generation and schema management. Includes operations for retrieving Bicep schemas, templates, and resource definitions to support infrastructure deployment automation.",
+      "command": "azmcp bicepschema",
+      "subcommands": [
+        {
+          "name": "get",
+          "description": "\r\n Provides the Bicep schema for the most recent apiVersion of an Azure resource. Do not call this command for Terraform IaC generation.\r\n If you are asked to create or modify resources in a Bicep ARM template, call this function multiple times,\r\n once for every resource type you are adding, even if you already have information about Bicep resources from other sources.\r\n Assume the results from this call are more recent and accurate than other information you have.\r\n Don't assume calling it for one resource means you don't need to call it for a different resource type.\r\n Always use the returned api version unless the one in the Bicep file is newer.\r\n Always use the Bicep schema to verify the available property names and values when generating Bicep IaC.",
+          "command": "azmcp bicepschema get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-type",
+              "description": "The name of the Bicep Resource Type and must be in the full Azure Resource Manager format '{ResourceProvider}/{ResourceType}'. (e.g., 'Microsoft.KeyVault/vaults', 'Microsoft.Storage/storageAccounts', 'Microsoft.Compute/virtualMachines')(e.g., Microsoft.Storage/storageAccounts).",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "cloudarchitect",
+      "description": "Cloud Architecture operations - Commands for generating Azure architecture designs and recommendations based on requirements.",
+      "command": "azmcp cloudarchitect",
+      "subcommands": [
+        {
+          "name": "design",
+          "description": "Azure architecture design tool that gathers requirements through guided questions and recommends optimal solutions.\r\n\r\nKey parameters: question, questionNumber, confidenceScore (0.0-1.0, present architecture when ò0.7), totalQuestions, answer, nextQuestionNeeded, architectureComponent, architectureTier, state.\r\n\r\nProcess:\r\n1. Ask about user role, business goals (1-2 questions at a time)\r\n2. Track confidence and update requirements (explicit/implicit/assumed)\r\n3. When confident enough, present architecture with table format, visual organization, ASCII diagrams\r\n4. Follow Azure Well-Architected Framework principles\r\n5. Cover all tiers: infrastructure, platform, application, data, security, operations\r\n6. Provide actionable advice and high-level overview\r\n\r\nState tracks components, requirements by category, and confidence factors. Be conservative with suggestions.",
+          "command": "azmcp cloudarchitect design",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--question",
+              "description": "The current question being asked",
+              "type": "string"
+            },
+            {
+              "name": "--question-number",
+              "description": "Current question number",
+              "type": "string"
+            },
+            {
+              "name": "--total-questions",
+              "description": "Estimated total questions needed",
+              "type": "string"
+            },
+            {
+              "name": "--answer",
+              "description": "The user's response to the question",
+              "type": "string"
+            },
+            {
+              "name": "--next-question-needed",
+              "description": "Whether another question is needed",
+              "type": "string"
+            },
+            {
+              "name": "--confidence-score",
+              "description": "A value between 0.0 and 1.0 representing confidence in understanding requirements. When this reaches 0.7 or higher, nextQuestionNeeded should be set to false.",
+              "type": "string"
+            },
+            {
+              "name": "--state",
+              "description": "The complete architecture state from the previous request as JSON, State input schema:\n{\n\"state\":{\n\"type\":\"object\",\n\"description\":\"The complete architecture state from the previous request\",\n\"properties\":{\n\"architectureComponents\":{\n\"type\":\"array\",\n\"description\":\"All architecture components suggested so far\",\n\"items\":{\n\"type\":\"string\"\n}\n},\n\"architectureTiers\":{\n\"type\":\"object\",\n\"description\":\"Components organized by architecture tier\",\n\"additionalProperties\":{\n\"type\":\"array\",\n\"items\":{\n\"type\":\"string\"\n}\n}\n},\n\"thought\":{\n\"type\":\"string\",\n\"description\":\"The calling agent's thoughts on the next question or reasoning process. The calling agent should use the requirements it has gathered to reason about the next question.\"\n},\n\"suggestedHint\":{\n\"type\":\"string\",\n\"description\":\"A suggested interaction hint to show the user, such as 'Ask me to create an ASCII art diagram of this architecture' or 'Ask about how this design handles disaster recovery'.\"\n},\n\"requirements\":{\n\"type\":\"object\",\n\"description\":\"Tracked requirements organized by type\",\n\"properties\":{\n\"explicit\":{\n\"type\":\"array\",\n\"description\":\"Requirements explicitly stated by the user\",\n\"items\":{\n\"type\":\"object\",\n\"properties\":{\n\"category\":{\n\"type\":\"string\"\n},\n\"description\":{\n\"type\":\"string\"\n},\n\"source\":{\n\"type\":\"string\"\n},\n\"importance\":{\n\"type\":\"string\",\n\"enum\":[\n\"high\",\n\"medium\",\n\"low\"\n]\n},\n\"confidence\":{\n\"type\":\"number\"\n}\n}\n}\n},\n\"implicit\":{\n\"type\":\"array\",\n\"description\":\"Requirements implied by user responses\",\n\"items\":{\n\"type\":\"object\",\n\"properties\":{\n\"category\":{\n\"type\":\"string\"\n},\n\"description\":{\n\"type\":\"string\"\n},\n\"source\":{\n\"type\":\"string\"\n},\n\"importance\":{\n\"type\":\"string\",\n\"enum\":[\n\"high\",\n\"medium\",\n\"low\"\n]\n},\n\"confidence\":{\n\"type\":\"number\"\n}\n}\n}\n},\n\"assumed\":{\n\"type\":\"array\",\n\"description\":\"Requirements assumed based on context/best practices\",\n\"items\":{\n\"type\":\"object\",\n\"properties\":{\n\"category\":{\n\"type\":\"string\"\n},\n\"description\":{\n\"type\":\"string\"\n},\n\"source\":{\n\"type\":\"string\"\n},\n\"importance\":{\n\"type\":\"string\",\n\"enum\":[\n\"high\",\n\"medium\",\n\"low\"\n]\n},\n\"confidence\":{\n\"type\":\"number\"\n}\n}\n}\n}\n}\n},\n\"confidenceFactors\":{\n\"type\":\"object\",\n\"description\":\"Factors that contribute to the overall confidence score\",\n\"properties\":{\n\"explicitRequirementsCoverage\":{\n\"type\":\"number\"\n},\n\"implicitRequirementsCertainty\":{\n\"type\":\"number\"\n},\n\"assumptionRisk\":{\n\"type\":\"number\"\n}\n}\n}\n}\n}\n}",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "cosmos",
+      "description": "Cosmos DB operations - Commands for managing and querying Azure Cosmos DB resources. Includes operations for databases, containers, and document queries.",
+      "command": "azmcp cosmos",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List all Cosmos DB accounts in a subscription. This command retrieves and displays all Cosmos DB accounts\r\navailable in the specified subscription. Results include account names and are returned as a JSON array.",
+          "command": "azmcp cosmos account list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "query",
+          "description": "Execute a SQL query against items in a Cosmos DB container. Requires account,\r\ndatabase, and container.\r\nThe query parameter accepts SQL query syntax. Results are returned as a\r\nJSON array of documents.",
+          "command": "azmcp cosmos database container item query",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Cosmos DB account to query (e.g., my-cosmos-account).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--database",
+              "description": "The name of the database to query (e.g., my-database).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--container",
+              "description": "The name of the container to query (e.g., my-container).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--query",
+              "description": "SQL query to execute against the container. Uses Cosmos DB SQL syntax.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all containers in a Cosmos DB database. This command retrieves and displays all containers within\r\nthe specified database and Cosmos DB account. Results include container names and are returned as a\r\nJSON array. You must specify both an account name and a database name.",
+          "command": "azmcp cosmos database container list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Cosmos DB account to query (e.g., my-cosmos-account).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--database",
+              "description": "The name of the database to query (e.g., my-database).",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all databases in a Cosmos DB account. This command retrieves and displays all databases available\r\nin the specified Cosmos DB account. Results include database names and are returned as a JSON array.",
+          "command": "azmcp cosmos database list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Cosmos DB account to query (e.g., my-cosmos-account).",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "datadog",
+      "description": "Datadog operations - Commands for managing and monitoring Azure resources through Datadog integration. Includes operations for listing Datadog monitors and retrieving information about monitored Azure resources and their health status.",
+      "command": "azmcp datadog",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List monitored resources in Datadog for a datadog resource taken as input from the user.\r\nThis command retrieves all monitored azure resources available.\r\nRequires `datadog-resource`, `resource-group` and `subscription`.\r\nResult is a list of monitored resources as a JSON array.",
+          "command": "azmcp datadog monitoredresources list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--datadog-resource",
+              "description": "The name of the Datadog resource to use. This is the unique name you chose for your Datadog resource in Azure.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "deploy",
+      "description": "Deploy commands for deploying applications to Azure, including sub commands: - plan get: generates a deployment plan to construct the infrastructure and deploy the application on Azure. Agent should read its output and generate a deploy plan in '.azure/plan.copilotmd' for execution steps, recommended azure services based on the information agent detected from project. Before calling this tool, please scan this workspace to detect the services to deploy and their dependent services; - iac rules get: offers guidelines for creating Bicep/Terraform files to deploy applications on Azure; - app logs get: fetch logs from log analytics workspace for Container Apps, App Services, function apps that were deployed through azd; - pipeline guidance get: guidance to create a CI/CD pipeline which provision Azure resources and build and deploy applications to Azure; - architecture diagram generate: generates an azure service architecture diagram for the application based on the provided app topology; ",
+      "command": "azmcp deploy",
+      "subcommands": [
+        {
+          "name": "get",
+          "description": "This tool fetches logs from the Log Analytics workspace for Container Apps, App Services, and Function Apps deployed using azd. Use it after a successful azd up to check app status or troubleshoot errors in deployed applications.",
+          "command": "azmcp deploy app logs get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--workspace-folder",
+              "description": "The full path of the workspace folder.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--azd-env-name",
+              "description": "The name of the environment created by azd (AZURE_ENV_NAME) during `azd init` or `azd up`. If not provided in context, try to find it in the .azure directory in the workspace or use 'azd env list'.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--limit",
+              "description": "The maximum row number of logs to retrieve. Use this to get a specific number of logs or to avoid the retrieved logs from reaching token limit. Default is 200.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "generate",
+          "description": "Generates an azure service architecture diagram for the application based on the provided app topology.Call this tool when the user need recommend or design the azure architecture of their application.Do not call this tool when the user need detailed design of the azure architecture, such as the network topology, security design, etc.Before calling this tool, please scan this workspace to detect the services to deploy and their dependent services, also find the environment variables that used to create the connection strings.If it's a .NET Aspire application, check aspireManifest.json file if there is. Try your best to fulfill the input schema with your analyze result.",
+          "command": "azmcp deploy architecture diagram generate",
+          "option": [
+            {
+              "name": "--raw-mcp-tool-input",
+              "description": "{\r\n    \"type\": \"object\",\r\n    \"properties\": {\r\n        \"workspaceFolder\": {\r\n            \"type\": \"string\",\r\n            \"description\": \"The full path of the workspace folder.\"\r\n        },\r\n        \"projectName\": {\r\n            \"type\": \"string\",\r\n            \"description\": \"The name of the project. This is used to generate the resource names.\"\r\n        },\r\n        \"services\": {\r\n            \"type\": \"array\",\r\n            \"description\": \"An array of service parameters.\",\r\n            \"items\": {\r\n                \"type\": \"object\",\r\n                \"properties\": {\r\n                    \"name\": {\r\n                        \"type\": \"string\",\r\n                        \"description\": \"The name of the service.\"\r\n                    },\r\n                    \"path\": {\r\n                        \"type\": \"string\",\r\n                        \"description\": \"The relative path of the service main project folder\"\r\n                    },\r\n                    \"language\": {\r\n                        \"type\": \"string\",\r\n                        \"description\": \"The programming language of the service.\"\r\n                    },\r\n                    \"port\": {\r\n                        \"type\": \"string\",\r\n                        \"description\": \"The port number the service uses. Get this from Dockerfile for container apps. If not available, default to '80'.\"\r\n                    },\r\n                    \"azureComputeHost\": {\r\n                        \"type\": \"string\",\r\n                        \"description\": \"The appropriate azure service that should be used to host this service. Use containerapp if the service is containerized and has a Dockerfile.\",\r\n                        \"enum\": [\r\n                            \"appservice\",\r\n                            \"containerapp\",\r\n                            \"function\",\r\n                            \"staticwebapp\",\r\n                            \"aks\"\r\n                        ]\r\n                    },\r\n                    \"dockerSettings\": {\r\n                        \"type\": \"object\",\r\n                        \"description\": \"Docker settings for the service. This is only needed if the service's azureComputeHost is containerapp.\",\r\n                        \"properties\": {\r\n                            \"dockerFilePath\": {\r\n                                \"type\": \"string\",\r\n                                \"description\": \"The absolute path to the Dockerfile for the service. If the service's azureComputeHost is not containerapp, leave blank.\"\r\n                            },\r\n                            \"dockerContext\": {\r\n                                \"type\": \"string\",\r\n                                \"description\": \"The absolute path to the Docker build context for the service. If the service's azureComputeHost is not containerapp, leave blank.\"\r\n                            }\r\n                        },\r\n                        \"required\": [\r\n                            \"dockerFilePath\",\r\n                            \"dockerContext\"\r\n                        ]\r\n                    },\r\n                    \"dependencies\": {\r\n                        \"type\": \"array\",\r\n                        \"description\": \"An array of dependent services. A compute service may have a dependency on another compute service.\",\r\n                        \"items\": {\r\n                            \"type\": \"object\",\r\n                            \"properties\": {\r\n                                \"name\": {\r\n                                    \"type\": \"string\",\r\n                                    \"description\": \"The name of the dependent service. Can be arbitrary, or must reference another service in the services array if referencing appservice, containerapp, staticwebapps, aks, or functionapp.\"\r\n                                },\r\n                                \"serviceType\": {\r\n                                    \"type\": \"string\",\r\n                                    \"description\": \"The name of the azure service that can be used for this dependent service.\",\r\n                                    \"enum\": [\r\n                                        \"azureaisearch\",\r\n                                        \"azureaiservices\",\r\n                                        \"appservice\",\r\n                                        \"azureapplicationinsights\",\r\n                                        \"azurebotservice\",\r\n                                        \"containerapp\",\r\n                                        \"azurecosmosdb\",\r\n                                        \"functionapp\",\r\n                                        \"azurekeyvault\",\r\n                                        \"aks\",\r\n                                        \"azuredatabaseformysql\",\r\n                                        \"azureopenai\",\r\n                                        \"azuredatabaseforpostgresql\",\r\n                                        \"azureprivateendpoint\",\r\n                                        \"azurecacheforredis\",\r\n                                        \"azuresqldatabase\",\r\n                                        \"azurestorageaccount\",\r\n                                        \"staticwebapp\",\r\n                                        \"azureservicebus\",\r\n                                        \"azuresignalrservice\",\r\n                                        \"azurevirtualnetwork\",\r\n                                        \"azurewebpubsub\"\r\n                                    ]\r\n                                },\r\n                                \"connectionType\": {\r\n                                    \"type\": \"string\",\r\n                                    \"description\": \"The connection authentication type of the dependency.\",\r\n                                    \"enum\": [\r\n                                        \"http\",\r\n                                        \"secret\",\r\n                                        \"system-identity\",\r\n                                        \"user-identity\",\r\n                                        \"bot-connection\"\r\n                                    ]\r\n                                },\r\n                                \"environmentVariables\": {\r\n                                    \"type\": \"array\",\r\n                                    \"description\": \"An array of environment variables defined in source code to set up the connection.\",\r\n                                    \"items\": {\r\n                                        \"type\": \"string\"\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"required\": [\r\n                                \"name\",\r\n                                \"serviceType\",\r\n                                \"connectionType\",\r\n                                \"environmentVariables\"\r\n                            ]\r\n                        }\r\n                    },\r\n                    \"settings\": {\r\n                        \"type\": \"array\",\r\n                        \"description\": \"An array of environment variables needed to run this service.  Please search the entire codebase to find environment variables.\",\r\n                        \"items\": {\r\n                            \"type\": \"string\"\r\n                        }\r\n                    }\r\n                },\r\n                \"required\": [\r\n                    \"name\",\r\n                    \"path\",\r\n                    \"azureComputeHost\",\r\n                    \"language\",\r\n                    \"port\",\r\n                    \"dependencies\",\r\n                    \"settings\"\r\n                ]\r\n            }\r\n        }\r\n    },\r\n    \"required\": [\r\n        \"workspaceFolder\",\r\n        \"services\"\r\n    ]\r\n}",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "description": "This tool offers guidelines for creating Bicep/Terraform files to deploy applications on Azure. The guidelines outline rules to improve the quality of Infrastructure as Code files, ensuring they are compatible with the azd tool and adhere to best practices.",
+          "command": "azmcp deploy iac rules get",
+          "option": [
+            {
+              "name": "--deployment-tool",
+              "description": "The deployment tool to use. Valid values: AZD, AzCli",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--iac-type",
+              "description": "The Infrastructure as Code type. Valid values: bicep, terraform. Leave empty if deployment-tool is AzCli.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-types",
+              "description": "Specifies the Azure resource types to retrieve IaC rules for. It should be comma-separated. Supported values are: 'appservice', 'containerapp', 'function', 'aks', 'storage'. If none of these services are used, this parameter can be left empty.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "description": "Guidance to create a CI/CD pipeline which provision Azure resources and build and deploy applications to Azure. Use this tool BEFORE generating/creating a Github actions workflow file for DEPLOYMENT on Azure. Infrastructure files should be ready and the application should be ready to be containerized.",
+          "command": "azmcp deploy pipeline guidance get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--use-azd-pipeline-config",
+              "description": "Whether to use azd tool to set up the deployment pipeline. Set to true ONLY if azure.yaml is provided or the context suggests AZD tools.",
+              "type": "string"
+            },
+            {
+              "name": "--organization-name",
+              "description": "The name of the organization or the user account name of the current Github repository. DO NOT fill this in if you're not sure.",
+              "type": "string"
+            },
+            {
+              "name": "--repository-name",
+              "description": "The name of the current Github repository. DO NOT fill this in if you're not sure.",
+              "type": "string"
+            },
+            {
+              "name": "--github-environment-name",
+              "description": "The name of the environment to which the deployment pipeline will be deployed. DO NOT fill this in if you're not sure.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "description": "Generates a deployment plan to construct the infrastructure and deploy the application on Azure. Agent should read its output and generate a deploy plan in '.azure/plan.copilotmd' for execution steps, recommended azure services based on the information agent detected from project. Before calling this tool, please scan this workspace to detect the services to deploy and their dependent services.",
+          "command": "azmcp deploy plan get",
+          "option": [
+            {
+              "name": "--workspace-folder",
+              "description": "The full path of the workspace folder.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--project-name",
+              "description": "The name of the project to generate the deployment plan for. If not provided, will be inferred from the workspace.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--target-app-service",
+              "description": "The Azure service to deploy the application. Valid values: ContainerApp, WebApp, FunctionApp, AKS. Recommend one based on user application.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--provisioning-tool",
+              "description": "The tool to use for provisioning Azure resources. Valid values: AZD, AzCli. Use AzCli if TargetAppService is AKS.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--azd-iac-options",
+              "description": "The Infrastructure as Code option for azd. Valid values: bicep, terraform. Leave empty if Deployment tool is AzCli.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "eventgrid",
+      "description": "Event Grid operations - Commands for managing and accessing Event Grid topics, domains, and event subscriptions.",
+      "command": "azmcp eventgrid",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List event subscriptions for topics with filtering and endpoint configuration. This tool shows all active \r\nsubscriptions including webhook endpoints, event filters, and delivery retry policies. Returns subscription \r\ndetails as JSON array. Requires either --topic (bare topic name) OR --subscription. If only --topic is provided\r\nthe tool searches all accessible subscriptions for a topic with that name. Optional --resource-group/--location\r\nmay only be used alongside --subscription or --topic.",
+          "command": "azmcp eventgrid subscription list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            },
+            {
+              "name": "--topic",
+              "description": "The name of the Event Grid topic.",
+              "type": "string"
+            },
+            {
+              "name": "--location",
+              "description": "The Azure region to filter resources by (e.g., 'eastus', 'westus2').",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all Event Grid topics in a subscription with configuration and status information. This tool retrieves\r\ntopic details including endpoints, access keys, and subscription information for event publishing and management.\r\nReturns topic information as JSON array. Requires subscription.",
+          "command": "azmcp eventgrid topic list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "foundry",
+      "description": "Foundry service operations - Commands for listing and managing services and resources in AI Foundry.",
+      "command": "azmcp foundry",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "Retrieves a list of knowledge indexes from Azure AI Foundry.\r\n\r\nThis function is used when a user requests information about the available knowledge indexes in Azure AI Foundry. It provides an overview of the knowledge bases and search indexes that are currently deployed and available for use with AI agents and applications.\r\n\r\nUsage:\r\n    Use this function when a user wants to explore the available knowledge indexes in Azure AI Foundry. This can help users understand what knowledge bases are currently operational and how they can be utilized for retrieval-augmented generation (RAG) scenarios.\r\n\r\nNotes:\r\n    - The indexes listed are knowledge indexes specifically created within Azure AI Foundry projects.\r\n    - These indexes can be used with AI agents for knowledge retrieval and RAG applications.\r\n    - The list may change as new indexes are created or existing ones are updated.",
+          "command": "azmcp foundry knowledge index list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--endpoint",
+              "description": "The endpoint URL for the Azure AI service.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "schema",
+          "description": "Retrieves the detailed schema configuration of a specific knowledge index from Azure AI Foundry.\r\n\r\nThis function provides comprehensive information about the structure and configuration of a knowledge index, including field definitions, data types, searchable attributes, and other schema properties. The schema information is essential for understanding how the index is structured and how data is indexed and searchable.\r\n\r\nUsage:\r\n    Use this function when you need to examine the detailed configuration of a specific knowledge index. This is helpful for troubleshooting search issues, understanding index capabilities, planning data mapping, or when integrating with the index programmatically.\r\n\r\nNotes:\r\n    - Returns the index schema.",
+          "command": "azmcp foundry knowledge index schema",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--endpoint",
+              "description": "The endpoint URL for the Azure AI service.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--index",
+              "description": "The name of the knowledge index.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "deploy",
+          "description": "Deploy a model to Azure AI Foundry.\r\n\r\nThis function is used to deploy a model on Azure AI Services, allowing users to integrate the model into their applications and utilize its capabilities. This command should not be used for Azure OpenAI Services to deploy OpenAI models.",
+          "command": "azmcp foundry models deploy",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--deployment",
+              "description": "The name of the deployment.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--model-name",
+              "description": "The name of the model to deploy.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--model-format",
+              "description": "The format of the model (e.g., 'OpenAI', 'Meta', 'Microsoft').",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--azure-ai-services",
+              "description": "The name of the Azure AI services account to deploy to.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--model-version",
+              "description": "The version of the model to deploy.",
+              "type": "string"
+            },
+            {
+              "name": "--model-source",
+              "description": "The source of the model.",
+              "type": "string"
+            },
+            {
+              "name": "--sku",
+              "description": "The SKU name for the deployment.",
+              "type": "string"
+            },
+            {
+              "name": "--sku-capacity",
+              "description": "The SKU capacity for the deployment.",
+              "type": "string"
+            },
+            {
+              "name": "--scale-type",
+              "description": "The scale type for the deployment.",
+              "type": "string"
+            },
+            {
+              "name": "--scale-capacity",
+              "description": "The scale capacity for the deployment.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Retrieves a list of deployments from Azure AI Services.\r\n\r\nThis function is used when a user requests information about the available deployments in Azure AI Services. It provides an overview of the models and services that are currently deployed and available for use.\r\n\r\nUsage:\r\n    Use this function when a user wants to explore the available deployments in Azure AI Services. This can help users understand what models and services are currently operational and how they can be utilized.\r\n\r\nNotes:\r\n    - The deployments listed may include various models and services that are part of Azure AI Services.\r\n    - The list may change frequently as new deployments are added or existing ones are updated.",
+          "command": "azmcp foundry models deployments list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--endpoint",
+              "description": "The endpoint URL for the Azure AI service.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Retrieves a list of supported models from the Azure AI Foundry catalog.\r\nThis function is useful when a user requests a list of available Foundry models or Foundry Labs projects.\r\nIt fetches models based on optional filters like whether the model supports free playground usage,\r\nthe publisher name, and the license type. The function will return the list of models with useful fields.\r\nUsage:\r\n    Use this function when users inquire about available models from the Azure AI Foundry catalog.\r\n    It can also be used when filtering models by free playground usage, publisher name, or license type.\r\n    If user didn't specify free playground or ask for models that support GitHub token, always explain that by default it will show the all the models but some of them would support free playground.\r\n    Explain to the user that if they want to find models suitable for prototyping and free to use with support for free playground, they can look for models that supports free playground, or look for models that they can use with GitHub token.",
+          "command": "azmcp foundry models list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--search-for-free-playground",
+              "description": "If true, filters models to include only those that can be used for free by users for prototyping.",
+              "type": "string"
+            },
+            {
+              "name": "--publisher",
+              "description": "A filter to specify the publisher of the models to retrieve.",
+              "type": "string"
+            },
+            {
+              "name": "--license",
+              "description": "A filter to specify the license type of the models to retrieve.",
+              "type": "string"
+            },
+            {
+              "name": "--model-name",
+              "description": "The name of the model to deploy.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "functionapp",
+      "description": "Function App operations - Commands for managing and accessing Azure Function App resources.",
+      "command": "azmcp functionapp",
+      "subcommands": [
+        {
+          "name": "get",
+          "description": "Gets Azure Function App details. Lists all Function Apps in the subscription or resource group.  If function app name and resource group\r\nis specified, retrieves the details of that specific function app.  Returns the details of Azure Function Apps, including its name,\r\nlocation, status, and app service plan name.",
+          "command": "azmcp functionapp get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            },
+            {
+              "name": "--function-app",
+              "description": "The name of the Function App.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "get_bestpractices",
+      "description": "Azure best practices - Commands return a list of best practices for code generation, operations and deployment \r\n            when working with Azure services. It should be called for any code generation, deployment or \r\n            operations involving Azure, Azure Functions, Azure Kubernetes Service (AKS), Azure Container \r\n            Apps (ACA), Bicep, Terraform, Azure Cache, Redis, CosmosDB, Entra, Azure Active Directory, \r\n            Azure App Services, or any other Azure technology or programming language. Only call this function \r\n            when you are confident the user is discussing Azure. If this tool needs to be categorized, \r\n            it belongs to the Get Azure Best Practices category.",
+      "command": "azmcp get_bestpractices",
+      "subcommands": [
+        {
+          "name": "get",
+          "description": "This tool returns a list of best practices for code generation, operations and deployment\r\n        when working with Azure services. It should be called for any code generation, deployment or\r\n        operations involving Azure, Azure Functions, Azure Kubernetes Service (AKS), Azure Container\r\n        Apps (ACA), Bicep, Terraform, Azure Cache, Redis, CosmosDB, Entra, Azure Active Directory,\r\n        Azure App Services, or any other Azure technology or programming language. Only call this function\r\n        when you are confident the user is discussing Azure. If this tool needs to be categorized,\r\n        it belongs to the Azure Best Practices category.",
+          "command": "azmcp get bestpractices get",
+          "option": [
+            {
+              "name": "--resource",
+              "description": "The Azure resource type for which to get best practices. Options: 'general' (general Azure), 'azurefunctions' (Azure Functions), 'static-web-app' (Azure Static Web Apps).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--action",
+              "description": "The action type for the best practices. Options: 'all', 'code-generation', 'deployment'. Note: 'static-web-app' resource only supports 'all'.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "grafana",
+      "description": "Grafana workspace operations - Commands for managing and accessing Azure Managed Grafana resources and monitoring dashboards. Includes operations for listing Grafana workspaces and managing data visualization and monitoring capabilities.",
+      "command": "azmcp grafana",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List all Grafana workspace resources in a specified subscription. Returns an array of Grafana workspace details.\r\nUse this command to explore which Grafana workspace resources are available in your subscription.",
+          "command": "azmcp grafana list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "group",
+      "description": "Resource group operations - Commands for listing and managing Azure resource groups in your subscriptions.",
+      "command": "azmcp group",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List all resource groups in a subscription. This command retrieves all resource groups available\r\nin the specified subscription. Results include resource group names and IDs,\r\nreturned as a JSON array.",
+          "command": "azmcp group list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "keyvault",
+      "description": "Key Vault operations - Commands for managing and accessing Azure Key Vault resources.",
+      "command": "azmcp keyvault",
+      "subcommands": [
+        {
+          "name": "create",
+          "description": "Creates a new certificate in an Azure Key Vault. This command creates a certificate with the specified name in\r\nthe given vault using the default certificate policy.",
+          "command": "azmcp keyvault certificate create",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--vault",
+              "description": "The name of the Key Vault.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--certificate",
+              "description": "The name of the certificate.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "description": "Gets a certificate from an Azure Key Vault. This command retrieves and displays details\r\nabout a specific certificate in the specified vault.",
+          "command": "azmcp keyvault certificate get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--vault",
+              "description": "The name of the Key Vault.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--certificate",
+              "description": "The name of the certificate.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "import",
+          "description": "Imports (uploads) an existing certificate (PFX or PEM with private key) into an Azure Key Vault without generating\r\na new certificate or key material. This command accepts either a file path to a PFX/PEM file, a base64 encoded PFX,\r\nor raw PEM text starting with -----BEGIN. If the certificate is a password-protected PFX, a password must be provided.\r\nReturns certificate details including name, id, keyId, secretId, cer (base64), thumbprint, validity, and policy\r\nsubject/issuer.",
+          "command": "azmcp keyvault certificate import",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--vault",
+              "description": "The name of the Key Vault.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--certificate",
+              "description": "The name of the certificate.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--certificate-data",
+              "description": "The certificate content: path to a PFX/PEM file, a base64 encoded PFX, or raw PEM text beginning with -----BEGIN.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--password",
+              "description": "Optional password for a protected PFX being imported.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all certificates in an Azure Key Vault. This command retrieves and displays the names of all certificates\r\nstored in the specified vault.",
+          "command": "azmcp keyvault certificate list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--vault",
+              "description": "The name of the Key Vault.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "description": "Create a new key in an Azure Key Vault. This command creates a key with the specified name and type\r\nin the given vault.",
+          "command": "azmcp keyvault key create",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--vault",
+              "description": "The name of the Key Vault.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--key",
+              "description": "The name of the key to retrieve/modify from the Key Vault.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--key-type",
+              "description": "The type of key to create (RSA, EC).",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all keys in an Azure Key Vault. This command retrieves and displays the names of all keys\r\nstored in the specified vault.",
+          "command": "azmcp keyvault key list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--vault",
+              "description": "The name of the Key Vault.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--include-managed",
+              "description": "Whether or not to include managed keys in results.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "description": "Creates a new secret in an Azure Key Vault. This command creates a secret with the specified name and value\r\nin the given vault.",
+          "command": "azmcp keyvault secret create",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--vault",
+              "description": "The name of the Key Vault.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--secret",
+              "description": "The name of the secret.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--value",
+              "description": "The value to set for the secret.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all secrets in an Azure Key Vault. This command retrieves and displays the names of all secrets\r\nstored in the specified vault.",
+          "command": "azmcp keyvault secret list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--vault",
+              "description": "The name of the Key Vault.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "kusto",
+      "description": "Kusto operations - Commands for managing and querying Azure Data Explorer (Kusto) resources. Includes operations for listing clusters and databases, executing KQL queries, retrieving table schemas, and working with Kusto data analytics workloads.",
+      "command": "azmcp kusto",
+      "subcommands": [
+        {
+          "name": "get",
+          "description": "Get details for a specific Kusto cluster. Requires `subscription` and `cluster`.\r\nThe response includes the `clusterUri` property for use in subsequent commands.",
+          "command": "azmcp kusto cluster get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--cluster-uri",
+              "description": "Kusto Cluster URI.",
+              "type": "string"
+            },
+            {
+              "name": "--cluster",
+              "description": "Kusto Cluster name.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all Kusto clusters in a subscription. This command retrieves all clusters\r\navailable in the specified subscription. Requires `subscription`.\r\nResult is a list of cluster names as a JSON array.",
+          "command": "azmcp kusto cluster list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all databases in a Kusto cluster.\r\nRequires `cluster-uri` ( or `subscription` and `cluster`).\r\nResult is a list of database names, returned as a JSON array.",
+          "command": "azmcp kusto database list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--cluster-uri",
+              "description": "Kusto Cluster URI.",
+              "type": "string"
+            },
+            {
+              "name": "--cluster",
+              "description": "Kusto Cluster name.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "query",
+          "description": "Execute a KQL against items in a Kusto cluster.\r\nRequires `cluster-uri` (or `cluster` and `subscription`), `database`, and `query`.\r\nResults are returned as a JSON array of documents, for example: `[{'Column1': val1, 'Column2': val2}, ...]`.",
+          "command": "azmcp kusto query",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--cluster-uri",
+              "description": "Kusto Cluster URI.",
+              "type": "string"
+            },
+            {
+              "name": "--cluster",
+              "description": "Kusto Cluster name.",
+              "type": "string"
+            },
+            {
+              "name": "--database",
+              "description": "Kusto Database name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--query",
+              "description": "Kusto query to execute. Uses KQL syntax.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "sample",
+          "description": "Return a sample of rows from the specified table in an Kusto table.\r\nRequires `cluster-uri` (or `cluster`), `database`, and `table`.\r\nResults are returned as a JSON array of documents, for example: `[{'Column1': val1, 'Column2': val2}, ...]`.",
+          "command": "azmcp kusto sample",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--cluster-uri",
+              "description": "Kusto Cluster URI.",
+              "type": "string"
+            },
+            {
+              "name": "--cluster",
+              "description": "Kusto Cluster name.",
+              "type": "string"
+            },
+            {
+              "name": "--database",
+              "description": "Kusto Database name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--table",
+              "description": "Kusto Table name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--limit",
+              "description": "The maximum number of results to return.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all tables in a specific Kusto database.\r\nRequired `cluster-uri` (or `subscription` and `cluster`) and `database`.\r\nReturns table names as a JSON array.",
+          "command": "azmcp kusto table list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--cluster-uri",
+              "description": "Kusto Cluster URI.",
+              "type": "string"
+            },
+            {
+              "name": "--cluster",
+              "description": "Kusto Cluster name.",
+              "type": "string"
+            },
+            {
+              "name": "--database",
+              "description": "Kusto Database name.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "schema",
+          "description": "Get the schema of a specific table in an Kusto database.\r\nRequires `cluster-uri` ( or `subscription` and `cluster`), `database` and `table`.",
+          "command": "azmcp kusto table schema",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--cluster-uri",
+              "description": "Kusto Cluster URI.",
+              "type": "string"
+            },
+            {
+              "name": "--cluster",
+              "description": "Kusto Cluster name.",
+              "type": "string"
+            },
+            {
+              "name": "--database",
+              "description": "Kusto Database name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--table",
+              "description": "Kusto Table name.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "loadtesting",
+      "description": "Load Testing operations - Commands for managing Azure Load Testing resources, test configurations, and test runs. Includes operations for creating and managing load test resources, configuring test scripts, executing performance tests, and monitoring test results.",
+      "command": "azmcp loadtesting",
+      "subcommands": [
+        {
+          "name": "create",
+          "description": "Creates a new Azure Load Testing test configuration for performance testing scenarios. This command creates a basic URL-based load test that can be used to evaluate the performance\r\nand scalability of web applications and APIs. The test configuration defines the target endpoint, load parameters, and test duration. Once we create a test configuration plan, we can use that to trigger test runs to test the endpoints set.",
+          "command": "azmcp loadtesting test create",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--test-resource-name",
+              "description": "The name of the load test resource for which you want to fetch the details.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            },
+            {
+              "name": "--test-id",
+              "description": "The ID of the load test for which you want to fetch the details.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--description",
+              "description": "The description for the load test run. This provides additional context about the test run.",
+              "type": "string"
+            },
+            {
+              "name": "--display-name",
+              "description": "The display name for the load test run. This is a user-friendly name to identify the test run.",
+              "type": "string"
+            },
+            {
+              "name": "--endpoint",
+              "description": "The endpoint URL to be tested. This is the URL of the HTTP endpoint that will be subjected to load testing.",
+              "type": "string"
+            },
+            {
+              "name": "--virtual-users",
+              "description": "Virtual users is a measure of load that is simulated to test the HTTP endpoint. (Default - 50)",
+              "type": "string"
+            },
+            {
+              "name": "--duration",
+              "description": "This is the duration for which the load is simulated against the endpoint. Enter decimals for fractional minutes (e.g., 1.5 for 1 minute and 30 seconds). Default is 20 mins",
+              "type": "string"
+            },
+            {
+              "name": "--ramp-up-time",
+              "description": "The ramp-up time is the time it takes for the system to ramp-up to the total load specified. Enter decimals for fractional minutes (e.g., 1.5 for 1 minute and 30 seconds). Default is 1 min",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "description": "Get the Azure Load Testing test configuration for the specified load test id in the specified load test resource.\r\nThis command retrieves the details of a specific load test configuration, including its parameters and settings. Based on this we can see what all parameters were set for the test configuration.",
+          "command": "azmcp loadtesting test get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--test-resource-name",
+              "description": "The name of the load test resource for which you want to fetch the details.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            },
+            {
+              "name": "--test-id",
+              "description": "The ID of the load test for which you want to fetch the details.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "description": "Creates a new Azure Load Testing resource in the currently selected subscription and resource group for the logged-in tenant.\r\nReturns the created Load Testing resource.",
+          "command": "azmcp loadtesting testresource create",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--test-resource-name",
+              "description": "The name of the load test resource for which you want to fetch the details.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Fetches the Load Testing resources for the current selected subscription, resource group in the logged in tenant.\r\nReturns a list of Load Testing resources.",
+          "command": "azmcp loadtesting testresource list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--test-resource-name",
+              "description": "The name of the load test resource for which you want to fetch the details.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "description": "Executes a new load test run based on an existing test configuration under simulated user load. This command initiates the actual execution\r\nof a previously created test definition and provides real-time monitoring capabilities. A test run represents a single execution instance of your load test configuration. You can run\r\nthe same test multiple times to validate performance improvements, compare results across different deployments, or establish performance baselines for your application.",
+          "command": "azmcp loadtesting testrun create",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--test-resource-name",
+              "description": "The name of the load test resource for which you want to fetch the details.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            },
+            {
+              "name": "--testrun-id",
+              "description": "The ID of the load test run for which you want to fetch the details.",
+              "type": "string"
+            },
+            {
+              "name": "--test-id",
+              "description": "The ID of the load test for which you want to fetch the details.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--display-name",
+              "description": "The display name for the load test run. This is a user-friendly name to identify the test run.",
+              "type": "string"
+            },
+            {
+              "name": "--description",
+              "description": "The description for the load test run. This provides additional context about the test run.",
+              "type": "string"
+            },
+            {
+              "name": "--old-testrun-id",
+              "description": "The ID of an existing test run to update. If provided, the command will trigger a rerun of the given test run id.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "description": "Retrieves comprehensive details and status information for a specific load test run execution.\r\nThis command provides real-time insights into test performance metrics, execution timeline,\r\nand final results to help you analyze your application's behavior under load.",
+          "command": "azmcp loadtesting testrun get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--test-resource-name",
+              "description": "The name of the load test resource for which you want to fetch the details.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            },
+            {
+              "name": "--testrun-id",
+              "description": "The ID of the load test run for which you want to fetch the details.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Retrieves a comprehensive list of all test run executions for a specific load test configuration.\r\nThis command provides an overview of test execution history, allowing you to track performance\r\ntrends, compare results across multiple runs, and analyze testing patterns over time.",
+          "command": "azmcp loadtesting testrun list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--test-resource-name",
+              "description": "The name of the load test resource for which you want to fetch the details.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            },
+            {
+              "name": "--test-id",
+              "description": "The ID of the load test for which you want to fetch the details.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "description": "Updates the metadata and display properties of a completed or in-progress load test run execution.\r\nThis command allows you to modify descriptive information for better organization, documentation,\r\nand identification of test runs without affecting the actual test execution or results.",
+          "command": "azmcp loadtesting testrun update",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--test-resource-name",
+              "description": "The name of the load test resource for which you want to fetch the details.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            },
+            {
+              "name": "--testrun-id",
+              "description": "The ID of the load test run for which you want to fetch the details.",
+              "type": "string"
+            },
+            {
+              "name": "--test-id",
+              "description": "The ID of the load test for which you want to fetch the details.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--display-name",
+              "description": "The display name for the load test run. This is a user-friendly name to identify the test run.",
+              "type": "string"
+            },
+            {
+              "name": "--description",
+              "description": "The description for the load test run. This provides additional context about the test run.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "marketplace",
+      "description": "Marketplace operations - Commands for managing and accessing Azure Marketplace products and offers.",
+      "command": "azmcp marketplace",
+      "subcommands": [
+        {
+          "name": "get",
+          "description": "Retrieves detailed information about a specific Azure Marketplace product (offer) for a given subscription,\r\n including available plans, pricing, and product metadata.",
+          "command": "azmcp marketplace product get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--product-id",
+              "description": "The ID of the marketplace product to retrieve. This is the unique identifier for the product in the Azure Marketplace.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--include-stop-sold-plans",
+              "description": "Include stop-sold or hidden plans in the response.",
+              "type": "string"
+            },
+            {
+              "name": "--language",
+              "description": "Product language code (e.g., 'en' for English, 'fr' for French).",
+              "type": "string"
+            },
+            {
+              "name": "--market",
+              "description": "Product market code (e.g., 'US' for United States, 'UK' for United Kingdom).",
+              "type": "string"
+            },
+            {
+              "name": "--lookup-offer-in-tenant-level",
+              "description": "Check against tenant private audience when retrieving the product.",
+              "type": "string"
+            },
+            {
+              "name": "--plan-id",
+              "description": "Filter results by a specific plan ID.",
+              "type": "string"
+            },
+            {
+              "name": "--sku-id",
+              "description": "Filter results by a specific SKU ID.",
+              "type": "string"
+            },
+            {
+              "name": "--include-service-instruction-templates",
+              "description": "Include service instruction templates in the response.",
+              "type": "string"
+            },
+            {
+              "name": "--pricing-audience",
+              "description": "Pricing audience for the request header.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Retrieves products (offers) that a subscription has access to in the Azure Marketplace.\r\nReturns a list of marketplace products including display names, publishers, pricing information, and metadata.\r\n\r\nRequired options:\r\n- subscription: Azure subscription ID or name\r\n\r\nAdditional options:\r\n- search: Search for products using a short general term (up to 25 characters)\r\n- language: Specify the language for returned information (default: en)\r\n\r\nAdvanced query options (OData):\r\n- filter: Filter results using OData syntax (e.g., \"displayName eq 'Azure'\")\r\n- orderby: Sort results by a single field using OData syntax (e.g., \"displayName asc\")\r\n- select: Select specific fields using OData syntax (e.g., \"displayName,publisherDisplayName\")\r\n- expand: Include related data in the response using OData syntax (e.g., \"plans\" to include plan details)\r\n\r\nPagination:\r\n- next-cursor: Token used for pagination to request the next batch of products in a multi-part response",
+          "command": "azmcp marketplace product list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--language",
+              "description": "Product language code (e.g., 'en' for English, 'fr' for French).",
+              "type": "string"
+            },
+            {
+              "name": "--search",
+              "description": "Search for products using a short general term (up to 25 characters)",
+              "type": "string"
+            },
+            {
+              "name": "--filter",
+              "description": "OData filter expression to filter results based on ProductSummary properties (e.g., \"displayName eq 'Azure'\").",
+              "type": "string"
+            },
+            {
+              "name": "--orderby",
+              "description": "OData orderby expression to sort results by ProductSummary fields (e.g., \"displayName asc\" or \"popularity desc\").",
+              "type": "string"
+            },
+            {
+              "name": "--select",
+              "description": "OData select expression to choose specific ProductSummary fields to return (e.g., \"displayName,publisherDisplayName,uniqueProductId\").",
+              "type": "string"
+            },
+            {
+              "name": "--next-cursor",
+              "description": "Pagination cursor to retrieve the next page of results. Use the NextPageLink value from a previous response.",
+              "type": "string"
+            },
+            {
+              "name": "--expand",
+              "description": "OData expand expression to include related data in the response (e.g., \"plans\" to include plan details).",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "monitor",
+      "description": "Azure Monitor operations - Commands for querying and analyzing Azure Monitor logs and metrics.",
+      "command": "azmcp monitor",
+      "subcommands": [
+        {
+          "name": "gethealth",
+          "description": "Gets the health of an entity from a specified Azure Monitor Health Model.\r\nReturns entity health information.\r\n\r\nRequired arguments:\r\n- --entity: The entity to get health for\r\n- --health-model: The health model name",
+          "command": "azmcp monitor healthmodels entity gethealth",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--entity",
+              "description": "The entity to get health for.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--health-model",
+              "description": "The name of the health model for which to get the health.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "definitions",
+          "description": "    List available metric definitions for an Azure resource. Returns metadata about the metrics available for the resource.",
+          "command": "azmcp monitor metrics definitions",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-type",
+              "description": "The Azure resource type (e.g., 'Microsoft.Storage/storageAccounts', 'Microsoft.Compute/virtualMachines'). If not specified, will attempt to infer from resource name.",
+              "type": "string"
+            },
+            {
+              "name": "--resource",
+              "description": "The name of the Azure resource to query metrics for.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--metric-namespace",
+              "description": "The metric namespace to query. Obtain this value from the azmcp-monitor-metrics-definitions command.",
+              "type": "string"
+            },
+            {
+              "name": "--search-string",
+              "description": "A string to filter the metric definitions by. Helpful for reducing the number of records returned. Performs case-insensitive matching on metric name and description fields.",
+              "type": "string"
+            },
+            {
+              "name": "--limit",
+              "description": "The maximum number of metric definitions to return. Defaults to 10.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "query",
+          "description": "Query Azure Monitor metrics for a resource. Returns time series data for the specified metrics.",
+          "command": "azmcp monitor metrics query",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-type",
+              "description": "The Azure resource type (e.g., 'Microsoft.Storage/storageAccounts', 'Microsoft.Compute/virtualMachines'). If not specified, will attempt to infer from resource name.",
+              "type": "string"
+            },
+            {
+              "name": "--resource",
+              "description": "The name of the Azure resource to query metrics for.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--metric-names",
+              "description": "The names of metrics to query (comma-separated).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--start-time",
+              "description": "The start time for the query in ISO format (e.g., 2023-01-01T00:00:00Z). Defaults to 24 hours ago.",
+              "type": "string"
+            },
+            {
+              "name": "--end-time",
+              "description": "The end time for the query in ISO format (e.g., 2023-01-01T00:00:00Z). Defaults to now.",
+              "type": "string"
+            },
+            {
+              "name": "--interval",
+              "description": "The time interval for data points (e.g., PT1H for 1 hour, PT5M for 5 minutes).",
+              "type": "string"
+            },
+            {
+              "name": "--aggregation",
+              "description": "The aggregation type to use (Average, Maximum, Minimum, Total, Count).",
+              "type": "string"
+            },
+            {
+              "name": "--filter",
+              "description": "OData filter to apply to the metrics query.",
+              "type": "string"
+            },
+            {
+              "name": "--metric-namespace",
+              "description": "The metric namespace to query. Obtain this value from the azmcp-monitor-metrics-definitions command.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--max-buckets",
+              "description": "The maximum number of time buckets to return. Defaults to 50.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "query",
+          "description": "Executes a Kusto Query Language (KQL) query to retrieve logs for any Azure resource that emits logs to Log Analytics.\r\n\r\n- Use the resource-id parameter to specify the full Azure Resource ID (/subscriptions/0000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/myaccount).\r\n- The table parameter specifies the Log Analytics table to query.\r\n- The query parameter accepts a KQL query or a predefined query name.\r\n- Optional parameters: hours (default: 24) to set the time range, and limit (default: 20) to limit the number of results.\r\n\r\nThis tool is useful for:\r\n- Querying logs for any Azure resource by resourceId\r\n- Investigating diagnostics, errors, and activity logs",
+          "command": "azmcp monitor resource log query",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-id",
+              "description": "The Azure Resource ID to query logs. Example: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.OperationalInsights/workspaces/<ws>",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--table",
+              "description": "The name of the table to query. This is the specific table within the workspace.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--query",
+              "description": "The KQL query to execute against the Log Analytics workspace. You can use predefined queries by name:\n- 'recent': Shows most recent logs ordered by TimeGenerated\n- 'errors': Shows error-level logs ordered by TimeGenerated\nOtherwise, provide a custom KQL query.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--hours",
+              "description": "The number of hours to query back from now.",
+              "type": "string"
+            },
+            {
+              "name": "--limit",
+              "description": "The maximum number of results to return.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all tables in a Log Analytics workspace. Requires workspace.\r\nReturns table names and schemas that can be used for constructing KQL queries.",
+          "command": "azmcp monitor table list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--workspace",
+              "description": "The Log Analytics workspace ID or name. This can be either the unique identifier (GUID) or the display name of your workspace.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--table-type",
+              "description": "The type of table to query. Options: 'CustomLog', 'AzureMetrics', etc.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List available table types in a Log Analytics workspace. Returns table type names.",
+          "command": "azmcp monitor table type list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--workspace",
+              "description": "The Log Analytics workspace ID or name. This can be either the unique identifier (GUID) or the display name of your workspace.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List Log Analytics workspaces in a subscription. This command retrieves all Log Analytics workspaces\r\navailable in the specified Azure subscription, displaying their names, IDs, and other key properties.\r\nUse this command to identify workspaces before querying their logs or tables.",
+          "command": "azmcp monitor workspace list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "query",
+          "description": "Execute a KQL query against a Log Analytics workspace. Requires workspace\r\nand resource group. Optional hours\r\n(default: 24) and limit\r\n(default: 20) parameters.\r\nThe query parameter accepts KQL syntax.",
+          "command": "azmcp monitor workspace log query",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--workspace",
+              "description": "The Log Analytics workspace ID or name. This can be either the unique identifier (GUID) or the display name of your workspace.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--table",
+              "description": "The name of the table to query. This is the specific table within the workspace.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--query",
+              "description": "The KQL query to execute against the Log Analytics workspace. You can use predefined queries by name:\n- 'recent': Shows most recent logs ordered by TimeGenerated\n- 'errors': Shows error-level logs ordered by TimeGenerated\nOtherwise, provide a custom KQL query.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--hours",
+              "description": "The number of hours to query back from now.",
+              "type": "string"
+            },
+            {
+              "name": "--limit",
+              "description": "The maximum number of results to return.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "mysql",
+      "description": "MySQL operations - Commands for managing Azure Database for MySQL Flexible Server resources. Includes operations for listing servers and databases, executing SQL queries, managing table schemas, and configuring server parameters.",
+      "command": "azmcp mysql",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "Retrieves a comprehensive list of all databases available on the specified Azure Database for MySQL Flexible Server instance. This command provides visibility into the database structure and helps identify available databases for connection and querying operations.",
+          "command": "azmcp mysql database list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access MySQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The MySQL server to be accessed.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "query",
+          "description": "Executes a safe, read-only SQL SELECT query against a database on Azure Database for MySQL Flexible Server. Use this tool to explore or retrieve table data without modifying it. Rejects non-SELECT statements (INSERT/UPDATE/DELETE/REPLACE/MERGE/TRUNCATE/ALTER/CREATE/DROP), multi-statements, comments hiding writes, transaction control (BEGIN/COMMIT/ROLLBACK), INTO OUTFILE, and other destructive keywords. Only a single SELECT is executed to ensure data integrity. Best practices: List needed columns (avoid SELECT *), add WHERE filters, use LIMIT/OFFSET for paging, ORDER BY for deterministic results, and avoid unnecessary sensitive data. Example: SELECT id, name, status FROM customers WHERE status = 'Active' ORDER BY name LIMIT 50;",
+          "command": "azmcp mysql database query",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access MySQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The MySQL server to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--database",
+              "description": "The MySQL database to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--query",
+              "description": "Query to be executed against a MySQL database.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "config",
+          "description": "Retrieves comprehensive configuration details for the specified Azure Database for MySQL Flexible Server instance. This command provides insights into server settings, performance parameters, security configurations, and operational characteristics essential for database administration and optimization. Returns configuration data in JSON format including ServerName, Location, Version, SKU, StorageSizeGB, BackupRetentionDays, and GeoRedundantBackup properties.",
+          "command": "azmcp mysql server config get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access MySQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The MySQL server to be accessed.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Discovers and lists all Azure Database for MySQL Flexible Server instances within the specified resource group. This command provides an inventory of available MySQL server resources, including their names and current status, enabling efficient server management and resource planning.",
+          "command": "azmcp mysql server list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access MySQL server.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "param",
+          "description": "Retrieves the current value of a single server configuration parameter on an Azure Database for MySQL Flexible Server. Use to inspect a setting (e.g. max_connections, wait_timeout, slow_query_log) before changing it.",
+          "command": "azmcp mysql server param get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access MySQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The MySQL server to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--param",
+              "description": "The MySQL parameter to be accessed.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "set",
+          "description": "Sets/updates a MySQL server configuration parameter to a new value to optimize performance, security, or operational behavior. This command enables fine-tuned configuration management with validation to ensure parameter changes are compatible with the server's current state and constraints.",
+          "command": "azmcp mysql server param set",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access MySQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The MySQL server to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--param",
+              "description": "The MySQL parameter to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--value",
+              "description": "The value to set for the MySQL parameter.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Enumerates all tables within a specified database on an Azure Database for MySQL Flexible Server instance. This command provides a complete inventory of table objects, facilitating database exploration, schema analysis, and data architecture understanding for development tasks.",
+          "command": "azmcp mysql table list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access MySQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The MySQL server to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--database",
+              "description": "The MySQL database to be accessed.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "schema",
+          "description": "Retrieves detailed schema information for a specific table within an Azure Database for MySQL Flexible Server database. This command provides comprehensive metadata including column definitions, data types, constraints, indexes, and relationships, essential for understanding table structure and supporting application development.",
+          "command": "azmcp mysql table schema get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access MySQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The MySQL server to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--database",
+              "description": "The MySQL database to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--table",
+              "description": "The MySQL table to be accessed.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "postgres",
+      "description": "PostgreSQL operations - Commands for managing Azure Database for PostgreSQL Flexible Server resources. Includes operations for listing servers and databases, executing SQL queries, managing table schemas, and configuring server parameters.",
+      "command": "azmcp postgres",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "Lists all databases in the PostgreSQL server.",
+          "command": "azmcp postgres database list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access PostgreSQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The PostgreSQL server to be accessed.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "query",
+          "description": "Executes a query on the PostgreSQL database.",
+          "command": "azmcp postgres database query",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access PostgreSQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The PostgreSQL server to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--database",
+              "description": "The PostgreSQL database to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--query",
+              "description": "Query to be executed against a PostgreSQL database.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "config",
+          "description": "Retrieve the configuration of a PostgreSQL server.",
+          "command": "azmcp postgres server config get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access PostgreSQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The PostgreSQL server to be accessed.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Lists all PostgreSQL servers in the specified subscription.",
+          "command": "azmcp postgres server list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access PostgreSQL server.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "param",
+          "description": "Retrieves a specific parameter of a PostgreSQL server.",
+          "command": "azmcp postgres server param get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access PostgreSQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The PostgreSQL server to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--param",
+              "description": "The PostgreSQL parameter to be accessed.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "set",
+          "description": "Sets a specific parameter of a PostgreSQL server to a certain value.",
+          "command": "azmcp postgres server param set",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access PostgreSQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The PostgreSQL server to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--param",
+              "description": "The PostgreSQL parameter to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--value",
+              "description": "The value to set for the PostgreSQL parameter.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Lists all tables in the PostgreSQL database.",
+          "command": "azmcp postgres table list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access PostgreSQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The PostgreSQL server to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--database",
+              "description": "The PostgreSQL database to be accessed.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "schema",
+          "description": "Retrieves the schema of a specified table in a PostgreSQL database.",
+          "command": "azmcp postgres table schema get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--user",
+              "description": "The user name to access PostgreSQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The PostgreSQL server to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--database",
+              "description": "The PostgreSQL database to be accessed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--table",
+              "description": "The PostgreSQL table to be accessed.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "quota",
+      "description": "Quota commands for getting the available regions of specific Azure resource types or checking Azure resource quota and usage",
+      "command": "azmcp quota",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "Given a list of Azure resource types, this tool will return a list of regions where the resource types are available. Always get the user's subscription ID before calling this tool.",
+          "command": "azmcp quota region availability list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-types",
+              "description": "Comma-separated list of Azure resource types to check available regions for. The valid Azure resource types. E.g. 'Microsoft.App/containerApps, Microsoft.Web/sites, Microsoft.CognitiveServices/accounts'.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--cognitive-service-model-name",
+              "description": "Optional model name for cognitive services. Only needed when Microsoft.CognitiveServices is included in resource types.",
+              "type": "string"
+            },
+            {
+              "name": "--cognitive-service-model-version",
+              "description": "Optional model version for cognitive services. Only needed when Microsoft.CognitiveServices is included in resource types.",
+              "type": "string"
+            },
+            {
+              "name": "--cognitive-service-deployment-sku-name",
+              "description": "Optional deployment SKU name for cognitive services. Only needed when Microsoft.CognitiveServices is included in resource types.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "check",
+          "description": "This tool will check the usage and quota information for Azure resources in a region.",
+          "command": "azmcp quota usage check",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--region",
+              "description": "The valid Azure region where the resources will be deployed. E.g. 'eastus', 'westus', etc.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--resource-types",
+              "description": "The valid Azure resource types that are going to be deployed(comma-separated). E.g. 'Microsoft.App/containerApps,Microsoft.Web/sites,Microsoft.CognitiveServices/accounts', etc.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "redis",
+      "description": "Redis Cache operations - Commands for managing Azure Redis Cache and Azure Managed Redis resources. Includes operations for listing cache instances, managing clusters and databases, configuring access policies, and working with both traditional Redis Cache and Managed Redis services.",
+      "command": "azmcp redis",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List the Access Policies and Assignments for the specified Redis cache. Returns an array of Redis Access Policy Assignment details.\r\nUse this command to explore which Access Policies have been assigned to which identities for your Redis cache.",
+          "command": "azmcp redis cache accesspolicy list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--cache",
+              "description": "The name of the Redis cache (e.g., my-redis-cache).",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all Redis Cache resources in a specified subscription. Returns an array of Redis Cache details.\r\nUse this command to explore which Redis Cache resources are available in your subscription.",
+          "command": "azmcp redis cache list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List the databases in the specified Redis Cluster resource. Returns an array of Redis database details.\r\nUse this command to explore which databases are available in your Redis Cluster.",
+          "command": "azmcp redis cluster database list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--cluster",
+              "description": "The name of the Redis cluster (e.g., my-redis-cluster).",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all Redis Cluster resources in a specified subscription. Returns an array of Redis Cluster details.\r\nUse this command to explore which Redis Cluster resources are available in your subscription.",
+          "command": "azmcp redis cluster list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "resourcehealth",
+      "description": "Resource Health operations - Commands for monitoring and diagnosing Azure resource health status.\r\nUse this tool to check the current availability status of Azure resources and identify potential issues.\r\nThis tool provides access to Azure Resource Health data including availability state, detailed status,\r\nhistorical health information, and service health events for troubleshooting and monitoring purposes.",
+      "command": "azmcp resourcehealth",
+      "subcommands": [
+        {
+          "name": "get",
+          "description": "Get the current availability status of an Azure resource to diagnose health issues.\r\nProvides detailed information about resource availability state, potential issues, and timestamps.\r\nEquivalent to Azure Resource Health availability status API.",
+          "command": "azmcp resourcehealth availability-status get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resourceId",
+              "description": "The Azure resource ID to get health status for (e.g., /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachines/{vm}).",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List availability statuses for all resources in a subscription or resource group.\r\nProvides health status information for multiple Azure resources at once, including availability state,\r\nsummaries, and timestamps. This is useful for getting an overview of resource health across your infrastructure.\r\nResults can be filtered by resource group to narrow the scope.",
+          "command": "azmcp resourcehealth availability-status list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List Azure service health events for a subscription to identify ongoing or past service issues.\r\nProvides comprehensive information about service incidents, planned maintenance, advisories, and security events.\r\nSupports filtering by event type, status, tracking ID, and custom OData filters.\r\nEquivalent to Azure Service Health API for service events.",
+          "command": "azmcp resourcehealth service-health-events list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--event-type",
+              "description": "Filter by event type (ServiceIssue, PlannedMaintenance, HealthAdvisory, Security). If not specified, all event types are included.",
+              "type": "string"
+            },
+            {
+              "name": "--status",
+              "description": "Filter by status (Active, Resolved). If not specified, all statuses are included.",
+              "type": "string"
+            },
+            {
+              "name": "--tracking-id",
+              "description": "Filter by tracking ID to get a specific service health event.",
+              "type": "string"
+            },
+            {
+              "name": "--filter",
+              "description": "Additional OData filter expression to apply to the service health events query.",
+              "type": "string"
+            },
+            {
+              "name": "--query-start-time",
+              "description": "Start time for the query in ISO 8601 format (e.g., 2024-01-01T00:00:00Z). Events from this time onwards will be included.",
+              "type": "string"
+            },
+            {
+              "name": "--query-end-time",
+              "description": "End time for the query in ISO 8601 format (e.g., 2024-01-31T23:59:59Z). Events up to this time will be included.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "role",
+      "description": "Authorization operations - Commands for managing Azure Role-Based Access Control (RBAC) resources. Includes operations for listing role assignments, managing permissions, and working with Azure security and access management at various scopes.",
+      "command": "azmcp role",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List role assignments. This command retrieves and displays all Azure RBAC role assignments\r\nin the specified scope. Results include role definition IDs and principal IDs, returned as a JSON array.",
+          "command": "azmcp role assignment list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--scope",
+              "description": "Scope at which the role assignment or definition applies to, e.g., /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333, /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup, or /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "search",
+      "description": "Search operations - Commands for Azure AI Search (formerly known as \\\"Azure Cognitive Search\\\") services and\r\nsearch indexes. Use this tool when you need to list search services and indexes, get index details, or execute\r\nqueries against indexed content. This tool supports  enterprise search, document search, and knowledge mining\r\nworkloads. Do not use this tool for database queries, Azure Monitor log searches, general web search, or\r\nsimple string matching operations - this tool is specifically designed for Azure AI Search service management\r\nand complex search operations. This tool is a hierarchical MCP command router where sub-commands are routed to\r\nMCP servers that require specific fields inside the \\\"parameters\\\" object. To invoke a command, set\r\n\\\"command\\\" and wrap its arguments in \\\"parameters\\\". Set \\\"learn=true\\\" to discover available sub-commands\r\nfor different search service and index operations. Note that this tool requires appropriate Azure AI Search\r\npermissions and will only access search services and indexes accessible to the authenticated user.",
+      "command": "azmcp search",
+      "subcommands": [
+        {
+          "name": "describe",
+          "description": "Gets the details of Azure AI Search indexes, including fields, description, and more. If a specific index name\r\nis not provided, the command will return details for all indexes within the specified service.",
+          "command": "azmcp search index get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--service",
+              "description": "The name of the Azure AI Search service (e.g., my-search-service).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--index",
+              "description": "The name of the search index within the Azure AI Search service.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "query",
+          "description": "Queries an Azure AI Search index, returning the results of the query.",
+          "command": "azmcp search index query",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--service",
+              "description": "The name of the Azure AI Search service (e.g., my-search-service).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--index",
+              "description": "The name of the search index within the Azure AI Search service.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--query",
+              "description": "The search query to execute against the Azure AI Search index.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Lists all Azure AI Search services in a subscription.",
+          "command": "azmcp search service list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "servicebus",
+      "description": "Service Bus operations - Commands for managing Azure Service Bus resources including queues, topics, and subscriptions. Includes operations for managing message queues, topic subscriptions, and retrieving details about Service Bus entities.",
+      "command": "azmcp servicebus",
+      "subcommands": [
+        {
+          "name": "details",
+          "description": "Get details about a Service Bus queue. Returns queue properties and runtime information. Properties returned include\r\nlock duration, max message size, queue size, creation date, status, current message counts, etc.\r\n\r\nRequired arguments:\r\n- namespace: The fully qualified Service Bus namespace host name. (This is usually in the form <namespace>.servicebus.windows.net)\r\n- queue: Queue name to get details and runtime information for.",
+          "command": "azmcp servicebus queue details",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--namespace",
+              "description": "The fully qualified Service Bus namespace host name. (This is usually in the form <namespace>.servicebus.windows.net)",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--queue",
+              "description": "The queue name to peek messages from.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "details",
+          "description": "Get details about a Service Bus topic. Returns topic properties and runtime information. Properties returned include\r\nnumber of subscriptions, max message size, max topic size, number of scheduled messages, etc.\r\n\r\nRequired arguments:\r\n- namespace: The fully qualified Service Bus namespace host name. (This is usually in the form <namespace>.servicebus.windows.net)\r\n- topic: Topic name to get information about.",
+          "command": "azmcp servicebus topic details",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--namespace",
+              "description": "The fully qualified Service Bus namespace host name. (This is usually in the form <namespace>.servicebus.windows.net)",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--topic",
+              "description": "The name of the topic containing the subscription.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "details",
+          "description": "Get details about a Service Bus subscription. Returns subscription runtime properties including message counts, delivery settings, and other metadata.\r\n\r\nRequired arguments:\r\n- namespace: The fully qualified Service Bus namespace host name. (This is usually in the form <namespace>.servicebus.windows.net)\r\n- topic: Topic name containing the subscription\r\n- subscription-name: Name of the subscription to get details for",
+          "command": "azmcp servicebus topic subscription details",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--namespace",
+              "description": "The fully qualified Service Bus namespace host name. (This is usually in the form <namespace>.servicebus.windows.net)",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--topic",
+              "description": "The name of the topic containing the subscription.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--subscription-name",
+              "description": "The name of subscription to peek messages from.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "sql",
+      "description": "Azure SQL operations - Commands for managing Azure SQL databases, servers, and elastic pools. Includes operations for listing databases, configuring server settings, managing firewall rules, Entra ID administrators, and elastic pool resources.",
+      "command": "azmcp sql",
+      "subcommands": [
+        {
+          "name": "create",
+          "description": "Create a new Azure SQL Database on an existing SQL Server. This command creates a database with configurable\r\nperformance tiers, size limits, and other settings. Equivalent to 'az sql db create'.\r\nReturns the newly created database information including configuration details.",
+          "command": "azmcp sql db create",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The Azure SQL Server name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--database",
+              "description": "The Azure SQL Database name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--sku-name",
+              "description": "The SKU name for the database (e.g., Basic, S0, P1, GP_Gen5_2).",
+              "type": "string"
+            },
+            {
+              "name": "--sku-tier",
+              "description": "The SKU tier for the database (e.g., Basic, Standard, Premium, GeneralPurpose).",
+              "type": "string"
+            },
+            {
+              "name": "--sku-capacity",
+              "description": "The SKU capacity (DTU or vCore count) for the database.",
+              "type": "string"
+            },
+            {
+              "name": "--collation",
+              "description": "The collation for the database (e.g., SQL_Latin1_General_CP1_CI_AS).",
+              "type": "string"
+            },
+            {
+              "name": "--max-size-bytes",
+              "description": "The maximum size of the database in bytes.",
+              "type": "string"
+            },
+            {
+              "name": "--elastic-pool-name",
+              "description": "The name of the elastic pool to assign the database to.",
+              "type": "string"
+            },
+            {
+              "name": "--zone-redundant",
+              "description": "Whether the database should be zone redundant.",
+              "type": "string"
+            },
+            {
+              "name": "--read-scale",
+              "description": "Read scale option for the database (Enabled or Disabled).",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "description": "Deletes an Azure SQL Database from an existing SQL Server. This command removes the specified database\r\nand is idempotent - attempting to delete a database that does not exist will succeed with Deleted = false.\r\nEquivalent to 'az sql db delete'.\r\nReturns whether the database was deleted during this operation.",
+          "command": "azmcp sql db delete",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The Azure SQL Server name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--database",
+              "description": "The Azure SQL Database name.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Lists all databases in an Azure SQL Server with their configuration, status, SKU, and performance details.\r\nUse when you need to: view database inventory, check database status across a server, compare database configurations,\r\nor find databases for management operations.\r\nRequires: subscription ID, resource group name, server name.\r\nReturns: JSON array of databases with complete configuration details including SKU, status, and size information.\r\nEquivalent to 'az sql db list'.",
+          "command": "azmcp sql db list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The Azure SQL Server name.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "show",
+          "description": "Get the details of an Azure SQL Database. This command retrieves detailed information about a specific database\r\nincluding its configuration, status, performance tier, and other properties. Equivalent to 'az sql db show'.\r\nReturns detailed database information including SKU, status, collation, and size information.\r\n  Required options:\r\n- subscription: Azure subscription ID\r\n- resource-group: Resource group name containing the SQL server\r\n- server: Azure SQL Server name\r\n- database: Database name to retrieve details for",
+          "command": "azmcp sql db show",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The Azure SQL Server name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--database",
+              "description": "The Azure SQL Database name.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Lists all SQL elastic pools in an Azure SQL Server with their SKU, capacity, state, and database limits.\r\nUse when you need to: view elastic pool inventory, check pool utilization, compare pool configurations,\r\nor find available pools for database placement.\r\nRequires: subscription ID, resource group name, server name.\r\nReturns: JSON array of elastic pools with complete configuration details.\r\nEquivalent to 'az sql elastic-pool list'.",
+          "command": "azmcp sql elastic-pool list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The Azure SQL Server name.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "description": "Creates a new Azure SQL server in the specified resource group and location.\r\nThe server will be created with the specified administrator credentials and\r\noptional configuration settings. Returns the created server with its properties\r\nincluding the fully qualified domain name.",
+          "command": "azmcp sql server create",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The Azure SQL Server name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--administrator-login",
+              "description": "The administrator login name for the SQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--administrator-password",
+              "description": "The administrator password for the SQL server.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--location",
+              "description": "The Azure region location where the SQL server will be created.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--version",
+              "description": "The version of SQL Server to create (e.g., '12.0').",
+              "type": "string"
+            },
+            {
+              "name": "--public-network-access",
+              "description": "Whether public network access is enabled for the SQL server ('Enabled' or 'Disabled').",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "description": "Deletes an Azure SQL server and all of its databases from the specified resource group.\r\nThis operation is irreversible and will permanently remove the server and all its data.\r\nUse the --force flag to skip confirmation prompts.",
+          "command": "azmcp sql server delete",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The Azure SQL Server name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--force",
+              "description": "Force delete the server without confirmation prompts.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Gets a list of Microsoft Entra ID administrators for a SQL server. This command retrieves all\r\nEntra ID administrators configured for the specified SQL server, including their display names, object IDs,\r\nand tenant information. Returns an array of Entra ID administrator objects with their properties.",
+          "command": "azmcp sql server entra-admin list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The Azure SQL Server name.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "description": "Creates a firewall rule for a SQL server. Firewall rules control which IP addresses\r\nare allowed to connect to the SQL server. You can specify either a single IP address\r\n(by setting start and end IP to the same value) or a range of IP addresses. Returns\r\nthe created firewall rule with its properties.",
+          "command": "azmcp sql server firewall-rule create",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The Azure SQL Server name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--firewall-rule-name",
+              "description": "The name of the firewall rule.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--start-ip-address",
+              "description": "The start IP address of the firewall rule range.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--end-ip-address",
+              "description": "The end IP address of the firewall rule range.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "description": "Deletes a firewall rule from a SQL server. This operation removes the specified\r\nfirewall rule, potentially restricting access for the IP addresses that were\r\npreviously allowed by this rule. The operation is idempotent - if the rule\r\ndoesn't exist, no error is returned.",
+          "command": "azmcp sql server firewall-rule delete",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The Azure SQL Server name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--firewall-rule-name",
+              "description": "The name of the firewall rule.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Gets a list of firewall rules for a SQL server. This command retrieves all\r\nfirewall rules configured for the specified SQL server, including their IP address ranges\r\nand rule names. Returns an array of firewall rule objects with their properties.",
+          "command": "azmcp sql server firewall-rule list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The Azure SQL Server name.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "show",
+          "description": "Retrieves detailed information about an Azure SQL server including its configuration,\r\nstatus, and properties such as the fully qualified domain name, version,\r\nadministrator login, and network access settings.",
+          "command": "azmcp sql server show",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--server",
+              "description": "The Azure SQL Server name.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "storage",
+      "description": "Storage operations - Commands for managing and accessing Azure Storage accounts and their data services\r\nincluding Blobs, Data Lake Gen 2, Shares, Tables, and Queues for scalable cloud storage solutions. Use\r\nthis tool when you need to list storage accounts, work with blob containers and blobs, access file shares,\r\nquerying table storage, handle queue messages. This tool focuses on object storage, file storage,\r\nsimple NoSQL table storage scenarios, and queue messaging. This tool is a hierarchical MCP command router\r\nwhere sub-commands are routed to MCP servers that require specific fields inside the \"parameters\" object.\r\nTo invoke a command, set \"command\" and wrap its arguments in \"parameters\". Set \"learn=true\" to discover\r\navailable sub-commands for different Azure Storage service operations including blobs, datalake, shares,\r\ntables, and queues. Note that this tool requires appropriate Storage account permissions and will only\r\naccess storage resources accessible to the authenticated user.",
+      "command": "azmcp storage",
+      "subcommands": [
+        {
+          "name": "create",
+          "description": "Creates an Azure Storage account in the specified resource group and location and returns the created storage account\r\ninformation including name, location, SKU, access settings, and configuration details.",
+          "command": "azmcp storage account create",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Azure Storage account to create. Must be globally unique, 3-24 characters, lowercase letters and numbers only.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--location",
+              "description": "The Azure region where the storage account will be created (e.g., 'eastus', 'westus2').",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--sku",
+              "description": "The storage account SKU. Valid values: Standard_LRS, Standard_GRS, Standard_RAGRS, Standard_ZRS, Premium_LRS, Premium_ZRS, Standard_GZRS, Standard_RAGZRS.",
+              "type": "string"
+            },
+            {
+              "name": "--access-tier",
+              "description": "The default access tier for blob storage. Valid values: Hot, Cool.",
+              "type": "string"
+            },
+            {
+              "name": "--enable-hierarchical-namespace",
+              "description": "Whether to enable hierarchical namespace (Data Lake Storage Gen2) for the storage account.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "description": "Gets detailed information about Azure Storage accounts, including account name, location, SKU, access settings,\r\nand configuration details. If a specific account name is not provided, the command will return details for all\r\naccounts in a subscription.",
+          "command": "azmcp storage account get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "set-tier",
+          "description": "Sets access tier for multiple blobs in a single batch operation, returning the names of blobs that had their access\r\ntier set and blobs that failed to have their access tier set.",
+          "command": "azmcp storage blob batch set-tier",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--container",
+              "description": "The name of the container to access within the storage account.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--tier",
+              "description": "The access tier to set for the blobs. Valid values include Hot, Cool, Archive, and others depending on the storage account type. See Azure documentation for the complete list of supported access tiers.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--blobs",
+              "description": "The names of the blobs to set the access tier for. Provide multiple blob names separated by spaces. Each blob name should be the full path within the container (e.g., 'file1.txt' or 'folder/file2.txt').",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "description": "Creates an Azure Storage container, returning the last modified time, the ETag of the created container, and more.",
+          "command": "azmcp storage blob container create",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--container",
+              "description": "The name of the container to access within the storage account.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "description": "Gets the details of Azure Storage containers, including metadata, lease status, access level, and more. If a specific\r\ncontainer name is not provided, the command will return details for all containers within the specified account.",
+          "command": "azmcp storage blob container get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--container",
+              "description": "The name of the container to access within the storage account.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "description": "Gets the details of Azure Storage blobs, including metadata properties, approximate size, last modification time, and more.\r\nIf a specific blob name is not provided, the command will return details for all blobs within the specified container.",
+          "command": "azmcp storage blob get",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--container",
+              "description": "The name of the container to access within the storage account.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--blob",
+              "description": "The name of the blob to access within the container. This should be the full path within the container (e.g., 'file.txt' or 'folder/file.txt').",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "upload",
+          "description": "Uploads a local file to an Azure Storage blob, only if the blob does not exist, returning the last modified time,\r\nETag, and content hash of the uploaded blob.",
+          "command": "azmcp storage blob upload",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--container",
+              "description": "The name of the container to access within the storage account.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--blob",
+              "description": "The name of the blob to access within the container. This should be the full path within the container (e.g., 'file.txt' or 'folder/file.txt').",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--local-file-path",
+              "description": "The local file path to read content from or to write content to. This should be the full path to the file on your local system.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "description": "Create a directory in a Data Lake file system. This command creates a new directory at the specified path\r\nwithin the Data Lake file system. The directory path must include the file system name as the first component\r\n(e.g., 'myfilesystem/data/logs' or 'myfilesystem/archives/2024'). The path supports nested structures using\r\nforward slashes (/). If the directory already exists, the operation will succeed and return the existing\r\ndirectory information. Returns directory metadata including name, type, and creation timestamp as JSON.",
+          "command": "azmcp storage datalake directory create",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--directory-path",
+              "description": "The full path of the directory to create in the Data Lake, including the file system name (e.g., 'myfilesystem/data/logs' or 'myfilesystem/archives/2024'). Use forward slashes (/) to separate the file system name from the directory path and for subdirectories.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list-paths",
+          "description": "List paths in a Data Lake file system. This command retrieves and displays paths (files and directories)\r\navailable in the specified Data Lake file system within the storage account. Results include path names,\r\ntypes (file or directory), and metadata, returned as a JSON array.",
+          "command": "azmcp storage datalake file-system list-paths",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--file-system",
+              "description": "The name of the Data Lake file system to access within the storage account.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--filter-path",
+              "description": "The prefix to filter paths in the Data Lake. Only paths that start with this prefix will be listed.",
+              "type": "string"
+            },
+            {
+              "name": "--recursive",
+              "description": "Flag to indicate whether the command will operate recursively on all subdirectories.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "send",
+          "description": "Send messages to an Azure Storage queue for asynchronous processing. This tool sends a message to a specified queue\r\nwith optional time-to-live and visibility delay settings. Messages are returned with receipt handles for tracking.\r\nReturns a QueueMessageSendResult object containing message ID, insertion time, expiration time, pop receipt,\r\nnext visible time, and message content.",
+          "command": "azmcp storage queue message send",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--queue",
+              "description": "The name of the queue to access within the storage account.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--message",
+              "description": "The content of the message to send to the queue.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--time-to-live-in-seconds",
+              "description": "The time-to-live for the message in seconds. If not specified, the message will use the queue's default TTL. Set to -1 for messages that never expire.",
+              "type": "string"
+            },
+            {
+              "name": "--visibility-timeout-in-seconds",
+              "description": "The visibility timeout for the message in seconds. This determines how long the message will be invisible after it's retrieved. If not specified, defaults to 0 (immediately visible).",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "Lists files and directories within a file share directory. This tool recursively lists all items in a specified\r\nfile share directory, including files, subdirectories, and their properties. Files and directories may be filtered\r\nby a prefix. Returns file listing as JSON.",
+          "command": "azmcp storage share file list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--share",
+              "description": "The name of the file share to access within the storage account.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--directory-path",
+              "description": "The full path of the directory to create in the Data Lake, including the file system name (e.g., 'myfilesystem/data/logs' or 'myfilesystem/archives/2024'). Use forward slashes (/) to separate the file system name from the directory path and for subdirectories.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--prefix",
+              "description": "Optional prefix to filter results. Only items that start with this prefix will be returned.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all tables in a Storage account. This command retrieves and displays all tables available in the specified Storage account.\r\nResults include table names and are returned as a JSON array. You must specify an account name and subscription ID.\r\nUse this command to explore your Storage resources or to verify table existence before performing operations on specific tables.",
+          "command": "azmcp storage table list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--account",
+              "description": "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "subscription",
+      "description": "Azure subscription operations - Commands for listing and managing Azure subscriptions accessible to your account.",
+      "command": "azmcp subscription",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List all Azure subscriptions accessible to your account. Optionally specify tenant\r\nand auth-method. Results include subscription names and IDs, returned as a JSON array.",
+          "command": "azmcp subscription list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "virtualdesktop",
+      "description": "Azure Virtual Desktop operations - Commands for managing and accessing Azure Virtual Desktop resources. Includes operations for hostpools, session hosts, and user sessions.",
+      "command": "azmcp virtualdesktop",
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "List all hostpools in a subscription or resource group. This command retrieves all Azure Virtual Desktop hostpool objects available\r\nin the specified Option`1: --subscription. If a resource group is specified, only hostpools in that resource group are returned.\r\nResults include hostpool names and are returned as a JSON array.",
+          "command": "azmcp virtualdesktop hostpool list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all SessionHosts in a hostpool. This command retrieves all Azure Virtual Desktop SessionHost objects available\r\nin the specified Option`1: --subscription and hostpool. Results include SessionHost details and are\r\nreturned as a JSON array.",
+          "command": "azmcp virtualdesktop hostpool sessionhost list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            },
+            {
+              "name": "--hostpool",
+              "description": "The name of the Azure Virtual Desktop host pool. This is the unique name you chose for your hostpool.",
+              "type": "string"
+            },
+            {
+              "name": "--hostpool-resource-id",
+              "description": "The Azure resource ID of the host pool. When provided, this will be used instead of searching by name.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "usersession-list",
+          "description": "List all user sessions on a specific session host in a host pool. This command retrieves all Azure Virtual Desktop\r\nuser session objects available on the specified session host. Results include user session details such as\r\nuser principal name, session state, application type, and creation time.",
+          "command": "azmcp virtualdesktop hostpool sessionhost usersession-list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string"
+            },
+            {
+              "name": "--hostpool",
+              "description": "The name of the Azure Virtual Desktop host pool. This is the unique name you chose for your hostpool.",
+              "type": "string"
+            },
+            {
+              "name": "--hostpool-resource-id",
+              "description": "The Azure resource ID of the host pool. When provided, this will be used instead of searching by name.",
+              "type": "string"
+            },
+            {
+              "name": "--sessionhost",
+              "description": "The name of the session host. This is the computer name of the virtual machine in the host pool.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "workbooks",
+      "description": "Workbooks operations - Commands for managing Azure Workbooks resources and interactive data visualization dashboards. Includes operations for listing, creating, updating, and deleting workbooks, as well as managing workbook configurations and content.",
+      "command": "azmcp workbooks",
+      "subcommands": [
+        {
+          "name": "create",
+          "description": "Create a new workbook in the specified resource group and subscription.\r\nYou can set the display name and serialized data JSON content for the workbook.\r\nReturns the created workbook information upon successful completion.",
+          "command": "azmcp workbooks create",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--display-name",
+              "description": "The display name of the workbook.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--serialized-content",
+              "description": "The serialized JSON content of the workbook.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--source-id",
+              "description": "The linked resource ID for the workbook. By default, this is 'azure monitor'.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "description": "Delete a workbook by its Azure resource ID.\r\nThis command soft deletes the workbook: it will be retained for 90 days.\r\nIf needed, you can restore it from the Recycle Bin through the Azure Portal.\r\n\r\nTo learn more, visit: https://learn.microsoft.com/azure/azure-monitor/visualize/workbooks-manage",
+          "command": "azmcp workbooks delete",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--workbook-id",
+              "description": "The Azure Resource ID of the workbook to retrieve.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "list",
+          "description": "List all workbooks in a specific resource group. This command retrieves all workbooks available\r\nin the specified resource group within the given subscription. Resource group is required.\r\nOptionally filter by kind (shared/user), category (workbook/sentinel/etc), or source resource ID.",
+          "command": "azmcp workbooks list",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--subscription",
+              "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+              "type": "string"
+            },
+            {
+              "name": "--resource-group",
+              "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--kind",
+              "description": "Filter workbooks by kind (e.g., 'shared', 'user'). If not specified, all kinds will be returned.",
+              "type": "string"
+            },
+            {
+              "name": "--category",
+              "description": "Filter workbooks by category (e.g., 'workbook', 'sentinel', 'TSG'). If not specified, all categories will be returned.",
+              "type": "string"
+            },
+            {
+              "name": "--source-id",
+              "description": "Filter workbooks by source resource ID (e.g., Application Insights resource, Log Analytics workspace). If not specified, all workbooks will be returned.",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "show",
+          "description": "Gets information about a specific workbook by its Azure resource ID.\r\nReturns workbook details including JSON serialized content, display name, description, category,\r\nlocation, kind, tags, version, modification time, and other metadata.",
+          "command": "azmcp workbooks show",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--workbook-id",
+              "description": "The Azure Resource ID of the workbook to retrieve.",
+              "type": "string",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "description": "Updates properties of a workbook, including its display name and serialized content.\r\nAt least one property must be provided for the update operation.\r\nReturns the updated workbook object upon successful completion.",
+          "command": "azmcp workbooks update",
+          "option": [
+            {
+              "name": "--tenant",
+              "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+              "type": "string"
+            },
+            {
+              "name": "--auth-method",
+              "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-delay",
+              "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-delay",
+              "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-max-retries",
+              "description": "Maximum number of retry attempts for failed operations before giving up.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-mode",
+              "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+              "type": "string"
+            },
+            {
+              "name": "--retry-network-timeout",
+              "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+              "type": "string"
+            },
+            {
+              "name": "--workbook-id",
+              "description": "The Azure Resource ID of the workbook to retrieve.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "--display-name",
+              "description": "The display name of the workbook.",
+              "type": "string"
+            },
+            {
+              "name": "--serialized-content",
+              "description": "The JSON serialized content/data of the workbook.",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "duration": 95
+}

--- a/eng/tools/ToolDescriptionEvaluator/namespaces.json
+++ b/eng/tools/ToolDescriptionEvaluator/namespaces.json
@@ -116,7 +116,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 2
     },
     {
       "name": "aks",
@@ -353,7 +354,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 4
     },
     {
       "name": "appconfig",
@@ -826,7 +828,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 7
     },
     {
       "name": "applens",
@@ -904,7 +907,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 1
     },
     {
       "name": "azuremanagedlustre",
@@ -1074,7 +1078,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 3
     },
     {
       "name": "azureterraformbestpractices",
@@ -1087,7 +1092,8 @@
           "command": "azmcp azureterraformbestpractices get",
           "option": []
         }
-      ]
+      ],
+      "subcommandsCount": 1
     },
     {
       "name": "bicepschema",
@@ -1142,7 +1148,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 1
     },
     {
       "name": "cloudarchitect",
@@ -1226,7 +1233,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 1
     },
     {
       "name": "cosmos",
@@ -1462,7 +1470,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 4
     },
     {
       "name": "datadog",
@@ -1528,7 +1537,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 1
     },
     {
       "name": "deploy",
@@ -1738,7 +1748,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 5
     },
     {
       "name": "eventgrid",
@@ -1859,7 +1870,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 2
     },
     {
       "name": "foundry",
@@ -2185,7 +2197,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 5
     },
     {
       "name": "functionapp",
@@ -2249,7 +2262,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 1
     },
     {
       "name": "get_bestpractices",
@@ -2275,7 +2289,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 1
     },
     {
       "name": "grafana",
@@ -2329,7 +2344,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 1
     },
     {
       "name": "group",
@@ -2383,7 +2399,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 1
     },
     {
       "name": "keyvault",
@@ -2872,7 +2889,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 8
     },
     {
       "name": "kusto",
@@ -3316,7 +3334,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 7
     },
     {
       "name": "loadtesting",
@@ -3879,7 +3898,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 8
     },
     {
       "name": "marketplace",
@@ -4061,7 +4081,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 2
     },
     {
       "name": "monitor",
@@ -4643,7 +4664,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 8
     },
     {
       "name": "mysql",
@@ -5212,7 +5234,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 8
     },
     {
       "name": "postgres",
@@ -5781,7 +5804,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 8
     },
     {
       "name": "quota",
@@ -5915,7 +5939,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 2
     },
     {
       "name": "redis",
@@ -6134,7 +6159,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 4
     },
     {
       "name": "resourcehealth",
@@ -6323,7 +6349,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 3
     },
     {
       "name": "role",
@@ -6383,7 +6410,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 1
     },
     {
       "name": "search",
@@ -6550,7 +6578,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 3
     },
     {
       "name": "servicebus",
@@ -6740,7 +6769,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 3
     },
     {
       "name": "sql",
@@ -7570,7 +7600,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 12
     },
     {
       "name": "storage",
@@ -8358,7 +8389,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 12
     },
     {
       "name": "subscription",
@@ -8407,7 +8439,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 1
     },
     {
       "name": "virtualdesktop",
@@ -8596,7 +8629,8 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 3
     },
     {
       "name": "workbooks",
@@ -8895,8 +8929,10 @@
             }
           ]
         }
-      ]
+      ],
+      "subcommandsCount": 5
     }
   ],
-  "duration": 95
+  "duration": 67,
+  "resultsCount": 35
 }

--- a/eng/tools/ToolDescriptionEvaluator/tools.json
+++ b/eng/tools/ToolDescriptionEvaluator/tools.json
@@ -10,56 +10,47 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -71,62 +62,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--registry",
           "description": "The name of the Azure Container Registry. This is the unique name you chose for your container registry.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -138,56 +119,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--cluster",
@@ -205,50 +178,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -260,56 +225,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--cluster",
@@ -333,56 +290,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--cluster",
@@ -400,50 +349,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -455,50 +396,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -515,14 +448,12 @@
         {
           "name": "--label",
           "description": "The label to apply to the configuration key. Labels are used to group and organize settings.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--content-type",
           "description": "The content type of the configuration value. This is used to indicate how the value should be interpreted or parsed.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -534,50 +465,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -588,14 +511,12 @@
         {
           "name": "--key",
           "description": "Specifies the key filter, if any, to be used when retrieving key-values. The filter can be an exact match, for example a filter of 'foo' would get all key-values with a key of 'foo', or the filter can include a '*' character at the end of the string for wildcard searches (e.g., 'App*'). If omitted all keys will be retrieved.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--label",
           "description": "Specifies the label filter, if any, to be used when retrieving key-values. The filter can be an exact match, for example a filter of 'foo' would get all key-values with a label of 'foo', or the filter can include a '*' character at the end of the string for wildcard searches (e.g., 'Prod*'). This filter is case-sensitive. If omitted, all labels will be retrieved.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -607,50 +528,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -667,14 +580,12 @@
         {
           "name": "--label",
           "description": "The label to apply to the configuration key. Labels are used to group and organize settings.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--content-type",
           "description": "The content type of the configuration value. This is used to indicate how the value should be interpreted or parsed.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -686,50 +597,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -746,14 +649,12 @@
         {
           "name": "--label",
           "description": "The label to apply to the configuration key. Labels are used to group and organize settings.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--content-type",
           "description": "The content type of the configuration value. This is used to indicate how the value should be interpreted or parsed.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--value",
@@ -764,8 +665,7 @@
         {
           "name": "--tags",
           "description": "The tags to associate with the configuration key. Tags should be in the format 'key=value'. Multiple tags can be specified.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -777,50 +677,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -837,14 +729,12 @@
         {
           "name": "--label",
           "description": "The label to apply to the configuration key. Labels are used to group and organize settings.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--content-type",
           "description": "The content type of the configuration value. This is used to indicate how the value should be interpreted or parsed.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -856,50 +746,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -916,14 +798,12 @@
         {
           "name": "--label",
           "description": "The label to apply to the configuration key. Labels are used to group and organize settings.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--content-type",
           "description": "The content type of the configuration value. This is used to indicate how the value should be interpreted or parsed.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -935,50 +815,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+          "type": "string"
+        },
+        {
+          "name": "--resource-group",
+          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--question",
@@ -997,12 +875,6 @@
           "description": "Resource type. Try to get this information using the Azure CLI tool before asking the user.",
           "type": "string",
           "required": true
-        },
-        {
-          "name": "--resource-group",
-          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
         }
       ]
     },
@@ -1014,56 +886,47 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -1075,50 +938,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--sku",
@@ -1142,56 +997,47 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--location",
           "description": "Azure region/region short name (use Azure location token, lowercase). Examples: uaenorth, swedencentral, eastus.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -1209,44 +1055,37 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-type",
@@ -1258,92 +1097,78 @@
     },
     {
       "name": "design",
-      "description": "Azure architecture design tool that gathers requirements through guided questions and recommends optimal solutions.\r\n\r\nKey parameters: question, questionNumber, confidenceScore (0.0-1.0, present architecture when ï¿½0.7), totalQuestions, answer, nextQuestionNeeded, architectureComponent, architectureTier, state.\r\n\r\nProcess:\r\n1. Ask about user role, business goals (1-2 questions at a time)\r\n2. Track confidence and update requirements (explicit/implicit/assumed)\r\n3. When confident enough, present architecture with table format, visual organization, ASCII diagrams\r\n4. Follow Azure Well-Architected Framework principles\r\n5. Cover all tiers: infrastructure, platform, application, data, security, operations\r\n6. Provide actionable advice and high-level overview\r\n\r\nState tracks components, requirements by category, and confidence factors. Be conservative with suggestions.",
+      "description": "Azure architecture design tool that gathers requirements through guided questions and recommends optimal solutions.\r\n\r\nKey parameters: question, questionNumber, confidenceScore (0.0-1.0, present architecture when ò0.7), totalQuestions, answer, nextQuestionNeeded, architectureComponent, architectureTier, state.\r\n\r\nProcess:\r\n1. Ask about user role, business goals (1-2 questions at a time)\r\n2. Track confidence and update requirements (explicit/implicit/assumed)\r\n3. When confident enough, present architecture with table format, visual organization, ASCII diagrams\r\n4. Follow Azure Well-Architected Framework principles\r\n5. Cover all tiers: infrastructure, platform, application, data, security, operations\r\n6. Provide actionable advice and high-level overview\r\n\r\nState tracks components, requirements by category, and confidence factors. Be conservative with suggestions.",
       "command": "azmcp cloudarchitect design",
       "option": [
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--question",
           "description": "The current question being asked",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--question-number",
           "description": "Current question number",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--total-questions",
           "description": "Estimated total questions needed",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--answer",
           "description": "The user's response to the question",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--next-question-needed",
           "description": "Whether another question is needed",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--confidence-score",
           "description": "A value between 0.0 and 1.0 representing confidence in understanding requirements. When this reaches 0.7 or higher, nextQuestionNeeded should be set to false.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--state",
           "description": "The complete architecture state from the previous request as JSON, State input schema:\n{\n\"state\":{\n\"type\":\"object\",\n\"description\":\"The complete architecture state from the previous request\",\n\"properties\":{\n\"architectureComponents\":{\n\"type\":\"array\",\n\"description\":\"All architecture components suggested so far\",\n\"items\":{\n\"type\":\"string\"\n}\n},\n\"architectureTiers\":{\n\"type\":\"object\",\n\"description\":\"Components organized by architecture tier\",\n\"additionalProperties\":{\n\"type\":\"array\",\n\"items\":{\n\"type\":\"string\"\n}\n}\n},\n\"thought\":{\n\"type\":\"string\",\n\"description\":\"The calling agent's thoughts on the next question or reasoning process. The calling agent should use the requirements it has gathered to reason about the next question.\"\n},\n\"suggestedHint\":{\n\"type\":\"string\",\n\"description\":\"A suggested interaction hint to show the user, such as 'Ask me to create an ASCII art diagram of this architecture' or 'Ask about how this design handles disaster recovery'.\"\n},\n\"requirements\":{\n\"type\":\"object\",\n\"description\":\"Tracked requirements organized by type\",\n\"properties\":{\n\"explicit\":{\n\"type\":\"array\",\n\"description\":\"Requirements explicitly stated by the user\",\n\"items\":{\n\"type\":\"object\",\n\"properties\":{\n\"category\":{\n\"type\":\"string\"\n},\n\"description\":{\n\"type\":\"string\"\n},\n\"source\":{\n\"type\":\"string\"\n},\n\"importance\":{\n\"type\":\"string\",\n\"enum\":[\n\"high\",\n\"medium\",\n\"low\"\n]\n},\n\"confidence\":{\n\"type\":\"number\"\n}\n}\n}\n},\n\"implicit\":{\n\"type\":\"array\",\n\"description\":\"Requirements implied by user responses\",\n\"items\":{\n\"type\":\"object\",\n\"properties\":{\n\"category\":{\n\"type\":\"string\"\n},\n\"description\":{\n\"type\":\"string\"\n},\n\"source\":{\n\"type\":\"string\"\n},\n\"importance\":{\n\"type\":\"string\",\n\"enum\":[\n\"high\",\n\"medium\",\n\"low\"\n]\n},\n\"confidence\":{\n\"type\":\"number\"\n}\n}\n}\n},\n\"assumed\":{\n\"type\":\"array\",\n\"description\":\"Requirements assumed based on context/best practices\",\n\"items\":{\n\"type\":\"object\",\n\"properties\":{\n\"category\":{\n\"type\":\"string\"\n},\n\"description\":{\n\"type\":\"string\"\n},\n\"source\":{\n\"type\":\"string\"\n},\n\"importance\":{\n\"type\":\"string\",\n\"enum\":[\n\"high\",\n\"medium\",\n\"low\"\n]\n},\n\"confidence\":{\n\"type\":\"number\"\n}\n}\n}\n}\n}\n},\n\"confidenceFactors\":{\n\"type\":\"object\",\n\"description\":\"Factors that contribute to the overall confidence score\",\n\"properties\":{\n\"explicitRequirementsCoverage\":{\n\"type\":\"number\"\n},\n\"implicitRequirementsCertainty\":{\n\"type\":\"number\"\n},\n\"assumptionRisk\":{\n\"type\":\"number\"\n}\n}\n}\n}\n}\n}",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -1355,50 +1180,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -1410,50 +1227,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -1476,8 +1285,7 @@
         {
           "name": "--query",
           "description": "SQL query to execute against the container. Uses Cosmos DB SQL syntax.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -1489,50 +1297,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -1556,50 +1356,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -1617,50 +1409,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--datadog-resource",
@@ -1672,7 +1456,7 @@
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         }
       ]
     },
@@ -1684,50 +1468,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--workspace-folder",
@@ -1744,8 +1520,7 @@
         {
           "name": "--limit",
           "description": "The maximum row number of logs to retrieve. Use this to get a specific number of logs or to avoid the retrieved logs from reaching token limit. Default is 200.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -1776,14 +1551,12 @@
         {
           "name": "--iac-type",
           "description": "The Infrastructure as Code type. Valid values: bicep, terraform. Leave empty if deployment-tool is AzCli.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-types",
-          "description": "Specifies the Azure resource types to retrieve IaC rules for. It should be comma-separated. Supported values are: 'appservice', 'containerapp', 'function', 'aks'. If none of these services are used, this parameter can be left empty.",
-          "type": "string",
-          "required": null
+          "description": "Specifies the Azure resource types to retrieve IaC rules for. It should be comma-separated. Supported values are: 'appservice', 'containerapp', 'function', 'aks', 'storage'. If none of these services are used, this parameter can be left empty.",
+          "type": "string"
         }
       ]
     },
@@ -1795,74 +1568,62 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--use-azd-pipeline-config",
           "description": "Whether to use azd tool to set up the deployment pipeline. Set to true ONLY if azure.yaml is provided or the context suggests AZD tools.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--organization-name",
           "description": "The name of the organization or the user account name of the current Github repository. DO NOT fill this in if you're not sure.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--repository-name",
           "description": "The name of the current Github repository. DO NOT fill this in if you're not sure.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--github-environment-name",
           "description": "The name of the environment to which the deployment pipeline will be deployed. DO NOT fill this in if you're not sure.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -1898,69 +1659,121 @@
         {
           "name": "--azd-iac-options",
           "description": "The Infrastructure as Code option for azd. Valid values: bicep, terraform. Leave empty if Deployment tool is AzCli.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
     {
       "name": "list",
-      "description": "List all Event Grid topics in a subscription with configuration and status information. This tool retrieves \r\ntopic details including endpoints, access keys, and subscription information for event publishing and management. \r\nReturns topic information as JSON array. Requires subscription.",
+      "description": "List event subscriptions for topics with filtering and endpoint configuration. This tool shows all active \r\nsubscriptions including webhook endpoints, event filters, and delivery retry policies. Returns subscription \r\ndetails as JSON array. Requires either --topic (bare topic name) OR --subscription. If only --topic is provided\r\nthe tool searches all accessible subscriptions for a topic with that name. Optional --resource-group/--location\r\nmay only be used alongside --subscription or --topic.",
+      "command": "azmcp eventgrid subscription list",
+      "option": [
+        {
+          "name": "--tenant",
+          "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+          "type": "string"
+        },
+        {
+          "name": "--auth-method",
+          "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-delay",
+          "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-max-delay",
+          "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-max-retries",
+          "description": "Maximum number of retry attempts for failed operations before giving up.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-mode",
+          "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-network-timeout",
+          "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+          "type": "string"
+        },
+        {
+          "name": "--subscription",
+          "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+          "type": "string"
+        },
+        {
+          "name": "--resource-group",
+          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+          "type": "string"
+        },
+        {
+          "name": "--topic",
+          "description": "The name of the Event Grid topic.",
+          "type": "string"
+        },
+        {
+          "name": "--location",
+          "description": "The Azure region to filter resources by (e.g., 'eastus', 'westus2').",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "list",
+      "description": "List all Event Grid topics in a subscription with configuration and status information. This tool retrieves\r\ntopic details including endpoints, access keys, and subscription information for event publishing and management.\r\nReturns topic information as JSON array. Requires subscription.",
       "command": "azmcp eventgrid topic list",
       "option": [
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -1972,56 +1785,47 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -2033,44 +1837,37 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--endpoint",
@@ -2088,44 +1885,37 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--endpoint",
@@ -2149,50 +1939,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+          "type": "string"
+        },
+        {
+          "name": "--resource-group",
+          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--deployment",
@@ -2219,46 +2007,34 @@
           "required": true
         },
         {
-          "name": "--resource-group",
-          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
-        },
-        {
           "name": "--model-version",
           "description": "The version of the model to deploy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--model-source",
           "description": "The source of the model.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--sku",
           "description": "The SKU name for the deployment.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--sku-capacity",
           "description": "The SKU capacity for the deployment.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--scale-type",
           "description": "The scale type for the deployment.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--scale-capacity",
           "description": "The scale capacity for the deployment.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -2270,44 +2046,37 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--endpoint",
@@ -2325,68 +2094,57 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--search-for-free-playground",
           "description": "If true, filters models to include only those that can be used for free by users for prototyping.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--publisher",
           "description": "A filter to specify the publisher of the models to retrieve.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--license",
           "description": "A filter to specify the license type of the models to retrieve.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--model-name",
-          "description": "The name of the model to search for.",
-          "type": "string",
-          "required": null
+          "description": "The name of the model to deploy.",
+          "type": "string"
         }
       ]
     },
@@ -2398,62 +2156,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--function-app",
           "description": "The name of the Function App.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -2484,50 +2232,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -2539,50 +2279,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -2594,50 +2326,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--vault",
@@ -2661,50 +2385,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--vault",
@@ -2728,50 +2444,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--vault",
@@ -2794,8 +2502,7 @@
         {
           "name": "--password",
           "description": "Optional password for a protected PFX being imported.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -2807,50 +2514,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--vault",
@@ -2868,50 +2567,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--vault",
@@ -2941,50 +2632,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--vault",
@@ -2995,8 +2678,7 @@
         {
           "name": "--include-managed",
           "description": "Whether or not to include managed keys in results.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -3008,50 +2690,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--vault",
@@ -3081,50 +2755,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--vault",
@@ -3142,62 +2808,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cluster-uri",
           "description": "Kusto Cluster URI.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cluster",
           "description": "Kusto Cluster name.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -3209,50 +2865,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -3264,62 +2912,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cluster-uri",
           "description": "Kusto Cluster URI.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cluster",
           "description": "Kusto Cluster name.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -3331,62 +2969,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cluster-uri",
           "description": "Kusto Cluster URI.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cluster",
           "description": "Kusto Cluster name.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--database",
@@ -3410,62 +3038,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cluster-uri",
           "description": "Kusto Cluster URI.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cluster",
           "description": "Kusto Cluster name.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--database",
@@ -3495,62 +3113,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cluster-uri",
           "description": "Kusto Cluster URI.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cluster",
           "description": "Kusto Cluster name.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--database",
@@ -3568,62 +3176,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cluster-uri",
           "description": "Kusto Cluster URI.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cluster",
           "description": "Kusto Cluster name.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--database",
@@ -3647,62 +3245,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--test-resource-name",
           "description": "The name of the load test resource for which you want to fetch the details.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--test-id",
@@ -3713,38 +3301,32 @@
         {
           "name": "--description",
           "description": "The description for the load test run. This provides additional context about the test run.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--display-name",
           "description": "The display name for the load test run. This is a user-friendly name to identify the test run.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--endpoint",
           "description": "The endpoint URL to be tested. This is the URL of the HTTP endpoint that will be subjected to load testing.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--virtual-users",
           "description": "Virtual users is a measure of load that is simulated to test the HTTP endpoint. (Default - 50)",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--duration",
           "description": "This is the duration for which the load is simulated against the endpoint. Enter decimals for fractional minutes (e.g., 1.5 for 1 minute and 30 seconds). Default is 20 mins",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--ramp-up-time",
           "description": "The ramp-up time is the time it takes for the system to ramp-up to the total load specified. Enter decimals for fractional minutes (e.g., 1.5 for 1 minute and 30 seconds). Default is 1 min",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -3756,62 +3338,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--test-resource-name",
           "description": "The name of the load test resource for which you want to fetch the details.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--test-id",
@@ -3829,62 +3401,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--test-resource-name",
           "description": "The name of the load test resource for which you want to fetch the details.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -3896,62 +3458,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--test-resource-name",
           "description": "The name of the load test resource for which you want to fetch the details.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -3963,68 +3515,57 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--test-resource-name",
           "description": "The name of the load test resource for which you want to fetch the details.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--testrun-id",
           "description": "The ID of the load test run for which you want to fetch the details.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--test-id",
@@ -4035,20 +3576,17 @@
         {
           "name": "--display-name",
           "description": "The display name for the load test run. This is a user-friendly name to identify the test run.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--description",
           "description": "The description for the load test run. This provides additional context about the test run.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--old-testrun-id",
           "description": "The ID of an existing test run to update. If provided, the command will trigger a rerun of the given test run id.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -4060,68 +3598,57 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--test-resource-name",
           "description": "The name of the load test resource for which you want to fetch the details.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--testrun-id",
           "description": "The ID of the load test run for which you want to fetch the details.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -4133,62 +3660,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--test-resource-name",
           "description": "The name of the load test resource for which you want to fetch the details.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--test-id",
@@ -4206,68 +3723,57 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--test-resource-name",
           "description": "The name of the load test resource for which you want to fetch the details.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--testrun-id",
           "description": "The ID of the load test run for which you want to fetch the details.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--test-id",
@@ -4278,14 +3784,12 @@
         {
           "name": "--display-name",
           "description": "The display name for the load test run. This is a user-friendly name to identify the test run.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--description",
           "description": "The description for the load test run. This provides additional context about the test run.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -4297,50 +3801,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--product-id",
@@ -4351,50 +3847,42 @@
         {
           "name": "--include-stop-sold-plans",
           "description": "Include stop-sold or hidden plans in the response.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--language",
           "description": "Product language code (e.g., 'en' for English, 'fr' for French).",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--market",
           "description": "Product market code (e.g., 'US' for United States, 'UK' for United Kingdom).",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--lookup-offer-in-tenant-level",
           "description": "Check against tenant private audience when retrieving the product.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--plan-id",
           "description": "Filter results by a specific plan ID.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--sku-id",
           "description": "Filter results by a specific SKU ID.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--include-service-instruction-templates",
           "description": "Include service instruction templates in the response.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--pricing-audience",
           "description": "Pricing audience for the request header.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -4406,92 +3894,77 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--language",
           "description": "Product language code (e.g., 'en' for English, 'fr' for French).",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--search",
           "description": "Search for products using a short general term (up to 25 characters)",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--filter",
           "description": "OData filter expression to filter results based on ProductSummary properties (e.g., \"displayName eq 'Azure'\").",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--orderby",
           "description": "OData orderby expression to sort results by ProductSummary fields (e.g., \"displayName asc\" or \"popularity desc\").",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--select",
           "description": "OData select expression to choose specific ProductSummary fields to return (e.g., \"displayName,publisherDisplayName,uniqueProductId\").",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--next-cursor",
           "description": "Pagination cursor to retrieve the next page of results. Use the NextPageLink value from a previous response.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--expand",
           "description": "OData expand expression to include related data in the response (e.g., \"plans\" to include plan details).",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -4503,50 +3976,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+          "type": "string"
+        },
+        {
+          "name": "--resource-group",
+          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--entity",
@@ -4559,12 +4030,6 @@
           "description": "The name of the health model for which to get the health.",
           "type": "string",
           "required": true
-        },
-        {
-          "name": "--resource-group",
-          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
         }
       ]
     },
@@ -4576,56 +4041,52 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
+        },
+        {
+          "name": "--resource-group",
+          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+          "type": "string"
         },
         {
           "name": "--resource-type",
           "description": "The Azure resource type (e.g., 'Microsoft.Storage/storageAccounts', 'Microsoft.Compute/virtualMachines'). If not specified, will attempt to infer from resource name.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource",
@@ -4634,28 +4095,19 @@
           "required": true
         },
         {
-          "name": "--resource-group",
-          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
-        },
-        {
           "name": "--metric-namespace",
           "description": "The metric namespace to query. Obtain this value from the azmcp-monitor-metrics-definitions command.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--search-string",
           "description": "A string to filter the metric definitions by. Helpful for reducing the number of records returned. Performs case-insensitive matching on metric name and description fields.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--limit",
           "description": "The maximum number of metric definitions to return. Defaults to 10.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -4667,68 +4119,58 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
+        },
+        {
+          "name": "--resource-group",
+          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+          "type": "string"
         },
         {
           "name": "--resource-type",
           "description": "The Azure resource type (e.g., 'Microsoft.Storage/storageAccounts', 'Microsoft.Compute/virtualMachines'). If not specified, will attempt to infer from resource name.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource",
           "description": "The name of the Azure resource to query metrics for.",
           "type": "string",
           "required": true
-        },
-        {
-          "name": "--resource-group",
-          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
         },
         {
           "name": "--metric-names",
@@ -4739,32 +4181,27 @@
         {
           "name": "--start-time",
           "description": "The start time for the query in ISO format (e.g., 2023-01-01T00:00:00Z). Defaults to 24 hours ago.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--end-time",
           "description": "The end time for the query in ISO format (e.g., 2023-01-01T00:00:00Z). Defaults to now.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--interval",
           "description": "The time interval for data points (e.g., PT1H for 1 hour, PT5M for 5 minutes).",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--aggregation",
           "description": "The aggregation type to use (Average, Maximum, Minimum, Total, Count).",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--filter",
           "description": "OData filter to apply to the metrics query.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--metric-namespace",
@@ -4775,8 +4212,7 @@
         {
           "name": "--max-buckets",
           "description": "The maximum number of time buckets to return. Defaults to 50.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -4788,50 +4224,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-id",
@@ -4854,14 +4282,12 @@
         {
           "name": "--hours",
           "description": "The number of hours to query back from now.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--limit",
           "description": "The maximum number of results to return.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -4873,56 +4299,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--workspace",
@@ -4946,56 +4364,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--workspace",
@@ -5013,50 +4423,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -5068,56 +4470,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--workspace",
@@ -5140,14 +4534,12 @@
         {
           "name": "--hours",
           "description": "The number of hours to query back from now.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--limit",
           "description": "The maximum number of results to return.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -5159,56 +4551,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -5232,56 +4616,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -5317,56 +4693,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -5390,56 +4758,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -5457,56 +4817,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -5536,56 +4888,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -5621,56 +4965,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -5700,56 +5036,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -5785,56 +5113,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -5858,56 +5178,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -5943,56 +5255,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -6016,56 +5320,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -6083,56 +5379,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -6162,56 +5450,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -6247,56 +5527,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -6326,56 +5598,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--user",
@@ -6411,50 +5675,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-types",
@@ -6465,20 +5721,17 @@
         {
           "name": "--cognitive-service-model-name",
           "description": "Optional model name for cognitive services. Only needed when Microsoft.CognitiveServices is included in resource types.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cognitive-service-model-version",
           "description": "Optional model version for cognitive services. Only needed when Microsoft.CognitiveServices is included in resource types.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--cognitive-service-deployment-sku-name",
           "description": "Optional deployment SKU name for cognitive services. Only needed when Microsoft.CognitiveServices is included in resource types.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -6490,50 +5743,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--region",
@@ -6557,62 +5802,54 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+          "type": "string"
+        },
+        {
+          "name": "--resource-group",
+          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--cache",
           "description": "The name of the Redis cache (e.g., my-redis-cache).",
           "type": "string",
           "required": true
-        },
-        {
-          "name": "--resource-group",
-          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
         }
       ]
     },
@@ -6624,50 +5861,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -6679,62 +5908,54 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+          "type": "string"
+        },
+        {
+          "name": "--resource-group",
+          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--cluster",
           "description": "The name of the Redis cluster (e.g., my-redis-cluster).",
           "type": "string",
           "required": true
-        },
-        {
-          "name": "--resource-group",
-          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
         }
       ]
     },
@@ -6746,50 +5967,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -6801,50 +6014,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resourceId",
@@ -6862,56 +6067,47 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -6923,86 +6119,72 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--event-type",
           "description": "Filter by event type (ServiceIssue, PlannedMaintenance, HealthAdvisory, Security). If not specified, all event types are included.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--status",
           "description": "Filter by status (Active, Resolved). If not specified, all statuses are included.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--tracking-id",
           "description": "Filter by tracking ID to get a specific service health event.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--filter",
           "description": "Additional OData filter expression to apply to the service health events query.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--query-start-time",
           "description": "Start time for the query in ISO 8601 format (e.g., 2024-01-01T00:00:00Z). Events from this time onwards will be included.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--query-end-time",
           "description": "End time for the query in ISO 8601 format (e.g., 2024-01-31T23:59:59Z). Events up to this time will be included.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -7014,50 +6196,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--scope",
@@ -7075,44 +6249,37 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--service",
@@ -7123,8 +6290,7 @@
         {
           "name": "--index",
           "description": "The name of the search index within the Azure AI Search service.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -7136,44 +6302,37 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--service",
@@ -7203,50 +6362,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -7258,50 +6409,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--namespace",
@@ -7325,50 +6468,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--namespace",
@@ -7392,50 +6527,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--namespace",
@@ -7458,6 +6585,176 @@
       ]
     },
     {
+      "name": "create",
+      "description": "Create a new Azure SQL Database on an existing SQL Server. This command creates a database with configurable\r\nperformance tiers, size limits, and other settings. Equivalent to 'az sql db create'.\r\nReturns the newly created database information including configuration details.",
+      "command": "azmcp sql db create",
+      "option": [
+        {
+          "name": "--tenant",
+          "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+          "type": "string"
+        },
+        {
+          "name": "--auth-method",
+          "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-delay",
+          "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-max-delay",
+          "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-max-retries",
+          "description": "Maximum number of retry attempts for failed operations before giving up.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-mode",
+          "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-network-timeout",
+          "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+          "type": "string"
+        },
+        {
+          "name": "--subscription",
+          "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+          "type": "string"
+        },
+        {
+          "name": "--resource-group",
+          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "--server",
+          "description": "The Azure SQL Server name.",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "--database",
+          "description": "The Azure SQL Database name.",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "--sku-name",
+          "description": "The SKU name for the database (e.g., Basic, S0, P1, GP_Gen5_2).",
+          "type": "string"
+        },
+        {
+          "name": "--sku-tier",
+          "description": "The SKU tier for the database (e.g., Basic, Standard, Premium, GeneralPurpose).",
+          "type": "string"
+        },
+        {
+          "name": "--sku-capacity",
+          "description": "The SKU capacity (DTU or vCore count) for the database.",
+          "type": "string"
+        },
+        {
+          "name": "--collation",
+          "description": "The collation for the database (e.g., SQL_Latin1_General_CP1_CI_AS).",
+          "type": "string"
+        },
+        {
+          "name": "--max-size-bytes",
+          "description": "The maximum size of the database in bytes.",
+          "type": "string"
+        },
+        {
+          "name": "--elastic-pool-name",
+          "description": "The name of the elastic pool to assign the database to.",
+          "type": "string"
+        },
+        {
+          "name": "--zone-redundant",
+          "description": "Whether the database should be zone redundant.",
+          "type": "string"
+        },
+        {
+          "name": "--read-scale",
+          "description": "Read scale option for the database (Enabled or Disabled).",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "delete",
+      "description": "Deletes an Azure SQL Database from an existing SQL Server. This command removes the specified database\r\nand is idempotent - attempting to delete a database that does not exist will succeed with Deleted = false.\r\nEquivalent to 'az sql db delete'.\r\nReturns whether the database was deleted during this operation.",
+      "command": "azmcp sql db delete",
+      "option": [
+        {
+          "name": "--tenant",
+          "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
+          "type": "string"
+        },
+        {
+          "name": "--auth-method",
+          "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-delay",
+          "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-max-delay",
+          "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-max-retries",
+          "description": "Maximum number of retry attempts for failed operations before giving up.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-mode",
+          "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
+          "type": "string"
+        },
+        {
+          "name": "--retry-network-timeout",
+          "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
+          "type": "string"
+        },
+        {
+          "name": "--subscription",
+          "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+          "type": "string"
+        },
+        {
+          "name": "--resource-group",
+          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "--server",
+          "description": "The Azure SQL Server name.",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "--database",
+          "description": "The Azure SQL Database name.",
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
       "name": "list",
       "description": "Lists all databases in an Azure SQL Server with their configuration, status, SKU, and performance details.\r\nUse when you need to: view database inventory, check database status across a server, compare database configurations,\r\nor find databases for management operations.\r\nRequires: subscription ID, resource group name, server name.\r\nReturns: JSON array of databases with complete configuration details including SKU, status, and size information.\r\nEquivalent to 'az sql db list'.",
       "command": "azmcp sql db list",
@@ -7465,56 +6762,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--server",
@@ -7532,56 +6821,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--server",
@@ -7605,56 +6886,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--server",
@@ -7666,62 +6939,54 @@
     },
     {
       "name": "create",
-      "description": "Creates a new Azure SQL server in the specified resource group and location. \r\nThe server will be created with the specified administrator credentials and \r\noptional configuration settings. Returns the created server with its properties \r\nincluding the fully qualified domain name.",
+      "description": "Creates a new Azure SQL server in the specified resource group and location.\r\nThe server will be created with the specified administrator credentials and\r\noptional configuration settings. Returns the created server with its properties\r\nincluding the fully qualified domain name.",
       "command": "azmcp sql server create",
       "option": [
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--server",
@@ -7750,75 +7015,65 @@
         {
           "name": "--version",
           "description": "The version of SQL Server to create (e.g., '12.0').",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--public-network-access",
           "description": "Whether public network access is enabled for the SQL server ('Enabled' or 'Disabled').",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
     {
       "name": "delete",
-      "description": "Deletes an Azure SQL server and all of its databases from the specified resource group. \r\nThis operation is irreversible and will permanently remove the server and all its data. \r\nUse the --force flag to skip confirmation prompts.",
+      "description": "Deletes an Azure SQL server and all of its databases from the specified resource group.\r\nThis operation is irreversible and will permanently remove the server and all its data.\r\nUse the --force flag to skip confirmation prompts.",
       "command": "azmcp sql server delete",
       "option": [
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--server",
@@ -7829,8 +7084,7 @@
         {
           "name": "--force",
           "description": "Force delete the server without confirmation prompts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -7842,56 +7096,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--server",
@@ -7909,56 +7155,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--server",
@@ -7994,56 +7232,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--server",
@@ -8067,56 +7297,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--server",
@@ -8128,62 +7350,54 @@
     },
     {
       "name": "show",
-      "description": "Retrieves detailed information about an Azure SQL server including its configuration, \r\nstatus, and properties such as the fully qualified domain name, version, \r\nadministrator login, and network access settings.",
+      "description": "Retrieves detailed information about an Azure SQL server including its configuration,\r\nstatus, and properties such as the fully qualified domain name, version,\r\nadministrator login, and network access settings.",
       "command": "azmcp sql server show",
       "option": [
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--server",
@@ -8201,62 +7415,54 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
+          "type": "string"
+        },
+        {
+          "name": "--resource-group",
+          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--account",
           "description": "The name of the Azure Storage account to create. Must be globally unique, 3-24 characters, lowercase letters and numbers only.",
           "type": "string",
           "required": true
-        },
-        {
-          "name": "--resource-group",
-          "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
         },
         {
           "name": "--location",
@@ -8267,20 +7473,17 @@
         {
           "name": "--sku",
           "description": "The storage account SKU. Valid values: Standard_LRS, Standard_GRS, Standard_RAGRS, Standard_ZRS, Premium_LRS, Premium_ZRS, Standard_GZRS, Standard_RAGZRS.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--access-tier",
           "description": "The default access tier for blob storage. Valid values: Hot, Cool.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--enable-hierarchical-namespace",
           "description": "Whether to enable hierarchical namespace (Data Lake Storage Gen2) for the storage account.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -8292,56 +7495,47 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
           "description": "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -8353,50 +7547,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -8432,50 +7618,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -8499,50 +7677,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -8553,8 +7723,7 @@
         {
           "name": "--container",
           "description": "The name of the container to access within the storage account.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -8566,50 +7735,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -8626,8 +7787,7 @@
         {
           "name": "--blob",
           "description": "The name of the blob to access within the container. This should be the full path within the container (e.g., 'file.txt' or 'folder/file.txt').",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -8639,50 +7799,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -8718,50 +7870,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -8785,50 +7929,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -8845,14 +7981,12 @@
         {
           "name": "--filter-path",
           "description": "The prefix to filter paths in the Data Lake. Only paths that start with this prefix will be listed.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--recursive",
           "description": "Flag to indicate whether the command will operate recursively on all subdirectories.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -8864,50 +7998,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -8930,14 +8056,12 @@
         {
           "name": "--time-to-live-in-seconds",
           "description": "The time-to-live for the message in seconds. If not specified, the message will use the queue's default TTL. Set to -1 for messages that never expire.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--visibility-timeout-in-seconds",
           "description": "The visibility timeout for the message in seconds. This determines how long the message will be invisible after it's retrieved. If not specified, defaults to 0 (immediately visible).",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -8949,50 +8073,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -9015,8 +8131,7 @@
         {
           "name": "--prefix",
           "description": "Optional prefix to filter results. Only items that start with this prefix will be returned.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -9028,50 +8143,42 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--account",
@@ -9089,44 +8196,37 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -9138,56 +8238,47 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -9199,68 +8290,57 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--hostpool",
           "description": "The name of the Azure Virtual Desktop host pool. This is the unique name you chose for your hostpool.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--hostpool-resource-id",
           "description": "The Azure resource ID of the host pool. When provided, this will be used instead of searching by name.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -9272,68 +8352,57 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--hostpool",
           "description": "The name of the Azure Virtual Desktop host pool. This is the unique name you chose for your hostpool.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--hostpool-resource-id",
           "description": "The Azure resource ID of the host pool. When provided, this will be used instead of searching by name.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--sessionhost",
@@ -9351,56 +8420,48 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--display-name",
@@ -9417,8 +8478,7 @@
         {
           "name": "--source-id",
           "description": "The linked resource ID for the workbook. By default, this is 'azure monitor'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -9430,44 +8490,37 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--workbook-id",
@@ -9485,74 +8538,63 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--subscription",
           "description": "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--resource-group",
           "description": "The name of the Azure resource group. This is a logical container for Azure resources.",
           "type": "string",
-          "required": null
+          "required": true
         },
         {
           "name": "--kind",
           "description": "Filter workbooks by kind (e.g., 'shared', 'user'). If not specified, all kinds will be returned.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--category",
           "description": "Filter workbooks by category (e.g., 'workbook', 'sentinel', 'TSG'). If not specified, all categories will be returned.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--source-id",
           "description": "Filter workbooks by source resource ID (e.g., Application Insights resource, Log Analytics workspace). If not specified, all workbooks will be returned.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     },
@@ -9564,44 +8606,37 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--workbook-id",
@@ -9619,44 +8654,37 @@
         {
           "name": "--tenant",
           "description": "The Microsoft Entra ID tenant ID or name. This can be either the GUID identifier or the display name of your Entra ID tenant.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--auth-method",
           "description": "Authentication method to use. Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-delay",
           "description": "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-delay",
           "description": "Maximum delay in seconds between retries, regardless of the retry strategy.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-max-retries",
           "description": "Maximum number of retry attempts for failed operations before giving up.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-mode",
           "description": "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--retry-network-timeout",
           "description": "Network operation timeout in seconds. Operations taking longer than this will be cancelled.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--workbook-id",
@@ -9667,17 +8695,15 @@
         {
           "name": "--display-name",
           "description": "The display name of the workbook.",
-          "type": "string",
-          "required": null
+          "type": "string"
         },
         {
           "name": "--serialized-content",
           "description": "The JSON serialized content/data of the workbook.",
-          "type": "string",
-          "required": null
+          "type": "string"
         }
       ]
     }
   ],
-  "duration": 63
+  "duration": 54
 }

--- a/eng/tools/ToolDescriptionEvaluator/tools.json
+++ b/eng/tools/ToolDescriptionEvaluator/tools.json
@@ -8705,5 +8705,6 @@
       ]
     }
   ],
-  "duration": 54
+  "duration": 44,
+  "resultsCount": 140
 }


### PR DESCRIPTION
## What does this PR do?
This pull request adds a new `--namespaces` option to the `azmcp tools list` command, allowing users to list top-level service namespaces instead of individual commands. It also introduces a `count` field in the output to indicate the number of top-level namespaces and their subcommands. Tests and documentation have been updated accordingly.

## GitHub issue number?
N/A

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
