### PR TITLE
Test out using GenericResource instead of needing AppConfig Resource Manager

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,6 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.ResourceManager" Version="1.13.2" />
     <PackageVersion Include="Azure.ResourceManager.ApplicationInsights" Version="1.1.0-beta.1" />
-    <PackageVersion Include="Azure.ResourceManager.AppConfiguration" Version="1.4.1" />
     <PackageVersion Include="Azure.ResourceManager.AppContainers" Version="1.4.1" />
     <PackageVersion Include="Azure.ResourceManager.AppService" Version="1.4.1" />
     <PackageVersion Include="Azure.ResourceManager.ContainerInstance" Version="1.3.0-beta.3" />

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Azure.Mcp.Tools.AppConfig.csproj
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Azure.Mcp.Tools.AppConfig.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Data.AppConfiguration" />
     <PackageReference Include="Azure.ResourceManager" />
-    <PackageReference Include="Azure.ResourceManager.AppConfiguration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="System.CommandLine" />

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/AppConfigJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/AppConfigJsonContext.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.AppConfig.Commands.KeyValue.Lock;
 namespace Azure.Mcp.Tools.AppConfig.Commands;
 
 [JsonSerializable(typeof(AccountListCommand.AccountListCommandResult))]
+[JsonSerializable(typeof(IDictionary<string, object>))]
 [JsonSerializable(typeof(KeyValueDeleteCommand.KeyValueDeleteCommandResult))]
 [JsonSerializable(typeof(KeyValueListCommand.KeyValueListCommandResult))]
 [JsonSerializable(typeof(KeyValueLockSetCommand.KeyValueLockSetCommandResult))]


### PR DESCRIPTION
## What does this PR do?

Quick investigation into using the generic mechanism to retrieve resource manager resources, rather than pulling in the entirety of `Azure.ResourceManager.AppConfiguration` for a single API.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
