### PR TITLE
Update Monitor live tests to use static resources

### DIFF
--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.LiveTests/MonitorCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.LiveTests/MonitorCommandTests.cs
@@ -74,63 +74,53 @@ public class MonitorCommandTests(ITestOutputHelper output) : CommandTestsBase(ou
         Assert.NotEmpty(array);
     }
 
-    [Fact(Skip = "Intermittent failures due to slow ingestion")]
+    [Fact]
     public async Task Should_get_table_contents()
     {
         // Query AzureMetrics table - fastest to propagate and most reliable
+        var workspace = "monitor-query-ws";
+        var resourceGroup = "static-test-resources";
         await QueryForLogsAsync(
             async args => await CallToolAsync("azmcp_monitor_workspace_log_query", args),
             new()
             {
                 { "subscription", Settings.SubscriptionId },
-                { "workspace", Settings.ResourceBaseName },
-                { "resource-group", Settings.ResourceGroupName },
+                { "workspace", workspace },
+                { "resource-group", resourceGroup },
                 { "query", "AzureMetrics | where ResourceProvider == 'MICROSOFT.STORAGE' | project TimeGenerated, MetricName, Total, ResourceId" },
                 { "table", "AzureMetrics" },
                 { "limit", 5 },
                 { "hours", 24 }
             },
             $"AzureMetrics | where ResourceProvider == 'MICROSOFT.STORAGE' | project TimeGenerated, MetricName, Total, ResourceId",
-            sendLogInfo: "Generating storage metrics...",
-            sendLogAction: async () =>
-            {
-                // Generate minimal storage activity to ensure metrics are created
-                await CallToolAsync("azmcp_storage_account_list", new()
-                {
-                    { "subscription", Settings.SubscriptionId }
-                });
-                Output.WriteLine("Listed storage accounts to ensure metrics are generated");
-            },
+            sendLogInfo: null,
+            sendLogAction: null,
             output: Output,
             cancellationToken: TestContext.Current.CancellationToken,
             maxWaitTimeSeconds: 180, // 3 minutes - metrics are faster than logs
             failMessage: "No storage metrics found after waiting 180 seconds");
     }
 
-    [Fact(Skip = "Intermittent failures due to slow ingestion")]
+    [Fact]
     public async Task Should_query_monitor_logs()
     {
+        var workspace = "monitor-query-ws";
+        var resourceGroup = "static-test-resources";
         await QueryForLogsAsync(
             async args => await CallToolAsync("azmcp_monitor_workspace_log_query", args),
             new()
             {
                 { "subscription", Settings.SubscriptionId },
-                { "workspace", Settings.ResourceBaseName },
-                { "resource-group", Settings.ResourceGroupName },
+                { "workspace", workspace },
+                { "resource-group", resourceGroup },
                 { "table", "StorageBlobLogs" },
                 { "query", "StorageBlobLogs | project TimeGenerated, OperationName, StatusText" },
                 { "limit", 1 },
                 { "hours", 24 }
             },
             $"StorageBlobLogs | project TimeGenerated, OperationName, StatusText",
-            sendLogInfo: "Generating storage blob logs...",
-            sendLogAction: async () =>
-            {
-                // Generate some storage activity to create logs
-                await GenerateStorageActivityAsync();
-                Output.WriteLine("Storage activity generated to create diagnostic logs");
-            },
-            output: Output,
+            sendLogInfo: null,
+            sendLogAction: null,
             cancellationToken: TestContext.Current.CancellationToken,
             maxWaitTimeSeconds: 300, // 5 minutes - realistic for storage diagnostic logs
             failMessage: "No storage blob logs found after waiting 300 seconds");
@@ -154,10 +144,15 @@ public class MonitorCommandTests(ITestOutputHelper output) : CommandTestsBase(ou
         Assert.NotEmpty(array);
     }
 
-    [Fact(Skip = "Intermittent failures due to slow ingestion")]
+    [Fact]
     public async Task Should_query_monitor_logs_by_resource_id()
     {
-        var storageResourceId = $"/subscriptions/{Settings.SubscriptionId}/resourceGroups/{Settings.ResourceGroupName}/providers/Microsoft.Storage/storageAccounts/{_storageAccountName}";
+        var subscriptionId = Settings.SubscriptionId;
+        var resourceGroup = "static-test-resources";
+        var storageAccountName = "azuresdktrainingdatatme";
+
+        var storageResourceId = $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Storage/storageAccounts/{storageAccountName}";
+        
         await QueryForLogsAsync(
             async args => await CallToolAsync("azmcp_monitor_resource_log_query", args),
             new()
@@ -170,13 +165,8 @@ public class MonitorCommandTests(ITestOutputHelper output) : CommandTestsBase(ou
                 { "hours", 24 }
             },
             $"StorageBlobLogs | where TimeGenerated > datetime({DateTime.UtcNow:yyyy-MM-dd HH:mm:ss.fff}) | project TimeGenerated, OperationName, StatusText",
-            sendLogInfo: "Generating storage blob logs for resource query...",
-            sendLogAction: async () =>
-            {
-                // Generate some storage activity to create logs
-                await GenerateStorageActivityAsync();
-                Output.WriteLine("Storage activity generated to create diagnostic logs");
-            },
+            sendLogInfo: null,
+            sendLogAction: null,
             output: Output,
             cancellationToken: TestContext.Current.CancellationToken,
             maxWaitTimeSeconds: 300, // 5 minutes - realistic for storage diagnostic logs


### PR DESCRIPTION
## What does this PR do?
This PR updates Monitor live tests that queries for logs to use static resources as these tests require logs to pre-exist. By using static resources, we avoid having to ingest new data and then wait for ingestion to complete and then query which can result in tests being flaky.


## GitHub issue number?
https://github.com/microsoft/mcp/issues/482

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
