### PR TITLE
Onboard Azure Monitor Web Test commands (monitor-webtests-list, monitor-webtests-get, monitor-webtests-createorupdate tools)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -130,10 +130,10 @@
 
 
 # PRLabel: %tools-Monitor
-/tools/Azure.Mcp.Tools.Monitor/        @smritiy @srnagar @jongio @microsoft/azure-mcp
+/tools/Azure.Mcp.Tools.Monitor/        @smritiy @srnagar @jongio @zaaslam @microsoft/azure-mcp
 
 # ServiceLabel: %tools-Monitor
-# ServiceOwners:                       @smritiy @srnagar @jongio
+# ServiceOwners:                       @smritiy @srnagar @jongio @zaaslam
 
 # PRLabel: %tools-AzureManagedLustre
 /tools/Azure.Mcp.Tools.AzureManagedLustre/                        @wolfgang-desalvador @microsoft/azure-mcp

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -201,7 +201,16 @@
                 "vectorizable",
                 "vectorizer",
                 "vsix",
-                "vsixtarget"
+                "vsixtarget",
+                "VSTEST",
+                "Xunit",
+                "webtest",
+                "webtests",
+                "resourcename",
+                "appinsights",
+                "createorupdate",
+                "Multstep",
+                "multistep"
             ]
         }
     ],

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -871,6 +871,41 @@ azmcp monitor metrics query --subscription <subscription> \
                             --aggregation "Average"
 ```
 
+#### Web Tests (Availability Tests)
+```bash
+# List all web tests in a subscription or optionally, within a resource group
+azmcp monitor webtests list --subscription <subscription> [--resource-group <resource-group>]
+
+# Get details for a specific web test
+azmcp monitor webtests get --subscription <subscription> \
+                          --resource-group <resource-group> \
+                          --webtest-resource <webtest-resource-name>
+
+# Create or update a web test in Azure Monitor
+azmcp monitor webtests createorupdate --subscription <subscription> \
+                                     --resource-group <resource-group> \
+                                     --webtest-resource <webtest-resource-name> \
+                                     --appinsights-component <component-name> \
+                                     --location <location> \
+                                     --webtest-locations <locations> \
+                                     --request-url <url> \
+                                     [--webtest <display-name>] \
+                                     [--description <description>] \
+                                     [--enabled <true|false>] \
+                                     [--expected-status-code <code>] \
+                                     [--follow-redirects <true|false>] \
+                                     [--frequency <seconds>] \
+                                     [--headers <key=value,key2=value2>] \
+                                     [--http-verb <get|post|..>] \
+                                     [--ignore-status-code <true|false>] \
+                                     [--parse-requests <true|false>] \
+                                     [--request-body <body>] \
+                                     [--retry-enabled <true|false>] \
+                                     [--ssl-check <true|false>] \
+                                     [--ssl-lifetime-check <days>] \
+                                     [--timeout <seconds>]
+```
+
 ### Azure Managed Lustre
 
 ```bash

--- a/docs/e2eTestPrompts.md
+++ b/docs/e2eTestPrompts.md
@@ -297,6 +297,11 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | azmcp_monitor_workspace_list | Show me my Log Analytics workspaces |
 | azmcp_monitor_workspace_list | Show me the Log Analytics workspaces in my subscription |
 | azmcp_monitor_workspace_log_query | Show me the logs for the past hour in the Log Analytics workspace <workspace_name> |
+| azmcp_monitor_webtests_list | List all Web Test resources in my subscription |
+| azmcp_-_monitor_webtests_list | List all Web Test resources in my subscription in <resource_group> |
+| azmcp_-_monitor_webtests_get | Get Web Test details for <webtest_resource_name> in my subscription in <resource_group> |
+| azmcp_-_monitor_webtests_createorupdate | Create a new Web Test with name <webtest_resource_name> in my subscription in <resource_group> in a given <appinsights_component> |
+| azmcp_-_monitor_webtests_createorupdate | Update an existing Web Test with name <webtest_resource_name> in my subscription in <resource_group> in a given <appinsights_component> |
 
 ## Azure Native ISV
 

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -4,6 +4,11 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 ## 0.8.1 (Unreleased)
 
+- Added support for Azure Monitor Web Tests management operations:
+  - `azmcp-monitor-webtests-list` - List all web tests in a subscription or optionally, within a resource group
+  - `azmcp-monitor-webtests-get` - Get details for a specific web test
+  - `azmcp-monitor-webtests-createorupdate` - Create or update a web test in Azure Monitor
+  
 ### Features Added
 
 - Added support for `azmcp sql server list` command to list SQL servers in a subscription and resource group. [[#503](https://github.com/microsoft/mcp/issues/503)]

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -4,15 +4,14 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 ## 0.8.1 (Unreleased)
 
+### Features Added
+
+- Added support for `azmcp sql server list` command to list SQL servers in a subscription and resource group. [[#503](https://github.com/microsoft/mcp/issues/503)]
 - Added support for Azure Monitor Web Tests management operations:
   - `azmcp-monitor-webtests-list` - List all web tests in a subscription or optionally, within a resource group
   - `azmcp-monitor-webtests-get` - Get details for a specific web test
   - `azmcp-monitor-webtests-createorupdate` - Create or update a web test in Azure Monitor
   
-### Features Added
-
-- Added support for `azmcp sql server list` command to list SQL servers in a subscription and resource group. [[#503](https://github.com/microsoft/mcp/issues/503)]
-
 ### Breaking Changes
 
 - Removed the following Storage tools:

--- a/tools/Azure.Mcp.Tools.Monitor/src/Azure.Mcp.Tools.Monitor.csproj
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Azure.Mcp.Tools.Monitor.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Monitor.Query" />
     <PackageReference Include="Azure.ResourceManager" />
+    <PackageReference Include="Azure.ResourceManager.ApplicationInsights" />
     <PackageReference Include="Azure.ResourceManager.OperationalInsights" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="ModelContextProtocol" />

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/MonitorJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/MonitorJsonContext.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 using Azure.Mcp.Tools.Monitor.Commands.Metrics;
 using Azure.Mcp.Tools.Monitor.Commands.Table;
 using Azure.Mcp.Tools.Monitor.Commands.TableType;
+using Azure.Mcp.Tools.Monitor.Commands.WebTests;
 using Azure.Mcp.Tools.Monitor.Commands.Workspace;
 
 namespace Azure.Mcp.Tools.Monitor.Commands;
@@ -16,6 +17,9 @@ namespace Azure.Mcp.Tools.Monitor.Commands;
 [JsonSerializable(typeof(TableTypeListCommand.TableTypeListCommandResult))]
 [JsonSerializable(typeof(MetricsQueryCommand.MetricsQueryCommandResult))]
 [JsonSerializable(typeof(MetricsDefinitionsCommand.MetricsDefinitionsCommandResult))]
+[JsonSerializable(typeof(WebTestsListCommand.WebTestsListCommandResult))]
+[JsonSerializable(typeof(WebTestsGetCommand.WebTestsGetCommandResult))]
+[JsonSerializable(typeof(WebTestsCreateOrUpdateCommand.WebTestsCreateCommandResult))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class MonitorJsonContext : JsonSerializerContext
 {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/BaseMonitorWebTestsCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/BaseMonitorWebTestsCommand.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Core.Commands.Subscription;
+using Azure.Mcp.Core.Options;
+
+namespace Azure.Mcp.Tools.Monitor.Commands.WebTests;
+
+public abstract class BaseMonitorWebTestsCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions>
+    : SubscriptionCommand<TOptions>
+    where TOptions : SubscriptionOptions, new()
+{
+    protected BaseMonitorWebTestsCommand() : base()
+    {
+    }
+}

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsCreateOrUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsCreateOrUpdateCommand.cs
@@ -92,7 +92,7 @@ public sealed class WebTestsCreateOrUpdateCommand(ILogger<WebTestsCreateOrUpdate
         options.Location = parseResult.GetValueOrDefault(_resourceLocationOption)!;
         options.Locations = parseResult.GetValueOrDefault(_locationsOption)!;
         options.RequestUrl = parseResult.GetValueOrDefault(_requestUrlOption)!;
-        options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
+        options.ResourceGroup ??= parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
 
         options.WebTestName = parseResult.GetValueOrDefault(_webTestNameOption);
         options.Description = parseResult.GetValueOrDefault(_descriptionOption);

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsCreateOrUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsCreateOrUpdateCommand.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Tools.Monitor.Models.WebTests;
+using Azure.Mcp.Tools.Monitor.Options;
+using Azure.Mcp.Tools.Monitor.Options.WebTests;
+using Azure.Mcp.Tools.Monitor.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Mcp.Tools.Monitor.Commands.WebTests;
+
+public sealed class WebTestsCreateOrUpdateCommand(ILogger<WebTestsCreateOrUpdateCommand> logger) : BaseMonitorWebTestsCommand<WebTestsCreateOrUpdateOptions>
+{
+    private const string _commandTitle = "Create or updates a web test in Azure Monitor";
+    private const string _commandName = "createorupdate";
+
+    private readonly ILogger<WebTestsCreateOrUpdateCommand> _logger = logger;
+
+    private readonly Option<string> _resourceNameOption = MonitorOptionDefinitions.WebTest.WebTestResourceName;
+    private readonly Option<string> _appInsightsComponentIdOption = MonitorOptionDefinitions.WebTest.AppInsightsComponentId;
+    private readonly Option<string> _resourceLocationOption = MonitorOptionDefinitions.WebTest.ResourceLocation;
+    private readonly Option<string> _locationsOption = MonitorOptionDefinitions.WebTest.Locations;
+    private readonly Option<string> _requestUrlOption = MonitorOptionDefinitions.WebTest.RequestUrl;
+
+    private readonly Option<string> _webTestNameOption = MonitorOptionDefinitions.WebTest.WebTestName;
+    private readonly Option<string> _descriptionOption = MonitorOptionDefinitions.WebTest.Description;
+    private readonly Option<bool> _enabledOption = MonitorOptionDefinitions.WebTest.Enabled;
+    private readonly Option<int> _expectedStatusCodeOption = MonitorOptionDefinitions.WebTest.ExpectedStatusCode;
+    private readonly Option<bool> _followRedirectsOption = MonitorOptionDefinitions.WebTest.FollowRedirects;
+    private readonly Option<int> _frequencyInSecondsOption = MonitorOptionDefinitions.WebTest.FrequencyInSeconds;
+    private readonly Option<string> _headersOption = MonitorOptionDefinitions.WebTest.Headers;
+    private readonly Option<string> _httpVerbOption = MonitorOptionDefinitions.WebTest.HttpVerb;
+    private readonly Option<bool> _ignoreStatusCodeOption = MonitorOptionDefinitions.WebTest.IgnoreStatusCode;
+    private readonly Option<bool> _parseRequestsOption = MonitorOptionDefinitions.WebTest.ParseRequests;
+    private readonly Option<string> _requestBodyOption = MonitorOptionDefinitions.WebTest.RequestBody;
+    private readonly Option<bool> _retryEnabledOption = MonitorOptionDefinitions.WebTest.RetryEnabled;
+    private readonly Option<bool> _sslCheckOption = MonitorOptionDefinitions.WebTest.SslCheck;
+    private readonly Option<int> _sslLifetimeCheckInDaysOption = MonitorOptionDefinitions.WebTest.SslLifetimeCheckInDays;
+    private readonly Option<int> _timeoutInSecondsOption = MonitorOptionDefinitions.WebTest.TimeoutInSeconds;
+
+    public override string Name => _commandName;
+
+    public override string Description =>
+        """
+        Creates a new standard web test in Azure Monitor or updates an existing one. Ping/Multstep web tests are deprecated and are not supported.
+        Returns the created/updated web test details.
+        """;
+
+    public override string Title => _commandTitle;
+
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+
+        // Add required options
+        command.Options.Add(_resourceNameOption);
+        command.Options.Add(_appInsightsComponentIdOption);
+        command.Options.Add(_resourceLocationOption);
+        command.Options.Add(_locationsOption);
+        command.Options.Add(_requestUrlOption);
+        RequireResourceGroup();
+
+        // Add optional options
+        command.Options.Add(_webTestNameOption);
+        command.Options.Add(_descriptionOption);
+        command.Options.Add(_enabledOption);
+        command.Options.Add(_expectedStatusCodeOption);
+        command.Options.Add(_followRedirectsOption);
+        command.Options.Add(_frequencyInSecondsOption);
+        command.Options.Add(_headersOption);
+        command.Options.Add(_httpVerbOption);
+        command.Options.Add(_ignoreStatusCodeOption);
+        command.Options.Add(_parseRequestsOption);
+        command.Options.Add(_requestBodyOption);
+        command.Options.Add(_retryEnabledOption);
+        command.Options.Add(_sslCheckOption);
+        command.Options.Add(_sslLifetimeCheckInDaysOption);
+        command.Options.Add(_timeoutInSecondsOption);
+    }
+
+    protected override WebTestsCreateOrUpdateOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+
+        options.ResourceName = parseResult.GetValueOrDefault(_resourceNameOption)!;
+        options.AppInsightsComponentId = parseResult.GetValueOrDefault(_appInsightsComponentIdOption)!;
+        options.Location = parseResult.GetValueOrDefault(_resourceLocationOption)!;
+        options.Locations = parseResult.GetValueOrDefault(_locationsOption)!;
+        options.RequestUrl = parseResult.GetValueOrDefault(_requestUrlOption)!;
+
+        options.WebTestName = parseResult.GetValueOrDefault(_webTestNameOption);
+        options.Description = parseResult.GetValueOrDefault(_descriptionOption);
+        options.Enabled = parseResult.GetValueOrDefault(_enabledOption);
+        options.ExpectedStatusCode = parseResult.GetValueOrDefault(_expectedStatusCodeOption);
+        options.FollowRedirects = parseResult.GetValueOrDefault(_followRedirectsOption);
+        options.FrequencyInSeconds = parseResult.GetValueOrDefault(_frequencyInSecondsOption);
+        options.Headers = parseResult.GetValueOrDefault(_headersOption);
+        options.HttpVerb = parseResult.GetValueOrDefault(_httpVerbOption);
+        options.IgnoreStatusCode = parseResult.GetValueOrDefault(_ignoreStatusCodeOption);
+        options.ParseRequests = parseResult.GetValueOrDefault(_parseRequestsOption);
+        options.RequestBody = parseResult.GetValueOrDefault(_requestBodyOption);
+        options.RetryEnabled = parseResult.GetValueOrDefault(_retryEnabledOption);
+        options.SslCheck = parseResult.GetValueOrDefault(_sslCheckOption);
+        options.SslLifetimeCheckInDays = parseResult.GetValueOrDefault(_sslLifetimeCheckInDaysOption);
+        options.TimeoutInSeconds = parseResult.GetValueOrDefault(_timeoutInSecondsOption);
+
+        return options;
+    }
+
+    public override ValidationResult Validate(CommandResult commandResult, CommandResponse? response)
+    {
+        if (response == null)
+        {
+            return new ValidationResult { IsValid = false };
+        }
+
+        var baseValidation = base.Validate(commandResult, response);
+        if (!baseValidation.IsValid)
+        {
+            return baseValidation;
+        }
+
+        var locations = commandResult.GetValueOrDefault(_locationsOption);
+        if (locations == null || locations.Length == 0)
+        {
+            response.Status = 400;
+            response.Message = "The locations option is required and must include at least one location.";
+            return new ValidationResult { IsValid = false };
+        }
+
+        var requestUrl = commandResult.GetValueOrDefault(_requestUrlOption);
+        if (!Uri.TryCreate(requestUrl, UriKind.Absolute, out _))
+        {
+            response.Status = 400;
+            response.Message = "The request url option must be a valid absolute URL.";
+            return new ValidationResult { IsValid = false };
+        }
+
+        var timeoutInSeconds = commandResult.GetValueOrDefault(_timeoutInSecondsOption);
+        if (timeoutInSeconds > 120)
+        {
+            response.Status = 400;
+            response.Message = "The timeout cannot be greater than 2 minutes.";
+            return new ValidationResult { IsValid = false };
+        }
+
+        return new ValidationResult { IsValid = true };
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            var locationsArray = options.Locations!.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            var headersDictionary = options.Headers?
+                .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Split('=', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+                .Where(x => x.Length == 2)
+                .ToDictionary(x => x[0], x => x[1]) ?? new Dictionary<string, string>(0);
+
+            var monitorWebTestService = context.GetService<IMonitorWebTestService>();
+            var webTest = await monitorWebTestService.CreateOrUpdateWebTest(
+                subscription: options.Subscription!,
+                resourceGroup: options.ResourceGroup!,
+                resourceName: options.ResourceName!,
+                appInsightsComponentId: options.AppInsightsComponentId!,
+                location: options.Location!,
+                locations: locationsArray,
+                requestUrl: options.RequestUrl!,
+                webTestName: options.WebTestName,
+                description: options.Description,
+                enabled: options.Enabled,
+                expectedStatusCode: options.ExpectedStatusCode,
+                followRedirects: options.FollowRedirects,
+                frequencyInSeconds: options.FrequencyInSeconds,
+                headers: headersDictionary,
+                httpVerb: options.HttpVerb,
+                ignoreStatusCode: options.IgnoreStatusCode,
+                parseRequests: options.ParseRequests,
+                requestBody: options.RequestBody,
+                retryEnabled: options.RetryEnabled,
+                sslCheck: options.SslCheck,
+                sslLifetimeCheckInDays: options.SslLifetimeCheckInDays,
+                timeoutInSeconds: options.TimeoutInSeconds,
+                tenant: options.Tenant,
+                retryPolicy: options.RetryPolicy);
+
+            context.Response.Results = ResponseResult.Create(
+                new WebTestsCreateCommandResult(webTest),
+                MonitorJsonContext.Default.WebTestsCreateCommandResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating web test '{WebTestName}' in resource group '{ResourceGroup}'",
+                options.WebTestName ?? options.ResourceName, options.ResourceGroup);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    internal record WebTestsCreateCommandResult(WebTestDetailedInfo WebTest);
+}

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsCreateOrUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsCreateOrUpdateCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine.Parsing;
 using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Monitor.Models.WebTests;
 using Azure.Mcp.Tools.Monitor.Options;
 using Azure.Mcp.Tools.Monitor.Options.WebTests;
@@ -62,7 +63,7 @@ public sealed class WebTestsCreateOrUpdateCommand(ILogger<WebTestsCreateOrUpdate
         command.Options.Add(_resourceLocationOption);
         command.Options.Add(_locationsOption);
         command.Options.Add(_requestUrlOption);
-        RequireResourceGroup();
+        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsRequired());
 
         // Add optional options
         command.Options.Add(_webTestNameOption);
@@ -91,6 +92,7 @@ public sealed class WebTestsCreateOrUpdateCommand(ILogger<WebTestsCreateOrUpdate
         options.Location = parseResult.GetValueOrDefault(_resourceLocationOption)!;
         options.Locations = parseResult.GetValueOrDefault(_locationsOption)!;
         options.RequestUrl = parseResult.GetValueOrDefault(_requestUrlOption)!;
+        options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
 
         options.WebTestName = parseResult.GetValueOrDefault(_webTestNameOption);
         options.Description = parseResult.GetValueOrDefault(_descriptionOption);

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsGetCommand.cs
@@ -37,14 +37,14 @@ public sealed class WebTestsGetCommand(ILogger<WebTestsGetCommand> logger) : Bas
     {
         base.RegisterOptions(command);
         command.Options.Add(_webTestResourceNameOption);
-        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsOptional());
+        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsRequired());
     }
 
     protected override WebTestsGetOptions BindOptions(ParseResult parseResult)
     {
         var options = base.BindOptions(parseResult);
         options.ResourceName = parseResult.GetValueOrDefault(_webTestResourceNameOption);
-        options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
+        options.ResourceGroup ??= parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
         return options;
     }
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsGetCommand.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Tools.Monitor.Models.WebTests;
+using Azure.Mcp.Tools.Monitor.Options;
+using Azure.Mcp.Tools.Monitor.Options.WebTests;
+using Azure.Mcp.Tools.Monitor.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Mcp.Tools.Monitor.Commands.WebTests;
+
+public sealed class WebTestsGetCommand(ILogger<WebTestsGetCommand> logger) : BaseMonitorWebTestsCommand<WebTestsGetOptions>
+{
+    private const string _commandTitle = "Get details of a specific web test";
+    private const string _commandName = "get";
+
+    private readonly Option<string> _webTestResourceNameOption = MonitorOptionDefinitions.WebTest.WebTestResourceName;
+
+    public override string Name => _commandName;
+
+    public override string Description =>
+         $"""
+        Gets details for a specific web test in the provided resource group based on webtest resource name.
+        Returns detailed information about a single web test.
+        """;
+
+    public override string Title => _commandTitle;
+
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
+
+    private readonly ILogger<WebTestsGetCommand> _logger = logger;
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(_webTestResourceNameOption);
+        RequireResourceGroup();
+    }
+
+    protected override WebTestsGetOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.ResourceName = parseResult.GetValueOrDefault(_webTestResourceNameOption);
+        return options;
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            var monitorWebTestService = context.GetService<IMonitorWebTestService>();
+            var webTest = await monitorWebTestService.GetWebTest(
+                options.Subscription!,
+                options.ResourceGroup!,
+                options.ResourceName!,
+                options.Tenant,
+                options.RetryPolicy);
+
+            if (webTest != null)
+            {
+                context.Response.Results = ResponseResult.Create(
+                    new WebTestsGetCommandResult(webTest),
+                    MonitorJsonContext.Default.WebTestsGetCommandResult);
+            }
+            else
+            {
+                context.Response.Status = 404;
+                context.Response.Message = $"Web test '{options.ResourceName}' not found in resource group '{options.ResourceGroup}'";
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving web test '{Name}' in resource group '{ResourceGroup}', subscription '{Subscription}'",
+                options.ResourceName, options.ResourceGroup, options.Subscription);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    internal record WebTestsGetCommandResult(WebTestDetailedInfo WebTest);
+}

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsGetCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine.Parsing;
 using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Monitor.Models.WebTests;
 using Azure.Mcp.Tools.Monitor.Options;
 using Azure.Mcp.Tools.Monitor.Options.WebTests;
@@ -36,13 +37,14 @@ public sealed class WebTestsGetCommand(ILogger<WebTestsGetCommand> logger) : Bas
     {
         base.RegisterOptions(command);
         command.Options.Add(_webTestResourceNameOption);
-        RequireResourceGroup();
+        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsOptional());
     }
 
     protected override WebTestsGetOptions BindOptions(ParseResult parseResult)
     {
         var options = base.BindOptions(parseResult);
         options.ResourceName = parseResult.GetValueOrDefault(_webTestResourceNameOption);
+        options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
         return options;
     }
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsListCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Monitor.Models.WebTests;
 using Azure.Mcp.Tools.Monitor.Options.WebTests;
 using Azure.Mcp.Tools.Monitor.Services;
@@ -31,7 +32,14 @@ public sealed class WebTestsListCommand(ILogger<WebTestsListCommand> logger) : B
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
-        UseResourceGroup();
+        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsOptional());
+    }
+
+    protected override WebTestsListOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
+        return options;
     }
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsListCommand.cs
@@ -38,7 +38,7 @@ public sealed class WebTestsListCommand(ILogger<WebTestsListCommand> logger) : B
     protected override WebTestsListOptions BindOptions(ParseResult parseResult)
     {
         var options = base.BindOptions(parseResult);
-        options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
+        options.ResourceGroup ??= parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
         return options;
     }
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsListCommand.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Tools.Monitor.Models.WebTests;
+using Azure.Mcp.Tools.Monitor.Options.WebTests;
+using Azure.Mcp.Tools.Monitor.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Mcp.Tools.Monitor.Commands.WebTests;
+
+public sealed class WebTestsListCommand(ILogger<WebTestsListCommand> logger) : BaseMonitorWebTestsCommand<WebTestsListOptions>
+{
+    private const string _commandTitle = "List all web tests in a subscription or resource group";
+    private const string _commandName = "list";
+
+    public override string Name => _commandName;
+
+    public override string Description =>
+         $"""
+        Lists all web tests in a specified subscription and optionally, a resource group.
+        Returns a list of web tests.
+        """;
+
+    public override string Title => _commandTitle;
+
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
+
+    private readonly ILogger<WebTestsListCommand> _logger = logger;
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        UseResourceGroup();
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            var monitorWebTestService = context.GetService<IMonitorWebTestService>();
+            var webTests = options.ResourceGroup == null
+                ? await monitorWebTestService.ListWebTests(options.Subscription!, options.Tenant, options.RetryPolicy)
+                : await monitorWebTestService.ListWebTests(options.Subscription!, options.ResourceGroup, options.Tenant, options.RetryPolicy);
+
+            context.Response.Results = webTests?.Count > 0 ?
+                ResponseResult.Create(new WebTestsListCommandResult(webTests), MonitorJsonContext.Default.WebTestsListCommandResult) :
+                null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"Error listing web tests in subscription '{options.Subscription}'");
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    internal record WebTestsListCommandResult(List<WebTestSummaryInfo> WebTests);
+}

--- a/tools/Azure.Mcp.Tools.Monitor/src/Models/WebTests/WebTestDetailedInfo.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Models/WebTests/WebTestDetailedInfo.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using Azure.ResourceManager.ApplicationInsights.Models;
+
+namespace Azure.Mcp.Tools.Monitor.Models.WebTests;
+
+public class WebTestDetailedInfo
+{
+    [JsonPropertyName("resourceName")]
+    public required string ResourceName { get; set; }
+
+    [JsonPropertyName("location")]
+    public required string Location { get; set; }
+
+    [JsonPropertyName("resourceGroup")]
+    public string? ResourceGroup { get; set; }
+
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("kind")]
+    public string? Kind { get; set; }
+
+    [JsonPropertyName("webTestName")]
+    public string? WebTestName { get; set; }
+
+    [JsonPropertyName("isEnabled")]
+    public bool? IsEnabled { get; set; }
+
+    [JsonPropertyName("syntheticMonitorId")]
+    public string? SyntheticMonitorId { get; set; }
+
+    [JsonPropertyName("frequencyInSeconds")]
+    public int? FrequencyInSeconds { get; set; } = 300; // Default to 5 minutes
+
+    [JsonPropertyName("timeoutInSeconds")]
+    public int? TimeoutInSeconds { get; set; } = 30; // Default to 30 seconds
+
+    [JsonPropertyName("isRetryEnabled")]
+    public bool? IsRetryEnabled { get; set; } = false; // Default to disabled
+
+    [JsonPropertyName("locations")]
+    public IList<string>? Locations { get; set; }
+
+    [JsonPropertyName("request")]
+    public WebTestRequest? Request { get; set; }
+
+    [JsonPropertyName("validationRules")]
+    public WebTestValidationRules? ValidationRules { get; set; }
+
+    [JsonPropertyName("appInsightsComponentId")]
+    public string? AppInsightsComponentId { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.Monitor/src/Models/WebTests/WebTestSummaryInfo.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Models/WebTests/WebTestSummaryInfo.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Mcp.Tools.Monitor.Models.WebTests;
+
+public class WebTestSummaryInfo
+{
+
+    [JsonPropertyName("resourceName")]
+    public required string ResourceName { get; set; }
+
+    [JsonPropertyName("location")]
+    public required string Location { get; set; }
+
+    [JsonPropertyName("resourceGroup")]
+    public string? ResourceGroup { get; set; }
+
+    [JsonPropertyName("kind")]
+    public string? Kind { get; set; }
+
+    [JsonPropertyName("appInsightsComponentId")]
+    public string? AppInsightsComponentId { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.Monitor/src/MonitorSetup.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/MonitorSetup.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Tools.Monitor.Commands.Log;
 using Azure.Mcp.Tools.Monitor.Commands.Metrics;
 using Azure.Mcp.Tools.Monitor.Commands.Table;
 using Azure.Mcp.Tools.Monitor.Commands.TableType;
+using Azure.Mcp.Tools.Monitor.Commands.WebTests;
 using Azure.Mcp.Tools.Monitor.Commands.Workspace;
 using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +24,7 @@ public class MonitorSetup : IAreaSetup
     {
         services.AddSingleton<IMonitorService, MonitorService>();
         services.AddSingleton<IMonitorHealthModelService, MonitorHealthModelService>();
+        services.AddSingleton<IMonitorWebTestService, MonitorWebTestService>();
         services.AddSingleton<IResourceResolverService, ResourceResolverService>();
         services.AddSingleton<IMetricsQueryClientService, MetricsQueryClientService>();
         services.AddSingleton<IMonitorMetricsService, MonitorMetricsService>();
@@ -77,5 +79,13 @@ public class MonitorSetup : IAreaSetup
 
         metrics.AddCommand("query", new MetricsQueryCommand(loggerFactory.CreateLogger<MetricsQueryCommand>()));
         metrics.AddCommand("definitions", new MetricsDefinitionsCommand(loggerFactory.CreateLogger<MetricsDefinitionsCommand>()));
+
+        // Register Monitor.WebTest sub-group commands
+        var webTests = new CommandGroup("webtests", "Azure Monitor Web Test operations - Commands for working with Azure Availability/Web Tests.");
+        monitor.AddSubGroup(webTests);
+
+        webTests.AddCommand("get", new WebTestsGetCommand(loggerFactory.CreateLogger<WebTestsGetCommand>()));
+        webTests.AddCommand("list", new WebTestsListCommand(loggerFactory.CreateLogger<WebTestsListCommand>()));
+        webTests.AddCommand("createorupdate", new WebTestsCreateOrUpdateCommand(loggerFactory.CreateLogger<WebTestsCreateOrUpdateCommand>()));
     }
 }

--- a/tools/Azure.Mcp.Tools.Monitor/src/Options/MonitorOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Options/MonitorOptionDefinitions.cs
@@ -374,7 +374,7 @@ public static class MonitorOptionDefinitions
             Description = "Number of days to check SSL certificate lifetime",
             DefaultValueFactory = _ => 7
         };
-        
+
         public static readonly Option<int> TimeoutInSeconds = new(
             $"--{TimeoutInSecondsName}"
         )

--- a/tools/Azure.Mcp.Tools.Monitor/src/Options/MonitorOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Options/MonitorOptionDefinitions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net;
+
 namespace Azure.Mcp.Tools.Monitor.Options;
 
 public static class MonitorOptionDefinitions
@@ -12,6 +14,7 @@ public static class MonitorOptionDefinitions
     public const string LimitName = "limit";
     public const string EntityName = "entity";
     public const string HealthModelName = "health-model";
+    public const string WebTestResourceName = "webtest-resource";
 
     public static readonly Option<string> TableType = new(
         $"--{TableTypeName}"
@@ -202,6 +205,182 @@ public static class MonitorOptionDefinitions
         {
             Description = "The name of the health model for which to get the health.",
             Required = true
+        };
+    }
+
+    public static class WebTest
+    {
+        public const string WebTestsLocationsName = "webtest-locations";
+        public const string RequestUrlName = "request-url";
+        public const string AppInsightsComponentIdName = "appinsights-component";
+        public const string ResourceLocationName = "location";
+        public const string WebTestNameName = "webtest";
+        public const string DescriptionName = "description";
+        public const string EnabledName = "enabled";
+        public const string ExpectedStatusCodeName = "expected-status-code";
+        public const string FollowRedirectsName = "follow-redirects";
+        public const string FrequencyInSecondsName = "frequency";
+        public const string HeadersName = "headers";
+        public const string HttpVerbName = "http-verb";
+        public const string IgnoreStatusCodeName = "ignore-status-code";
+        public const string ParseRequestsName = "parse-requests";
+        public const string RequestBodyName = "request-body";
+        public const string RetryEnabledName = "retry-enabled";
+        public const string SslCheckName = "ssl-check";
+        public const string SslLifetimeCheckInDaysName = "ssl-lifetime-check";
+        public const string TimeoutInSecondsName = "timeout";
+
+        public static readonly Option<string> WebTestResourceName = new(
+            $"--{MonitorOptionDefinitions.WebTestResourceName}"
+        )
+        {
+            Description = "The name of the Web Test resource to operate on.",
+            Required = true
+        };
+
+        public static readonly Option<string> AppInsightsComponentId = new(
+            $"--{AppInsightsComponentIdName}"
+        )
+        {
+            Description = "The resource id of the Application Insights component to associate with the web test.",
+            Required = true
+        };
+
+        public static readonly Option<string> ResourceLocation = new(
+            $"--{ResourceLocationName}"
+        )
+        {
+            Description = "The location where the web test resource is created. This should be the same as the AppInsights component location.",
+            Required = true
+        };
+
+        public static readonly Option<string> Locations = new(
+            $"--{WebTestsLocationsName}"
+        )
+        {
+            Description = "List of locations to run the test from (comma-separated values). Location refers to the geo-location population tag specific to Availability Tests.",
+            Required = true
+        };
+
+        public static readonly Option<string> RequestUrl = new(
+            $"--{RequestUrlName}"
+        )
+        {
+            Description = "The absolute URL to test",
+            Required = true
+        };
+
+        public static readonly Option<string> WebTestName = new(
+            $"--{WebTestNameName}"
+        )
+        {
+            Description = "The name of the test in web test resource"
+        };
+
+        public static readonly Option<string> Description = new(
+            $"--{DescriptionName}"
+        )
+        {
+            Description = "The description of the web test"
+        };
+
+        public static readonly Option<bool> Enabled = new(
+            $"--{EnabledName}"
+        )
+        {
+            Description = "Whether the web test is enabled",
+            DefaultValueFactory = _ => true
+        };
+
+        public static readonly Option<int> ExpectedStatusCode = new(
+            $"--{ExpectedStatusCodeName}"
+        )
+        {
+            Description = "Expected HTTP status code",
+            DefaultValueFactory = _ => (int)HttpStatusCode.OK,
+        };
+
+        public static readonly Option<bool> FollowRedirects = new(
+            $"--{FollowRedirectsName}"
+        )
+        {
+            Description = "Whether to follow redirects"
+        };
+
+        public static readonly Option<int> FrequencyInSeconds = new(
+            $"--{FrequencyInSecondsName}"
+        )
+        {
+            Description = "Test frequency in seconds. Supported values 300, 600, 900 seconds.",
+            DefaultValueFactory = _ => 300
+        };
+
+        public static readonly Option<string> Headers = new(
+            $"--{HeadersName}"
+        )
+        {
+            Description = "HTTP headers to include in the request. Comma-separated KEY=VALUE"
+        };
+
+        public static readonly Option<string> HttpVerb = new(
+            $"--{HttpVerbName}"
+        )
+        {
+            Description = "HTTP method (get, post, etc.)",
+            DefaultValueFactory = _ => HttpMethod.Get.ToString()
+        };
+
+        public static readonly Option<bool> IgnoreStatusCode = new(
+            $"--{IgnoreStatusCodeName}"
+        )
+        {
+            Description = "Whether to ignore the status code validation",
+            DefaultValueFactory = _ => false
+        };
+
+        public static readonly Option<bool> ParseRequests = new(
+            $"--{ParseRequestsName}"
+        )
+        {
+            Description = "Whether to parse dependent requests"
+        };
+
+        public static readonly Option<string> RequestBody = new(
+            $"--{RequestBodyName}"
+        )
+        {
+            Description = "The body of the request"
+        };
+
+        public static readonly Option<bool> RetryEnabled = new(
+            $"--{RetryEnabledName}"
+        )
+        {
+            Description = "Whether retries are enabled"
+        };
+
+        public static readonly Option<bool> SslCheck = new(
+            $"--{SslCheckName}"
+        )
+        {
+            Description = "Whether to check SSL certificates",
+            DefaultValueFactory = _ => true
+        };
+
+        public static readonly Option<int> SslLifetimeCheckInDays = new(
+            $"--{SslLifetimeCheckInDaysName}"
+        )
+        {
+            Description = "Number of days to check SSL certificate lifetime",
+            DefaultValueFactory = _ => 7
+        };
+        
+        public static readonly Option<int> TimeoutInSeconds = new(
+            $"--{TimeoutInSecondsName}"
+        )
+        {
+            Description = "Request timeout in seconds (max 2 minutes). Supported values: 30, 60, 90, 120 seconds",
+            DefaultValueFactory = _ => 120
         };
     }
 }

--- a/tools/Azure.Mcp.Tools.Monitor/src/Options/WebTests/WebTestsCreateOrUpdateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Options/WebTests/WebTestsCreateOrUpdateOptions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Tools.Monitor.Options;
+
+namespace Azure.Mcp.Tools.Monitor.Options.WebTests;
+
+public class WebTestsCreateOrUpdateOptions : BaseMonitorOptions
+{
+    public string? ResourceName { get; set; }
+    public string? AppInsightsComponentId { get; set; }
+    public string? Location { get; set; }
+    public string? Locations { get; set; }
+    public string? RequestUrl { get; set; }
+    public string? ContentValidation { get; set; }
+    public string? WebTestName { get; set; }
+    public string? Description { get; set; }
+    public bool Enabled { get; set; } = true;
+    public int? ExpectedStatusCode { get; set; }
+    public bool? FollowRedirects { get; set; }
+    public int? FrequencyInSeconds { get; set; }
+    public string? Headers { get; set; }
+    public string? HttpVerb { get; set; }
+    public bool? IgnoreStatusCode { get; set; }
+    public bool? ParseRequests { get; set; }
+    public string? RequestBody { get; set; }
+    public bool? RetryEnabled { get; set; }
+    public bool? SslCheck { get; set; }
+    public int? SslLifetimeCheckInDays { get; set; }
+    public int? TimeoutInSeconds { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.Monitor/src/Options/WebTests/WebTestsGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Options/WebTests/WebTestsGetOptions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using Azure.Mcp.Tools.Monitor.Options;
+
+namespace Azure.Mcp.Tools.Monitor.Options.WebTests;
+
+public class WebTestsGetOptions : BaseMonitorOptions
+{
+    [JsonPropertyName(MonitorOptionDefinitions.WebTestResourceName)]
+    public string? ResourceName { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.Monitor/src/Options/WebTests/WebTestsListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Options/WebTests/WebTestsListOptions.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Tools.Monitor.Options;
+
+namespace Azure.Mcp.Tools.Monitor.Options.WebTests;
+
+public class WebTestsListOptions : BaseMonitorOptions
+{
+}

--- a/tools/Azure.Mcp.Tools.Monitor/src/Options/WebTests/WebTestsListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Options/WebTests/WebTestsListOptions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Tools.Monitor.Options;
-
 namespace Azure.Mcp.Tools.Monitor.Options.WebTests;
 
 public class WebTestsListOptions : BaseMonitorOptions

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/IMonitorWebTestService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/IMonitorWebTestService.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Tools.Monitor.Models.WebTests;
+
+namespace Azure.Mcp.Tools.Monitor.Services;
+
+public interface IMonitorWebTestService
+{
+    Task<List<WebTestSummaryInfo>> ListWebTests(
+        string subscription,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null);
+
+    Task<List<WebTestSummaryInfo>> ListWebTests(
+        string subscription,
+        string resourceGroup,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null);
+
+    Task<WebTestDetailedInfo> GetWebTest(
+        string subscription,
+        string resourceGroup,
+        string name,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null);
+
+    Task<WebTestDetailedInfo> CreateOrUpdateWebTest(
+        string subscription,
+        string resourceGroup,
+        string resourceName,
+        string appInsightsComponentId,
+        string location,
+        string[] locations,
+        string requestUrl,
+        string? webTestName = null,
+        string? description = null,
+        bool enabled = true,
+        int? expectedStatusCode = null,
+        bool? followRedirects = false,
+        int? frequencyInSeconds = null,
+        IReadOnlyDictionary<string, string>? headers = null,
+        string? httpVerb = "GET",
+        bool? ignoreStatusCode = false,
+        bool? parseRequests = false,
+        string? requestBody = null,
+        bool? retryEnabled = false,
+        bool? sslCheck = false,
+        int? sslLifetimeCheckInDays = null,
+        int? timeoutInSeconds = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null);
+}

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorWebTestService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorWebTestService.cs
@@ -3,14 +3,14 @@
 
 using System.Text.RegularExpressions;
 using Azure.Core;
-using Azure.ResourceManager.ApplicationInsights;
-using Azure.ResourceManager.ApplicationInsights.Models;
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Core.Services.Azure.ResourceGroup;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.Monitor.Models.WebTests;
+using Azure.ResourceManager.ApplicationInsights;
+using Azure.ResourceManager.ApplicationInsights.Models;
 
 namespace Azure.Mcp.Tools.Monitor.Services;
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorWebTestService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorWebTestService.cs
@@ -1,0 +1,330 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+using Azure.Core;
+using Azure.ResourceManager.ApplicationInsights;
+using Azure.ResourceManager.ApplicationInsights.Models;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Core.Services.Azure;
+using Azure.Mcp.Core.Services.Azure.ResourceGroup;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Core.Services.Azure.Tenant;
+using Azure.Mcp.Tools.Monitor.Models.WebTests;
+
+namespace Azure.Mcp.Tools.Monitor.Services;
+
+public class MonitorWebTestService(ISubscriptionService subscriptionService, ITenantService tenantService, IResourceGroupService resourceGroupService)
+    : BaseAzureService(tenantService), IMonitorWebTestService
+{
+    private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
+    private readonly IResourceGroupService _resourceGroupService = resourceGroupService ?? throw new ArgumentNullException(nameof(resourceGroupService));
+
+    public async Task<List<WebTestSummaryInfo>> ListWebTests(
+        string subscription,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null)
+    {
+        ValidateRequiredParameters(subscription);
+
+        try
+        {
+            var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
+
+            var webTests = await subscriptionResource
+                .GetApplicationInsightsWebTestsAsync()
+                .Select(webTest => new WebTestSummaryInfo
+                {
+                    ResourceName = webTest.Data.Name,
+                    Location = webTest.Data.Location,
+                    ResourceGroup = webTest.Id.ResourceGroupName,
+                    Kind = webTest.Data.WebTestKind?.ToString(),
+                    AppInsightsComponentId = GetAppInsightsComponentIdFromWebTestData(webTest.Data)
+                })
+                .ToListAsync()
+                .ConfigureAwait(false);
+
+            return webTests;
+        }
+        catch (Exception ex) when (ex is not ArgumentNullException)
+        {
+            throw new Exception($"Error retrieving web tests: {ex.Message}", ex);
+        }
+    }
+
+    public async Task<List<WebTestSummaryInfo>> ListWebTests(
+        string subscription,
+        string resourceGroup,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null)
+    {
+        ValidateRequiredParameters(subscription);
+
+        try
+        {
+            var resourceGroupResource = await _resourceGroupService.GetResourceGroupResource(subscription, resourceGroup, tenant, retryPolicy) ??
+                throw new Exception($"Resource group {resourceGroup} not found in subscription {subscription}");
+
+            var webTests = await resourceGroupResource
+                .GetApplicationInsightsWebTests()
+                .GetAllAsync()
+                .Select(webTest => new WebTestSummaryInfo
+                {
+                    ResourceName = webTest.Data.Name,
+                    Location = webTest.Data.Location,
+                    ResourceGroup = webTest.Id.ResourceGroupName,
+                    Kind = webTest.Data.WebTestKind?.ToString(),
+                    AppInsightsComponentId = GetAppInsightsComponentIdFromWebTestData(webTest.Data)
+                })
+                .ToListAsync()
+                .ConfigureAwait(false);
+
+            return webTests;
+        }
+        catch (Exception ex) when (ex is not ArgumentNullException)
+        {
+            throw new Exception($"Error retrieving web tests: {ex.Message}", ex);
+        }
+    }
+    public async Task<WebTestDetailedInfo> GetWebTest(
+      string subscription,
+      string resourceGroup,
+      string resourceName,
+      string? tenant = null,
+      RetryPolicyOptions? retryPolicy = null)
+    {
+        ValidateRequiredParameters(subscription, resourceGroup, resourceName);
+
+        try
+        {
+            var resourceGroupResource = await _resourceGroupService.GetResourceGroupResource(subscription, resourceGroup, tenant, retryPolicy) ??
+                throw new Exception($"Resource group {resourceGroup} not found in subscription {subscription}");
+
+            var webTest = await resourceGroupResource.GetApplicationInsightsWebTestAsync(resourceName).ConfigureAwait(false);
+            if (webTest == null || !webTest.HasValue || !webTest.Value!.HasData)
+            {
+                throw new Exception($"Error retrieving details for web test '{resourceName}'");
+            }
+
+            if (webTest.Value.Data.WebTestKind == WebTestKind.Ping || webTest.Value.Data.WebTestKind == WebTestKind.MultiStep)
+            {
+                throw new NotSupportedException($"Web test '{resourceName}' is of type '{webTest.Value.Data.WebTestKind}', which has been deprecated and is not supported by this command.");
+            }
+
+            var webTestData = webTest.Value.Data;
+            var webTestId = webTest.Value.Id;
+
+            var parsedHeaders = ParseHeadersFromRawResponse(webTest.GetRawResponse());
+            PatchRequestWithCorrectedHeaders(webTestData.Request, parsedHeaders);
+
+            return new WebTestDetailedInfo
+            {
+                ResourceName = webTestData.Name,
+                Location = webTestData.Location.ToString(),
+                Locations = webTestData.Locations
+                    .Where(x => x.Location != null)
+                    .Select(x => x.Location.ToString())
+                    .Cast<string>()
+                    .ToList(),
+                ResourceGroup = webTestId.ResourceGroupName,
+                Id = webTestId.ToString(),
+                Kind = webTestData.WebTestKind?.ToString(),
+                WebTestName = webTestData.WebTestName,
+                IsEnabled = webTestData.IsEnabled,
+                SyntheticMonitorId = webTestData.SyntheticMonitorId,
+                FrequencyInSeconds = webTestData.FrequencyInSeconds,
+                TimeoutInSeconds = webTestData.TimeoutInSeconds,
+                IsRetryEnabled = webTestData.IsRetryEnabled,
+                Request = webTestData.Request,
+                ValidationRules = webTestData.ValidationRules,
+                AppInsightsComponentId = GetAppInsightsComponentIdFromWebTestData(webTestData)
+            };
+        }
+        catch (Exception ex) when (ex is not ArgumentNullException)
+        {
+            throw new Exception($"Error retrieving web test {resourceName}: {ex.Message}", ex);
+        }
+    }
+
+    public async Task<WebTestDetailedInfo> CreateOrUpdateWebTest(
+        string subscription,
+        string resourceGroup,
+        string resourceName,
+        string appInsightsComponentId,
+        string location,
+        string[] locations,
+        string requestUrl,
+        string? webTestName = null,
+        string? description = null,
+        bool enabled = true,
+        int? expectedStatusCode = null,
+        bool? followRedirects = false,
+        int? frequencyInSeconds = null,
+        IReadOnlyDictionary<string, string>? headers = null,
+        string? httpVerb = "get",
+        bool? ignoreStatusCode = false,
+        bool? parseRequests = false,
+        string? requestBody = null,
+        bool? retryEnabled = false,
+        bool? sslCheck = false,
+        int? sslLifetimeCheckInDays = null,
+        int? timeoutInSeconds = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null)
+    {
+        ValidateRequiredParameters(subscription, resourceGroup, resourceName);
+
+        try
+        {
+            var resourceGroupResource = await _resourceGroupService.GetResourceGroupResource(subscription, resourceGroup, tenant, retryPolicy) ??
+                throw new Exception($"Resource group {resourceGroup} not found in subscription {subscription}");
+
+            var webTestData = new ApplicationInsightsWebTestData(new(location))
+            {
+                WebTestName = webTestName ?? resourceName,
+                SyntheticMonitorId = resourceName,
+                WebTestKind = WebTestKind.Standard,
+                IsEnabled = enabled,
+                FrequencyInSeconds = frequencyInSeconds,
+                TimeoutInSeconds = timeoutInSeconds,
+                IsRetryEnabled = retryEnabled,
+                Description = description,
+                Request = new WebTestRequest
+                {
+                    RequestUri = new Uri(requestUrl),
+                    HttpVerb = (httpVerb ?? HttpMethod.Get.ToString()).ToUpperInvariant(),
+                    RequestBody = requestBody,
+                    FollowRedirects = followRedirects,
+                    ParseDependentRequests = parseRequests
+                },
+                ValidationRules = new WebTestValidationRules
+                {
+                    ExpectedHttpStatusCode = expectedStatusCode,
+                    IgnoreHttpStatusCode = ignoreStatusCode,
+                    CheckSsl = sslCheck,
+                    SslCertRemainingLifetimeCheck = sslCheck.HasValue && sslCheck.Value ? sslLifetimeCheckInDays : null
+                },
+            };
+
+            webTestData.Tags.Add($"hidden-link:{appInsightsComponentId}", "Resource");
+
+            foreach (var webTestLocation in locations)
+            {
+                webTestData.Locations.Add(new WebTestGeolocation
+                {
+                    Location = new AzureLocation(webTestLocation)
+                });
+            }
+
+            if (headers != null)
+            {
+                foreach (var headerKey in headers.Keys)
+                {
+                    webTestData.Request.Headers.Add(new WebTestRequestHeaderField()
+                    {
+                        HeaderFieldName = headerKey,
+                        HeaderFieldValue = headers[headerKey]
+                    });
+                }
+            }
+
+            var webTestArmResource = await resourceGroupResource.GetApplicationInsightsWebTests()
+                .CreateOrUpdateAsync(
+                    WaitUntil.Completed,
+                    resourceName,
+                    webTestData
+                ).ConfigureAwait(false);
+
+            if (webTestArmResource == null || !webTestArmResource.HasCompleted || !webTestArmResource.HasValue)
+            {
+                throw new Exception($"Error creating web test resource with name '{resourceName}' in resource group '{resourceGroup}'");
+            }
+
+            var createdWebTest = webTestArmResource.Value.Data;
+
+            var parsedHeaders = ParseHeadersFromRawResponse(webTestArmResource.GetRawResponse());
+            PatchRequestWithCorrectedHeaders(createdWebTest.Request, parsedHeaders);
+
+            return new WebTestDetailedInfo
+            {
+                ResourceName = createdWebTest.Name,
+                Location = createdWebTest.Location.ToString(),
+                Locations = createdWebTest.Locations
+                    .Where(x => x.Location != null)
+                    .Select(x => x.Location.ToString())
+                    .Cast<string>()
+                    .ToList(),
+                ResourceGroup = webTestArmResource.Value.Id.ResourceGroupName,
+                Id = webTestArmResource.Value.Id.ToString(),
+                Kind = createdWebTest.WebTestKind?.ToString(),
+                WebTestName = createdWebTest.WebTestName,
+                IsEnabled = createdWebTest.IsEnabled,
+                SyntheticMonitorId = createdWebTest.SyntheticMonitorId,
+                FrequencyInSeconds = createdWebTest.FrequencyInSeconds,
+                TimeoutInSeconds = createdWebTest.TimeoutInSeconds,
+                IsRetryEnabled = createdWebTest.IsRetryEnabled,
+                Request = createdWebTest.Request,
+                ValidationRules = createdWebTest.ValidationRules,
+                AppInsightsComponentId = GetAppInsightsComponentIdFromWebTestData(createdWebTest)
+            };
+        }
+        catch (Exception ex) when (ex is not ArgumentNullException)
+        {
+            throw new Exception($"Error creating web test {resourceName}: {ex.Message}", ex);
+        }
+    }
+
+    private List<WebTestRequestHeaderField> ParseHeadersFromRawResponse(Response response)
+    {
+        using (var document = JsonDocument.Parse(response.Content))
+        {
+            var root = document.RootElement;
+            var headers = new List<WebTestRequestHeaderField>();
+
+            if (root.TryGetProperty("properties", out JsonElement properties) &&
+                properties.TryGetProperty("Request", out JsonElement request) &&
+                request.TryGetProperty("Headers", out JsonElement headersArray) &&
+                headersArray.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var header in headersArray.EnumerateArray())
+                {
+                    if (header.TryGetProperty("Key", out JsonElement keyElement) &&
+                        header.TryGetProperty("Value", out JsonElement valueElement))
+                    {
+                        string key = keyElement.GetString()!;
+                        string value = valueElement.GetString()!;
+                        headers.Add(new WebTestRequestHeaderField
+                        {
+                            HeaderFieldName = key,
+                            HeaderFieldValue = value
+                        });
+                    }
+                }
+            }
+
+            return headers;
+        }
+    }
+
+    private void PatchRequestWithCorrectedHeaders(WebTestRequest request, List<WebTestRequestHeaderField> headers)
+    {
+        request.Headers.Clear();
+        foreach (var header in headers)
+        {
+            request.Headers.Add(header);
+        }
+    }
+
+    private string? GetAppInsightsComponentIdFromWebTestData(ApplicationInsightsWebTestData webTest)
+    {
+        if (webTest.Tags == null || webTest.Tags.Count == 0)
+        {
+            return null;
+        }
+
+        var hiddenLinkMatch = webTest.Tags.Keys.Select(x => AppInsightsComponentHiddenLinkTagRegex.Match(x)).FirstOrDefault(match => match.Success);
+        return hiddenLinkMatch?.Groups[1].Value;
+    }
+
+    private readonly Regex AppInsightsComponentHiddenLinkTagRegex = new Regex("^hidden-link:(\\/subscriptions\\/[^\\/]+\\/resourceGroups\\/[^\\/]+\\/providers\\/microsoft\\.insights\\/components\\/[^\\/]+)$", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+}

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.LiveTests/MonitorCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.LiveTests/MonitorCommandTests.cs
@@ -20,12 +20,16 @@ public class MonitorCommandTests(ITestOutputHelper output) : CommandTestsBase(ou
     private const string TestLogType = "TestLogs_CL";
     private IMonitorService? _monitorService;
     private string? _storageAccountName;
+    private string? _appInsightsName;
+    private string? _bingWebTestName;
 
     public override async ValueTask InitializeAsync()
     {
         await base.InitializeAsync();
         _monitorService = GetMonitorService();
         _storageAccountName = $"{Settings.ResourceBaseName}mon";
+        _appInsightsName = $"{Settings.ResourceBaseName}-ai";
+        _bingWebTestName = $"{Settings.ResourceBaseName}-bing-test";
         _logHelper = new LogAnalyticsHelper(Settings.ResourceBaseName, Settings.SubscriptionId, _monitorService, Settings.TenantId, TestLogType);
     }
 
@@ -452,5 +456,158 @@ public class MonitorCommandTests(ITestOutputHelper output) : CommandTestsBase(ou
             // Don't fail the test if storage activity generation fails
         }
     }
-}
 
+    #region WebTests Integration Tests
+
+    [Fact]
+    public async Task Should_List_WebTests()
+    {
+        var result = await CallToolAsync(
+            "azmcp_monitor_webtests_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId }
+            });
+
+        var webTestsArray = result.AssertProperty("webTests");
+        Assert.Equal(JsonValueKind.Array, webTestsArray.ValueKind);
+
+        // Should have at least 2 web tests (bing and microsoft from test resources)
+        var webTests = webTestsArray.EnumerateArray().ToList();
+        Assert.True(webTests.Count >= 2, $"Expected at least 2 web tests, but found {webTests.Count}");
+
+        foreach (var webTest in webTests)
+        {
+            Assert.True(webTest.TryGetProperty("resourceName", out var resourceName));
+            Assert.Equal(JsonValueKind.String, resourceName.ValueKind);
+            Assert.False(string.IsNullOrEmpty(resourceName.GetString()));
+
+            Assert.True(webTest.TryGetProperty("location", out var location));
+            Assert.Equal(JsonValueKind.String, location.ValueKind);
+            Assert.False(string.IsNullOrEmpty(location.GetString()));
+        }
+    }
+
+    [Fact]
+    public async Task Should_List_WebTests_ByResourceGroup()
+    {
+        var result = await CallToolAsync(
+            "azmcp_monitor_webtests_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName }
+            });
+
+        var webTestsArray = result.AssertProperty("webTests");
+        Assert.Equal(JsonValueKind.Array, webTestsArray.ValueKind);
+
+        // The array can be empty if no web tests exist in the resource group, which is fine for this test
+        foreach (var webTest in webTestsArray.EnumerateArray())
+        {
+            Assert.True(webTest.TryGetProperty("resourceName", out var resourceName));
+            Assert.Equal(JsonValueKind.String, resourceName.ValueKind);
+            Assert.False(string.IsNullOrEmpty(resourceName.GetString()));
+
+            Assert.True(webTest.TryGetProperty("location", out var location));
+            Assert.Equal(JsonValueKind.String, location.ValueKind);
+            Assert.False(string.IsNullOrEmpty(location.GetString()));
+
+            // Verify the resource group matches what was requested
+            if (webTest.TryGetProperty("resourceGroup", out var resourceGroup))
+            {
+                Assert.Equal(Settings.ResourceGroupName, resourceGroup.GetString());
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Should_Get_WebTest_Details()
+    {
+        // Use one of the test availability tests we created - using resource base name pattern
+        var webTestName = _bingWebTestName;
+
+        var result = await CallToolAsync(
+            "azmcp_monitor_webtests_get",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "webtest-resource", webTestName }
+            });
+
+        var webTest = result.AssertProperty("webTest");
+        Assert.Equal(JsonValueKind.Object, webTest.ValueKind);
+
+        // Verify required properties exist
+        Assert.True(webTest.TryGetProperty("resourceName", out var resourceName));
+        Assert.Equal(webTestName, resourceName.GetString());
+
+        Assert.True(webTest.TryGetProperty("location", out var location));
+        Assert.Equal(JsonValueKind.String, location.ValueKind);
+        Assert.False(string.IsNullOrEmpty(location.GetString()));
+
+        Assert.True(webTest.TryGetProperty("kind", out var webTestKind));
+        Assert.Equal("Standard", webTestKind.GetString());
+
+        Assert.True(webTest.TryGetProperty("isEnabled", out var enabled));
+        Assert.True(enabled.GetBoolean());
+    }
+
+    [Theory]
+    [InlineData("--invalid-param")]
+    [InlineData("--subscription invalidSub")]
+    [InlineData("--subscription sub --resource-group rg")] // Missing required params for get
+    public async Task Should_Return400_WithInvalidWebTestInput(string args)
+    {
+        var result = await CallToolAsync(
+            "azmcp_monitor_webtests_list",
+            new()
+            {
+                { "args", args }
+            });
+
+        Assert.NotEqual(200, result?.GetProperty("status").GetInt32() ?? 500);
+    }
+
+    [Fact]
+    public async Task Should_CreateOrUpdate_WebTest()
+    {
+        // Use the Application Insights component we created in test resources with proper base name pattern
+        var webTestName = $"test-webtest-{DateTime.UtcNow:yyyyMMddHHmmss}";
+        var appInsightsComponentId = $"/subscriptions/{Settings.SubscriptionId}/resourceGroups/{Settings.ResourceGroupName}/providers/Microsoft.Insights/components/{_appInsightsName}";
+
+        var result = await CallToolAsync(
+            "azmcp_monitor_webtests_createorupdate",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "webtest-resource", webTestName },
+                { "appinsights-component", appInsightsComponentId },
+                { "location", "West US" },
+                { "webtest-locations", "us-ca-sjc-azr" },
+                { "request-url", "https://example.com" },
+                { "webtest", "Test Web Test" },
+                { "description", "Integration test web test" },
+                { "enabled", "true" },
+                { "frequency", "300" },
+                { "timeout", "30" }
+            });
+
+        var webTest = result.AssertProperty("webTest");
+        Assert.Equal(JsonValueKind.Object, webTest.ValueKind);
+
+        // Verify the created web test
+        Assert.True(webTest.TryGetProperty("resourceName", out var resourceName));
+        Assert.Equal(webTestName, resourceName.GetString());
+
+        Assert.True(webTest.TryGetProperty("isEnabled", out var enabled));
+        Assert.True(enabled.GetBoolean());
+
+        Assert.True(webTest.TryGetProperty("kind", out var webTestKind));
+        Assert.Equal("Standard", webTestKind.GetString());
+    }
+
+    #endregion
+}

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsCreateOrUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsCreateOrUpdateCommandTests.cs
@@ -1,0 +1,539 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.Text.Json;
+using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Tools.Monitor.Commands.WebTests;
+using Azure.Mcp.Tools.Monitor.Models.WebTests;
+using Azure.Mcp.Tools.Monitor.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Monitor.UnitTests.WebTests;
+
+public class WebTestsCreateOrUpdateCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IMonitorWebTestService _service;
+    private readonly ILogger<WebTestsCreateOrUpdateCommand> _logger;
+    private readonly WebTestsCreateOrUpdateCommand _command;
+    private readonly CommandContext _context;
+    private readonly Command _commandDefinition;
+
+    public WebTestsCreateOrUpdateCommandTests()
+    {
+        _service = Substitute.For<IMonitorWebTestService>();
+        _logger = Substitute.For<ILogger<WebTestsCreateOrUpdateCommand>>();
+
+        var collection = new ServiceCollection().AddSingleton(_service);
+        _serviceProvider = collection.BuildServiceProvider();
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _commandDefinition = _command.GetCommand();
+    }
+
+    #region Constructor and Properties Tests
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("createorupdate", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+        Assert.Contains("Creates a new standard web test", command.Description);
+    }
+
+    [Fact]
+    public void Name_ReturnsCorrectValue()
+    {
+        Assert.Equal("createorupdate", _command.Name);
+    }
+
+    [Fact]
+    public void Title_ReturnsCorrectValue()
+    {
+        Assert.Equal("Create or updates a web test in Azure Monitor", _command.Title);
+    }
+
+    [Fact]
+    public void Description_ContainsRequiredInformation()
+    {
+        var description = _command.Description;
+        Assert.Contains("standard web test", description);
+        Assert.Contains("Azure Monitor", description);
+        Assert.Contains("deprecated", description);
+    }
+
+    [Fact]
+    public void Metadata_IsConfiguredCorrectly()
+    {
+        var metadata = _command.Metadata;
+        Assert.False(metadata.Destructive);
+        Assert.False(metadata.ReadOnly);
+    }
+
+    #endregion
+
+    #region Option Registration Tests
+
+    [Fact]
+    public void RegisterOptions_AddsAllExpectedOptions()
+    {
+        var command = _command.GetCommand();
+        var options = command.Options.Select(o => o.Name).ToList();
+
+        // Base options from BaseMonitorWebTestsCommand (subscription from SubscriptionCommand)
+        Assert.Contains("--subscription", options);
+
+        // Required options
+        Assert.Contains("--webtest-resource", options);
+        Assert.Contains("--resource-group", options);
+        Assert.Contains("--appinsights-component", options);
+        Assert.Contains("--location", options);
+        Assert.Contains("--webtest-locations", options);
+        Assert.Contains("--request-url", options);
+
+        // Optional options
+        Assert.Contains("--webtest", options);
+        Assert.Contains("--description", options);
+        Assert.Contains("--enabled", options);
+        Assert.Contains("--expected-status-code", options);
+        Assert.Contains("--follow-redirects", options);
+        Assert.Contains("--frequency", options);
+        Assert.Contains("--headers", options);
+        Assert.Contains("--http-verb", options);
+        Assert.Contains("--ignore-status-code", options);
+        Assert.Contains("--parse-requests", options);
+        Assert.Contains("--request-body", options);
+        Assert.Contains("--retry-enabled", options);
+        Assert.Contains("--ssl-check", options);
+        Assert.Contains("--ssl-lifetime-check", options);
+        Assert.Contains("--timeout", options);
+
+        // Verify required options are marked as required
+        var requiredOptions = command.Options.Where(o => o.Required).Select(o => o.Name).ToList();
+        Assert.Contains("--webtest-resource", requiredOptions);
+        Assert.Contains("--appinsights-component", requiredOptions);
+        Assert.Contains("--location", requiredOptions);
+        Assert.Contains("--webtest-locations", requiredOptions);
+        Assert.Contains("--request-url", requiredOptions);
+    }
+
+    #endregion
+
+    #region Validation Tests
+
+    [Theory]
+    [InlineData("https://example.com", true)]
+    [InlineData("http://example.com", true)]
+    [InlineData("https://sub.example.com/path", true)]
+    [InlineData("example.com", false)]
+    [InlineData("ftp://example.com", true)]
+    [InlineData("invalid-url", false)]
+    [InlineData("", false)]
+    public async Task Validate_RequestUrl_ValidatesCorrectly(string requestUrl, bool shouldBeValid)
+    {
+        // Arrange
+        var args = new[]
+        {
+            "--subscription", "sub1",
+            "--resource-group", "rg1",
+            "--webtest-resource", "webtest1",
+            "--appinsights-component", "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1",
+            "--location", "eastus",
+            "--webtest-locations", "East US",
+            "--request-url", requestUrl
+        };
+        var parseResult = _commandDefinition.Parse(args);
+
+        if (shouldBeValid)
+        {
+            var expectedResult = new WebTestDetailedInfo
+            {
+                ResourceName = "webtest1",
+                Location = "eastus"
+            };
+
+            _service.CreateOrUpdateWebTest(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
+                Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
+                Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
+                Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>())
+
+                .Returns(expectedResult);
+        }
+
+        // Act
+        var result = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        if (!shouldBeValid)
+        {
+            Assert.Equal(400, result.Status);
+            if (requestUrl == "")
+            {
+                Assert.Contains("Missing Required options: --request-url", result.Message);
+            }
+            else
+            {
+                Assert.Contains("must be a valid absolute URL", result.Message);
+            }
+        }
+        else
+        {
+            Assert.Equal(200, result.Status);
+        }
+    }
+
+    [Theory]
+    [InlineData("US East", true)]
+    [InlineData("US East,US West", true)]
+    [InlineData("US East, US West, US Central", true)]
+    [InlineData("", false)]
+    public async Task Validate_Locations_ValidatesCorrectly(string locations, bool shouldBeValid)
+    {
+        // Arrange
+        var args = new[]
+        {
+            "--subscription", "sub1",
+            "--resource-group", "rg1",
+            "--webtest-resource", "webtest1",
+            "--appinsights-component", "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1",
+            "--location", "eastus",
+            "--webtest-locations", locations,
+            "--request-url", "https://example.com"
+        };
+        var parseResult = _commandDefinition.Parse(args);
+
+        if (shouldBeValid)
+        {
+            var expectedResult = new WebTestDetailedInfo
+            {
+                ResourceName = "webtest1",
+                Location = "eastus"
+            };
+            _service.CreateOrUpdateWebTest(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
+                Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
+                Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
+                Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>())
+                .Returns(expectedResult);
+        }
+
+        // Act
+        var result = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        if (!shouldBeValid)
+        {
+            Assert.Equal(400, result.Status);
+            if (locations == "")
+            {
+                Assert.Contains("Missing Required options: --webtest-locations", result.Message);
+            }
+            else
+            {
+                Assert.Contains("must include at least one location", result.Message);
+            }
+        }
+        else
+        {
+            Assert.Equal(200, result.Status);
+        }
+    }
+
+    [Theory]
+    [InlineData(30, true)]
+    [InlineData(120, true)]
+    [InlineData(121, false)]
+    [InlineData(300, false)]
+    public async Task Validate_TimeoutInSeconds_ValidatesCorrectly(int timeoutInSeconds, bool shouldBeValid)
+    {
+        // Arrange
+        var args = new[]
+        {
+            "--subscription", "sub1",
+            "--resource-group", "rg1",
+            "--webtest-resource", "webtest1",
+            "--appinsights-component", "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1",
+            "--location", "eastus",
+            "--webtest-locations", "US East",
+            "--request-url", "https://example.com",
+            "--timeout", timeoutInSeconds.ToString()
+        };
+        var parseResult = _commandDefinition.Parse(args);
+
+        if (shouldBeValid)
+        {
+            var expectedResult = new WebTestDetailedInfo
+            {
+                ResourceName = "webtest1",
+                Location = "eastus"
+            };
+            _service.CreateOrUpdateWebTest(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
+                Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
+                Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
+                Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>())
+                .Returns(expectedResult);
+        }
+
+        // Act
+        var result = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        if (!shouldBeValid)
+        {
+            Assert.Equal(400, result.Status);
+            Assert.Contains("cannot be greater than 2 minutes", result.Message);
+        }
+        else
+        {
+            Assert.Equal(200, result.Status);
+        }
+    }
+
+    #endregion
+
+    #region ExecuteAsync Tests - Success Scenarios
+
+    [Fact]
+    public async Task ExecuteAsync_ValidMinimalInput_ReturnsSuccess()
+    {
+        // Arrange
+        var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1", "--appinsights-component", "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1", "--location", "eastus", "--webtest-locations", "US East", "--request-url", "https://example.com" };
+        var expectedResult = new WebTestDetailedInfo
+        {
+            ResourceName = "webtest1",
+            Location = "eastus",
+            ResourceGroup = "rg1",
+            Id = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/webtests/webtest1",
+            Kind = "standard",
+            IsEnabled = true,
+            FrequencyInSeconds = 300,
+            TimeoutInSeconds = 30
+        };
+
+        _service.CreateOrUpdateWebTest(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
+            Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
+            Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
+            Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns(expectedResult);
+
+        var parseResult = _commandDefinition.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+        Assert.Equal("Success", response.Message);
+
+        // Verify the actual content of the results
+        var result = GetResult(response.Results);
+        Assert.NotNull(result);
+        Assert.Equal("webtest1", result.ResourceName);
+        Assert.Equal("eastus", result.Location);
+        Assert.Equal("standard", result.Kind);
+        Assert.True(result.IsEnabled);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidCompleteInput_ReturnsSuccess()
+    {
+        // Arrange
+        var args = new string[] {
+            "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1",
+            "--appinsights-component", "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1",
+            "--location", "eastus", "--webtest-locations", "US East,US West", "--request-url", "https://example.com",
+            "--webtest", "My Web Test", "--description", "Test description", "--enabled", "true",
+            "--expected-status-code", "200", "--follow-redirects", "true", "--frequency", "600",
+            "--headers", "Content-Type=application/json,Authorization=Bearer token", "--http-verb", "POST",
+            "--ignore-status-code", "false", "--parse-requests", "true", "--request-body", "{\"test\":\"data\"}",
+            "--retry-enabled", "true", "--ssl-check", "true", "--ssl-lifetime-check", "30", "--timeout", "60"
+        };
+
+        var expectedResult = new WebTestDetailedInfo
+        {
+            ResourceName = "webtest1",
+            Location = "eastus",
+            ResourceGroup = "rg1",
+            WebTestName = "My Web Test",
+            IsEnabled = true,
+            FrequencyInSeconds = 600,
+            TimeoutInSeconds = 60,
+            IsRetryEnabled = true
+        };
+
+        _service.CreateOrUpdateWebTest(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
+            Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
+            Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
+            Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns(expectedResult);
+
+        var parseResult = _commandDefinition.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+
+        // Verify service was called with correct parameters
+        await _service.Received(1).CreateOrUpdateWebTest(
+            "sub1",
+            "rg1",
+            "webtest1",
+            "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1",
+            "eastus",
+            Arg.Is<string[]>(x => x.SequenceEqual(new[] { "US East", "US West" })),
+            "https://example.com",
+            "My Web Test",
+            "Test description",
+            true,
+            200,
+            true,
+            600,
+            Arg.Is<IReadOnlyDictionary<string, string>>(h =>
+                h.Count == 2 &&
+                h["Content-Type"] == "application/json" &&
+                h["Authorization"] == "Bearer token"),
+            "POST",
+            false,
+            true,
+            "{\"test\":\"data\"}",
+            true,
+            true,
+            30,
+            60,
+            null,
+            Arg.Any<RetryPolicyOptions?>());
+    }
+
+    #endregion
+
+    #region ExecuteAsync Tests - Validation Failures
+
+    [Theory]
+    [InlineData("")]                                                        // Missing all required options
+    [InlineData("--subscription sub1")]                                    // Missing other required options
+    [InlineData("--subscription sub1 --resource-group rg1")]              // Missing resource-name and others
+    [InlineData("--subscription sub1 --resource-group rg1 --webtest-resource webtest1")] // Missing app-insights-component-id and others
+    public async Task ExecuteAsync_InvalidInput_ReturnsBadRequest(string args)
+    {
+        // Arrange
+        var argArray = string.IsNullOrEmpty(args) ? Array.Empty<string>() : args.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var parseResult = _commandDefinition.Parse(argArray);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.NotEmpty(response.Message);
+        Assert.Null(response.Results);
+    }
+
+    #endregion
+
+    #region ExecuteAsync Tests - Error Handling
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrowsException_ReturnsInternalServerError()
+    {
+        // Arrange
+        var expectedException = new Exception("Service unavailable");
+        _service.When(x => x.CreateOrUpdateWebTest(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
+            Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
+            Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
+            Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>()))
+            .Do(x => throw expectedException);
+
+        var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1", "--appinsights-component", "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1", "--location", "eastus", "--webtest-locations", "US East", "--request-url", "https://example.com" };
+        var parseResult = _commandDefinition.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Service unavailable", response.Message);
+        Assert.Contains("troubleshooting", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrowsException_LogsError()
+    {
+        // Arrange
+        var expectedException = new Exception("Service error");
+        _service.When(x => x.CreateOrUpdateWebTest(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
+            Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
+            Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
+            Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>()))
+            .Do(x => throw expectedException);
+
+        var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1", "--appinsights-component", "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1", "--location", "eastus", "--webtest-locations", "US East", "--request-url", "https://example.com" };
+        var parseResult = _commandDefinition.Parse(args);
+
+        // Act
+        await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        _logger.Received(1).Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("Error creating web test")),
+            expectedException,
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private WebTestDetailedInfo? GetResult(ResponseResult? result)
+    {
+        if (result == null)
+        {
+            return null;
+        }
+        var json = JsonSerializer.Serialize(result);
+        return JsonSerializer.Deserialize<WebTestsCreateCommandResult>(json)?.webTest;
+    }
+
+    private record WebTestsCreateCommandResult(WebTestDetailedInfo webTest);
+
+    #endregion
+}

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsGetCommandTests.cs
@@ -1,0 +1,317 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.Text.Json;
+using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Tools.Monitor.Commands.WebTests;
+using Azure.Mcp.Tools.Monitor.Models.WebTests;
+using Azure.Mcp.Tools.Monitor.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Monitor.UnitTests.WebTests;
+
+public class WebTestsGetCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IMonitorWebTestService _service;
+    private readonly ILogger<WebTestsGetCommand> _logger;
+    private readonly WebTestsGetCommand _command;
+    private readonly CommandContext _context;
+    private readonly Command _commandDefinition;
+
+    public WebTestsGetCommandTests()
+    {
+        _service = Substitute.For<IMonitorWebTestService>();
+        _logger = Substitute.For<ILogger<WebTestsGetCommand>>();
+
+        var collection = new ServiceCollection().AddSingleton(_service);
+        _serviceProvider = collection.BuildServiceProvider();
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _commandDefinition = _command.GetCommand();
+    }
+
+    #region Constructor and Properties Tests
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("get", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+        Assert.Contains("Gets details for a specific web test", command.Description);
+    }
+
+    [Fact]
+    public void Name_ReturnsCorrectValue()
+    {
+        Assert.Equal("get", _command.Name);
+    }
+
+    [Fact]
+    public void Title_ReturnsCorrectValue()
+    {
+        Assert.Equal("Get details of a specific web test", _command.Title);
+    }
+
+    [Fact]
+    public void Description_ContainsRequiredInformation()
+    {
+        var description = _command.Description;
+        Assert.Contains("resource group", description);
+        Assert.Contains("webtest resource name", description);
+        Assert.Contains("detailed information", description);
+    }
+
+    [Fact]
+    public void Metadata_IsConfiguredCorrectly()
+    {
+        var metadata = _command.Metadata;
+        Assert.False(metadata.Destructive);
+        Assert.True(metadata.ReadOnly);
+    }
+
+    #endregion
+
+    #region Option Registration Tests
+
+    [Fact]
+    public void RegisterOptions_AddsAllExpectedOptions()
+    {
+        var command = _command.GetCommand();
+        var options = command.Options.Select(o => o.Name).ToList();
+
+        // Base options from BaseMonitorWebTestsCommand (subscription from SubscriptionCommand)
+        Assert.Contains("--subscription", options);
+
+        // WebTestsGetCommand specific options
+        Assert.Contains("--resource-group", options);
+        Assert.Contains("--webtest-resource", options);
+
+        // Verify required options are marked as required
+        var requiredOptions = command.Options.Where(o => o.Required).Select(o => o.Name).ToList();
+        Assert.Contains("--webtest-resource", requiredOptions);
+    }
+
+    #endregion
+
+    #region Option Binding Tests
+
+    [Fact]
+    public async Task ExecuteAsync_BindsAllOptionsCorrectly()
+    {
+        // Arrange
+        var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1" };
+        var expectedResult = new WebTestDetailedInfo
+        {
+            ResourceName = "webtest1",
+            Location = "eastus",
+            ResourceGroup = "rg1",
+            Id = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/webtests/webtest1"
+        };
+
+        _service.GetWebTest("sub1", "rg1", "webtest1", null, Arg.Any<RetryPolicyOptions?>())
+            .Returns(expectedResult);
+
+        var parseResult = _commandDefinition.Parse(args);
+
+        // Act
+        await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        await _service.Received(1).GetWebTest("sub1", "rg1", "webtest1", null, Arg.Any<RetryPolicyOptions?>());
+    }
+
+    #endregion
+
+    #region ExecuteAsync Tests - Success Scenarios
+
+    [Fact]
+    public async Task ExecuteAsync_ValidInput_ReturnsSuccess()
+    {
+        // Arrange
+        var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1" };
+        var expectedResult = new WebTestDetailedInfo
+        {
+            ResourceName = "webtest1",
+            Location = "eastus",
+            ResourceGroup = "rg1",
+            Id = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/webtests/webtest1",
+            Kind = "ping",
+            WebTestName = "Test web test",
+            IsEnabled = true,
+            FrequencyInSeconds = 300,
+            TimeoutInSeconds = 30,
+            IsRetryEnabled = false,
+            AppInsightsComponentId = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1"
+        };
+
+        _service.GetWebTest("sub1", "rg1", "webtest1", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+            .Returns(expectedResult);
+
+        var parseResult = _commandDefinition.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+        Assert.Equal("Success", response.Message);
+
+        // Verify the actual content of the results
+        var result = GetResult(response.Results);
+        Assert.NotNull(result);
+        Assert.Equal("webtest1", result.ResourceName);
+        Assert.Equal("eastus", result.Location);
+        Assert.Equal("ping", result.Kind);
+        Assert.Equal(300, result.FrequencyInSeconds);
+        Assert.Equal(30, result.TimeoutInSeconds);
+        Assert.True(result.IsEnabled);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WebTestNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "nonexistent" };
+
+        // The service throws an exception when a web test is not found (as seen in implementation)
+        _service.When(x => x.GetWebTest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>()))
+            .Do(x => throw new Exception("Error retrieving details for web test 'nonexistent'"));
+
+        var parseResult = _commandDefinition.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(500, response.Status); // Exception handling returns 500, not 404
+        Assert.Contains("troubleshooting", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CallsServiceWithCorrectParameters()
+    {
+        // Arrange
+        var expectedResult = new WebTestDetailedInfo
+        {
+            ResourceName = "webtest1",
+            Location = "eastus"
+        };
+
+        _service.GetWebTest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+            .Returns(expectedResult);
+
+        var parseResult = _commandDefinition.Parse(["--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1"]);
+
+        // Act
+        await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        await _service.Received(1).GetWebTest("sub1", "rg1", "webtest1", null, Arg.Any<RetryPolicyOptions?>());
+    }
+
+    #endregion
+
+    #region ExecuteAsync Tests - Validation Failures
+
+    [Theory]
+    [InlineData("")]                                                        // Missing all required options
+    [InlineData("--subscription sub1")]                                    // Missing resource-group and resource-name
+    [InlineData("--subscription sub1 --resource-group rg1")]              // Missing resource-name
+    [InlineData("--resource-group rg1 --webtest-resource webtest1")]         // Missing subscription
+    public async Task ExecuteAsync_InvalidInput_ReturnsBadRequest(string args)
+    {
+        // Arrange
+        var argArray = string.IsNullOrEmpty(args) ? Array.Empty<string>() : args.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var parseResult = _commandDefinition.Parse(argArray);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.NotEmpty(response.Message);
+        Assert.Null(response.Results);
+    }
+
+    #endregion
+
+    #region ExecuteAsync Tests - Error Handling
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrowsException_ReturnsInternalServerError()
+    {
+        // Arrange
+        var expectedException = new Exception("Service unavailable");
+        _service.When(x => x.GetWebTest(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>()))
+            .Do(x => throw expectedException);
+
+        var parseResult = _commandDefinition.Parse(["--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Service unavailable", response.Message);
+        Assert.Contains("troubleshooting", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrowsException_LogsError()
+    {
+        // Arrange
+        var expectedException = new Exception("Service error");
+        _service.When(x => x.GetWebTest(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>()))
+            .Do(x => throw expectedException);
+
+        var parseResult = _commandDefinition.Parse(["--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1"]);
+
+        // Act
+        await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        _logger.Received(1).Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("Error retrieving web test")),
+            expectedException,
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private WebTestDetailedInfo? GetResult(ResponseResult? result)
+    {
+        if (result == null)
+        {
+            return null;
+        }
+        var json = JsonSerializer.Serialize(result);
+        return JsonSerializer.Deserialize<WebTestsGetCommandResult>(json)?.webTest;
+    }
+
+    private record WebTestsGetCommandResult(WebTestDetailedInfo webTest);
+
+    #endregion
+}

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsListCommandTests.cs
@@ -1,0 +1,339 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.Text.Json;
+using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Tools.Monitor.Commands.WebTests;
+using Azure.Mcp.Tools.Monitor.Models.WebTests;
+using Azure.Mcp.Tools.Monitor.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Monitor.UnitTests.WebTests;
+
+public class WebTestsListCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IMonitorWebTestService _service;
+    private readonly ILogger<WebTestsListCommand> _logger;
+    private readonly WebTestsListCommand _command;
+    private readonly CommandContext _context;
+    private readonly Command _commandDefinition;
+
+    public WebTestsListCommandTests()
+    {
+        _service = Substitute.For<IMonitorWebTestService>();
+        _logger = Substitute.For<ILogger<WebTestsListCommand>>();
+
+        var collection = new ServiceCollection().AddSingleton(_service);
+        _serviceProvider = collection.BuildServiceProvider();
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _commandDefinition = _command.GetCommand();
+    }
+
+    #region Constructor and Properties Tests
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("list", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+        Assert.Contains("Lists all web tests", command.Description);
+    }
+
+    [Fact]
+    public void Name_ReturnsCorrectValue()
+    {
+        Assert.Equal("list", _command.Name);
+    }
+
+    [Fact]
+    public void Title_ReturnsCorrectValue()
+    {
+        Assert.Equal("List all web tests in a subscription or resource group", _command.Title);
+    }
+
+    [Fact]
+    public void Description_ContainsRequiredInformation()
+    {
+        var description = _command.Description;
+        Assert.Contains("subscription", description);
+        Assert.Contains("resource group", description);
+        Assert.Contains("web tests", description);
+    }
+
+    [Fact]
+    public void Metadata_IsConfiguredCorrectly()
+    {
+        var metadata = _command.Metadata;
+        Assert.False(metadata.Destructive);
+        Assert.True(metadata.ReadOnly);
+    }
+
+    #endregion
+
+    #region Option Registration Tests
+
+    [Fact]
+    public void RegisterOptions_AddsAllExpectedOptions()
+    {
+        var command = _command.GetCommand();
+        var options = command.Options.Select(o => o.Name).ToList();
+
+        // Base options from BaseMonitorWebTestsCommand (subscription from SubscriptionCommand)
+        Assert.Contains("--subscription", options);
+
+        // WebTestsListCommand specific options
+        Assert.Contains("--resource-group", options);
+    }
+
+    #endregion
+
+    #region Option Binding Tests
+
+    [Fact]
+    public async Task ExecuteAsync_BindsSubscriptionOnlyOptions()
+    {
+        // Arrange
+        var args = new string[] { "--subscription", "sub1" };
+        var expectedResults = new List<WebTestSummaryInfo>
+        {
+            new()
+            {
+                ResourceName = "test1",
+                Location = "eastus",
+                ResourceGroup = "rg1",
+                Kind = "ping",
+                AppInsightsComponentId = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1"
+            }
+        };
+
+        _service.ListWebTests("sub1", null, Arg.Any<RetryPolicyOptions?>())
+            .Returns(expectedResults);
+
+        var parseResult = _commandDefinition.Parse(args);
+
+        // Act
+        await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        await _service.Received(1).ListWebTests("sub1", null, Arg.Any<RetryPolicyOptions?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BindsResourceGroupOptions()
+    {
+        // Arrange
+        var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1" };
+        var expectedResults = new List<WebTestSummaryInfo>
+        {
+            new()
+            {
+                ResourceName = "test1",
+                Location = "eastus",
+                ResourceGroup = "rg1",
+                Kind = "ping",
+                AppInsightsComponentId = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1"
+            }
+        };
+
+        _service.ListWebTests("sub1", "rg1", null, Arg.Any<RetryPolicyOptions?>())
+            .Returns(expectedResults);
+
+        var parseResult = _commandDefinition.Parse(args);
+
+        // Act
+        await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        await _service.Received(1).ListWebTests("sub1", "rg1", null, Arg.Any<RetryPolicyOptions?>());
+    }
+
+    #endregion
+
+    #region ExecuteAsync Tests - Success Scenarios
+
+    [Theory]
+    [InlineData("--subscription sub1")]
+    [InlineData("--subscription sub1 --resource-group rg1")]
+    public async Task ExecuteAsync_ValidInput_ReturnsSuccess(string args)
+    {
+        // Arrange
+        var expectedResults = new List<WebTestSummaryInfo>
+        {
+            new()
+            {
+                ResourceName = "test1",
+                Location = "eastus",
+                ResourceGroup = "rg1",
+                Kind = "ping",
+                AppInsightsComponentId = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1"
+            },
+            new()
+            {
+                ResourceName = "test2",
+                Location = "westus",
+                ResourceGroup = "rg1",
+                Kind = "multistep",
+                AppInsightsComponentId = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights2"
+            }
+        };
+
+        _service.ListWebTests(Arg.Any<string>(), Arg.Is<string>(rg => rg != null), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+            .Returns(expectedResults);
+        _service.ListWebTests(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+            .Returns(expectedResults);
+
+        var argArray = string.IsNullOrEmpty(args) ? Array.Empty<string>() : args.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var parseResult = _commandDefinition.Parse(argArray);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+        Assert.Equal("Success", response.Message);
+
+        // Verify the actual content of the results
+        var results = GetResult(response.Results);
+        Assert.NotNull(results);
+        Assert.Equal(2, results.Count);
+        Assert.Equal("test1", results[0].ResourceName);
+        Assert.Equal("test2", results[1].ResourceName);
+        Assert.Equal("eastus", results[0].Location);
+        Assert.Equal("westus", results[1].Location);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyResults_ReturnsSuccessWithNullResults()
+    {
+        // Arrange
+        _service.ListWebTests(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+            .Returns(new List<WebTestSummaryInfo>());
+
+        var parseResult = _commandDefinition.Parse(["--subscription", "sub1"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.Null(response.Results);
+        Assert.Equal("Success", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CallsServiceWithCorrectParameters()
+    {
+        // Arrange
+        _service.ListWebTests(Arg.Any<string>(), Arg.Is<string>(rg => rg != null), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+            .Returns(new List<WebTestSummaryInfo>());
+
+        var parseResult = _commandDefinition.Parse(["--subscription", "sub1", "--resource-group", "rg1"]);
+
+        // Act
+        await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        await _service.Received(1).ListWebTests("sub1", "rg1", null, Arg.Any<RetryPolicyOptions?>());
+    }
+
+    #endregion
+
+    #region ExecuteAsync Tests - Validation Failures
+
+    [Theory]
+    [InlineData("")]                            // Missing subscription
+    [InlineData("--resource-group rg1")]       // Missing subscription
+    public async Task ExecuteAsync_InvalidInput_ReturnsBadRequest(string args)
+    {
+        // Arrange
+        var argArray = string.IsNullOrEmpty(args) ? Array.Empty<string>() : args.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var parseResult = _commandDefinition.Parse(argArray);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.NotEmpty(response.Message);
+        Assert.Null(response.Results);
+    }
+
+    #endregion
+
+    #region ExecuteAsync Tests - Error Handling
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrowsException_ReturnsInternalServerError()
+    {
+        // Arrange
+        var expectedException = new Exception("Service unavailable");
+        _service.When(x => x.ListWebTests(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>()))
+            .Do(x => throw expectedException);
+
+        var parseResult = _commandDefinition.Parse(["--subscription", "sub1"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Service unavailable", response.Message);
+        Assert.Contains("troubleshooting", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrowsException_LogsError()
+    {
+        // Arrange
+        var expectedException = new Exception("Service error");
+        _service.When(x => x.ListWebTests(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>()))
+            .Do(x => throw expectedException);
+
+        var parseResult = _commandDefinition.Parse(["--subscription", "sub1"]);
+
+        // Act
+        await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        _logger.Received(1).Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("Error listing web tests")),
+            expectedException,
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private List<WebTestSummaryInfo>? GetResult(ResponseResult? result)
+    {
+        if (result == null)
+        {
+            return null;
+        }
+        var json = JsonSerializer.Serialize(result);
+        return JsonSerializer.Deserialize<WebTestsListCommandResult>(json)?.webTests;
+    }
+
+    private record WebTestsListCommandResult(List<WebTestSummaryInfo> webTests);
+
+    #endregion
+}

--- a/tools/Azure.Mcp.Tools.Monitor/tests/test-resources.bicep
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/test-resources.bicep
@@ -209,3 +209,14 @@ resource appBlobRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
     description: 'Blob Contributor for testApplicationOid'
   }
 }
+
+// Application Insights and Availability Tests module
+module webTestsModule 'test-resources.webtests.module.bicep' = {
+  name: 'webtests-module'
+  params: {
+    baseName: baseName
+    location: location
+    workspaceId: workspace.id
+    testApplicationOid: testApplicationOid
+  }
+}

--- a/tools/Azure.Mcp.Tools.Monitor/tests/test-resources.webtests.module.bicep
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/test-resources.webtests.module.bicep
@@ -1,0 +1,164 @@
+targetScope = 'resourceGroup'
+
+@minLength(4)
+@maxLength(21)
+@description('The base resource name.')
+param baseName string
+
+@description('The location of the resource. By default, this is the same as the resource group.')
+param location string = resourceGroup().location
+
+@description('The Log Analytics workspace ID for Application Insights.')
+param workspaceId string
+
+@description('The client OID to grant access to test resources.')
+param testApplicationOid string
+
+// Application Insights resource with cheapest SKU
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: '${baseName}-ai'
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: workspaceId
+    IngestionMode: 'LogAnalytics'
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+    Request_Source: 'rest'
+  }
+}
+
+// Standard availability test for Bing.com
+resource bingAvailabilityTest 'Microsoft.Insights/webtests@2022-06-15' = {
+  name: '${baseName}-bing-test'
+  location: location
+  kind: 'standard'
+  properties: {
+    SyntheticMonitorId: '${baseName}-bing-test'
+    Name: 'Bing Availability Test'
+    Description: 'Standard availability test for bing.com'
+    Enabled: true
+    Frequency: 300 // 5 minutes (cheapest frequency)
+    Timeout: 30
+    Kind: 'standard'
+    RetryEnabled: true
+    Locations: [
+      {
+        Id: 'us-ca-sjc-azr' // US West (San Jose)
+      }
+      {
+        Id: 'us-tx-sn1-azr' // US South Central (San Antonio)
+      }
+    ]
+    Request: {
+      RequestUrl: 'https://www.bing.com'
+      HttpVerb: 'GET'
+      ParseDependentRequests: false
+      FollowRedirects: true
+    }
+    ValidationRules: {
+      ExpectedHttpStatusCode: 200
+      IgnoreHttpStatusCode: false
+      SSLCheck: true
+      SSLCertRemainingLifetimeCheck: 7
+    }
+  }
+  tags: {
+    'hidden-link:${appInsights.id}': 'Resource'
+  }
+}
+
+// Role assignments for the test application to manage Application Insights and Web Tests
+resource applicationInsightsComponentContributorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  scope: subscription()
+  // This is the Application Insights Component Contributor role.
+  // Can manage Application Insights components
+  // See https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#application-insights-component-contributor
+  name: 'ae349356-3a1b-4a5e-921d-050484c6347e'
+}
+
+resource monitoringContributorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  scope: subscription()
+  // This is the Monitoring Contributor role.
+  // Can read all monitoring data and update monitoring settings including web tests
+  // See https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#monitoring-contributor
+  name: '749f88d5-cbae-40b8-bcfc-e573ddc772fa'
+}
+
+// Resource group level role assignments for Application Insights and Web Tests management
+resource appInsightsContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(applicationInsightsComponentContributorRoleDefinition.id, testApplicationOid, resourceGroup().id)
+  scope: resourceGroup()
+  properties: {
+    principalId: testApplicationOid
+    roleDefinitionId: applicationInsightsComponentContributorRoleDefinition.id
+    description: 'Application Insights Component Contributor for testApplicationOid'
+  }
+}
+
+resource monitoringContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(monitoringContributorRoleDefinition.id, testApplicationOid, resourceGroup().id)
+  scope: resourceGroup()
+  properties: {
+    principalId: testApplicationOid
+    roleDefinitionId: monitoringContributorRoleDefinition.id
+    description: 'Monitoring Contributor for testApplicationOid'
+  }
+}
+
+// Specific Application Insights resource level role assignment
+resource appInsightsComponentRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(applicationInsightsComponentContributorRoleDefinition.id, testApplicationOid, appInsights.id)
+  scope: appInsights
+  properties: {
+    principalId: testApplicationOid
+    roleDefinitionId: applicationInsightsComponentContributorRoleDefinition.id
+    description: 'Application Insights Component Contributor for testApplicationOid on specific AI resource'
+  }
+}
+
+// Standard availability test for Microsoft.com
+resource microsoftAvailabilityTest 'Microsoft.Insights/webtests@2022-06-15' = {
+  name: '${baseName}-microsoft-test'
+  location: location
+  kind: 'standard'
+  properties: {
+    SyntheticMonitorId: '${baseName}-microsoft-test'
+    Name: 'Microsoft Availability Test'
+    Description: 'Standard availability test for microsoft.com'
+    Enabled: true
+    Frequency: 300 // 5 minutes (cheapest frequency)
+    Timeout: 30
+    Kind: 'standard'
+    RetryEnabled: true
+    Locations: [
+      {
+        Id: 'us-ca-sjc-azr' // US West (San Jose)
+      }
+      {
+        Id: 'us-tx-sn1-azr' // US South Central (San Antonio)
+      }
+    ]
+    Request: {
+      RequestUrl: 'https://www.microsoft.com'
+      Headers: null
+      HttpVerb: 'GET'
+      ParseDependentRequests: false
+      FollowRedirects: true
+    }
+    ValidationRules: {
+      ExpectedHttpStatusCode: 200
+      IgnoreHttpStatusCode: false
+      SSLCheck: true
+      SSLCertRemainingLifetimeCheck: 7
+    }
+  }
+  tags: {
+    'hidden-link:${appInsights.id}': 'Resource'
+  }
+}
+
+// Outputs
+output appInsightsId string = appInsights.id
+output appInsightsName string = appInsights.name


### PR DESCRIPTION
## What does this PR do?
- Onboards tools for managing Azure Monitor Web Test Resources
- Tools added: monitor-webtests-list, monitor-webtests-get, monitor-webtests-createorupdate
- Comprehensive unit and live tests

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
[Azure/azure-mcp-pr#267](https://github.com/Azure/azure-mcp-pr/issues/267)

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
