### PR TITLE
Add `azmcp sql db rename` command and unit tests

### DIFF
--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -1127,6 +1127,13 @@ azmcp sql db update --subscription <subscription> \
                     [--elastic-pool-name <elastic-pool-name>] \
                     [--zone-redundant <true/false>] \
                     [--read-scale <Enabled|Disabled>]
+
+# Rename an existing SQL database to a new name within the same server
+azmcp sql db rename --subscription <subscription> \
+                    --resource-group <resource-group> \
+                    --server <server-name> \
+                    --database <current-database-name> \
+                    --new-database-name <new-database-name>
 ```
 
 #### Elastic Pool

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -1107,6 +1107,13 @@ azmcp sql db delete --subscription <subscription> \
 azmcp sql db list --subscription <subscription> \
                   --resource-group <resource-group> \
                   --server <server-name>
+                  
+# Rename an existing SQL database to a new name within the same server
+azmcp sql db rename --subscription <subscription> \
+                    --resource-group <resource-group> \
+                    --server <server-name> \
+                    --database <current-database-name> \
+                    --new-database-name <new-database-name>
 
 # Show details of a specific SQL database
 azmcp sql db show --subscription <subscription> \
@@ -1127,13 +1134,6 @@ azmcp sql db update --subscription <subscription> \
                     [--elastic-pool-name <elastic-pool-name>] \
                     [--zone-redundant <true/false>] \
                     [--read-scale <Enabled|Disabled>]
-
-# Rename an existing SQL database to a new name within the same server
-azmcp sql db rename --subscription <subscription> \
-                    --resource-group <resource-group> \
-                    --server <server-name> \
-                    --database <current-database-name> \
-                    --new-database-name <new-database-name>
 ```
 
 #### Elastic Pool

--- a/docs/e2eTestPrompts.md
+++ b/docs/e2eTestPrompts.md
@@ -399,6 +399,8 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | azmcp_sql_db_delete | Delete the database called <database_name> on server <server_name> |
 | azmcp_sql_db_list | List all databases in the Azure SQL server <server_name> |
 | azmcp_sql_db_list | Show me all the databases configuration details in the Azure SQL server <server_name> |
+| azmcp_sql_db_rename | Rename the SQL database <database_name> on server <server_name> to <new_database_name> |
+| azmcp_sql_db_rename | Rename my Azure SQL database <database_name> to <new_database_name> on server <server_name> |
 | azmcp_sql_db_show | Get the configuration details for the SQL database <database_name> on server <server_name> |
 | azmcp_sql_db_show | Show me the details of SQL database <database_name> in server <server_name> |
 | azmcp_sql_db_update | Update the performance tier of SQL database <database_name> on server <server_name> |

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -7,6 +7,7 @@ The Azure MCP Server updates automatically by default whenever a new release com
 ### Features Added
 
 - Added support for `azmcp sql server list` command to list SQL servers in a subscription and resource group. [[#503](https://github.com/microsoft/mcp/issues/503)]
+- Added support for `azmcp sql db rename` command to rename Azure SQL databases within a server while retaining configuration.
 - Added support for Azure App Service database management via the command:
   - `azmcp_appservice_database_add`: Add a database connection to an App Service web app (does not create the database itself; only adds the connection).
         This enables prompt-driven addition of database connections for Azure App Service web apps.

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -6,8 +6,8 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 ### Features Added
 
-- Added support for `azmcp sql server list` command to list SQL servers in a subscription and resource group. [[#503](https://github.com/microsoft/mcp/issues/503)]
-- Added support for `azmcp sql db rename` command to rename Azure SQL databases within a server while retaining configuration.
+- Added support for `azmcp sql server list` command to list SQL servers in a subscription and resource group. [[#503](https://github.com/microsoft/mcp/pull/503)]
+- Added support for `azmcp sql db rename` command to rename Azure SQL databases within a server while retaining configuration. [[#542](https://github.com/microsoft/mcp/pull/542)]
 - Added support for Azure App Service database management via the command:
   - `azmcp_appservice_database_add`: Add a database connection to an App Service web app (does not create the database itself; only adds the connection).
         This enables prompt-driven addition of database connections for Azure App Service web apps.

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -7,7 +7,7 @@ The Azure MCP Server updates automatically by default whenever a new release com
 ### Features Added
 
 - Added support for `azmcp sql server list` command to list SQL servers in a subscription and resource group. [[#503](https://github.com/microsoft/mcp/pull/503)]
-- Added support for `azmcp sql db rename` command to rename Azure SQL databases within a server while retaining configuration. [[#542](https://github.com/microsoft/mcp/pull/542)]
+- Added support for renaming Azure SQL databases within a server while retaining configuration via the `azmcp sql db rename` command. [[#542](https://github.com/microsoft/mcp/pull/542)]
 - Added support for Azure App Service database management via the command:
   - `azmcp_appservice_database_add`: Add a database connection to an App Service web app (does not create the database itself; only adds the connection).
         This enables prompt-driven addition of database connections for Azure App Service web apps.

--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -119,6 +119,7 @@ The Azure MCP Server supercharges your agents with Azure context. Here are some 
 * "Show me details about my Azure SQL database 'mydb'"
 * "List all databases in my Azure SQL server 'myserver'"
 * "Update the performance tier of my Azure SQL database 'mydb'"
+* "Rename my Azure SQL database 'mydb' to 'newname'"
 * "List all firewall rules for my Azure SQL server 'myserver'"
 * "Create a firewall rule for my Azure SQL server 'myserver'"
 * "Delete a firewall rule from my Azure SQL server 'myserver'"
@@ -320,6 +321,7 @@ The Azure MCP Server supercharges your agents with Azure context. Here are some 
 * List the details and properties of all databases
 * Create a SQL database
 * Update a SQL database configuration
+* Rename a SQL database
 * Delete a SQL database
 * List SQL server firewall rules
 * Create SQL server firewall rules

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseRenameCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseRenameCommand.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Core.Extensions;
+using Azure.Mcp.Tools.Sql.Models;
+using Azure.Mcp.Tools.Sql.Options;
+using Azure.Mcp.Tools.Sql.Options.Database;
+using Azure.Mcp.Tools.Sql.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Mcp.Tools.Sql.Commands.Database;
+
+public sealed class DatabaseRenameCommand(ILogger<DatabaseRenameCommand> logger)
+    : BaseDatabaseCommand<DatabaseRenameOptions>(logger)
+{
+    private const string CommandTitle = "Rename SQL Database";
+
+    public override string Name => "rename";
+
+    public override string Description =>
+        """
+        Rename an existing Azure SQL Database to a new name within the same SQL server. This command moves the
+        database resource to a new identifier while preserving configuration and data. Equivalent to
+        'az sql db rename'. Returns the updated database information using the new name.
+        """;
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new()
+    {
+        Destructive = true,
+        Idempotent = false,
+        OpenWorld = false,
+        ReadOnly = false,
+        LocalRequired = false,
+        Secret = false
+    };
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(SqlOptionDefinitions.NewDatabaseNameOption);
+    }
+
+    protected override DatabaseRenameOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.NewDatabaseName = parseResult.GetValueOrDefault<string>(SqlOptionDefinitions.NewDatabaseName);
+        return options;
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            var sqlService = context.GetService<ISqlService>();
+
+            var database = await sqlService.RenameDatabaseAsync(
+                options.Server!,
+                options.Database!,
+                options.NewDatabaseName!,
+                options.ResourceGroup!,
+                options.Subscription!,
+                options.RetryPolicy);
+
+            context.Response.Results = ResponseResult.Create(new(database), SqlJsonContext.Default.DatabaseRenameResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Error renaming SQL database. Server: {Server}, Database: {Database}, NewDatabase: {NewDatabase}, ResourceGroup: {ResourceGroup}, Options: {@Options}",
+                options.Server, options.Database, options.NewDatabaseName, options.ResourceGroup, options);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    protected override string GetErrorMessage(Exception ex) => ex switch
+    {
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.NotFound =>
+            "SQL server or database not found. Verify the server name, database name, resource group, and your access permissions.",
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.Conflict =>
+            $"Database rename conflict. Ensure the destination database name does not already exist. Details: {reqEx.Message}",
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.Forbidden =>
+            $"Authorization failed renaming the SQL database. Verify you have appropriate permissions. Details: {reqEx.Message}",
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.BadRequest =>
+            $"Invalid database rename operation. Check the provided parameters. Details: {reqEx.Message}",
+        RequestFailedException reqEx => reqEx.Message,
+        _ => base.GetErrorMessage(ex)
+    };
+
+    internal record DatabaseRenameResult(SqlDatabase Database);
+}

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseRenameCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseRenameCommand.cs
@@ -32,7 +32,7 @@ public sealed class DatabaseRenameCommand(ILogger<DatabaseRenameCommand> logger)
     {
         Destructive = true,
         Idempotent = false,
-        OpenWorld = true,
+        OpenWorld = false,
         ReadOnly = false,
         LocalRequired = false,
         Secret = false

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseRenameCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseRenameCommand.cs
@@ -32,7 +32,7 @@ public sealed class DatabaseRenameCommand(ILogger<DatabaseRenameCommand> logger)
     {
         Destructive = true,
         Idempotent = false,
-        OpenWorld = false,
+        OpenWorld = true,
         ReadOnly = false,
         LocalRequired = false,
         Secret = false

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/SqlJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/SqlJsonContext.cs
@@ -16,6 +16,7 @@ namespace Azure.Mcp.Tools.Sql.Commands;
 [JsonSerializable(typeof(DatabaseListCommand.DatabaseListResult))]
 [JsonSerializable(typeof(DatabaseCreateCommand.DatabaseCreateResult))]
 [JsonSerializable(typeof(DatabaseUpdateCommand.DatabaseUpdateResult))]
+[JsonSerializable(typeof(DatabaseRenameCommand.DatabaseRenameResult))]
 [JsonSerializable(typeof(DatabaseDeleteCommand.DatabaseDeleteResult))]
 [JsonSerializable(typeof(EntraAdminListCommand.EntraAdminListResult))]
 [JsonSerializable(typeof(FirewallRuleListCommand.FirewallRuleListResult))]

--- a/tools/Azure.Mcp.Tools.Sql/src/Options/Database/DatabaseRenameOptions.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Options/Database/DatabaseRenameOptions.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Mcp.Tools.Sql.Options.Database;
+
+public class DatabaseRenameOptions : BaseDatabaseOptions
+{
+    [JsonPropertyName(SqlOptionDefinitions.NewDatabaseName)]
+    public string? NewDatabaseName { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.Sql/src/Options/SqlOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Options/SqlOptionDefinitions.cs
@@ -7,6 +7,7 @@ public static class SqlOptionDefinitions
 {
     public const string ServerName = "server";
     public const string DatabaseName = "database";
+    public const string NewDatabaseName = "new-database-name";
     public const string FirewallRuleName = "firewall-rule-name";
     public const string StartIpAddress = "start-ip-address";
     public const string EndIpAddress = "end-ip-address";
@@ -38,6 +39,14 @@ public static class SqlOptionDefinitions
     )
     {
         Description = "The Azure SQL Database name.",
+        Required = true
+    };
+
+    public static readonly Option<string> NewDatabaseNameOption = new(
+        $"--{NewDatabaseName}"
+    )
+    {
+        Description = "The new name for the Azure SQL Database.",
         Required = true
     };
 

--- a/tools/Azure.Mcp.Tools.Sql/src/Services/ISqlService.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Services/ISqlService.cs
@@ -96,6 +96,26 @@ public interface ISqlService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Renames an existing SQL database to a new name.
+    /// </summary>
+    /// <param name="serverName">The name of the SQL server hosting the database</param>
+    /// <param name="databaseName">The current database name</param>
+    /// <param name="newDatabaseName">The desired new database name</param>
+    /// <param name="resourceGroup">The resource group name</param>
+    /// <param name="subscription">The subscription ID or name</param>
+    /// <param name="retryPolicy">Optional retry policy options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The renamed SQL database information</returns>
+    Task<SqlDatabase> RenameDatabaseAsync(
+        string serverName,
+        string databaseName,
+        string newDatabaseName,
+        string resourceGroup,
+        string subscription,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets a list of databases for a SQL server.
     /// </summary>
     /// <param name="serverName">The name of the SQL server</param>

--- a/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
@@ -291,6 +291,67 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
     }
 
     /// <summary>
+    /// Renames an existing SQL database to a new name.
+    /// </summary>
+    /// <param name="serverName">The name of the SQL server hosting the database</param>
+    /// <param name="databaseName">The current database name</param>
+    /// <param name="newDatabaseName">The desired new database name</param>
+    /// <param name="resourceGroup">The name of the resource group containing the server</param>
+    /// <param name="subscription">The subscription ID or name</param>
+    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
+    /// <param name="cancellationToken">Token to observe for cancellation requests</param>
+    /// <returns>The renamed SQL database information</returns>
+    /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
+    public async Task<SqlDatabase> RenameDatabaseAsync(
+        string serverName,
+        string databaseName,
+        string newDatabaseName,
+        string resourceGroup,
+        string subscription,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(serverName, databaseName, newDatabaseName, resourceGroup, subscription);
+
+        try
+        {
+            var armClient = await CreateArmClientAsync(null, retryPolicy);
+
+            var currentDatabaseId = SqlDatabaseResource.CreateResourceIdentifier(
+                subscription,
+                resourceGroup,
+                serverName,
+                databaseName);
+
+            var targetDatabaseId = SqlDatabaseResource.CreateResourceIdentifier(
+                subscription,
+                resourceGroup,
+                serverName,
+                newDatabaseName);
+
+            var databaseResource = armClient.GetSqlDatabaseResource(currentDatabaseId);
+            var moveDefinition = new SqlResourceMoveDefinition(targetDatabaseId);
+
+            await databaseResource.RenameAsync(moveDefinition, cancellationToken);
+
+            var renamedDatabaseResource = await armClient.GetSqlDatabaseResource(targetDatabaseId).GetAsync(cancellationToken);
+
+            _logger.LogInformation(
+                "Successfully renamed SQL database. Server: {Server}, Database: {Database}, NewDatabase: {NewDatabase}, ResourceGroup: {ResourceGroup}",
+                serverName, databaseName, newDatabaseName, resourceGroup);
+
+            return ConvertToSqlDatabaseModel(renamedDatabaseResource.Value);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Error renaming SQL database. Server: {Server}, Database: {Database}, NewDatabase: {NewDatabase}, ResourceGroup: {ResourceGroup}, Subscription: {Subscription}",
+                serverName, databaseName, newDatabaseName, resourceGroup, subscription);
+            throw;
+        }
+    }
+
+    /// <summary>
     /// Retrieves a list of all SQL databases from an Azure SQL Server.
     /// </summary>
     /// <param name="serverName">The name of the SQL server to list databases from</param>

--- a/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
@@ -311,8 +311,9 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters(serverName, databaseName, newDatabaseName, resourceGroup, subscription);
-
+        ValidateRequiredParameters(serverName, databaseName, resourceGroup, subscription);
+        if (string.IsNullOrWhiteSpace(newDatabaseName))
+            throw new ArgumentException("New database name cannot be null or empty.", nameof(newDatabaseName));
         try
         {
             var armClient = await CreateArmClientAsync(null, retryPolicy);

--- a/tools/Azure.Mcp.Tools.Sql/src/SqlSetup.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/SqlSetup.cs
@@ -24,6 +24,7 @@ public class SqlSetup : IAreaSetup
         services.AddSingleton<DatabaseShowCommand>();
         services.AddSingleton<DatabaseListCommand>();
         services.AddSingleton<DatabaseCreateCommand>();
+        services.AddSingleton<DatabaseRenameCommand>();
         services.AddSingleton<DatabaseUpdateCommand>();
         services.AddSingleton<DatabaseDeleteCommand>();
 
@@ -54,6 +55,8 @@ public class SqlSetup : IAreaSetup
         database.AddCommand(databaseList.Name, databaseList);
         var databaseCreate = serviceProvider.GetRequiredService<DatabaseCreateCommand>();
         database.AddCommand(databaseCreate.Name, databaseCreate);
+        var databaseRename = serviceProvider.GetRequiredService<DatabaseRenameCommand>();
+        database.AddCommand(databaseRename.Name, databaseRename);
         var databaseUpdate = serviceProvider.GetRequiredService<DatabaseUpdateCommand>();
         database.AddCommand(databaseUpdate.Name, databaseUpdate);
         var databaseDelete = serviceProvider.GetRequiredService<DatabaseDeleteCommand>();

--- a/tools/Azure.Mcp.Tools.Sql/src/SqlSetup.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/SqlSetup.cs
@@ -35,6 +35,7 @@ public class SqlSetup : IAreaSetup
         database.AddCommand("list", new DatabaseListCommand(loggerFactory.CreateLogger<DatabaseListCommand>()));
         database.AddCommand("create", new DatabaseCreateCommand(loggerFactory.CreateLogger<DatabaseCreateCommand>()));
         database.AddCommand("update", new DatabaseUpdateCommand(loggerFactory.CreateLogger<DatabaseUpdateCommand>()));
+        database.AddCommand("rename", new DatabaseRenameCommand(loggerFactory.CreateLogger<DatabaseRenameCommand>()));
         database.AddCommand("delete", new DatabaseDeleteCommand(loggerFactory.CreateLogger<DatabaseDeleteCommand>()));
 
         var server = new CommandGroup("server", "SQL server operations");

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Database/DatabaseRenameCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Database/DatabaseRenameCommandTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.Net;
+using Azure;
+using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Tools.Sql.Commands.Database;
+using Azure.Mcp.Tools.Sql.Models;
+using Azure.Mcp.Tools.Sql.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Sql.UnitTests.Database;
+
+public class DatabaseRenameCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ISqlService _sqlService;
+    private readonly ILogger<DatabaseRenameCommand> _logger;
+    private readonly DatabaseRenameCommand _command;
+    private readonly CommandContext _context;
+    private readonly Command _commandDefinition;
+
+    public DatabaseRenameCommandTests()
+    {
+        _sqlService = Substitute.For<ISqlService>();
+        _logger = Substitute.For<ILogger<DatabaseRenameCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_sqlService);
+        _serviceProvider = collection.BuildServiceProvider();
+
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _commandDefinition = _command.GetCommand();
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("rename", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.Contains("Rename an existing Azure SQL Database", command.Description);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithValidParameters_RenamesDatabase()
+    {
+        var mockDatabase = new SqlDatabase(
+            Name: "newdb",
+            Id: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/servers/server1/databases/newdb",
+            Type: "Microsoft.Sql/servers/databases",
+            Location: "East US",
+            Sku: null,
+            Status: "Online",
+            Collation: "SQL_Latin1_General_CP1_CI_AS",
+            CreationDate: DateTimeOffset.UtcNow,
+            MaxSizeBytes: 2147483648,
+            ServiceLevelObjective: "S0",
+            Edition: "Standard",
+            ElasticPoolName: null,
+            EarliestRestoreDate: DateTimeOffset.UtcNow,
+            ReadScale: "Disabled",
+            ZoneRedundant: false
+        );
+
+        _sqlService.RenameDatabaseAsync(
+                Arg.Is("server1"),
+                Arg.Is("olddb"),
+                Arg.Is("newdb"),
+                Arg.Is("rg"),
+                Arg.Is("sub"),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(mockDatabase);
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub",
+            "--resource-group", "rg",
+            "--server", "server1",
+            "--database", "olddb",
+            "--new-database-name", "newdb"
+        ]);
+
+        var response = await _command.ExecuteAsync(_context, args);
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+        Assert.Equal("Success", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrows_ReturnsError()
+    {
+        _sqlService.RenameDatabaseAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.Forbidden, "Forbidden"));
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub",
+            "--resource-group", "rg",
+            "--server", "server1",
+            "--database", "olddb",
+            "--new-database-name", "newdb"
+        ]);
+
+        var response = await _command.ExecuteAsync(_context, args);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.Status);
+        Assert.Contains("Forbidden", response.Message);
+    }
+
+}


### PR DESCRIPTION
## What does this PR do?
Add `azmcp sql db rename` command and unit tests

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [x] For MCP tool changes:
    - [x] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [x] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [x] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [x] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [x] Extra steps for **Azure MCP Server** tool changes:
    - [x] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [x] 👉 For Community (non-Microsoft team member) PRs:
        - [x] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [x] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
