### PR TITLE
Using ARG query to support ACR resource read operations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,6 @@
     <PackageVersion Include="Azure.ResourceManager.ContainerInstance" Version="1.3.0-beta.3" />
     <PackageVersion Include="Azure.ResourceManager.Compute" Version="1.11.0" />
     <PackageVersion Include="Azure.ResourceManager.HDInsight" Version="1.2.0-beta.4" />
-    <PackageVersion Include="Azure.ResourceManager.ContainerRegistry" Version="1.3.1" />
     <PackageVersion Include="Azure.ResourceManager.DesktopVirtualization" Version="1.3.2" />
     <PackageVersion Include="Azure.ResourceManager.ContainerService" Version="1.2.5" />
     <PackageVersion Include="Azure.ResourceManager.EventGrid" Version="1.2.0-beta.2" />

--- a/tools/Azure.Mcp.Tools.Acr/src/Azure.Mcp.Tools.Acr.csproj
+++ b/tools/Azure.Mcp.Tools.Acr/src/Azure.Mcp.Tools.Acr.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.ResourceManager" />
-    <PackageReference Include="Azure.ResourceManager.ContainerRegistry" />
     <PackageReference Include="Azure.Containers.ContainerRegistry" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="ModelContextProtocol" />

--- a/tools/Azure.Mcp.Tools.Acr/src/Commands/AcrJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.Acr/src/Commands/AcrJsonContext.cs
@@ -3,13 +3,18 @@
 
 using System.Text.Json.Serialization;
 using Azure.Mcp.Tools.Acr.Commands.Registry;
+using Azure.Mcp.Tools.Acr.Services.Models;
 
 namespace Azure.Mcp.Tools.Acr.Commands;
 
 [JsonSerializable(typeof(RegistryListCommand.RegistryListCommandResult))]
 [JsonSerializable(typeof(RegistryRepositoryListCommand.RegistryRepositoryListCommandResult))]
 [JsonSerializable(typeof(Models.AcrRegistryInfo))]
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(ContainerRegistryData))]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 internal sealed partial class AcrJsonContext : JsonSerializerContext
 {
 }

--- a/tools/Azure.Mcp.Tools.Acr/src/Services/AcrService.cs
+++ b/tools/Azure.Mcp.Tools.Acr/src/Services/AcrService.cs
@@ -1,19 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using Azure.Containers.ContainerRegistry;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
-using Azure.ResourceManager.ContainerRegistry;
+using Azure.Mcp.Tools.Acr.Models;
+using Microsoft.Extensions.Logging;
 
 namespace Azure.Mcp.Tools.Acr.Services;
 
-public sealed class AcrService(ISubscriptionService subscriptionService, ITenantService tenantService) : BaseAzureService(tenantService), IAcrService
+public sealed class AcrService(ISubscriptionService subscriptionService, ITenantService tenantService, ILogger<AcrService> logger)
+    : BaseAzureResourceService(subscriptionService, tenantService), IAcrService
 {
     private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
+    private readonly ILogger<AcrService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-    public async Task<List<Models.AcrRegistryInfo>> ListRegistries(
+    public async Task<List<AcrRegistryInfo>> ListRegistries(
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
@@ -21,43 +25,83 @@ public sealed class AcrService(ISubscriptionService subscriptionService, ITenant
     {
         ValidateRequiredParameters(subscription);
 
-        var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
-        var registries = new List<Models.AcrRegistryInfo>();
-
-        // Select enumeration source based on optional resource group
-        if (!string.IsNullOrWhiteSpace(resourceGroup))
+        try
         {
-            var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup);
-            await foreach (var registry in resourceGroupResource.Value.GetContainerRegistries().GetAllAsync())
-            {
-                AddProjectionIfValid(registries, registry);
-            }
-        }
-        else
-        {
-            await foreach (var registry in subscriptionResource.GetContainerRegistriesAsync())
-            {
-                AddProjectionIfValid(registries, registry);
-            }
-        }
+            var registries = await ExecuteResourceQueryAsync(
+                "Microsoft.ContainerRegistry/registries",
+                resourceGroup,
+                subscription,
+                retryPolicy,
+                ConvertToAcrRegistryInfoModel,
+                cancellationToken: CancellationToken.None);
 
-        return registries;
+            return registries;
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Error retrieving container registries: {ex.Message}", ex);
+        }
     }
 
-    private static void AddProjectionIfValid(List<Models.AcrRegistryInfo> list, ContainerRegistryResource? registry)
+    private async Task<AcrRegistryInfo> GetRegistry(
+        string subscription,
+        string registry,
+        string? resourceGroup = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null)
     {
-        var data = registry?.Data;
-        if (data?.Name is null)
+        ValidateRequiredParameters((nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(registry), registry));
+
+        try
         {
-            return;
+            var registrie = await ExecuteSingleResourceQueryAsync(
+                        "Microsoft.ContainerRegistry/registries",
+                        resourceGroup,
+                        subscription,
+                        retryPolicy,
+                        ConvertToAcrRegistryInfoModel,
+                        $"name =~ '{EscapeKqlString(registry)}'");
+            if (registrie == null)
+            {
+                throw new KeyNotFoundException($"Container registry '{registry}' not found for subscription '{subscription}'.");
+            }
+            return registrie;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Error retrieving Container registry '{RegistryName}' for subscription '{Subscription}'",
+                registry, subscription);
+            throw;
+        }
+    }
+
+    private async Task<List<string>> AddRepositoriesForRegistryAsync(AcrRegistryInfo reg, string? tenant, RetryPolicyOptions? retryPolicy)
+    {
+        // Build data-plane client for this login server
+        var credential = await GetCredential(tenant);
+        var options = ConfigureRetryPolicy(AddDefaultPolicies(new ContainerRegistryClientOptions()), retryPolicy);
+        var acrEndpoint = new Uri($"https://{reg.LoginServer}");
+        var client = new ContainerRegistryClient(acrEndpoint, credential, options);
+
+        var repoNames = new List<string>();
+        try
+        {
+            await foreach (var repo in client.GetRepositoryNamesAsync())
+            {
+                if (!string.IsNullOrWhiteSpace(repo))
+                {
+                    repoNames.Add(repo);
+                }
+            }
+        }
+        catch (RequestFailedException)
+        {
+            _logger.LogWarning("Failed to list repositories for registry '{RegistryName}' at '{LoginServer}'", reg.Name, reg.LoginServer);
         }
 
-        list.Add(new Models.AcrRegistryInfo(
-            data.Name,
-            data.Location,
-            data.LoginServer,
-            data.Sku?.Name.ToString(),
-            data.Sku?.Tier?.ToString()));
+        return repoNames;
     }
 
     public async Task<Dictionary<string, List<string>>> ListRegistryRepositories(
@@ -72,77 +116,47 @@ public sealed class AcrService(ISubscriptionService subscriptionService, ITenant
         var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
         var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
-        async Task AddRepositoriesForRegistryAsync(ContainerRegistryResource reg)
+        if (string.IsNullOrWhiteSpace(registry))
         {
-            var data = reg.Data;
-            if (data?.LoginServer is null || string.IsNullOrWhiteSpace(data.Name))
+            var registries = await ListRegistries(subscription, resourceGroup, tenant, retryPolicy);
+            foreach (var reg in registries)
             {
-                return;
-            }
-
-            // Build data-plane client for this login server
-            var credential = await GetCredential(tenant);
-            var options = ConfigureRetryPolicy(AddDefaultPolicies(new ContainerRegistryClientOptions()), retryPolicy);
-            var acrEndpoint = new Uri($"https://{data.LoginServer}");
-            var client = new ContainerRegistryClient(acrEndpoint, credential, options);
-
-            var repoNames = new List<string>();
-            try
-            {
-                await foreach (var repo in client.GetRepositoryNamesAsync())
+                if (!string.IsNullOrWhiteSpace(reg.Name) && !string.IsNullOrWhiteSpace(reg.LoginServer))
                 {
-                    if (!string.IsNullOrWhiteSpace(repo))
-                    {
-                        repoNames.Add(repo);
-                    }
+                    result[reg.Name] = await AddRepositoriesForRegistryAsync(reg, tenant, retryPolicy);
                 }
-            }
-            catch (RequestFailedException)
-            {
-                // If we cannot enumerate repositories (e.g., permissions), return empty list for that registry
-            }
-
-            result[data.Name] = repoNames;
-        }
-
-        if (!string.IsNullOrWhiteSpace(registry))
-        {
-            // Fetch a single registry by name, optionally within the provided resource group
-            if (!string.IsNullOrWhiteSpace(resourceGroup))
-            {
-                var rg = await subscriptionResource.GetResourceGroupAsync(resourceGroup);
-                var regRes = await rg.Value.GetContainerRegistries().GetAsync(registry);
-                await AddRepositoriesForRegistryAsync(regRes.Value);
-            }
-            else
-            {
-                // enumerate across subscription to find the registry name
-                await foreach (var regRes in subscriptionResource.GetContainerRegistriesAsync())
-                {
-                    if (string.Equals(regRes.Data?.Name, registry, StringComparison.OrdinalIgnoreCase))
-                    {
-                        await AddRepositoriesForRegistryAsync(regRes);
-                        break;
-                    }
-                }
-            }
-        }
-        else if (!string.IsNullOrWhiteSpace(resourceGroup))
-        {
-            var rg = await subscriptionResource.GetResourceGroupAsync(resourceGroup);
-            await foreach (var regRes in rg.Value.GetContainerRegistries().GetAllAsync())
-            {
-                await AddRepositoriesForRegistryAsync(regRes);
             }
         }
         else
         {
-            await foreach (var regRes in subscriptionResource.GetContainerRegistriesAsync())
+            var reg = await GetRegistry(subscription, registry, resourceGroup, tenant, retryPolicy);
+            if (!string.IsNullOrWhiteSpace(reg.Name) && !string.IsNullOrWhiteSpace(reg.LoginServer))
             {
-                await AddRepositoriesForRegistryAsync(regRes);
+                result[reg.Name] = await AddRepositoriesForRegistryAsync(reg, tenant, retryPolicy);
             }
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Converts a JsonElement from Azure Resource Graph query to a Container Registry model.
+    /// </summary>
+    /// <param name="item">The JsonElement containing Container Registry data</param>
+    /// <returns>The Container Registry model</returns>
+    private static AcrRegistryInfo ConvertToAcrRegistryInfoModel(JsonElement item)
+    {
+        var containerRegistryData = Models.ContainerRegistryData.FromJson(item);
+        if (containerRegistryData == null)
+            throw new InvalidOperationException("Failed to parse Container Registry data");
+
+        return new AcrRegistryInfo
+        (
+            containerRegistryData.ResourceName ?? string.Empty,
+            containerRegistryData.Location,
+            containerRegistryData.Properties?.LoginServer,
+            containerRegistryData.Sku?.Name,
+            containerRegistryData.Sku?.Tier
+        );
     }
 }

--- a/tools/Azure.Mcp.Tools.Acr/src/Services/IAcrService.cs
+++ b/tools/Azure.Mcp.Tools.Acr/src/Services/IAcrService.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Mcp.Tools.Acr.Models;
 namespace Azure.Mcp.Tools.Acr.Services;
 
 public interface IAcrService
 {
-    Task<List<Models.AcrRegistryInfo>> ListRegistries(
+    Task<List<AcrRegistryInfo>> ListRegistries(
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,

--- a/tools/Azure.Mcp.Tools.Acr/src/Services/Models/ContainerRegistryData.cs
+++ b/tools/Azure.Mcp.Tools.Acr/src/Services/Models/ContainerRegistryData.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Azure.Mcp.Core.Services.Azure.Models;
+using Azure.Mcp.Tools.Acr.Commands;
+
+namespace Azure.Mcp.Tools.Acr.Services.Models;
+
+/// <summary>
+/// A class representing the ContainerRegistryData data model.
+/// </summary>
+internal sealed class ContainerRegistryData
+{
+    /// <summary> The resource ID for the resource. </summary>
+    [JsonPropertyName("id")]
+    public string? ResourceId { get; set; }
+    /// <summary> The type of the resource. </summary>
+    [JsonPropertyName("type")]
+    public string? ResourceType { get; set; }
+    /// <summary> The name of the resource. </summary>
+    [JsonPropertyName("name")]
+    public string? ResourceName { get; set; }
+    /// <summary> The location of the resource. </summary>
+    public string? Location { get; set; }
+    /// <summary> The SKU of the resource. </summary>
+    public ResourceSku? Sku { get; set; }
+    /// <summary> Properties of the Container Registry. </summary>
+    public ContainerRegistryProperties? Properties { get; set; }
+
+    // Read the JSON response content and create a model instance from it.
+    public static ContainerRegistryData? FromJson(JsonElement source)
+    {
+        return JsonSerializer.Deserialize<ContainerRegistryData>(source, AcrJsonContext.Default.ContainerRegistryData);
+    }
+}

--- a/tools/Azure.Mcp.Tools.Acr/src/Services/Models/ContainerRegistryProperties.cs
+++ b/tools/Azure.Mcp.Tools.Acr/src/Services/Models/ContainerRegistryProperties.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Acr.Services.Models;
+
+/// <summary>
+/// A class representing the ContainerRegistry properties data model.
+/// </summary>
+internal sealed class ContainerRegistryProperties
+{
+    /// <summary> The URL that can be used to log into the container registry. </summary>
+    public string? LoginServer { get; set; }
+    /// <summary> The provisioning state of the container registry at the time the operation was called. </summary>
+    public string? ProvisioningState { get; set; }
+}


### PR DESCRIPTION
## What does this PR do?

This PR addresses part of the issue tracked in https://github.com/microsoft/mcp/issues/226 by updating the ACR tool to eliminate its dependency on Azure.ResourceManager.ContainerRegistry.
As a result, it reduces the MCP agent size by approximately 1.46 MB.

## GitHub issue number?

https://github.com/microsoft/mcp/issues/226

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
