### PR TITLE
Add the --tool option to start Azure MCP server with a list of specific tools

### DIFF
--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
@@ -47,6 +47,7 @@ public static class AzureMcpServiceCollectionExtensions
             Namespace = serviceStartOptions.Namespace,
             ReadOnly = serviceStartOptions.ReadOnly ?? false,
             InsecureDisableElicitation = serviceStartOptions.InsecureDisableElicitation,
+            Tool = serviceStartOptions.Tool,
         };
 
         if (serviceStartOptions.Mode == ModeTypes.NamespaceProxy)

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ServiceStartCommand.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ServiceStartCommand.cs
@@ -58,6 +58,7 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
         command.Options.Add(ServiceOptionDefinitions.Transport);
         command.Options.Add(ServiceOptionDefinitions.Namespace);
         command.Options.Add(ServiceOptionDefinitions.Mode);
+        command.Options.Add(ServiceOptionDefinitions.Tool);
         command.Options.Add(ServiceOptionDefinitions.ReadOnly);
         command.Options.Add(ServiceOptionDefinitions.Debug);
         command.Options.Add(ServiceOptionDefinitions.EnableInsecureTransports);
@@ -82,6 +83,7 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
             Transport = parseResult.GetValueOrDefault<string>(ServiceOptionDefinitions.Transport.Name) ?? TransportTypes.StdIo,
             Namespace = parseResult.GetValueOrDefault<string[]?>(ServiceOptionDefinitions.Namespace.Name),
             Mode = parseResult.GetValueOrDefault<string?>(ServiceOptionDefinitions.Mode.Name),
+            Tool = parseResult.GetValueOrDefault<string[]?>(ServiceOptionDefinitions.Tool.Name),
             ReadOnly = parseResult.GetValueOrDefault<bool?>(ServiceOptionDefinitions.ReadOnly.Name),
             Debug = parseResult.GetValueOrDefault<bool>(ServiceOptionDefinitions.Debug.Name),
             EnableInsecureTransports = parseResult.GetValueOrDefault<bool>(ServiceOptionDefinitions.EnableInsecureTransports.Name),

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -61,7 +61,15 @@ public sealed class CommandFactoryToolLoader(
     /// <returns>A result containing the list of available tools.</returns>
     public ValueTask<ListToolsResult> ListToolsHandler(RequestContext<ListToolsRequestParams> request, CancellationToken cancellationToken)
     {
-        var tools = CommandFactory.GetVisibleCommands(_toolCommands)
+        var visibleCommands = CommandFactory.GetVisibleCommands(_toolCommands);
+        
+        // Filter by specific tools if provided
+        if (_options.Value.Tool != null && _options.Value.Tool.Length > 0)
+        {
+            visibleCommands = visibleCommands.Where(kvp => _options.Value.Tool.Contains(kvp.Key, StringComparer.OrdinalIgnoreCase));
+        }
+
+        var tools = visibleCommands
             .Select(kvp => GetTool(kvp.Key, kvp.Value))
             .Where(tool => !_options.Value.ReadOnly || (tool.Annotations?.ReadOnlyHint == true))
             .ToList();
@@ -96,6 +104,25 @@ public sealed class CommandFactoryToolLoader(
         }
 
         var toolName = request.Params.Name;
+        
+        // Check if tool filtering is enabled and validate the requested tool
+        if (_options.Value.Tool != null && _options.Value.Tool.Length > 0)
+        {
+            if (!_options.Value.Tool.Contains(toolName, StringComparer.OrdinalIgnoreCase))
+            {
+                var content = new TextContentBlock
+                {
+                    Text = $"Tool '{toolName}' is not available. This server is configured to only expose the tools: {string.Join(", ", _options.Value.Tool.Select(t => $"'{t}'"))}",
+                };
+
+                return new CallToolResult
+                {
+                    Content = [content],
+                    IsError = true,
+                };
+            }
+        }
+        
         var command = _toolCommands.GetValueOrDefault(toolName);
         if (command == null)
         {

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/ToolLoaderOptions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/ToolLoaderOptions.cs
@@ -10,4 +10,5 @@ namespace Azure.Mcp.Core.Areas.Server.Commands.ToolLoading;
 /// <param name="Namespace">The namespaces to filter commands by. If null or empty, all commands will be included.</param>
 /// <param name="ReadOnly">Whether the tool loader should operate in read-only mode. When true, only tools marked as read-only will be exposed.</param>
 /// <param name="InsecureDisableElicitation">Whether elicitation is disabled (insecure mode). When true, elicitation will always be treated as accepted.</param>
-public sealed record ToolLoaderOptions(string[]? Namespace = null, bool ReadOnly = false, bool InsecureDisableElicitation = false);
+/// <param name="Tool">The specific tool names to filter by. When specified, only these tools will be exposed.</param>
+public sealed record ToolLoaderOptions(string[]? Namespace = null, bool ReadOnly = false, bool InsecureDisableElicitation = false, string[]? Tool = null);

--- a/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceOptionDefinitions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceOptionDefinitions.cs
@@ -8,6 +8,7 @@ public static class ServiceOptionDefinitions
     public const string TransportName = "transport";
     public const string NamespaceName = "namespace";
     public const string ModeName = "mode";
+    public const string ToolName = "tool";
     public const string ReadOnlyName = "read-only";
     public const string DebugName = "debug";
     public const string EnableInsecureTransportsName = "enable-insecure-transports";
@@ -39,6 +40,17 @@ public static class ServiceOptionDefinitions
         Required = false,
         Arity = ArgumentArity.ZeroOrOne,
         DefaultValueFactory = _ => (string?)ModeTypes.NamespaceProxy
+    };
+
+    public static readonly Option<string[]?> Tool = new Option<string[]?>(
+        $"--{ToolName}"
+    )
+    {
+        Description = "Filter to expose only specific tools by name (e.g., 'azmcp storage account list'). Can be specified multiple times.",
+        Required = false,
+        Arity = ArgumentArity.OneOrMore,
+        AllowMultipleArgumentsPerToken = true,
+        DefaultValueFactory = _ => null
     };
 
     public static readonly Option<bool?> ReadOnly = new(

--- a/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceStartOptions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceStartOptions.cs
@@ -32,6 +32,13 @@ public class ServiceStartOptions
     public string? Mode { get; set; } = ModeTypes.NamespaceProxy;
 
     /// <summary>
+    /// Gets or sets the specific tool names to expose.
+    /// When specified, only these tools will be available.
+    /// </summary>
+    [JsonPropertyName("tool")]
+    public string[]? Tool { get; set; } = null;
+
+    /// <summary>
     /// Gets or sets whether the server should operate in read-only mode.
     /// When true, only tools marked as read-only will be available.
     /// </summary>

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/CommandFactoryHelpers.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/CommandFactoryHelpers.cs
@@ -3,13 +3,46 @@
 
 using System.Diagnostics;
 using Azure.Mcp.Core.Areas;
+using Azure.Mcp.Core.Areas.Group;
+using Azure.Mcp.Core.Areas.Server;
 using Azure.Mcp.Core.Areas.Subscription;
+using Azure.Mcp.Core.Areas.Tools;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Services.Telemetry;
+using Azure.Mcp.Tools.Acr;
+using Azure.Mcp.Tools.Aks;
 using Azure.Mcp.Tools.AppConfig;
+using Azure.Mcp.Tools.AppLens;
+using Azure.Mcp.Tools.Authorization;
+using Azure.Mcp.Tools.AzureBestPractices;
+using Azure.Mcp.Tools.AzureIsv;
+using Azure.Mcp.Tools.AzureManagedLustre;
+using Azure.Mcp.Tools.AzureTerraformBestPractices;
+using Azure.Mcp.Tools.BicepSchema;
+using Azure.Mcp.Tools.CloudArchitect;
+using Azure.Mcp.Tools.Cosmos;
 using Azure.Mcp.Tools.Deploy;
+using Azure.Mcp.Tools.EventGrid;
+using Azure.Mcp.Tools.Extension;
+using Azure.Mcp.Tools.Foundry;
+using Azure.Mcp.Tools.FunctionApp;
+using Azure.Mcp.Tools.Grafana;
 using Azure.Mcp.Tools.KeyVault;
+using Azure.Mcp.Tools.Kusto;
+using Azure.Mcp.Tools.LoadTesting;
+using Azure.Mcp.Tools.Marketplace;
+using Azure.Mcp.Tools.Monitor;
+using Azure.Mcp.Tools.MySql;
+using Azure.Mcp.Tools.Postgres;
+using Azure.Mcp.Tools.Quota;
+using Azure.Mcp.Tools.Redis;
+using Azure.Mcp.Tools.ResourceHealth;
+using Azure.Mcp.Tools.Search;
+using Azure.Mcp.Tools.ServiceBus;
+using Azure.Mcp.Tools.Sql;
 using Azure.Mcp.Tools.Storage;
+using Azure.Mcp.Tools.VirtualDesktop;
+using Azure.Mcp.Tools.Workbooks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
@@ -21,11 +54,45 @@ internal class CommandFactoryHelpers
     public static CommandFactory CreateCommandFactory(IServiceProvider? serviceProvider = default)
     {
         IAreaSetup[] areaSetups = [
+            // Core areas
             new SubscriptionSetup(),
-            new KeyVaultSetup(),
-            new StorageSetup(),
+            new GroupSetup(),
+            
+            // Tool areas
+            new AcrSetup(),
+            new AksSetup(),
+            new AppConfigSetup(),
+            new AppLensSetup(),
+            new AuthorizationSetup(),
+            new AzureBestPracticesSetup(),
+            new AzureIsvSetup(),
+            new AzureManagedLustreSetup(),
+            new AzureTerraformBestPracticesSetup(),
+            new BicepSchemaSetup(),
+            new CloudArchitectSetup(),
+            new CosmosSetup(),
             new DeploySetup(),
-            new AppConfigSetup()
+            new EventGridSetup(),
+            new ExtensionSetup(),
+            new FoundrySetup(),
+            new FunctionAppSetup(),
+            new GrafanaSetup(),
+            new KeyVaultSetup(),
+            new KustoSetup(),
+            new LoadTestingSetup(),
+            new MarketplaceSetup(),
+            new MonitorSetup(),
+            new MySqlSetup(),
+            new PostgresSetup(),
+            new QuotaSetup(),
+            new RedisSetup(),
+            new ResourceHealthSetup(),
+            new SearchSetup(),
+            new ServiceBusSetup(),
+            new SqlSetup(),
+            new StorageSetup(),
+            new VirtualDesktopSetup(),
+            new WorkbooksSetup(),
         ];
 
         var services = serviceProvider ?? CreateDefaultServiceProvider();
@@ -44,11 +111,45 @@ internal class CommandFactoryHelpers
     public static IServiceCollection SetupCommonServices()
     {
         IAreaSetup[] areaSetups = [
+            // Core areas
             new SubscriptionSetup(),
-            new KeyVaultSetup(),
-            new StorageSetup(),
+            new GroupSetup(),
+            
+            // Tool areas
+            new AcrSetup(),
+            new AksSetup(),
+            new AppConfigSetup(),
+            new AppLensSetup(),
+            new AuthorizationSetup(),
+            new AzureBestPracticesSetup(),
+            new AzureIsvSetup(),
+            new AzureManagedLustreSetup(),
+            new AzureTerraformBestPracticesSetup(),
+            new BicepSchemaSetup(),
+            new CloudArchitectSetup(),
+            new CosmosSetup(),
             new DeploySetup(),
-            new AppConfigSetup()
+            new EventGridSetup(),
+            new ExtensionSetup(),
+            new FoundrySetup(),
+            new FunctionAppSetup(),
+            new GrafanaSetup(),
+            new KeyVaultSetup(),
+            new KustoSetup(),
+            new LoadTestingSetup(),
+            new MarketplaceSetup(),
+            new MonitorSetup(),
+            new MySqlSetup(),
+            new PostgresSetup(),
+            new QuotaSetup(),
+            new RedisSetup(),
+            new ResourceHealthSetup(),
+            new SearchSetup(),
+            new ServiceBusSetup(),
+            new SqlSetup(),
+            new StorageSetup(),
+            new VirtualDesktopSetup(),
+            new WorkbooksSetup(),
         ];
 
         var builder = new ServiceCollection()

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
@@ -100,6 +100,80 @@ public class CommandFactoryToolLoaderTests
     }
 
     [Fact]
+    public async Task ListToolsHandler_WithToolFilter_ReturnsOnlySpecifiedTool()
+    {
+        // Arrange
+        var (_, commandFactory) = CreateToolLoader();
+        var availableCommands = CommandFactory.GetVisibleCommands(commandFactory.AllCommands).ToList();
+        
+        // Skip test if no commands are available
+        if (!availableCommands.Any())
+        {
+            return;
+        }
+
+        var specificToolName = availableCommands.First().Key;
+        var toolOptions = new ToolLoaderOptions { Tool = [specificToolName] };
+        var (toolLoader, _) = CreateToolLoader(toolOptions);
+        var request = CreateRequest();
+
+        // Act
+        var result = await toolLoader.ListToolsHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tools);
+        Assert.Single(result.Tools);
+        Assert.Equal(specificToolName, result.Tools[0].Name);
+    }
+
+    [Fact]
+    public async Task ListToolsHandler_WithNonExistentToolFilter_ReturnsEmptyList()
+    {
+        // Arrange
+        var nonExistentTool = "non-existent-tool-name";
+        var toolOptions = new ToolLoaderOptions { Tool = [nonExistentTool] };
+        var (toolLoader, _) = CreateToolLoader(toolOptions);
+        var request = CreateRequest();
+
+        // Act
+        var result = await toolLoader.ListToolsHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tools);
+        Assert.Empty(result.Tools);
+    }
+
+    [Fact]
+    public async Task ListToolsHandler_WithToolFilterCaseInsensitive_ReturnsSpecifiedTool()
+    {
+        // Arrange
+        var (_, commandFactory) = CreateToolLoader();
+        var availableCommands = CommandFactory.GetVisibleCommands(commandFactory.AllCommands).ToList();
+        
+        // Skip test if no commands are available
+        if (!availableCommands.Any())
+        {
+            return;
+        }
+
+        var specificToolName = availableCommands.First().Key;
+        var toolOptions = new ToolLoaderOptions { Tool = [specificToolName.ToUpperInvariant()] }; // Test case insensitive
+        var (toolLoader, _) = CreateToolLoader(toolOptions);
+        var request = CreateRequest();
+
+        // Act
+        var result = await toolLoader.ListToolsHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tools);
+        Assert.Single(result.Tools);
+        Assert.Equal(specificToolName, result.Tools[0].Name);
+    }
+
+    [Fact]
     public async Task ListToolsHandler_WithServiceFilter_ReturnsOnlyFilteredTools()
     {
         // Try to filter by a specific service/group - using a common Azure service name
@@ -677,6 +751,189 @@ public class CommandFactoryToolLoaderTests
 
         // Assert
         Assert.True(options.InsecureDisableElicitation);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithToolFilter_AllowsSpecifiedTool()
+    {
+        // Arrange
+        var (_, commandFactory) = CreateToolLoader();
+        var availableCommands = CommandFactory.GetVisibleCommands(commandFactory.AllCommands).ToList();
+        
+        // Skip test if no commands are available
+        if (!availableCommands.Any())
+        {
+            return;
+        }
+
+        var specificToolName = availableCommands.First().Key;
+        var toolOptions = new ToolLoaderOptions { Tool = [specificToolName] };
+        var (toolLoader, _) = CreateToolLoader(toolOptions);
+
+        var mockServer = Substitute.For<ModelContextProtocol.Server.IMcpServer>();
+        var request = new ModelContextProtocol.Server.RequestContext<CallToolRequestParams>(mockServer)
+        {
+            Params = new CallToolRequestParams
+            {
+                Name = specificToolName,
+                Arguments = new Dictionary<string, JsonElement>()
+            }
+        };
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, CancellationToken.None);
+
+        // Assert - Should not reject due to tool filtering
+        Assert.NotNull(result);
+        // Note: The result might still be an error for other reasons (like missing parameters),
+        // but it should not be rejected specifically due to tool filtering
+        if (result.IsError == true)
+        {
+            var errorText = ((TextContentBlock)result.Content.First()).Text;
+            Assert.DoesNotContain("is not available", errorText);
+            Assert.DoesNotContain("only expose the tool", errorText);
+        }
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithToolFilter_RejectsNonSpecifiedTool()
+    {
+        // Arrange
+        var (_, commandFactory) = CreateToolLoader();
+        var availableCommands = CommandFactory.GetVisibleCommands(commandFactory.AllCommands).ToList();
+        
+        // Skip test if fewer than 2 commands are available
+        if (availableCommands.Count < 2)
+        {
+            return;
+        }
+
+        var specificToolName = availableCommands.First().Key;
+        var otherToolName = availableCommands.Skip(1).First().Key;
+        var toolOptions = new ToolLoaderOptions { Tool = [specificToolName] };
+        var (toolLoader, _) = CreateToolLoader(toolOptions);
+
+        var mockServer = Substitute.For<ModelContextProtocol.Server.IMcpServer>();
+        var request = new ModelContextProtocol.Server.RequestContext<CallToolRequestParams>(mockServer)
+        {
+            Params = new CallToolRequestParams
+            {
+                Name = otherToolName, // Request a different tool than the filtered one
+                Arguments = new Dictionary<string, JsonElement>()
+            }
+        };
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsError);
+        var errorText = ((TextContentBlock)result.Content.First()).Text;
+        Assert.Contains("is not available", errorText);
+        Assert.Contains("only expose the tool", errorText);
+        Assert.Contains(specificToolName, errorText);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithToolFilterCaseInsensitive_AllowsSpecifiedTool()
+    {
+        // Arrange
+        var (_, commandFactory) = CreateToolLoader();
+        var availableCommands = CommandFactory.GetVisibleCommands(commandFactory.AllCommands).ToList();
+        
+        // Skip test if no commands are available
+        if (!availableCommands.Any())
+        {
+            return;
+        }
+
+        var specificToolName = availableCommands.First().Key;
+        var toolOptions = new ToolLoaderOptions { Tool = [specificToolName.ToUpperInvariant()] }; // Set filter to uppercase
+        var (toolLoader, _) = CreateToolLoader(toolOptions);
+
+        var mockServer = Substitute.For<ModelContextProtocol.Server.IMcpServer>();
+        var request = new ModelContextProtocol.Server.RequestContext<CallToolRequestParams>(mockServer)
+        {
+            Params = new CallToolRequestParams
+            {
+                Name = specificToolName, // Request with original case
+                Arguments = new Dictionary<string, JsonElement>()
+            }
+        };
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, CancellationToken.None);
+
+        // Assert - Should not reject due to tool filtering (case insensitive match)
+        Assert.NotNull(result);
+        if (result.IsError == true)
+        {
+            var errorText = ((TextContentBlock)result.Content.First()).Text;
+            Assert.DoesNotContain("is not available", errorText);
+            Assert.DoesNotContain("only expose the tool", errorText);
+        }
+    }
+
+    [Fact]
+    public void ToolLoaderOptions_WithTool_IsSetCorrectly()
+    {
+        // Arrange & Act
+        var expectedTools = new[] { "azmcp storage account list" };
+        var options = new ToolLoaderOptions(Tool: expectedTools);
+
+        // Assert
+        Assert.Equal(expectedTools, options.Tool);
+    }
+
+    [Fact]
+    public void ToolLoaderOptions_WithMultipleTools_IsSetCorrectly()
+    {
+        // Arrange & Act
+        var expectedTools = new[] { "azmcp storage account list", "azmcp keyvault secret get" };
+        var options = new ToolLoaderOptions(Tool: expectedTools);
+
+        // Assert
+        Assert.Equal(expectedTools, options.Tool);
+    }
+
+    [Fact]
+    public async Task ListToolsHandler_WithMultipleToolFilter_ReturnsSpecifiedTools()
+    {
+        // Arrange
+        var (toolLoader, commandFactory) = CreateToolLoader();
+        var allCommands = CommandFactory.GetVisibleCommands(commandFactory.AllCommands);
+        
+        // Skip test if we don't have at least 2 commands
+        if (allCommands.Count() < 2)
+        {
+            return;
+        }
+
+        var toolNames = allCommands.Take(2).Select(kvp => kvp.Key).ToArray();
+        var toolOptions = new ToolLoaderOptions { Tool = toolNames };
+        var (filteredToolLoader, _) = CreateToolLoader(toolOptions);
+        var request = CreateRequest();
+
+        // Act
+        var result = await filteredToolLoader.ListToolsHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tools);
+        Assert.Equal(2, result.Tools.Count);
+        Assert.Contains(result.Tools, t => t.Name == toolNames[0]);
+        Assert.Contains(result.Tools, t => t.Name == toolNames[1]);
+    }
+
+    [Fact]
+    public void ToolLoaderOptions_DefaultTool_IsNull()
+    {
+        // Arrange & Act
+        var options = new ToolLoaderOptions();
+
+        // Assert
+        Assert.Null(options.Tool);
     }
 
     #endregion


### PR DESCRIPTION
## What does this PR do?
Add "--tool <name>" switch for fine grained control over tool list

## GitHub issue number?
https://github.com/microsoft/mcp/issues/565

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
