### PR TITLE
Disable Native build for Linux arm64

### DIFF
--- a/eng/pipelines/templates/jobs/build.yml
+++ b/eng/pipelines/templates/jobs/build.yml
@@ -55,7 +55,7 @@ jobs:
       version: 9.0.x
 
   - task: Powershell@2
-    displayName: "Build module"
+    displayName: "(Trimmed) Build module"
     condition: and(succeeded(), ne(variables['NoPackagesChanged'],'true'))
     inputs:
       pwsh: true
@@ -97,16 +97,17 @@ jobs:
     inputs:
       summaryFileLocation: $(CoverageFile)
 
-  - task: Powershell@2
-    displayName: "(Native AOT) Install Linux arm64 cross compile toolchain"
-    condition: and(succeeded(), eq('${{ parameters.OSName }}', 'linux'), eq(variables['Architecture'], 'arm64'))
-    inputs:
-      pwsh: true
-      filePath: $(Build.SourcesDirectory)/eng/scripts/Install-LinuxArm64CrossCompileToolchain.ps1
+  # Native build on Linux arm64 is disabled due to unstable cross platform tool chain install script
+  # - task: Powershell@2
+  #   displayName: "(Native AOT) Install Linux arm64 cross compile toolchain"
+  #   condition: and(succeeded(), eq('${{ parameters.OSName }}', 'linux'), eq(variables['Architecture'], 'arm64'))
+  #   inputs:
+  #     pwsh: true
+  #     filePath: $(Build.SourcesDirectory)/eng/scripts/Install-LinuxArm64CrossCompileToolchain.ps1
 
   - task: Powershell@2
     displayName: "(Native AOT) Build module"
-    condition: and(succeeded(), ne(variables['NoPackagesChanged'],'true'))
+    condition: and(succeeded(), ne(variables['NoPackagesChanged'],'true'), not(and(eq('${{ parameters.OSName }}', 'linux'), eq(variables['Architecture'], 'arm64'))))
     inputs:
       pwsh: true
       filePath: $(Build.SourcesDirectory)/eng/scripts/Build-Code.ps1


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

Disabling Native build for Linux ARM64 due to an unstable cross-platform toolchain setup. The official script (see: https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/cross-compile#linux) is broken, and the alternative script we came up with also seems to be running into issues after running fine for 5 weeks. We’re disabling this to unblock PR merges, and will investigate further.

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
