### PR TITLE
NamespaceToolLoader: the tool loader that supports namespace mode without creating child azmcp processes

### DIFF
--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Net;
 using System.Text.Json.Nodes;
+using Azure.Mcp.Core.Areas.Server.Commands.Discovery;
 using Azure.Mcp.Core.Areas.Server.Models;
 using Azure.Mcp.Core.Areas.Server.Options;
 using Azure.Mcp.Core.Commands;
@@ -33,7 +34,7 @@ public sealed class NamespaceToolLoader(
     private readonly Lazy<IReadOnlyList<string>> _availableNamespaces = new Lazy<IReadOnlyList<string>>(() =>
     {
         return commandFactory.RootGroup.SubGroup
-            .Where(group => !IgnoreCommandGroups.Contains(group.Name, StringComparer.OrdinalIgnoreCase))
+            .Where(group => !DiscoveryConstants.IgnoredCommandGroups.Contains(group.Name, StringComparer.OrdinalIgnoreCase))
             .Where(group => options.Value.Namespace == null ||
                            options.Value.Namespace.Length == 0 ||
                            options.Value.Namespace.Contains(group.Name, StringComparer.OrdinalIgnoreCase))
@@ -41,7 +42,6 @@ public sealed class NamespaceToolLoader(
             .ToList();
     });
 
-    private static readonly List<string> IgnoreCommandGroups = ["extension", "server", "tools"];
     private readonly Dictionary<string, List<Tool>> _cachedToolLists = new(StringComparer.OrdinalIgnoreCase);
     private ListToolsResult? _cachedListToolsResult;
 
@@ -408,10 +408,10 @@ public sealed class NamespaceToolLoader(
             throw new ArgumentNullException(nameof(request.Params.Name), "Tool name cannot be null or empty.");
         }
 
-        var availableNamespaces = _availableNamespaces.Value;
-        if (!availableNamespaces.Any(ns => string.Equals(ns, namespaceName, StringComparison.OrdinalIgnoreCase)))
+        var namespaces = _availableNamespaces.Value;
+        if (!namespaces.Any(ns => string.Equals(ns, namespaceName, StringComparison.OrdinalIgnoreCase)))
         {
-            var availableList = string.Join(", ", availableNamespaces);
+            var availableList = string.Join(", ", namespaces);
             throw new KeyNotFoundException($"The namespace '{namespaceName}' was not found. Available namespaces: {availableList}");
         }
 

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
@@ -1,0 +1,738 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net;
+using System.Text.Json.Nodes;
+using Azure.Mcp.Core.Areas.Server.Models;
+using Azure.Mcp.Core.Areas.Server.Options;
+using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Core.Helpers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+
+namespace Azure.Mcp.Core.Areas.Server.Commands.ToolLoading;
+
+/// <summary>
+/// A tool loader that exposes Azure command groups as hierarchical namespace tools with direct in-process tool execution.
+/// Provides the same functionality as <see cref="ServerToolLoader"/> but without spawning child azmcp processes.
+/// Supports learn functionality for progressive discovery of commands within each namespace.
+/// </summary>
+public sealed class NamespaceToolLoader : BaseToolLoader
+{
+    private readonly CommandFactory _commandFactory;
+    private readonly IOptions<ServiceStartOptions> _options;
+    private readonly IServiceProvider _serviceProvider;
+    private static readonly List<string> IgnoreCommandGroups = ["extension", "server", "tools"];
+
+    private readonly Lazy<List<Tool>> _cachedNamespaceTools;
+    private readonly IReadOnlyList<string> _namespaceNames;
+    private readonly ConcurrentDictionary<string, IReadOnlyDictionary<string, IBaseCommand>> _commandsByNamespace = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, List<Tool>> _cachedLearnToolsByNamespace = new(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly Lazy<JsonElement> HierarchicalSchemaCache = new(CreateHierarchicalSchema);
+    private const string HierarchicalToolDescription =
+        "This tool is a hierarchical MCP command router.\n" +
+        "Sub commands are routed to MCP servers that require specific fields inside the \"parameters\" object.\n" +
+        "To invoke a command, set \"command\" and wrap its args in \"parameters\".\n" +
+        "Set \"learn=true\" to discover available sub commands.";
+
+    private const string ToolCallProxySchema = """
+        {
+          "type": "object",
+          "properties": {
+            "tool": {
+              "type": "string",
+              "description": "The name of the tool to call."
+            },
+            "parameters": {
+              "type": "object",
+              "description": "A key/value pair of parameters names and values to pass to the tool call command."
+            }
+          },
+          "additionalProperties": false
+        }
+        """;
+
+    public NamespaceToolLoader(
+        CommandFactory commandFactory,
+        IOptions<ServiceStartOptions> options,
+        IServiceProvider serviceProvider,
+        ILogger<NamespaceToolLoader> logger) : base(logger)
+    {
+        _commandFactory = commandFactory ?? throw new ArgumentNullException(nameof(commandFactory));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+
+        _namespaceNames = GetFilteredNamespaceNames();
+        _cachedNamespaceTools = new Lazy<List<Tool>>(() =>
+            _namespaceNames
+                .Select(ns => CreateNamespaceTool(ns, GetNamespaceDescription(ns)))
+                .ToList());
+    }
+
+    public override ValueTask<ListToolsResult> ListToolsHandler(
+        RequestContext<ListToolsRequestParams> request,
+        CancellationToken cancellationToken)
+    {
+        var tools = _cachedNamespaceTools.Value;
+        _logger.LogInformation("Listing {Count} namespace tools.", tools.Count);
+        return ValueTask.FromResult(new ListToolsResult { Tools = tools });
+    }
+
+    /// <summary>
+    /// Handles tool calls for namespace tools. Supports both learn mode (discovery) and
+    /// command execution mode (direct command invocation).
+    /// </summary>
+    public override async ValueTask<CallToolResult> CallToolHandler(
+        RequestContext<CallToolRequestParams> request,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Params?.Name))
+        {
+            throw new ArgumentNullException(nameof(request.Params.Name), "Tool name cannot be null or empty.");
+        }
+
+        var toolName = request.Params.Name;
+        var args = request.Params.Arguments;
+
+        // Validate namespace exists
+        if (!_namespaceNames.Contains(toolName, StringComparer.OrdinalIgnoreCase))
+        {
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock
+                {
+                    Text = $"Namespace '{toolName}' not found. Available namespaces: {string.Join(", ", _namespaceNames)}"
+                }],
+                IsError = true
+            };
+        }
+
+        // Parse hierarchical structure from tool arguments
+        var parsedArgs = request.Params.Arguments as IReadOnlyDictionary<string, JsonElement>;
+        if (parsedArgs == null && request.Params.Arguments != null)
+        {
+            // Convert from Dictionary<string, object?> if needed
+            parsedArgs = ConvertToJsonElements(request.Params.Arguments as Dictionary<string, object?>);
+        }
+
+        var (intent, command, parameters, learn) = ParseHierarchicalCall(parsedArgs);        // Auto-learn if intent provided but no command specified
+        if (!learn && !string.IsNullOrEmpty(intent) && string.IsNullOrEmpty(command))
+        {
+            learn = true;
+        }
+
+        try
+        {
+            if (learn && string.IsNullOrEmpty(command))
+            {
+                // Learn mode: Return available commands for this namespace
+                return await HandleLearnRequest(request, intent ?? "", toolName, cancellationToken);
+            }
+            else if (!string.IsNullOrEmpty(toolName) && !string.IsNullOrEmpty(command))
+            {
+                // Execution mode: Execute the specified command
+                return await ExecuteNamespaceCommand(request, intent ?? "", toolName, command, parameters, cancellationToken);
+            }
+        }
+        catch (KeyNotFoundException ex)
+        {
+            _logger.LogError(ex, "Key not found while calling namespace tool: {Tool}", toolName);
+
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock
+                {
+                    Text = $"""
+                        The tool '{toolName}.{command}' was not found or does not support the specified command.
+                        Please ensure the tool name and command are correct.
+                        If you want to learn about available tools, run again with the "learn=true" argument.
+                        """
+                }],
+                IsError = true
+            };
+        }
+
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock
+            {
+                Text = """
+                    The "command" parameter is required when not learning.
+                    Run again with the "learn" argument to get a list of available tools and their parameters.
+                    To learn about a specific tool, use the "tool" argument with the name of the tool.
+                    """
+            }],
+            IsError = false
+        };
+    }
+
+    /// <summary>
+    /// Handles learn requests for a namespace, returning available commands with their schemas.
+    /// Uses caching to avoid rebuilding tool definitions on repeated requests.
+    /// </summary>
+    private async Task<CallToolResult> HandleLearnRequest(
+        RequestContext<CallToolRequestParams> request,
+        string intent,
+        string nameSpace,
+        CancellationToken cancellationToken)
+    {
+        if (_cachedLearnToolsByNamespace.TryGetValue(nameSpace, out var cachedTools))
+        {
+            var cachedJson = JsonSerializer.Serialize(cachedTools, ServerJsonContext.Default.ListTool);
+            return CreateLearnResponse(nameSpace, cachedJson);
+        }
+
+        // Build tools for this namespace (lazy load if not cached)
+        var namespaceCommands = GetOrLoadNamespaceCommands(nameSpace);
+        var tools = namespaceCommands
+            .Where(kvp => !(_options.Value.ReadOnly ?? false) || kvp.Value.Metadata.ReadOnly)
+            .Select(kvp => CreateToolFromCommand(kvp.Key, kvp.Value))
+            .ToList();
+
+        // Cache for future requests
+        _cachedLearnToolsByNamespace[nameSpace] = tools;
+
+        var toolsJson = JsonSerializer.Serialize(tools, ServerJsonContext.Default.ListTool);
+
+        var learnResponse = CreateLearnResponse(nameSpace, toolsJson);
+
+        // If client supports sampling and intent is provided, try to infer command
+        if (SupportsSampling(request.Server) && !string.IsNullOrWhiteSpace(intent))
+        {
+            var (commandName, parameters) = await GetCommandAndParametersFromIntentAsync(
+                request, intent, nameSpace, tools, cancellationToken);
+
+            if (commandName != null)
+            {
+                return await ExecuteNamespaceCommand(request, intent, nameSpace, commandName, parameters, cancellationToken);
+            }
+        }
+
+        return learnResponse;
+    }
+
+    /// <summary>
+    /// Executes a command within a namespace.
+    /// </summary>
+    private async Task<CallToolResult> ExecuteNamespaceCommand(
+        RequestContext<CallToolRequestParams> request,
+        string intent,
+        string nameSpace,
+        string command,
+        IReadOnlyDictionary<string, JsonElement> parameters,
+        CancellationToken cancellationToken)
+    {
+        var namespaceCommands = GetOrLoadNamespaceCommands(nameSpace);
+
+        // Try to find the command - handle both "command" and "namespace command" formats
+        if (!namespaceCommands.TryGetValue(command, out var cmd))
+        {
+            var fullCommandName = $"{nameSpace} {command}";
+            if (!namespaceCommands.TryGetValue(fullCommandName, out cmd))
+            {
+                _logger.LogWarning("Namespace {Namespace} does not have a command {Command}.", nameSpace, command);
+
+                if (string.IsNullOrWhiteSpace(intent))
+                {
+                    return await HandleLearnRequest(request, intent, nameSpace, cancellationToken);
+                }
+
+                // Try to infer command from intent
+                var tools = _cachedLearnToolsByNamespace.GetValueOrDefault(nameSpace)
+                    ?? GetToolsForNamespace(nameSpace);
+
+                var samplingResult = await GetCommandAndParametersFromIntentAsync(
+                    request, intent, nameSpace, tools, cancellationToken);
+
+                if (string.IsNullOrWhiteSpace(samplingResult.commandName))
+                {
+                    return await HandleLearnRequest(request, intent, nameSpace, cancellationToken);
+                }
+
+                command = samplingResult.commandName;
+                parameters = samplingResult.parameters;
+
+                if (!namespaceCommands.TryGetValue(command, out cmd))
+                {
+                    return await HandleLearnRequest(request, intent, nameSpace, cancellationToken);
+                }
+            }
+        }
+
+        try
+        {
+            await NotifyProgressAsync(request, $"Calling {nameSpace} {command}...", cancellationToken);
+
+            // Direct execution (same as CommandFactoryToolLoader)
+            var commandContext = new CommandContext(_serviceProvider, Activity.Current);
+            var realCommand = cmd.GetCommand();
+
+            ParseResult commandOptions;
+            if (realCommand.Options.Count == 1 && IsRawMcpToolInputOption(realCommand.Options[0]))
+            {
+                commandOptions = realCommand.ParseFromRawMcpToolInput(parameters);
+            }
+            else
+            {
+                commandOptions = realCommand.ParseFromDictionary(parameters);
+            }
+
+            _logger.LogTrace("Executing namespace command '{Namespace} {Command}'", nameSpace, command);
+
+            var commandResponse = await cmd.ExecuteAsync(commandContext, commandOptions);
+
+            // Check if command requires missing parameters
+            var jsonResponse = JsonSerializer.Serialize(commandResponse, ModelsJsonContext.Default.CommandResponse);
+            var isError = commandResponse.Status < HttpStatusCode.OK || commandResponse.Status >= HttpStatusCode.Ambiguous;
+
+            if (jsonResponse.Contains("Missing required options", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning("Namespace command '{Namespace} {Command}' requires additional parameters.", nameSpace, command);
+
+                var commandTool = GetCommandTool(nameSpace, command);
+                var commandToolJson = JsonSerializer.Serialize(commandTool, ServerJsonContext.Default.Tool);
+
+                return new CallToolResult
+                {
+                    Content =
+                    [
+                        new TextContentBlock
+                        {
+                            Text = $"""
+                                The '{command}' command is missing required parameters.
+
+                                - Review the following command spec and identify the required arguments from the input schema.
+                                - Omit any arguments that are not required or do not apply to your use case.
+                                - Wrap all command arguments into the root "parameters" argument.
+                                - If required data is missing infer the data from your context or prompt the user as needed.
+                                - Run the tool again with the "command" and root "parameters" object.
+
+                                Command Spec:
+                                {commandToolJson}
+
+                                Original Error:
+                                {jsonResponse}
+                                """
+                        }
+                    ],
+                    IsError = true
+                };
+            }
+
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = jsonResponse }],
+                IsError = isError
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception thrown while calling namespace tool: {Namespace}, command: {Command}", nameSpace, command);
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock
+                {
+                    Text = $"""
+                        There was an error finding or calling tool and command.
+                        Failed to call namespace: {nameSpace}, command: {command}
+                        Error: {ex.Message}
+
+                        Run again with the "learn=true" to get a list of available commands and their parameters.
+                        """
+                }],
+                IsError = true
+            };
+        }
+    }
+
+    /// <summary>
+    /// Gets filtered namespace names at construction time (lightweight operation).
+    /// </summary>
+    private IReadOnlyList<string> GetFilteredNamespaceNames()
+    {
+        return _commandFactory.RootGroup.SubGroup
+            .Where(group => !IgnoreCommandGroups.Contains(group.Name, StringComparer.OrdinalIgnoreCase))
+            .Where(group => _options.Value.Namespace == null ||
+                           _options.Value.Namespace.Length == 0 ||
+                           _options.Value.Namespace.Contains(group.Name, StringComparer.OrdinalIgnoreCase))
+            .Select(group => group.Name)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Gets or lazily loads commands for a specific namespace.
+    /// Commands are only loaded when first accessed, improving startup time and memory usage.
+    /// </summary>
+    private IReadOnlyDictionary<string, IBaseCommand> GetOrLoadNamespaceCommands(string nameSpace)
+    {
+        return _commandsByNamespace.GetOrAdd(nameSpace, ns => _commandFactory.GroupCommands([ns]));
+    }
+
+    /// <summary>
+    /// Creates a hierarchical namespace tool with learn capabilities.
+    /// Uses cached hierarchical schema to avoid repeated JSON serialization.
+    /// </summary>
+    private static Tool CreateNamespaceTool(string nameSpace, string description)
+    {
+        return new Tool
+        {
+            Name = nameSpace,
+            Description = $"{description}\n{HierarchicalToolDescription}",
+            InputSchema = HierarchicalSchemaCache.Value
+        };
+    }
+
+    /// <summary>
+    /// Creates the hierarchical input schema used by all namespace tools.
+    /// This schema is shared across all instances and cached statically.
+    /// </summary>
+    private static JsonElement CreateHierarchicalSchema()
+    {
+        return JsonSerializer.Deserialize("""
+            {
+                "type": "object",
+                "properties": {
+                "intent": {
+                    "type": "string",
+                    "description": "The intent of the azure operation to perform."
+                },
+                "command": {
+                    "type": "string",
+                    "description": "The command to execute against the specified tool."
+                },
+                "parameters": {
+                    "type": "object",
+                    "description": "The parameters to pass to the tool command."
+                },
+                "learn": {
+                    "type": "boolean",
+                    "description": "To learn about the tool and its supported child tools and parameters.",
+                    "default": false
+                }
+                },
+                "required": ["intent"],
+                "additionalProperties": false
+            }
+            """, ServerJsonContext.Default.JsonElement);
+    }
+
+    /// <summary>
+    /// Creates a tool definition from a command (same logic as CommandFactoryToolLoader).
+    /// </summary>
+    private static Tool CreateToolFromCommand(string fullName, IBaseCommand command)
+    {
+        var underlyingCommand = command.GetCommand();
+        var tool = new Tool
+        {
+            Name = fullName,
+            Description = underlyingCommand.Description,
+        };
+
+        var metadata = command.Metadata;
+        tool.Annotations = new ToolAnnotations()
+        {
+            DestructiveHint = metadata.Destructive,
+            IdempotentHint = metadata.Idempotent,
+            OpenWorldHint = metadata.OpenWorld,
+            ReadOnlyHint = metadata.ReadOnly,
+            Title = command.Title,
+        };
+
+        if (metadata.Secret)
+        {
+            tool.Meta = new JsonObject { ["SecretHint"] = metadata.Secret };
+        }
+
+        var schema = new ToolInputSchema();
+        var options = command.GetCommand().Options;
+
+        if (options?.Count > 0)
+        {
+            if (options.Count == 1 && IsRawMcpToolInputOption(options[0]))
+            {
+                var arguments = JsonNode.Parse(options[0].Description ?? "{}") as JsonObject ?? new JsonObject();
+                tool.InputSchema = JsonSerializer.SerializeToElement(arguments, ServerJsonContext.Default.JsonObject);
+                return tool;
+            }
+            else
+            {
+                foreach (var option in options)
+                {
+                    var propName = NameNormalization.NormalizeOptionName(option.Name);
+                    schema.Properties.Add(propName, TypeToJsonTypeMapper.CreatePropertySchema(option.ValueType, option.Description));
+                }
+                schema.Required = [.. options.Where(p => p.Required).Select(p => NameNormalization.NormalizeOptionName(p.Name))];
+            }
+        }
+
+        tool.InputSchema = JsonSerializer.SerializeToElement(schema, ServerJsonContext.Default.ToolInputSchema);
+        return tool;
+    }
+
+    /// <summary>
+    /// Parses hierarchical call structure from MCP tool arguments.
+    /// </summary>
+    private static (string? intent, string? command, IReadOnlyDictionary<string, JsonElement> parameters, bool learn) ParseHierarchicalCall(
+        IReadOnlyDictionary<string, JsonElement>? args)
+    {
+        if (args == null)
+        {
+            return (null, null, new Dictionary<string, JsonElement>(), false);
+        }
+
+        string? intent = null;
+        string? command = null;
+        bool learn = false;
+        IReadOnlyDictionary<string, JsonElement> parameters = new Dictionary<string, JsonElement>();
+
+        if (args.TryGetValue("intent", out var intentElem) && intentElem.ValueKind == JsonValueKind.String)
+        {
+            intent = intentElem.GetString();
+        }
+
+        if (args.TryGetValue("learn", out var learnElem) && learnElem.ValueKind == JsonValueKind.True)
+        {
+            learn = true;
+        }
+
+        if (args.TryGetValue("command", out var commandElem) && commandElem.ValueKind == JsonValueKind.String)
+        {
+            command = commandElem.GetString();
+        }
+
+        if (args.TryGetValue("parameters", out var paramsElem) && paramsElem.ValueKind == JsonValueKind.Object)
+        {
+            parameters = paramsElem.EnumerateObject()
+                .ToDictionary(prop => prop.Name, prop => prop.Value);
+        }
+
+        return (intent, command, parameters, learn);
+    }
+
+    /// <summary>
+    /// Converts Dictionary<string, object?> to Dictionary<string, JsonElement> for command parsing.
+    /// </summary>
+    private static IReadOnlyDictionary<string, JsonElement> ConvertToJsonElements(Dictionary<string, object?>? dict)
+    {
+        if (dict == null || dict.Count == 0)
+        {
+            return new Dictionary<string, JsonElement>();
+        }
+
+        var result = new Dictionary<string, JsonElement>();
+        foreach (var kvp in dict)
+        {
+            if (kvp.Value == null)
+            {
+                result[kvp.Key] = JsonDocument.Parse("null").RootElement;
+            }
+            else if (kvp.Value is JsonElement elem)
+            {
+                result[kvp.Key] = elem;
+            }
+            else if (kvp.Value is string str)
+            {
+                result[kvp.Key] = JsonDocument.Parse($"\"{str}\"").RootElement;
+            }
+            else if (kvp.Value is bool b)
+            {
+                result[kvp.Key] = JsonDocument.Parse(b.ToString().ToLower()).RootElement;
+            }
+            else if (kvp.Value is int or long or double or float or decimal)
+            {
+                result[kvp.Key] = JsonDocument.Parse(kvp.Value.ToString() ?? "null").RootElement;
+            }
+            else
+            {
+                // For complex objects, use JsonElement.ValueKind if possible
+                // Otherwise convert to string representation
+                try
+                {
+                    var jsonString = JsonSerializer.SerializeToElement(kvp.Value, ServerJsonContext.Default.Object).GetRawText();
+                    result[kvp.Key] = JsonDocument.Parse(jsonString).RootElement;
+                }
+                catch
+                {
+                    // Fallback to string representation
+                    result[kvp.Key] = JsonDocument.Parse($"\"{kvp.Value}\"").RootElement;
+                }
+            }
+        }
+        return result;
+    }
+
+    private static bool IsRawMcpToolInputOption(Option option)
+    {
+        const string RawMcpToolInputOptionName = "raw-mcp-tool-input";
+        if (string.Equals(NameNormalization.NormalizeOptionName(option.Name), RawMcpToolInputOptionName, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return option.Aliases.Any(alias =>
+            string.Equals(NameNormalization.NormalizeOptionName(alias), RawMcpToolInputOptionName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private CallToolResult CreateLearnResponse(string nameSpace, string toolsJson)
+    {
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock
+            {
+                Text = $"""
+                    Here are the available command and their parameters for '{nameSpace}' tool.
+                    If you do not find a suitable command, run again with the "learn=true" to get a list of available commands and their parameters.
+                    Next, identify the command you want to execute and run again with the "command" and "parameters" arguments.
+
+                    {toolsJson}
+                    """
+            }],
+            IsError = false
+        };
+    }
+
+    private List<Tool> GetToolsForNamespace(string nameSpace)
+    {
+        var namespaceCommands = GetOrLoadNamespaceCommands(nameSpace);
+        return namespaceCommands
+            .Where(kvp => !(_options.Value.ReadOnly ?? false) || kvp.Value.Metadata.ReadOnly)
+            .Select(kvp => CreateToolFromCommand(kvp.Key, kvp.Value))
+            .ToList();
+    }
+
+    private Tool GetCommandTool(string nameSpace, string commandName)
+    {
+        var tools = _cachedLearnToolsByNamespace.GetValueOrDefault(nameSpace)
+            ?? GetToolsForNamespace(nameSpace);
+
+        return tools.First(t => string.Equals(t.Name, commandName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private string GetNamespaceDescription(string nameSpace)
+    {
+        var group = _commandFactory.RootGroup.SubGroup
+            .FirstOrDefault(g => string.Equals(g.Name, nameSpace, StringComparison.OrdinalIgnoreCase));
+
+        return group?.Description ?? $"Azure {nameSpace} operations";
+    }
+
+    private static bool SupportsSampling(McpServer server)
+    {
+        return server?.ClientCapabilities?.Sampling != null;
+    }
+
+    private static async Task NotifyProgressAsync(RequestContext<CallToolRequestParams> request, string message, CancellationToken cancellationToken)
+    {
+        var progressToken = request.Params?.ProgressToken;
+        if (progressToken == null)
+        {
+            return;
+        }
+
+        await request.Server.NotifyProgressAsync(progressToken.Value,
+            new ProgressNotificationValue
+            {
+                Progress = 0f,
+                Message = message,
+            }, cancellationToken);
+    }
+
+    private async Task<(string? commandName, IReadOnlyDictionary<string, JsonElement> parameters)> GetCommandAndParametersFromIntentAsync(
+        RequestContext<CallToolRequestParams> request,
+        string intent,
+        string nameSpace,
+        List<Tool> availableTools,
+        CancellationToken cancellationToken)
+    {
+        await NotifyProgressAsync(request, $"Learning about {nameSpace} capabilities...", cancellationToken);
+
+        JsonElement toolParams = GetParametersJsonElement(request);
+        var toolParamsJson = toolParams.GetRawText();
+        var availableToolsJson = JsonSerializer.Serialize(availableTools, ServerJsonContext.Default.ListTool);
+
+        var samplingRequest = new CreateMessageRequestParams
+        {
+            Messages = [
+                new SamplingMessage
+                {
+                    Role = Role.Assistant,
+                    Content = new TextContentBlock
+                    {
+                        Text = $"""
+                            This is a list of available commands for the {nameSpace} server.
+
+                            Your task:
+                            - Select the single command that best matches the user's intent.
+                            - Return a valid JSON object that matches the provided result schema.
+                            - Map the user's intent and known parameters to the command's input schema, ensuring parameter names and types match the schema exactly (no extra or missing parameters).
+                            - Only include parameters that are defined in the selected command's input schema.
+                            - Do not guess or invent parameters.
+                            - If no command matches, return JSON schema with "Unknown" tool name.
+
+                            Result Schema:
+                            {ToolCallProxySchema}
+
+                            Intent:
+                            {intent ?? "No specific intent provided"}
+
+                            Known Parameters:
+                            {toolParamsJson}
+
+                            Available Commands:
+                            {availableToolsJson}
+                            """
+                    }
+                }
+            ],
+        };
+
+        try
+        {
+            var samplingResponse = await request.Server.SampleAsync(samplingRequest, cancellationToken);
+            var samplingContent = samplingResponse.Content as TextContentBlock;
+            var toolCallJson = samplingContent?.Text?.Trim();
+            string? commandName = null;
+            IReadOnlyDictionary<string, JsonElement> parameters = new Dictionary<string, JsonElement>();
+
+            if (!string.IsNullOrEmpty(toolCallJson))
+            {
+                var doc = JsonDocument.Parse(toolCallJson);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("tool", out var toolProp) && toolProp.ValueKind == JsonValueKind.String)
+                {
+                    commandName = toolProp.GetString();
+                }
+                if (root.TryGetProperty("parameters", out var parametersElem) && parametersElem.ValueKind == JsonValueKind.Object)
+                {
+                    parameters = parametersElem.EnumerateObject().ToDictionary(prop => prop.Name, prop => prop.Value) ?? new Dictionary<string, JsonElement>();
+                }
+            }
+
+            if (commandName != null && commandName != "Unknown")
+            {
+                return (commandName, parameters);
+            }
+        }
+        catch
+        {
+            _logger.LogError("Failed to get command and parameters from intent: {Intent} for namespace: {Namespace}", intent, nameSpace);
+        }
+
+        return (null, new Dictionary<string, JsonElement>());
+    }
+
+    /// <summary>
+    /// Disposes resources owned by this tool loader.
+    /// Clears the cached tool lists dictionary.
+    /// </summary>
+    protected override async ValueTask DisposeAsyncCore()
+    {
+        _cachedLearnToolsByNamespace.Clear();
+        await ValueTask.CompletedTask;
+    }
+}

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ServiceCollectionExtensionsTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ServiceCollectionExtensionsTests.cs
@@ -101,13 +101,14 @@ public class ServiceCollectionExtensionsTests
         var provider = services.BuildServiceProvider();
 
         // Verify the correct tool loader is registered
-        // In namespace mode, we now use CompositeToolLoader that includes ServerToolLoader
+        // In namespace mode, we now use CompositeToolLoader that includes NamespaceToolLoader
         Assert.NotNull(provider.GetService<IToolLoader>());
         Assert.IsType<CompositeToolLoader>(provider.GetService<IToolLoader>());
 
         // Verify discovery strategy is registered
+        // In namespace mode, we only use RegistryDiscoveryStrategy (for external MCP servers)
         Assert.NotNull(provider.GetService<IMcpDiscoveryStrategy>());
-        Assert.IsType<CompositeDiscoveryStrategy>(provider.GetService<IMcpDiscoveryStrategy>());
+        Assert.IsType<RegistryDiscoveryStrategy>(provider.GetService<IMcpDiscoveryStrategy>());
     }
 
     [Fact]

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
@@ -469,28 +469,9 @@ public sealed class NamespaceToolLoaderTests : IDisposable
         string toolName,
         Dictionary<string, object?> arguments)
     {
-        // Convert Dictionary<string, object?> to Dictionary<string, JsonElement>
-        var jsonArguments = new Dictionary<string, JsonElement>();
-        foreach (var kvp in arguments)
-        {
-            if (kvp.Value is bool b)
-            {
-                jsonArguments[kvp.Key] = JsonDocument.Parse(b.ToString().ToLower()).RootElement;
-            }
-            else if (kvp.Value is string s)
-            {
-                jsonArguments[kvp.Key] = JsonDocument.Parse($"\"{s}\"").RootElement;
-            }
-            else if (kvp.Value is Dictionary<string, object?> dict)
-            {
-                var json = JsonSerializer.Serialize(dict);
-                jsonArguments[kvp.Key] = JsonDocument.Parse(json).RootElement;
-            }
-            else if (kvp.Value == null)
-            {
-                jsonArguments[kvp.Key] = JsonDocument.Parse("null").RootElement;
-            }
-        }
+        var jsonArguments = arguments.ToDictionary(
+            kvp => kvp.Key,
+            kvp => JsonSerializer.SerializeToElement(kvp.Value));
 
         var mockServer = Substitute.For<ModelContextProtocol.Server.McpServer>();
         return new ModelContextProtocol.Server.RequestContext<CallToolRequestParams>(mockServer, new() { Method = RequestMethods.ToolsCall })

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
@@ -448,7 +448,7 @@ public sealed class NamespaceToolLoaderTests : IDisposable
     private string GetFirstAvailableNamespace()
     {
         var namespaces = _commandFactory.RootGroup.SubGroup
-            .Where(g => g.Name != "extension" && g.Name != "server" && g.Name != "tools")
+            .Where(g => !Azure.Mcp.Core.Areas.Server.Commands.Discovery.DiscoveryConstants.IgnoredCommandGroups.Contains(g.Name, StringComparer.OrdinalIgnoreCase))
             .Select(g => g.Name)
             .ToList();
 

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
@@ -1,0 +1,525 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Azure.Mcp.Core.Areas.Server.Commands.ToolLoading;
+using Azure.Mcp.Core.Areas.Server.Options;
+using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Core.UnitTests.Areas.Server;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Mcp.Core.UnitTests.Areas.Server.Commands.ToolLoading;
+
+public sealed class NamespaceToolLoaderTests : IDisposable
+{
+    private readonly ServiceProvider _serviceProvider;
+    private readonly CommandFactory _commandFactory;
+    private readonly IOptions<ServiceStartOptions> _options;
+    private readonly ILogger<NamespaceToolLoader> _logger;
+
+    public NamespaceToolLoaderTests()
+    {
+        _serviceProvider = CommandFactoryHelpers.CreateDefaultServiceProvider() as ServiceProvider
+            ?? throw new InvalidOperationException("Failed to create service provider");
+        _commandFactory = CommandFactoryHelpers.CreateCommandFactory(_serviceProvider);
+        _options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
+        _logger = _serviceProvider.GetRequiredService<ILogger<NamespaceToolLoader>>();
+    }
+
+    [Fact]
+    public void Constructor_InitializesSuccessfully()
+    {
+        // Arrange & Act
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+
+        // Assert
+        Assert.NotNull(loader);
+    }
+
+    [Fact]
+    public void Constructor_ThrowsOnNullCommandFactory()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new NamespaceToolLoader(null!, _options, _serviceProvider, _logger));
+    }
+
+    [Fact]
+    public void Constructor_ThrowsOnNullOptions()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new NamespaceToolLoader(_commandFactory, null!, _serviceProvider, _logger));
+    }
+
+    [Fact]
+    public void Constructor_ThrowsOnNullServiceProvider()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new NamespaceToolLoader(_commandFactory, _options, null!, _logger));
+    }
+
+    [Fact]
+    public async Task ListToolsHandler_ReturnsNamespaceTools()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var request = CreateListToolsRequest();
+
+        // Act
+        var result = await loader.ListToolsHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tools);
+        Assert.NotEmpty(result.Tools);
+
+        // Verify hierarchical structure
+        foreach (var tool in result.Tools)
+        {
+            Assert.NotNull(tool.Name);
+            Assert.NotNull(tool.Description);
+            Assert.Contains("hierarchical", tool.Description, StringComparison.OrdinalIgnoreCase);
+
+            // Verify hierarchical schema structure
+            var schema = tool.InputSchema;
+            Assert.True(schema.TryGetProperty("properties", out var properties));
+            Assert.True(properties.TryGetProperty("intent", out _));
+            Assert.True(properties.TryGetProperty("command", out _));
+            Assert.True(properties.TryGetProperty("parameters", out _));
+            Assert.True(properties.TryGetProperty("learn", out _));
+        }
+    }
+
+    [Fact]
+    public async Task ListToolsHandler_CachesResults()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var request = CreateListToolsRequest();
+
+        // Act - Call twice
+        var result1 = await loader.ListToolsHandler(request, CancellationToken.None);
+        var result2 = await loader.ListToolsHandler(request, CancellationToken.None);
+
+        // Assert - Should return same cached instance
+        Assert.Same(result1.Tools, result2.Tools);
+    }
+
+    [Fact]
+    public async Task ListToolsHandler_FiltersNamespacesWhenConfigured()
+    {
+        // Arrange
+        using var serviceProvider = CommandFactoryHelpers.CreateDefaultServiceProvider() as ServiceProvider
+            ?? throw new InvalidOperationException("Failed to create service provider");
+        var commandFactory = CommandFactoryHelpers.CreateCommandFactory(serviceProvider);
+        var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions
+        {
+            Namespace = ["storage", "keyvault"]
+        });
+        var logger = serviceProvider.GetRequiredService<ILogger<NamespaceToolLoader>>();
+
+        var loader = new NamespaceToolLoader(commandFactory, options, serviceProvider, logger);
+        var request = CreateListToolsRequest();
+
+        // Act
+        var result = await loader.ListToolsHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result.Tools);
+        Assert.All(result.Tools, tool =>
+            Assert.True(tool.Name == "storage" || tool.Name == "keyvault"));
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithLearnTrue_ReturnsAvailableCommands()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var toolName = GetFirstAvailableNamespace();
+        var request = CreateCallToolRequest(toolName, new Dictionary<string, object?>
+        {
+            ["learn"] = true,
+            ["intent"] = "list resources"
+        });
+
+        // Act
+        var result = await loader.CallToolHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(result.IsError);
+        Assert.NotNull(result.Content);
+        Assert.Single(result.Content);
+
+        var textContent = result.Content[0] as TextContentBlock;
+        Assert.NotNull(textContent);
+        Assert.Contains("available command", textContent.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithLearnTrue_CachesCommandList()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var toolName = GetFirstAvailableNamespace();
+        var request = CreateCallToolRequest(toolName, new Dictionary<string, object?>
+        {
+            ["learn"] = true,
+            ["intent"] = "list resources"
+        });
+
+        // Act - Call twice
+        var result1 = await loader.CallToolHandler(request, CancellationToken.None);
+        var result2 = await loader.CallToolHandler(request, CancellationToken.None);
+
+        // Assert - Both should succeed and return same cached content
+        Assert.False(result1.IsError);
+        Assert.False(result2.IsError);
+
+        var text1 = (result1.Content[0] as TextContentBlock)?.Text;
+        var text2 = (result2.Content[0] as TextContentBlock)?.Text;
+        Assert.Equal(text1, text2);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithIntentButNoCommand_AutoEnablesLearn()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var toolName = GetFirstAvailableNamespace();
+        var request = CreateCallToolRequest(toolName, new Dictionary<string, object?>
+        {
+            ["intent"] = "list resources"
+            // No command specified, should auto-enable learn
+        });
+
+        // Act
+        var result = await loader.CallToolHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(result.IsError);
+
+        var textContent = result.Content[0] as TextContentBlock;
+        Assert.NotNull(textContent);
+        Assert.Contains("available command", textContent.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithInvalidNamespace_ReturnsError()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var request = CreateCallToolRequest("nonexistent-namespace", new Dictionary<string, object?>
+        {
+            ["learn"] = true
+        });
+
+        // Act
+        var result = await loader.CallToolHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsError);
+
+        var textContent = result.Content[0] as TextContentBlock;
+        Assert.NotNull(textContent);
+        Assert.Contains("not found", textContent.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Available namespaces", textContent.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithNullToolName_ThrowsArgumentException()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var request = CreateCallToolRequest(null!, new Dictionary<string, object?>());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            await loader.CallToolHandler(request, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithoutCommandOrLearn_ReturnsHelpMessage()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var toolName = GetFirstAvailableNamespace();
+        var request = CreateCallToolRequest(toolName, new Dictionary<string, object?>());
+
+        // Act
+        var result = await loader.CallToolHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(result.IsError);
+
+        var textContent = result.Content[0] as TextContentBlock;
+        Assert.NotNull(textContent);
+        Assert.Contains("command", textContent.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("learn", textContent.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_ParsesHierarchicalStructure()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var toolName = GetFirstAvailableNamespace();
+
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["intent"] = JsonDocument.Parse("\"list resources\"").RootElement,
+            ["command"] = JsonDocument.Parse("\"list\"").RootElement,
+            ["parameters"] = JsonDocument.Parse("""{"subscription":"test-sub"}""").RootElement,
+            ["learn"] = JsonDocument.Parse("false").RootElement
+        };
+
+        var request = CreateCallToolRequestWithJsonElements(toolName, arguments);
+
+        // Act
+        var result = await loader.CallToolHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        // Result depends on whether command exists, but parsing should succeed
+    }
+
+    [Fact]
+    public async Task CallToolHandler_ConvertsObjectDictionaryToJsonElements()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var toolName = GetFirstAvailableNamespace();
+
+        var arguments = new Dictionary<string, object?>
+        {
+            ["intent"] = "list resources",
+            ["command"] = "list",
+            ["parameters"] = new Dictionary<string, object?> { ["subscription"] = "test-sub" },
+            ["learn"] = false
+        };
+
+        var request = CreateCallToolRequest(toolName, arguments);
+
+        // Act
+        var result = await loader.CallToolHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        // Conversion should succeed without throwing
+    }
+
+    [Fact]
+    public async Task CallToolHandler_HandlesCommandNotFoundGracefully()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var toolName = GetFirstAvailableNamespace();
+
+        var request = CreateCallToolRequest(toolName, new Dictionary<string, object?>
+        {
+            ["intent"] = "do something",
+            ["command"] = "nonexistent-command",
+            ["parameters"] = new Dictionary<string, object?>()
+        });
+
+        // Act
+        var result = await loader.CallToolHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        // Should fallback to learn mode or return error
+        var textContent = result.Content[0] as TextContentBlock;
+        Assert.NotNull(textContent);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_LazyLoadsCommandsPerNamespace()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+
+        // Get two different namespaces
+        var listRequest = CreateListToolsRequest();
+        var tools = await loader.ListToolsHandler(listRequest, CancellationToken.None);
+
+        if (tools.Tools.Count < 2)
+        {
+            // Skip test if not enough namespaces
+            return;
+        }
+
+        var namespace1 = tools.Tools[0].Name;
+        var namespace2 = tools.Tools[1].Name;
+
+        // Act - Access only first namespace
+        var request1 = CreateCallToolRequest(namespace1, new Dictionary<string, object?>
+        {
+            ["learn"] = true,
+            ["intent"] = "test"
+        });
+
+        await loader.CallToolHandler(request1, CancellationToken.None);
+
+        // Now access second namespace
+        var request2 = CreateCallToolRequest(namespace2, new Dictionary<string, object?>
+        {
+            ["learn"] = true,
+            ["intent"] = "test"
+        });
+
+        var result2 = await loader.CallToolHandler(request2, CancellationToken.None);
+
+        // Assert - Both should succeed, proving lazy loading works
+        Assert.NotNull(result2);
+        Assert.False(result2.IsError);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_ThreadSafeLazyLoading()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var toolName = GetFirstAvailableNamespace();
+
+        // Act - Simulate concurrent access
+        var tasks = Enumerable.Range(0, 10).Select(async _ =>
+        {
+            var request = CreateCallToolRequest(toolName, new Dictionary<string, object?>
+            {
+                ["learn"] = true,
+                ["intent"] = "concurrent test"
+            });
+
+            return await loader.CallToolHandler(request, CancellationToken.None);
+        });
+
+        var results = await Task.WhenAll(tasks);
+
+        // Assert - All should succeed without race conditions
+        Assert.All(results, result =>
+        {
+            Assert.NotNull(result);
+            Assert.False(result.IsError);
+        });
+
+        // All should return same cached content
+        var firstText = (results[0].Content[0] as TextContentBlock)?.Text;
+        Assert.All(results, result =>
+        {
+            var text = (result.Content[0] as TextContentBlock)?.Text;
+            Assert.Equal(firstText, text);
+        });
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ClearsCaches()
+    {
+        // Arrange
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var toolName = GetFirstAvailableNamespace();
+
+        // Populate cache
+        var request = CreateCallToolRequest(toolName, new Dictionary<string, object?>
+        {
+            ["learn"] = true,
+            ["intent"] = "test"
+        });
+
+        await loader.CallToolHandler(request, CancellationToken.None);
+
+        // Act
+        await loader.DisposeAsync();
+
+        // Assert - No exception should be thrown
+        // Cache clearing is internal, but disposal should complete successfully
+    }
+
+    // Helper methods
+
+    private string GetFirstAvailableNamespace()
+    {
+        var namespaces = _commandFactory.RootGroup.SubGroup
+            .Where(g => g.Name != "extension" && g.Name != "server" && g.Name != "tools")
+            .Select(g => g.Name)
+            .ToList();
+
+        return namespaces.FirstOrDefault() ?? "storage";
+    }
+
+    private static ModelContextProtocol.Server.RequestContext<ListToolsRequestParams> CreateListToolsRequest()
+    {
+        var mockServer = Substitute.For<ModelContextProtocol.Server.McpServer>();
+        return new ModelContextProtocol.Server.RequestContext<ListToolsRequestParams>(mockServer, new() { Method = RequestMethods.ToolsList })
+        {
+            Params = new ListToolsRequestParams()
+        };
+    }
+
+    private static ModelContextProtocol.Server.RequestContext<CallToolRequestParams> CreateCallToolRequest(
+        string toolName,
+        Dictionary<string, object?> arguments)
+    {
+        // Convert Dictionary<string, object?> to Dictionary<string, JsonElement>
+        var jsonArguments = new Dictionary<string, JsonElement>();
+        foreach (var kvp in arguments)
+        {
+            if (kvp.Value is bool b)
+            {
+                jsonArguments[kvp.Key] = JsonDocument.Parse(b.ToString().ToLower()).RootElement;
+            }
+            else if (kvp.Value is string s)
+            {
+                jsonArguments[kvp.Key] = JsonDocument.Parse($"\"{s}\"").RootElement;
+            }
+            else if (kvp.Value is Dictionary<string, object?> dict)
+            {
+                var json = JsonSerializer.Serialize(dict);
+                jsonArguments[kvp.Key] = JsonDocument.Parse(json).RootElement;
+            }
+            else if (kvp.Value == null)
+            {
+                jsonArguments[kvp.Key] = JsonDocument.Parse("null").RootElement;
+            }
+        }
+
+        var mockServer = Substitute.For<ModelContextProtocol.Server.McpServer>();
+        return new ModelContextProtocol.Server.RequestContext<CallToolRequestParams>(mockServer, new() { Method = RequestMethods.ToolsCall })
+        {
+            Params = new CallToolRequestParams
+            {
+                Name = toolName,
+                Arguments = jsonArguments
+            }
+        };
+    }
+
+    private static ModelContextProtocol.Server.RequestContext<CallToolRequestParams> CreateCallToolRequestWithJsonElements(
+        string toolName,
+        Dictionary<string, JsonElement> arguments)
+    {
+        var mockServer = Substitute.For<ModelContextProtocol.Server.McpServer>();
+        return new ModelContextProtocol.Server.RequestContext<CallToolRequestParams>(mockServer, new() { Method = RequestMethods.ToolsCall })
+        {
+            Params = new CallToolRequestParams
+            {
+                Name = toolName,
+                Arguments = arguments
+            }
+        };
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider?.Dispose();
+    }
+}

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
@@ -232,7 +232,6 @@ public sealed class NamespaceToolLoaderTests : IDisposable
         var textContent = result.Content[0] as TextContentBlock;
         Assert.NotNull(textContent);
         Assert.Contains("not found", textContent.Text, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Available namespaces", textContent.Text, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?

Today, when we start `azmcp` in default mode (which is equivalent to `--mode namespace` , the default mode for VS Code as well), the server creates a new `azmcp` process for every command group (child namespace name) and uses a stdio channel to invoke commands. 

Below is the output of all azmcp processes after I used the "Azure MCP Server" (via VS Code extension) in Copilot and tried a few tool calls. Each `azmcp` process uses approximately 80-140 MB of memory.

| Process ID | Memory   | Command |
|------------|----------|---------|
| 56044 | 157.9 MB | `server/azmcp server start --mode namespace` |
| 56326 | 137.1 MB | `server/azmcp server start --mode all --namespace subscription` |
| 56441 | 180.9 MB | `server/azmcp server start --mode all --namespace marketplace` |
| 56476 | 138.5 MB | `server/azmcp server start --mode all --namespace storage` |
| 56505 | 143.4 MB | `server/azmcp server start --mode all --namespace cosmos` |
| 56526 | 140.9 MB | `server/azmcp server start --mode all --namespace aks` |
| 56552 | 139.3 MB | `server/azmcp server start --mode all --namespace acr` |
| 56579 | 84.0 MB | `server/azmcp server start --mode all --namespace postgres` |
| 56631 | 138.4 MB | `server/azmcp server start --mode all --namespace group` |
| 56824 | 79.2 MB | `server/azmcp server start --mode all --namespace keyvault` |
| 56833 | 135.7 MB | `server/azmcp server start --mode all --namespace kusto` |
| 56838 | 80.7 MB | `server/azmcp server start --mode all --namespace appservice` |


This PR introduces direct in-process command execution via the new `NamespaceToolLoader`, eliminating all child `azmcp` process spawning in namespace mode. This new tool loader executes Azure namespace  commands directly in-process via `CommandFactory.GroupCommands()`

### Benefits

- **Memory reduction**: Eliminates 80-140 MB overhead per command group  (e.g., ~1+ GB savings for 10+ active namespaces)
- **Faster startup**: No child process spawn latency for namespace tools
- **Lower latency**: Direct in-process method calls replace cross-process stdio communication
- **Better scalability**: Memory usage no longer grows linearly with  active namespaces
- **Same client experience**: Maintains hierarchical tool structure and  learn mode behavior
- **Zero child processes**: Only single azmcp process runs

-------

**Follow-up work item, another pr**: Apply a similar concept to the less frequently used `--mode single`, which collapses everything under a single `azure` tool.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
