### PR TITLE
Update devcontainer image to dotnet version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "mcr.microsoft.com/devcontainers:dev-10.0-preview",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:dev-10.0-preview",
     "name": "Microsoft MCP Codespace",
     "features": {
         "ghcr.io/devcontainers/features/node:1": {
@@ -7,6 +7,7 @@
         },
         "ghcr.io/devcontainers/features/azure-cli:1": {},
         "ghcr.io/devcontainers/features/powershell:1": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/azure/azure-dev/azd:0": {}
     },
     "hostRequirements": {


### PR DESCRIPTION
## What does this PR do?

This solves #612.  It uses the image that was intended and we also add docker-in-docker feature so you can build docker images directly in the dev container.

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?

#612 
