### PR TITLE
Added the support to return meta data in `tool list` command

### DIFF
--- a/core/Azure.Mcp.Core/src/Areas/Tools/Commands/ToolsListCommand.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Tools/Commands/ToolsListCommand.cs
@@ -131,7 +131,8 @@ public sealed class ToolsListCommand(ILogger<ToolsListCommand> logger) : BaseCom
             Name = commandDetails.Name,
             Description = commandDetails.Description ?? string.Empty,
             Command = tokenizedName.Replace(CommandFactory.Separator, ' '),
-            Options = optionInfos
+            Options = optionInfos,
+            Metadata = command.Metadata
         };
     }
 }

--- a/core/Azure.Mcp.Core/src/Commands/ToolMetadata.cs
+++ b/core/Azure.Mcp.Core/src/Commands/ToolMetadata.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+
 namespace Azure.Mcp.Core.Commands;
 
 /// <summary>
@@ -22,6 +24,7 @@ public sealed class ToolMetadata
     /// The default is <see langword="true"/>.
     /// </para>
     /// </remarks>
+    [JsonPropertyName("destructive")]
     public bool Destructive { get; init; } = true;
 
     /// <summary>
@@ -36,6 +39,7 @@ public sealed class ToolMetadata
     /// The default is <see langword="false"/>.
     /// </para>
     /// </remarks>
+    [JsonPropertyName("idempotent")]
     public bool Idempotent { get; init; } = false;
 
     /// <summary>
@@ -50,6 +54,7 @@ public sealed class ToolMetadata
     /// The default is <see langword="true"/>.
     /// </para>
     /// </remarks>
+    [JsonPropertyName("openWorld")]
     public bool OpenWorld { get; init; } = true;
 
     /// <summary>
@@ -68,6 +73,7 @@ public sealed class ToolMetadata
     /// The default is <see langword="false"/>.
     /// </para>
     /// </remarks>
+    [JsonPropertyName("readOnly")]
     public bool ReadOnly { get; init; } = false;
 
     /// <summary>
@@ -86,6 +92,7 @@ public sealed class ToolMetadata
     /// The default is <see langword="false"/>.
     /// </para>
     /// </remarks>
+    [JsonPropertyName("secret")]
     public bool Secret { get; init; } = false;
 
     /// <summary>
@@ -104,6 +111,7 @@ public sealed class ToolMetadata
     /// The default is <see langword="false"/>.
     /// </para>
     /// </remarks>
+    [JsonPropertyName("localRequired")]
     public bool LocalRequired { get; init; } = false;
 
     /// <summary>

--- a/core/Azure.Mcp.Core/src/Models/Command/CommandInfo.cs
+++ b/core/Azure.Mcp.Core/src/Models/Command/CommandInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
+using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Core.Models.Command;
@@ -24,4 +25,8 @@ public class CommandInfo
     [JsonPropertyName("option")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<OptionInfo>? Options { get; set; }
+
+    [JsonPropertyName("metadata")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ToolMetadata? Metadata { get; set; }
 }

--- a/core/Azure.Mcp.Core/src/Models/ModelsJsonContext.cs
+++ b/core/Azure.Mcp.Core/src/Models/ModelsJsonContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
+using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Models.Elicitation;
 
 namespace Azure.Mcp.Core.Models;
@@ -11,6 +12,7 @@ namespace Azure.Mcp.Core.Models;
 [JsonSerializable(typeof(ETag), TypeInfoPropertyName = "McpETag")]
 [JsonSerializable(typeof(ElicitationSchemaRoot))]
 [JsonSerializable(typeof(ElicitationSchemaProperty))]
+[JsonSerializable(typeof(ToolMetadata))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 public sealed partial class ModelsJsonContext : JsonSerializerContext
 {

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Tools/UnitTests/ToolsListCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Tools/UnitTests/ToolsListCommandTests.cs
@@ -406,4 +406,42 @@ public class ToolsListCommandTests
         Assert.True(metadata.ReadOnly, "Tool list command should be read-only");
     }
 
+    /// <summary>
+    /// Verifies that the command includes metadata for each tool in the output.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_IncludesMetadataForAllCommands()
+    {
+        // Arrange
+        var args = _commandDefinition.Parse([]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+
+        var result = DeserializeResults(response.Results);
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+
+        // Verify that all commands have metadata
+        foreach (var command in result)
+        {
+            Assert.NotNull(command.Metadata);
+
+            // Verify that metadata has the expected properties
+            // Destructive, ReadOnly, Idempotent, OpenWorld, Secret, LocalRequired
+            var metadata = command.Metadata;
+
+            // Check that at least the main properties are accessible
+            Assert.True(metadata.Destructive || !metadata.Destructive, "Destructive should be defined");
+            Assert.True(metadata.ReadOnly || !metadata.ReadOnly, "ReadOnly should be defined");
+            Assert.True(metadata.Idempotent || !metadata.Idempotent, "Idempotent should be defined");
+            Assert.True(metadata.OpenWorld || !metadata.OpenWorld, "OpenWorld should be defined");
+            Assert.True(metadata.Secret || !metadata.Secret, "Secret should be defined");
+            Assert.True(metadata.LocalRequired || !metadata.LocalRequired, "LocalRequired should be defined");
+        }
+    }
 }

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -6,6 +6,8 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 ### Features Added
 
+- Added the support to return meta data in `tool list` command[[#564](https://github.com/microsoft/mcp/issues/564)].
+
 ### Breaking Changes
 
 ### Bugs Fixed


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

#564

Added the support to return meta data in `tool list` command

Now `azmcp tools list` command also shows something like

    "metadata": {
        "destructive": true,
        "idempotent": true,
        "openWorld": false,
        "readOnly": false,
        "secret": false,
        "localRequired": false
      }

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
