### PR TITLE
Add tests for invalid tool requests handling

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Client/MockClientTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Client/MockClientTests.cs
@@ -180,6 +180,45 @@ public class MockClientTests
             });
     }
 
+    [Fact]
+    public async Task Invoke_Invalid_Tool_Returns_Error()
+    {
+        await Invoke_Request_To_Server(
+            method: "tools/call",
+            new ServerCapabilities
+            {
+                Tools = new()
+                {
+                    CallToolHandler = (request, ct) =>
+                    {
+                        // Simulate the behavior when an invalid tool is called
+                        return ValueTask.FromResult(new CallToolResult
+                        {
+                            Content = [new TextContentBlock { Text = $"The tool {request.Params?.Name} was not found" }],
+                            IsError = true
+                        });
+                    },
+                    ListToolsHandler = (request, ct) => throw new NotImplementedException(),
+                }
+            },
+            requestParams: JsonSerializer.SerializeToNode(new
+            {
+                name = "non_existent_tool",
+                arguments = new { }
+            }),
+            configureOptions: null,
+            assertResult: response =>
+            {
+                var result = JsonSerializer.Deserialize<CallToolResult>(response);
+                Assert.NotNull(result);
+                Assert.True(result.IsError, "Expected error response for non-existent tool");
+                Assert.NotEmpty(result.Content);
+                
+                var textContent = Assert.IsType<TextContentBlock>(result.Content[0]);
+                Assert.Contains("The tool non_existent_tool was not found", textContent.Text);
+            });
+    }
+
 
     private async Task Invoke_Request_To_Server(string method, ServerCapabilities? serverCapabilities, Action<McpServerOptions>? configureOptions, Action<JsonNode?> assertResult)
     {

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Client/MockClientTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Client/MockClientTests.cs
@@ -213,7 +213,7 @@ public class MockClientTests
                 Assert.NotNull(result);
                 Assert.True(result.IsError, "Expected error response for non-existent tool");
                 Assert.NotEmpty(result.Content);
-                
+
                 var textContent = Assert.IsType<TextContentBlock>(result.Content[0]);
                 Assert.Contains("The tool non_existent_tool was not found", textContent.Text);
             });


### PR DESCRIPTION
## What does this PR do?

We were getting an exception when calling mcp with an invalid tool name.  I don't see that error, but I'm adding a unit test.  We also have a live test covering the scenario.

## GitHub issue number?
Fixes #208

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
