### PR TITLE
Correct the command options for Kusto clust get and list tool

### DIFF
--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterGetCommand.cs
@@ -3,6 +3,9 @@
 
 using System.Net;
 using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Core.Commands.Subscription;
+using Azure.Mcp.Core.Extensions;
+using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Kusto.Models;
 using Azure.Mcp.Tools.Kusto.Options;
 using Azure.Mcp.Tools.Kusto.Services;
@@ -10,7 +13,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Azure.Mcp.Tools.Kusto.Commands;
 
-public sealed class ClusterGetCommand(ILogger<ClusterGetCommand> logger) : BaseClusterCommand<ClusterGetOptions>
+public sealed class ClusterGetCommand(ILogger<ClusterGetCommand> logger) : SubscriptionCommand<ClusterGetOptions>
 {
     private const string CommandTitle = "Get Kusto Cluster Details";
     private readonly ILogger<ClusterGetCommand> _logger = logger;
@@ -34,6 +37,20 @@ public sealed class ClusterGetCommand(ILogger<ClusterGetCommand> logger) : BaseC
         LocalRequired = false,
         Secret = false
     };
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(KustoOptionDefinitions.Cluster.AsRequired());
+    }
+
+    protected override ClusterGetOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.ClusterName = parseResult.GetValueOrDefault<string>(KustoOptionDefinitions.Cluster.Name);
+
+        return options;
+    }
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterListCommand.cs
@@ -3,7 +3,6 @@
 
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Tools.Kusto.Models;
 using Azure.Mcp.Tools.Kusto.Options;
 using Azure.Mcp.Tools.Kusto.Services;
 using Microsoft.Extensions.Logging;

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/ClusterGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/ClusterGetOptions.cs
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+using Azure.Mcp.Core.Options;
+
 namespace Azure.Mcp.Tools.Kusto.Options;
 
-public class ClusterGetOptions : BaseClusterOptions;
+public class ClusterGetOptions : SubscriptionOptions
+{
+    [JsonPropertyName(KustoOptionDefinitions.ClusterName)]
+    public string? ClusterName { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/ClusterListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/ClusterListOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Mcp.Core.Options;
+
 namespace Azure.Mcp.Tools.Kusto.Options;
 
-public class ClusterListOptions : BaseClusterOptions;
+public class ClusterListOptions : SubscriptionOptions;


### PR DESCRIPTION
## What does this PR do?

Update the command options for both `kusto-cluster-list` and `kusto-cluster-ge`t as part of the fix for https://github.com/microsoft/mcp/issues/549.

## GitHub issue number?

https://github.com/microsoft/mcp/issues/549

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
