### PR TITLE
Enhance the tool description for cosmos to reduce ambiguity

### DIFF
--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ItemQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ItemQueryCommand.cs
@@ -18,12 +18,7 @@ public sealed class ItemQueryCommand(ILogger<ItemQueryCommand> logger) : BaseCon
     public override string Name => "query";
 
     public override string Description =>
-        $"""
-        Execute a SQL query against items in a Cosmos DB container. Requires {CosmosOptionDefinitions.AccountName},
-        {CosmosOptionDefinitions.DatabaseName}, and {CosmosOptionDefinitions.ContainerName}.
-        The {CosmosOptionDefinitions.QueryText} parameter accepts SQL query syntax. Results are returned as a
-        JSON array of documents.
-        """;
+        "List items from a Cosmos DB container by executing SQL queries that can be filtered by account name, database name, container name, or query text.";
 
     public override string Title => CommandTitle;
 

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ItemQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ItemQueryCommand.cs
@@ -18,7 +18,7 @@ public sealed class ItemQueryCommand(ILogger<ItemQueryCommand> logger) : BaseCon
     public override string Name => "query";
 
     public override string Description =>
-        "List items from a Cosmos DB container by executing SQL queries that can be filtered by account name, database name, container name, or query text.";
+    "List items from a Cosmos DB container by specifying the account name, database name, and container name, optionally providing a custom SQL query to filter results.";
 
     public override string Title => CommandTitle;
 


### PR DESCRIPTION
## What does this PR do?
Enhance the tool description for cosmos to reduce ambiguity in the Cosmos Item Query command. The rest of the tools in Cosmos are doing good in terms of confidence score and do not fall in the ambiguous range. 

**After Change**

<img width="623" height="196" alt="image" src="https://github.com/user-attachments/assets/2d3b1c19-7f09-4bbb-9887-290c4fb11238" />

**Before Change**

<img width="766" height="225" alt="image" src="https://github.com/user-attachments/assets/2871a18d-f0c6-47ec-aaac-54f580bb2919" />


## GitHub issue number?
https://github.com/microsoft/mcp/issues/624
    
