### PR TITLE
Fix the name of the Key Vault settings get command

### DIFF
--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -701,7 +701,7 @@ azmcp functionapp get --subscription <subscription> \
 #### Administration
 
 ```bash
-# Gets Key Vault administration settings
+# Gets Key Vault Managed HSM account settings
 azmcp keyvault admin settings get --subscription <subscription> \
                                   --vault <vault-name>
 ```

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The Azure MCP Server updates automatically by default whenever a new release comes out 🚀. We ship updates twice a week on Tuesdays and Thursdays 😊
 
+## 0.8.4 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+- Fixed the name of the Key Vault Managed HSM settings get command from `azmcp_keyvault_admin_get` to `azmcp_keyvault_admin_settings_get`. [[#643](https://github.com/microsoft/mcp/issues/643)]
+
+### Other Changes
+
 ## 0.8.3 (2025-09-30)
 
 ### Features Added

--- a/tools/Azure.Mcp.Tools.KeyVault/src/KeyVaultSetup.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/KeyVaultSetup.cs
@@ -75,8 +75,11 @@ public class KeyVaultSetup : IAreaSetup
         var certificateImport = serviceProvider.GetRequiredService<CertificateImportCommand>();
         certificate.AddCommand(certificateImport.Name, certificateImport);
 
+        var settings = new CommandGroup("settings", "Key Vault Managed HSM account settings operations - Commands for managing Key Vault Managed HSM account settings.");
+        admin.AddSubGroup(settings);
+
         var adminSettingsGet = serviceProvider.GetRequiredService<AdminSettingsGetCommand>();
-        admin.AddCommand(adminSettingsGet.Name, adminSettingsGet);
+        settings.AddCommand(adminSettingsGet.Name, adminSettingsGet);
 
         return keyVault;
     }


### PR DESCRIPTION
## What does this PR do?
The Key Vault settings get command is supposed to show up as `azmcp_keyvault_admin_settings_get`, but was showing up as `azmcp_keyvault_admin_get`. This PR corrects that.

## GitHub issue number?
N/A

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
