### PR TITLE
Allow any branch to be built for release

### DIFF
--- a/eng/pipelines/templates/common.yml
+++ b/eng/pipelines/templates/common.yml
@@ -1,22 +1,28 @@
 parameters:
-- name: PublishPackages
-  type: boolean
-  default: false
-- name: ReleaseRun
-  type: boolean
-  default: false
+- name: ServerName
+  type: string
+  default: ''
+- name: PublishTarget
+  type: string
+  default: none
+  values:
+  - internal
+  - public
+  - none
 - name: RunLiveTests
   type: boolean
   default: false
 - name: IncludeNative
   type: boolean
   default: false
-- name: ServerName
-  type: string
-  default: ''
-- name: SkipDockerRelease
-  type: string
+- name: IncludeDockerRelease
+  type: boolean
   default: false
+- name: IsTestPipeline
+  type: boolean
+  default: false
+  # Test pipelines (e.g. Template.Mcp.Server) can release to public feeds, but they always use prerelease tags and automatically close their version bump PRs
+  # This allows us to run them multiple times from the same commit without hitting github release tag or package deployment conflicts
 
 resources:
   repositories:
@@ -28,7 +34,8 @@ resources:
 extends:
   template: /eng/pipelines/templates/1es-redirect.yml
   parameters:
-    autoBaseline: ${{ and(eq(variables['Build.DefinitionName'], 'azure - mcp'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['System.TeamProject'], 'internal')) }}
+    # We pick a single internal pipeline to use for autoBaseline. This should be a pipeline that runs often on main with normal code paths, i.e. not Template.Mcp.Server
+    autoBaseline: ${{ and(eq(variables['Build.DefinitionName'], 'mcp - Azure.Mcp.Server'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['System.TeamProject'], 'internal')) }}
     stages:
     - stage: Initialize
       pool:
@@ -41,7 +48,7 @@ extends:
       jobs:
       - template: /eng/pipelines/templates/jobs/initialize.yml
         parameters:
-          DynamicPrereleaseVersion: ${{ not(parameters.ReleaseRun) }}
+          DynamicPrereleaseVersion: ${{ or(ne(parameters.PublishTarget, 'public'), parameters.IsTestPipeline) }}
           ServerName: ${{ parameters.ServerName }}
 
     - stage: Build
@@ -86,7 +93,8 @@ extends:
         jobs:
         - template: /eng/pipelines/templates/jobs/live-test.yml
 
-    - ${{ if eq(parameters.PublishPackages, 'true') }}:
+    - ${{ if ne(parameters.PublishTarget, 'none') }}:
+      # We only sign if we're going to publish
       - stage: SignAndPack
         displayName: 'Sign and Pack'
         dependsOn:
@@ -106,7 +114,7 @@ extends:
           parameters:
             ServerName: ${{ parameters.ServerName }}
 
-      - ${{ if eq(parameters.ReleaseRun, 'true') }}:
+      - ${{ if eq(parameters.PublishTarget, 'public') }}:
         - stage: Release
           dependsOn:
           - Initialize
@@ -125,9 +133,10 @@ extends:
             parameters:
               ServerName: ${{ parameters.ServerName }}
               IncludeNative: false
-              SkipDockerRelease: ${{ parameters.SkipDockerRelease }}
+              IncludeDockerRelease: ${{ parameters.IncludeDockerRelease }}
+              IsTestPipeline: ${{ parameters.IsTestPipeline }}
 
-      - ${{ else }}:
+      - ${{ elseif eq(parameters.PublishTarget, 'internal') }}:
         - stage: Integration
           dependsOn:
           - Initialize

--- a/eng/pipelines/templates/jobs/release.yml
+++ b/eng/pipelines/templates/jobs/release.yml
@@ -79,4 +79,4 @@ jobs:
       CommitMsg: "Increment package version after release"
       PRTitle: "Increment version after release"
       RepoOwner: microsoft
-      CloseAfterOpenForTesting: ${{ parameters.IsTestPipeline}}
+      CloseAfterOpenForTesting: ${{ parameters.IsTestPipeline }}

--- a/eng/pipelines/templates/jobs/release.yml
+++ b/eng/pipelines/templates/jobs/release.yml
@@ -3,7 +3,9 @@ parameters:
   type: string
 - name: IncludeNative
   type: boolean
-- name: SkipDockerRelease
+- name: IncludeDockerRelease
+  type: boolean
+- name: IsTestPipeline
   type: boolean
 
 jobs:
@@ -47,7 +49,7 @@ jobs:
     ServerName: ${{ parameters.ServerName }}
     DependsOn: TagRepository
 
-- ${{ if ne(parameters.SkipDockerRelease, 'true') }}:
+- ${{ if parameters.IncludeDockerRelease }}:
   - template: /eng/pipelines/templates/jobs/docker/release-docker.yml
     parameters:
       ContainerRegistry: 'azuresdkimages'
@@ -77,6 +79,4 @@ jobs:
       CommitMsg: "Increment package version after release"
       PRTitle: "Increment version after release"
       RepoOwner: microsoft
-      # For CloseAfterOpenForTesting, create-pull-request.yml expects a bool as a string  and adds `$` to the front for
-      # powershell. We pass an environment variable reference and omit the `$`
-      CloseAfterOpenForTesting: env:SETDEVVERSION
+      CloseAfterOpenForTesting: ${{ parameters.IsTestPipeline}}

--- a/servers/Azure.Mcp.Server/build.yml
+++ b/servers/Azure.Mcp.Server/build.yml
@@ -1,13 +1,17 @@
+parameters:
+- name: PublishTarget
+  type: string
+  values: [ none, internal, public ]
+  default: 'none'
+
 trigger: none
 pr: none
 
 extends:
   template: /eng/pipelines/templates/common.yml
   parameters:
-    # We release signed, manual runs from main and hotfix branches
-    # All other runs get -alpha prerelease labels
-    PublishPackages: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
-    RunLiveTests: true
-    ReleaseRun: ${{ and(eq(variables['Build.Reason'], 'Manual'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startswith(variables['Build.SourceBranch'], 'refs/heads/hotfix/'))) }}
     ServerName: Azure.Mcp.Server
+    PublishTarget: ${{ parameters.PublishTarget }}
+    RunLiveTests: true
+    IncludeDockerRelease : true
     IncludeNative: true

--- a/servers/Fabric.Mcp.Server/build.yml
+++ b/servers/Fabric.Mcp.Server/build.yml
@@ -1,13 +1,17 @@
+parameters:
+- name: PublishTarget
+  type: string
+  values: [ none, internal, public ]
+  default: 'none'
+
 trigger: none
 pr: none
 
 extends:
   template: /eng/pipelines/templates/common.yml
   parameters:
-    # We release signed, manual runs from main and hotfix branches
-    # All other runs get -alpha prerelease labels
-    PublishPackages: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
-    RunLiveTests: true
-    ReleaseRun: ${{ and(eq(variables['Build.Reason'], 'Manual'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startswith(variables['Build.SourceBranch'], 'refs/heads/hotfix/'))) }}
     ServerName: Fabric.Mcp.Server
-    SkipDockerRelease : true
+    PublishTarget: ${{ parameters.PublishTarget }}
+    RunLiveTests: true
+    IncludeDockerRelease : false
+    IncludeNative: false

--- a/servers/Template.Mcp.Server/build.yml
+++ b/servers/Template.Mcp.Server/build.yml
@@ -1,13 +1,18 @@
+parameters:
+- name: PublishTarget
+  type: string
+  values: [ none, internal, public ]
+  default: 'none'
+
 trigger: none
 pr: none
 
 extends:
   template: /eng/pipelines/templates/common.yml
   parameters:
-    # We release signed, manual runs from main and hotfix branches
-    # All other runs get -alpha prerelease labels
-    PublishPackages: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
-    RunLiveTests: true
-    ReleaseRun: ${{ and(eq(variables['Build.Reason'], 'Manual'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startswith(variables['Build.SourceBranch'], 'refs/heads/hotfix/'))) }}
     ServerName: Template.Mcp.Server
-    SkipDockerRelease : true
+    PublishTarget: ${{ parameters.PublishTarget }}
+    RunLiveTests: true
+    IncludeDockerRelease : false
+    IncludeNative: true
+    IsTestPipeline: true


### PR DESCRIPTION
## What does this PR do?
Instead of inferring the release target and dynamic version settings based on the branch being built, we'll now rely on 2 parameters:
- PublishTarget (public, internal, none) if and where we're publishing
- IsTestPipeline (always build a dynamic prerelease version)

Public builds won't make a prerelease tagged version, except for test pipelines, which always build prerelease versions
IsTestPipeline also controls if we're going to automatically close the Bump Version PR

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
