### PR TITLE
Update ValidateRequiredParameters references

### DIFF
--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureResourceService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureResourceService.cs
@@ -91,7 +91,7 @@ public abstract class BaseAzureResourceService(
         int limit = 50,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters(resourceType, subscription);
+        ValidateRequiredParameters((nameof(resourceType), resourceType), (nameof(subscription), subscription));
         ArgumentNullException.ThrowIfNull(converter);
 
         var results = new List<T>();
@@ -158,7 +158,7 @@ public abstract class BaseAzureResourceService(
         string? additionalFilter = null,
         CancellationToken cancellationToken = default) where T : class
     {
-        ValidateRequiredParameters(resourceType, subscription);
+        ValidateRequiredParameters((nameof(resourceType), resourceType), (nameof(subscription), subscription));
         ArgumentNullException.ThrowIfNull(converter);
 
         var subscriptionResource = await _subscriptionService.GetSubscription(subscription, null, retryPolicy);

--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
@@ -168,19 +168,6 @@ public abstract class BaseAzureService(ITenantService? tenantService = null, ILo
     }
 
     /// <summary>
-    /// Validates that the provided parameters are not null or empty
-    /// </summary>
-    /// <param name="parameters">Array of parameters to validate</param>
-    /// <exception cref="ArgumentException">Thrown when any parameter is null or empty</exception>
-    protected static void ValidateRequiredParameters(params string?[] parameters)
-    {
-        foreach (var param in parameters)
-        {
-            ArgumentException.ThrowIfNullOrEmpty(param);
-        }
-    }
-
-    /// <summary>
     /// Validates that the provided named parameters are not null or empty
     /// </summary>
     /// <param name="namedParameters">Array of tuples containing parameter names and values to validate</param>

--- a/core/Azure.Mcp.Core/src/Services/Azure/ResourceGroup/ResourceGroupService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/ResourceGroup/ResourceGroupService.cs
@@ -20,7 +20,7 @@ public class ResourceGroupService(ICacheService cacheService, ISubscriptionServi
 
     public async Task<List<ResourceGroupInfo>> GetResourceGroups(string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
         var subscriptionId = subscriptionResource.Data.SubscriptionId;
@@ -57,7 +57,7 @@ public class ResourceGroupService(ICacheService cacheService, ISubscriptionServi
 
     public async Task<ResourceGroupInfo?> GetResourceGroup(string subscription, string resourceGroupName, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, resourceGroupName);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceGroupName), resourceGroupName));
 
         var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
         var subscriptionId = subscriptionResource.Data.SubscriptionId;
@@ -91,7 +91,7 @@ public class ResourceGroupService(ICacheService cacheService, ISubscriptionServi
 
     public async Task<ResourceGroupResource?> GetResourceGroupResource(string subscription, string resourceGroupName, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, resourceGroupName);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceGroupName), resourceGroupName));
 
         try
         {

--- a/core/Azure.Mcp.Core/src/Services/Azure/Subscription/SubscriptionService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Subscription/SubscriptionService.cs
@@ -45,7 +45,7 @@ public class SubscriptionService(ICacheService cacheService, ITenantService tena
 
     public async Task<SubscriptionResource> GetSubscription(string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         // Get the subscription ID first, whether the input is a name or ID
         var subscriptionId = await GetSubscriptionId(subscription, tenant, retryPolicy);

--- a/tools/Azure.Mcp.Tools.Acr/src/Services/AcrService.cs
+++ b/tools/Azure.Mcp.Tools.Acr/src/Services/AcrService.cs
@@ -23,7 +23,7 @@ public sealed class AcrService(ISubscriptionService subscriptionService, ITenant
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         try
         {
@@ -111,7 +111,7 @@ public sealed class AcrService(ISubscriptionService subscriptionService, ITenant
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
         var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);

--- a/tools/Azure.Mcp.Tools.Aks/src/Services/AksService.cs
+++ b/tools/Azure.Mcp.Tools.Aks/src/Services/AksService.cs
@@ -31,7 +31,7 @@ public sealed class AksService(
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+    ValidateRequiredParameters((nameof(subscription), subscription));
 
         // Create cache key
         var cacheKey = string.IsNullOrEmpty(tenant)
@@ -76,7 +76,10 @@ public sealed class AksService(
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, clusterName, resourceGroup);
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(clusterName), clusterName),
+            (nameof(resourceGroup), resourceGroup));
 
         // Create cache key
         var cacheKey = string.IsNullOrEmpty(tenant)
@@ -131,7 +134,10 @@ public sealed class AksService(
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, resourceGroup, clusterName);
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(clusterName), clusterName));
 
         // Create cache key
         var cacheKey = string.IsNullOrEmpty(tenant)
@@ -194,7 +200,11 @@ public sealed class AksService(
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, resourceGroup, clusterName, nodePoolName);
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(clusterName), clusterName),
+            (nameof(nodePoolName), nodePoolName));
 
         // Create cache key
         var cacheKey = string.IsNullOrEmpty(tenant)

--- a/tools/Azure.Mcp.Tools.Aks/src/Services/AksService.cs
+++ b/tools/Azure.Mcp.Tools.Aks/src/Services/AksService.cs
@@ -31,7 +31,7 @@ public sealed class AksService(
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         // Create cache key
         var cacheKey = string.IsNullOrEmpty(tenant)

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
@@ -24,7 +24,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
 
     public async Task<List<AppConfigurationAccount>> GetAppConfigAccounts(string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+    ValidateRequiredParameters((nameof(subscription), subscription));
 
         try
         {
@@ -54,7 +54,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(accountName, subscription);
+    ValidateRequiredParameters((nameof(accountName), accountName), (nameof(subscription), subscription));
 
         var client = await GetConfigurationClient(accountName, subscription, tenant, retryPolicy);
         var settings = new List<KeyValueSetting>();
@@ -96,14 +96,14 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
 
     public async Task SetKeyValueLockState(string accountName, string key, bool locked, string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null, string? label = null)
     {
-        ValidateRequiredParameters(accountName, key, subscription);
+        ValidateRequiredParameters((nameof(accountName), accountName), (nameof(key), key), (nameof(subscription), subscription));
         var client = await GetConfigurationClient(accountName, subscription, tenant, retryPolicy);
         await client.SetReadOnlyAsync(key, label, locked, cancellationToken: default);
     }
 
     public async Task SetKeyValue(string accountName, string key, string value, string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null, string? label = null, string? contentType = null, string[]? tags = null)
     {
-        ValidateRequiredParameters(accountName, key, value, subscription);
+        ValidateRequiredParameters((nameof(accountName), accountName), (nameof(key), key), (nameof(value), value), (nameof(subscription), subscription));
         var client = await GetConfigurationClient(accountName, subscription, tenant, retryPolicy);
 
         // Create a ConfigurationSetting object to include contentType if provided
@@ -138,7 +138,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
     }
     public async Task DeleteKeyValue(string accountName, string key, string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null, string? label = null)
     {
-        ValidateRequiredParameters(accountName, key, subscription);
+    ValidateRequiredParameters((nameof(accountName), accountName), (nameof(key), key), (nameof(subscription), subscription));
         var client = await GetConfigurationClient(accountName, subscription, tenant, retryPolicy);
         await client.DeleteConfigurationSettingAsync(key, label, cancellationToken: default);
     }

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
@@ -24,7 +24,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
 
     public async Task<List<AppConfigurationAccount>> GetAppConfigAccounts(string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         try
         {
@@ -54,7 +54,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(accountName), accountName), (nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(accountName), accountName), (nameof(subscription), subscription));
 
         var client = await GetConfigurationClient(accountName, subscription, tenant, retryPolicy);
         var settings = new List<KeyValueSetting>();
@@ -138,7 +138,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
     }
     public async Task DeleteKeyValue(string accountName, string key, string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null, string? label = null)
     {
-    ValidateRequiredParameters((nameof(accountName), accountName), (nameof(key), key), (nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(accountName), accountName), (nameof(key), key), (nameof(subscription), subscription));
         var client = await GetConfigurationClient(accountName, subscription, tenant, retryPolicy);
         await client.DeleteConfigurationSettingAsync(key, label, cancellationToken: default);
     }

--- a/tools/Azure.Mcp.Tools.AppService/src/Services/AppServiceService.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Services/AppServiceService.cs
@@ -38,7 +38,14 @@ public class AppServiceService(
         try
         {
             // Validate inputs
-            ValidateRequiredParameters(appName, resourceGroup, databaseType, databaseServer, databaseName, subscription);
+            ValidateRequiredParameters(
+                (nameof(appName), appName),
+                (nameof(resourceGroup), resourceGroup),
+                (nameof(databaseType), databaseType),
+                (nameof(databaseServer), databaseServer),
+                (nameof(databaseName), databaseName),
+                (nameof(subscription), subscription)
+                );
 
             // Get Azure resources
             var webApp = await GetWebAppResourceAsync(subscription, resourceGroup, appName, tenant, retryPolicy);

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/ApplicationInsightsService.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/ApplicationInsightsService.cs
@@ -28,14 +28,14 @@ public class ApplicationInsightsService(
 
     public async Task<IEnumerable<JsonNode>> GetProfilerInsightsAsync(string subscription, string? resourceGroup = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+        ValidateRequiredParameters((nameof(subscription), subscription));
         IEnumerable<JsonNode> results = await GetProfilerInsightsImpAsync(subscription, resourceGroup, tenant, retryPolicy).ConfigureAwait(false);
         return results.Take(MaxRecommendations);
     }
 
     private async Task<IEnumerable<JsonNode>> GetProfilerInsightsImpAsync(string subscription, string? resourceGroup, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+        ValidateRequiredParameters((nameof(subscription), subscription));
         List<JsonNode> results = [];
 
         try

--- a/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Services/AzureManagedLustreService.cs
+++ b/tools/Azure.Mcp.Tools.AzureManagedLustre/src/Services/AzureManagedLustreService.cs
@@ -119,7 +119,7 @@ public sealed class AzureManagedLustreService(ISubscriptionService subscriptionS
         RetryPolicyOptions? retryPolicy = null
         )
     {
-        ValidateRequiredParameters(subscription);
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy) ?? throw new Exception($"Subscription '{subscription}' not found");
 
@@ -167,7 +167,7 @@ public sealed class AzureManagedLustreService(ISubscriptionService subscriptionS
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters([subscription, sku, subnetId, location]);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(sku), sku), (nameof(subnetId), subnetId), (nameof(location), location));
 
         var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy) ?? throw new Exception($"Subscription '{subscription}' not found");
         var content = new AmlFileSystemSubnetContent

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
@@ -31,7 +31,7 @@ public class CosmosService(ISubscriptionService subscriptionService, ITenantServ
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(subscription), subscription), (nameof(accountName), accountName));
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(accountName), accountName));
 
         var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
 

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
@@ -31,7 +31,7 @@ public class CosmosService(ISubscriptionService subscriptionService, ITenantServ
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, accountName);
+    ValidateRequiredParameters((nameof(subscription), subscription), (nameof(accountName), accountName));
 
         var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
 
@@ -115,7 +115,7 @@ public class CosmosService(ISubscriptionService subscriptionService, ITenantServ
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(accountName, subscription);
+        ValidateRequiredParameters((nameof(accountName), accountName), (nameof(subscription), subscription));
 
         var key = CosmosClientsCacheKeyPrefix + accountName;
         var cosmosClient = await _cacheService.GetAsync<CosmosClient>(CacheGroup, key, s_cacheDurationResources);
@@ -156,7 +156,7 @@ public class CosmosService(ISubscriptionService subscriptionService, ITenantServ
 
     public async Task<List<string>> GetCosmosAccounts(string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
         var accounts = new List<string>();
@@ -185,7 +185,7 @@ public class CosmosService(ISubscriptionService subscriptionService, ITenantServ
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(accountName, subscription);
+        ValidateRequiredParameters((nameof(accountName), accountName), (nameof(subscription), subscription));
 
         var cacheKey = CosmosDatabasesCacheKeyPrefix + accountName;
 
@@ -239,7 +239,7 @@ public class CosmosService(ISubscriptionService subscriptionService, ITenantServ
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(accountName, databaseName, subscription);
+        ValidateRequiredParameters((nameof(accountName), accountName), (nameof(databaseName), databaseName), (nameof(subscription), subscription));
 
         var cacheKey = CosmosContainersCacheKeyPrefix + accountName + "_" + databaseName;
 
@@ -296,7 +296,7 @@ public class CosmosService(ISubscriptionService subscriptionService, ITenantServ
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(accountName, databaseName, containerName, subscription);
+        ValidateRequiredParameters((nameof(accountName), accountName), (nameof(databaseName), databaseName), (nameof(containerName), containerName), (nameof(subscription), subscription));
 
         var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, retryPolicy);
 

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
@@ -88,7 +88,7 @@ public class EventHubsService(ISubscriptionService subscriptionService, ITenantS
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         try
         {

--- a/tools/Azure.Mcp.Tools.Foundry/src/Services/FoundryService.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/src/Services/FoundryService.cs
@@ -170,7 +170,7 @@ public class FoundryService(
 
     public async Task<List<Deployment>> ListDeployments(string endpoint, string? tenantId = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(endpoint);
+    ValidateRequiredParameters((nameof(endpoint), endpoint));
 
         try
         {
@@ -195,7 +195,13 @@ public class FoundryService(
         string azureAiServicesName, string resourceGroup, string subscriptionId, string? modelVersion = null, string? modelSource = null,
         string? skuName = null, int? skuCapacity = null, string? scaleType = null, int? scaleCapacity = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(deploymentName, modelName, modelFormat, azureAiServicesName, resourceGroup, subscriptionId);
+        ValidateRequiredParameters(
+            (nameof(deploymentName), deploymentName),
+            (nameof(modelName), modelName),
+            (nameof(modelFormat), modelFormat),
+            (nameof(azureAiServicesName), azureAiServicesName),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(subscriptionId), subscriptionId));
 
         try
         {
@@ -267,7 +273,7 @@ public class FoundryService(
 
     public async Task<List<KnowledgeIndexInformation>> ListKnowledgeIndexes(string endpoint, string? tenantId = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(endpoint);
+    ValidateRequiredParameters((nameof(endpoint), endpoint));
 
         try
         {
@@ -309,7 +315,9 @@ public class FoundryService(
 
     public async Task<KnowledgeIndexSchema> GetKnowledgeIndexSchema(string endpoint, string indexName, string? tenantId = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(endpoint, indexName);
+        ValidateRequiredParameters(
+            (nameof(endpoint), endpoint),
+            (nameof(indexName), indexName));
 
         try
         {
@@ -363,7 +371,12 @@ public class FoundryService(
         AuthMethod authMethod = AuthMethod.Credential,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(resourceName, deploymentName, promptText, subscription, resourceGroup);
+        ValidateRequiredParameters(
+            (nameof(resourceName), resourceName),
+            (nameof(deploymentName), deploymentName),
+            (nameof(promptText), promptText),
+            (nameof(subscription), subscription),
+            (nameof(resourceGroup), resourceGroup));
 
         var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup);
@@ -456,7 +469,7 @@ public class FoundryService(
 
     public async Task<List<PersistentAgent>> ListAgents(string endpoint, string? tenantId = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(endpoint);
+    ValidateRequiredParameters((nameof(endpoint), endpoint));
 
         try
         {
@@ -489,7 +502,10 @@ public class FoundryService(
     {
         try
         {
-            ValidateRequiredParameters(agentId, query, endpoint);
+            ValidateRequiredParameters(
+                (nameof(agentId), agentId),
+                (nameof(query), query),
+                (nameof(endpoint), endpoint));
 
             var credential = await GetCredential(tenantId);
             var agentsClient = new AIProjectClient(new Uri(endpoint), credential).GetPersistentAgentsClient();
@@ -572,7 +588,10 @@ public class FoundryService(
     {
         try
         {
-            ValidateRequiredParameters(agentId, query, endpoint);
+            ValidateRequiredParameters(
+                (nameof(agentId), agentId),
+                (nameof(query), query),
+                (nameof(endpoint), endpoint));
 
             var connectAgentResult = await ConnectAgent(agentId, query, endpoint, tenant, retryPolicy);
 
@@ -631,7 +650,10 @@ public class FoundryService(
 
     public async Task<AgentsEvaluateResult> EvaluateAgent(string evaluatorName, string query, string agentResponse, string azureOpenAIEndpoint, string azureOpenAIDeployment, string? toolDefinitions, string? tenantId = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(evaluatorName, query, agentResponse);
+        ValidateRequiredParameters(
+            (nameof(evaluatorName), evaluatorName),
+            (nameof(query), query),
+            (nameof(agentResponse), agentResponse));
         try
         {
             if (!AgentEvaluatorDictionary.ContainsKey(evaluatorName.ToLowerInvariant()))

--- a/tools/Azure.Mcp.Tools.Foundry/src/Services/FoundryService.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/src/Services/FoundryService.cs
@@ -170,7 +170,7 @@ public class FoundryService(
 
     public async Task<List<Deployment>> ListDeployments(string endpoint, string? tenantId = null, RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(endpoint), endpoint));
+        ValidateRequiredParameters((nameof(endpoint), endpoint));
 
         try
         {
@@ -273,7 +273,7 @@ public class FoundryService(
 
     public async Task<List<KnowledgeIndexInformation>> ListKnowledgeIndexes(string endpoint, string? tenantId = null, RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(endpoint), endpoint));
+        ValidateRequiredParameters((nameof(endpoint), endpoint));
 
         try
         {
@@ -469,7 +469,7 @@ public class FoundryService(
 
     public async Task<List<PersistentAgent>> ListAgents(string endpoint, string? tenantId = null, RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(endpoint), endpoint));
+        ValidateRequiredParameters((nameof(endpoint), endpoint));
 
         try
         {

--- a/tools/Azure.Mcp.Tools.FunctionApp/src/Services/FunctionAppService.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/src/Services/FunctionAppService.cs
@@ -28,7 +28,7 @@ public sealed class FunctionAppService(
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
         var functionApps = new List<FunctionAppInfo>();

--- a/tools/Azure.Mcp.Tools.FunctionApp/src/Services/FunctionAppService.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/src/Services/FunctionAppService.cs
@@ -28,7 +28,7 @@ public sealed class FunctionAppService(
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+    ValidateRequiredParameters((nameof(subscription), subscription));
 
         var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
         var functionApps = new List<FunctionAppInfo>();
@@ -69,7 +69,9 @@ public sealed class FunctionAppService(
         }
         else
         {
-            ValidateRequiredParameters(functionAppName, resourceGroup);
+            ValidateRequiredParameters(
+                (nameof(functionAppName), functionAppName),
+                (nameof(resourceGroup), resourceGroup));
 
             var cacheKey = string.IsNullOrEmpty(tenant)
                 ? $"{subscription}_{resourceGroup}_{functionAppName}"

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Services/KeyVaultService.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Services/KeyVaultService.cs
@@ -22,7 +22,7 @@ public sealed class KeyVaultService(ISubscriptionService subscriptionService, IT
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(vaultName, subscriptionId);
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId);
         var client = new KeyClient(new Uri($"https://{vaultName}.vault.azure.net"), credential);
@@ -50,7 +50,7 @@ public sealed class KeyVaultService(ISubscriptionService subscriptionService, IT
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(vaultName, keyName, subscriptionId);
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(keyName), keyName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId);
         var client = new KeyClient(new Uri($"https://{vaultName}.vault.azure.net"), credential);
@@ -73,7 +73,7 @@ public sealed class KeyVaultService(ISubscriptionService subscriptionService, IT
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(vaultName, keyName, keyType, subscriptionId);
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(keyName), keyName), (nameof(keyType), keyType), (nameof(subscriptionId), subscriptionId));
 
         var type = new KeyType(keyType);
         var credential = await GetCredential(tenantId);
@@ -95,7 +95,7 @@ public sealed class KeyVaultService(ISubscriptionService subscriptionService, IT
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(vaultName, subscriptionId);
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId);
         var client = new SecretClient(new Uri($"https://{vaultName}.vault.azure.net"), credential);
@@ -124,7 +124,7 @@ public sealed class KeyVaultService(ISubscriptionService subscriptionService, IT
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(vaultName, secretName, secretValue, subscriptionId);
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(secretName), secretName), (nameof(secretValue), secretValue), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId);
         var client = new SecretClient(new Uri($"https://{vaultName}.vault.azure.net"), credential);
@@ -146,7 +146,7 @@ public sealed class KeyVaultService(ISubscriptionService subscriptionService, IT
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(vaultName, secretName, subscriptionId);
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(secretName), secretName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId);
         var client = new SecretClient(new Uri($"https://{vaultName}.vault.azure.net"), credential);
@@ -168,7 +168,7 @@ public sealed class KeyVaultService(ISubscriptionService subscriptionService, IT
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(vaultName, subscriptionId);
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId);
         var client = new CertificateClient(new Uri($"https://{vaultName}.vault.azure.net"), credential);
@@ -196,7 +196,7 @@ public sealed class KeyVaultService(ISubscriptionService subscriptionService, IT
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(vaultName, certificateName, subscriptionId);
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(certificateName), certificateName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId);
         var client = new CertificateClient(new Uri($"https://{vaultName}.vault.azure.net"), credential);
@@ -218,7 +218,7 @@ public sealed class KeyVaultService(ISubscriptionService subscriptionService, IT
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(vaultName, certificateName, subscriptionId);
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(certificateName), certificateName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId);
         var client = new CertificateClient(new Uri($"https://{vaultName}.vault.azure.net"), credential);
@@ -242,7 +242,7 @@ public sealed class KeyVaultService(ISubscriptionService subscriptionService, IT
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(vaultName, certificateName, certificateData, subscriptionId);
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(certificateName), certificateName), (nameof(certificateData), certificateData), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId);
         var client = new CertificateClient(new Uri($"https://{vaultName}.vault.azure.net"), credential);
@@ -297,7 +297,7 @@ public sealed class KeyVaultService(ISubscriptionService subscriptionService, IT
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(vaultName, subscription);
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(subscription), subscription));
         var credential = await GetCredential(tenantId);
         var hsmUri = new Uri($"https://{vaultName}.managedhsm.azure.net");
         try

--- a/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoService.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoService.cs
@@ -115,7 +115,7 @@ public sealed class KustoService(
         AuthMethod? authMethod = AuthMethod.Credential,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(clusterUri);
+        ValidateRequiredParameters((nameof(clusterUri), clusterUri));
 
         var kustoClient = await GetOrCreateKustoClientAsync(clusterUri, tenant).ConfigureAwait(false);
         var kustoResult = await kustoClient.ExecuteControlCommandAsync(
@@ -149,7 +149,7 @@ public sealed class KustoService(
         AuthMethod? authMethod = AuthMethod.Credential,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(clusterUri, databaseName);
+        ValidateRequiredParameters((nameof(clusterUri), clusterUri), (nameof(databaseName), databaseName));
 
         var kustoClient = await GetOrCreateKustoClientAsync(clusterUri, tenant);
         var kustoResult = await kustoClient.ExecuteControlCommandAsync(
@@ -224,7 +224,10 @@ public sealed class KustoService(
         AuthMethod? authMethod = AuthMethod.Credential,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(clusterUri, databaseName, query);
+        ValidateRequiredParameters(
+            (nameof(clusterUri), clusterUri),
+            (nameof(databaseName), databaseName),
+            (nameof(query), query));
 
         var cslQueryProvider = await GetOrCreateCslQueryProviderAsync(clusterUri, tenant);
         var result = new List<JsonElement>();

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Services/LoadTestingService.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Services/LoadTestingService.cs
@@ -21,7 +21,7 @@ public class LoadTestingService(ISubscriptionService subscriptionService) : Base
     ISubscriptionService _subscriptionService = subscriptionService;
     public async Task<List<TestResource>> GetLoadTestResourcesAsync(string subscription, string? resourceGroup = null, string? testResourceName = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+    ValidateRequiredParameters((nameof(subscription), subscription));
         var subscriptionId = (await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy)).Data.SubscriptionId;
 
         var credential = await GetCredential(tenant);
@@ -75,7 +75,7 @@ public class LoadTestingService(ISubscriptionService subscriptionService) : Base
 
     public async Task<TestResource> CreateOrUpdateLoadTestingResourceAsync(string subscription, string resourceGroup, string? testResourceName = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, resourceGroup);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceGroup), resourceGroup));
         var subscriptionId = (await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy)).Data.SubscriptionId;
 
         var credential = await GetCredential(tenant);
@@ -105,7 +105,7 @@ public class LoadTestingService(ISubscriptionService subscriptionService) : Base
 
     public async Task<TestRun> GetLoadTestRunAsync(string subscription, string testResourceName, string testRunId, string? resourceGroup = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, testResourceName, testRunId);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(testResourceName), testResourceName), (nameof(testRunId), testRunId));
         var subscriptionId = (await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy)).Data.SubscriptionId;
 
         var loadTestResource = await GetLoadTestResourcesAsync(subscriptionId, resourceGroup, testResourceName, tenant, retryPolicy);
@@ -134,7 +134,7 @@ public class LoadTestingService(ISubscriptionService subscriptionService) : Base
 
     public async Task<List<TestRun>> GetLoadTestRunsFromTestIdAsync(string subscription, string testResourceName, string testId, string? resourceGroup = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, testResourceName, testId);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(testResourceName), testResourceName), (nameof(testId), testId));
         var subscriptionId = (await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy)).Data.SubscriptionId;
         var loadTestResource = await GetLoadTestResourcesAsync(subscriptionId, resourceGroup, testResourceName, tenant, retryPolicy);
         if (loadTestResource == null)
@@ -175,7 +175,7 @@ public class LoadTestingService(ISubscriptionService subscriptionService) : Base
 
     public async Task<TestRun> CreateOrUpdateLoadTestRunAsync(string subscription, string testResourceName, string testId, string? testRunId = null, string? oldTestRunId = null, string? resourceGroup = null, string? tenant = null, string? displayName = null, string? description = null, bool? debugMode = false, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, testResourceName, testRunId);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(testResourceName), testResourceName), (nameof(testRunId), testRunId));
         var subscriptionId = (await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy)).Data.SubscriptionId;
 
         var loadTestResource = await GetLoadTestResourcesAsync(subscriptionId, resourceGroup, testResourceName, tenant, retryPolicy);
@@ -213,7 +213,7 @@ public class LoadTestingService(ISubscriptionService subscriptionService) : Base
 
     public async Task<Test> GetTestAsync(string subscription, string testResourceName, string testId, string? resourceGroup = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, testResourceName, testId);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(testResourceName), testResourceName), (nameof(testId), testId));
         var subscriptionId = (await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy)).Data.SubscriptionId;
         var loadTestResource = await GetLoadTestResourcesAsync(subscriptionId, resourceGroup, testResourceName, tenant, retryPolicy);
         if (loadTestResource == null)
@@ -242,7 +242,7 @@ public class LoadTestingService(ISubscriptionService subscriptionService) : Base
         string? displayName = null, string? description = null,
         int? duration = 20, int? virtualUsers = 50, int? rampUpTime = 1, string? endpointUrl = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, testResourceName, testId);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(testResourceName), testResourceName), (nameof(testId), testId));
         var subscriptionId = (await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy)).Data.SubscriptionId;
 
         var loadTestResource = await GetLoadTestResourcesAsync(subscriptionId, resourceGroup, testResourceName, tenant, retryPolicy);

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Services/LoadTestingService.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Services/LoadTestingService.cs
@@ -21,7 +21,7 @@ public class LoadTestingService(ISubscriptionService subscriptionService) : Base
     ISubscriptionService _subscriptionService = subscriptionService;
     public async Task<List<TestResource>> GetLoadTestResourcesAsync(string subscription, string? resourceGroup = null, string? testResourceName = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(subscription), subscription));
         var subscriptionId = (await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy)).Data.SubscriptionId;
 
         var credential = await GetCredential(tenant);

--- a/tools/Azure.Mcp.Tools.Marketplace/src/Services/MarketplaceService.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/src/Services/MarketplaceService.cs
@@ -54,7 +54,9 @@ public class MarketplaceService(ITenantService tenantService)
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(productId, subscription);
+        ValidateRequiredParameters(
+            (nameof(productId), productId),
+            (nameof(subscription), subscription));
 
         string productUrl = BuildProductUrl(subscription, productId, includeStopSoldPlans, language, market,
             lookupOfferInTenantLevel, planId, skuId, includeServiceInstructionTemplates);
@@ -90,7 +92,7 @@ public class MarketplaceService(ITenantService tenantService)
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+    ValidateRequiredParameters((nameof(subscription), subscription));
 
         string productsUrl = BuildProductsListUrl(subscription, language, search, filter, orderBy, select, nextCursor, expand);
 
@@ -251,7 +253,7 @@ public class MarketplaceService(ITenantService tenantService)
         var pipeline = HttpPipelineBuilder.Build(clientOptions);
 
         string accessToken = await GetAccessTokenAsync(tenant);
-        ValidateRequiredParameters(accessToken);
+    ValidateRequiredParameters((nameof(accessToken), accessToken));
 
         var request = pipeline.CreateRequest();
         request.Method = RequestMethod.Get;

--- a/tools/Azure.Mcp.Tools.Marketplace/src/Services/MarketplaceService.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/src/Services/MarketplaceService.cs
@@ -92,7 +92,7 @@ public class MarketplaceService(ITenantService tenantService)
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         string productsUrl = BuildProductsListUrl(subscription, language, search, filter, orderBy, select, nextCursor, expand);
 
@@ -253,7 +253,7 @@ public class MarketplaceService(ITenantService tenantService)
         var pipeline = HttpPipelineBuilder.Build(clientOptions);
 
         string accessToken = await GetAccessTokenAsync(tenant);
-    ValidateRequiredParameters((nameof(accessToken), accessToken));
+        ValidateRequiredParameters((nameof(accessToken), accessToken));
 
         var request = pipeline.CreateRequest();
         request.Method = RequestMethod.Get;

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorHealthModelService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorHealthModelService.cs
@@ -46,7 +46,7 @@ public class MonitorHealthModelService(ITenantService tenantService, IHttpClient
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(entity, healthModelName, resourceGroupName, subscription);
+        ValidateRequiredParameters((nameof(entity), entity), (nameof(healthModelName), healthModelName), (nameof(resourceGroupName), resourceGroupName), (nameof(subscription), subscription));
 
         string dataplaneEndpoint = await GetDataplaneEndpointAsync(subscription, resourceGroupName, healthModelName);
         string entityHealthUrl = $"{dataplaneEndpoint}api/entities/{entity}/history";

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorMetricsService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorMetricsService.cs
@@ -34,7 +34,7 @@ public class MonitorMetricsService(IResourceResolverService resourceResolverServ
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, resourceName, metricNamespace);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceName), resourceName), (nameof(metricNamespace), metricNamespace));
         ArgumentNullException.ThrowIfNull(metricNames);
 
         var resourceId = await _resourceResolverService.ResolveResourceIdAsync(subscription, resourceGroup, resourceType, resourceName, tenant, retryPolicy);
@@ -211,7 +211,7 @@ public class MonitorMetricsService(IResourceResolverService resourceResolverServ
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, resourceName);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceName), resourceName));
 
         var resourceId = await _resourceResolverService.ResolveResourceIdAsync(subscription, resourceGroup, resourceType, resourceName, tenant, retryPolicy);
         var client = await _metricsQueryClientService.CreateClientAsync(tenant, retryPolicy);
@@ -278,7 +278,7 @@ public class MonitorMetricsService(IResourceResolverService resourceResolverServ
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, resourceName);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceName), resourceName));
 
         var resourceId = await _resourceResolverService.ResolveResourceIdAsync(subscription, resourceGroup, resourceType, resourceName, tenant, retryPolicy);
         var client = await _metricsQueryClientService.CreateClientAsync(tenant, retryPolicy);

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorService.cs
@@ -37,7 +37,7 @@ public class MonitorService : BaseAzureService, IMonitorService
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, resourceId, table);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceId), resourceId), (nameof(table), table));
         query = BuildQuery(query, table, limit);
 
         var credential = await GetCredential(tenant);
@@ -97,7 +97,7 @@ public class MonitorService : BaseAzureService, IMonitorService
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, workspace, query);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(workspace), workspace), (nameof(query), query));
 
         var credential = await GetCredential(tenant);
         var options = AddDefaultPolicies(new LogsQueryClientOptions());
@@ -157,7 +157,7 @@ public class MonitorService : BaseAzureService, IMonitorService
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, resourceGroup, workspace);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceGroup), resourceGroup), (nameof(workspace), workspace));
 
         try
         {
@@ -196,7 +196,7 @@ public class MonitorService : BaseAzureService, IMonitorService
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         try
         {
@@ -229,11 +229,11 @@ public class MonitorService : BaseAzureService, IMonitorService
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, workspace, table);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(workspace), workspace), (nameof(table), table));
 
         var (workspaceId, _) = await GetWorkspaceInfo(workspace, subscription, tenant, retryPolicy);
         query = BuildQuery(query, table, limit);
-        ValidateRequiredParameters(query);
+        ValidateRequiredParameters((nameof(query), query));
 
         try
         {
@@ -319,7 +319,7 @@ public class MonitorService : BaseAzureService, IMonitorService
         string? tenant,
         RetryPolicyOptions? retryPolicy)
     {
-        ValidateRequiredParameters(subscription, resourceGroup, workspace);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceGroup), resourceGroup), (nameof(workspace), workspace));
         try
         {
             var (_, resolvedWorkspaceName) = await GetWorkspaceInfo(workspace, subscription, tenant, retryPolicy);

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/ResourceResolverService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/ResourceResolverService.cs
@@ -22,7 +22,7 @@ public class ResourceResolverService(ISubscriptionService subscriptionService, I
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription, resourceName);
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceName), resourceName));
 
         if (ResourceIdentifier.TryParse(resourceName, out ResourceIdentifier? result))
         {

--- a/tools/Azure.Mcp.Tools.Redis/src/Services/RedisService.cs
+++ b/tools/Azure.Mcp.Tools.Redis/src/Services/RedisService.cs
@@ -24,7 +24,7 @@ public class RedisService(ISubscriptionService _subscriptionService, IResourceGr
         AuthMethod? authMethod = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+    ValidateRequiredParameters((nameof(subscription), subscription));
 
         try
         {
@@ -122,7 +122,10 @@ public class RedisService(ISubscriptionService _subscriptionService, IResourceGr
         AuthMethod? authMethod = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(cacheName, resourceGroupName, subscription);
+        ValidateRequiredParameters(
+            (nameof(cacheName), cacheName),
+            (nameof(resourceGroupName), resourceGroupName),
+            (nameof(subscription), subscription));
 
         try
         {
@@ -162,7 +165,7 @@ public class RedisService(ISubscriptionService _subscriptionService, IResourceGr
         AuthMethod? authMethod = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+    ValidateRequiredParameters((nameof(subscription), subscription));
 
         try
         {
@@ -229,7 +232,10 @@ public class RedisService(ISubscriptionService _subscriptionService, IResourceGr
         AuthMethod? authMethod = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(clusterName, resourceGroupName, subscription);
+        ValidateRequiredParameters(
+            (nameof(clusterName), clusterName),
+            (nameof(resourceGroupName), resourceGroupName),
+            (nameof(subscription), subscription));
 
         try
         {

--- a/tools/Azure.Mcp.Tools.Redis/src/Services/RedisService.cs
+++ b/tools/Azure.Mcp.Tools.Redis/src/Services/RedisService.cs
@@ -24,7 +24,7 @@ public class RedisService(ISubscriptionService _subscriptionService, IResourceGr
         AuthMethod? authMethod = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         try
         {
@@ -165,7 +165,7 @@ public class RedisService(ISubscriptionService _subscriptionService, IResourceGr
         AuthMethod? authMethod = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         try
         {

--- a/tools/Azure.Mcp.Tools.ResourceHealth/src/Services/ResourceHealthService.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/src/Services/ResourceHealthService.cs
@@ -26,7 +26,7 @@ public class ResourceHealthService(ISubscriptionService subscriptionService, ITe
         string resourceId,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(resourceId);
+    ValidateRequiredParameters((nameof(resourceId), resourceId));
 
         try
         {
@@ -69,7 +69,7 @@ public class ResourceHealthService(ISubscriptionService subscriptionService, ITe
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+    ValidateRequiredParameters((nameof(subscription), subscription));
 
         try
         {
@@ -122,7 +122,7 @@ public class ResourceHealthService(ISubscriptionService subscriptionService, ITe
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+    ValidateRequiredParameters((nameof(subscription), subscription));
 
         try
         {

--- a/tools/Azure.Mcp.Tools.ResourceHealth/src/Services/ResourceHealthService.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/src/Services/ResourceHealthService.cs
@@ -26,7 +26,7 @@ public class ResourceHealthService(ISubscriptionService subscriptionService, ITe
         string resourceId,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(resourceId), resourceId));
+        ValidateRequiredParameters((nameof(resourceId), resourceId));
 
         try
         {
@@ -69,7 +69,7 @@ public class ResourceHealthService(ISubscriptionService subscriptionService, ITe
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         try
         {
@@ -122,7 +122,7 @@ public class ResourceHealthService(ISubscriptionService subscriptionService, ITe
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         try
         {

--- a/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
@@ -29,7 +29,7 @@ public sealed class SearchService(ISubscriptionService subscriptionService, ICac
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         var cacheKey = string.IsNullOrEmpty(tenantId)
             ? $"{SearchServicesCacheKey}_{subscription}"
@@ -68,7 +68,7 @@ public sealed class SearchService(ISubscriptionService subscriptionService, ICac
         string? indexName,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(serviceName), serviceName));
+        ValidateRequiredParameters((nameof(serviceName), serviceName));
 
         var indexes = new List<IndexInfo>();
 

--- a/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
@@ -29,7 +29,7 @@ public sealed class SearchService(ISubscriptionService subscriptionService, ICac
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(subscription);
+    ValidateRequiredParameters((nameof(subscription), subscription));
 
         var cacheKey = string.IsNullOrEmpty(tenantId)
             ? $"{SearchServicesCacheKey}_{subscription}"
@@ -68,7 +68,7 @@ public sealed class SearchService(ISubscriptionService subscriptionService, ICac
         string? indexName,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(serviceName);
+    ValidateRequiredParameters((nameof(serviceName), serviceName));
 
         var indexes = new List<IndexInfo>();
 
@@ -112,7 +112,10 @@ public sealed class SearchService(ISubscriptionService subscriptionService, ICac
         string searchText,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(serviceName, indexName, searchText);
+        ValidateRequiredParameters(
+            (nameof(serviceName), serviceName),
+            (nameof(indexName), indexName),
+            (nameof(searchText), searchText));
 
         try
         {

--- a/tools/Azure.Mcp.Tools.Speech/src/Services/SpeechService.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Services/SpeechService.cs
@@ -37,7 +37,7 @@ public class SpeechService(ITenantService tenantService, ILogger<SpeechService> 
         string? profanity = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(endpoint, filePath);
+    ValidateRequiredParameters((nameof(endpoint), endpoint), (nameof(filePath), filePath));
 
         if (!File.Exists(filePath))
         {

--- a/tools/Azure.Mcp.Tools.Speech/src/Services/SpeechService.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Services/SpeechService.cs
@@ -37,7 +37,7 @@ public class SpeechService(ITenantService tenantService, ILogger<SpeechService> 
         string? profanity = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(endpoint), endpoint), (nameof(filePath), filePath));
+        ValidateRequiredParameters((nameof(endpoint), endpoint), (nameof(filePath), filePath));
 
         if (!File.Exists(filePath))
         {

--- a/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
@@ -101,7 +101,7 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters(serverName, resourceGroup, subscription, databaseName);
+        ValidateRequiredParameters((nameof(serverName), serverName), (nameof(resourceGroup), resourceGroup), (nameof(subscription), subscription), (nameof(databaseName), databaseName));
 
         try
         {
@@ -215,7 +215,7 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters(serverName, resourceGroup, subscription, databaseName);
+        ValidateRequiredParameters((nameof(serverName), serverName), (nameof(resourceGroup), resourceGroup), (nameof(subscription), subscription), (nameof(databaseName), databaseName));
 
         try
         {
@@ -311,7 +311,7 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters(serverName, databaseName, resourceGroup, subscription);
+        ValidateRequiredParameters((nameof(serverName), serverName), (nameof(databaseName), databaseName), (nameof(resourceGroup), resourceGroup), (nameof(subscription), subscription));
         if (string.IsNullOrWhiteSpace(newDatabaseName))
             throw new ArgumentException("New database name cannot be null or empty.", nameof(newDatabaseName));
         try
@@ -524,7 +524,7 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters(serverName, resourceGroup, subscription, firewallRuleName, startIpAddress, endIpAddress);
+        ValidateRequiredParameters((nameof(serverName), serverName), (nameof(resourceGroup), resourceGroup), (nameof(subscription), subscription), (nameof(firewallRuleName), firewallRuleName), (nameof(startIpAddress), startIpAddress), (nameof(endIpAddress), endIpAddress));
 
         try
         {
@@ -584,7 +584,7 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters(serverName, resourceGroup, subscription, firewallRuleName);
+        ValidateRequiredParameters((nameof(serverName), serverName), (nameof(resourceGroup), resourceGroup), (nameof(subscription), subscription), (nameof(firewallRuleName), firewallRuleName));
 
         try
         {
@@ -649,7 +649,7 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters(serverName, resourceGroup, subscription, location, administratorLogin, administratorPassword);
+        ValidateRequiredParameters((nameof(serverName), serverName), (nameof(resourceGroup), resourceGroup), (nameof(subscription), subscription), (nameof(location), location), (nameof(administratorLogin), administratorLogin), (nameof(administratorPassword), administratorPassword));
 
         try
         {
@@ -723,7 +723,7 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters(serverName, resourceGroup, subscription);
+        ValidateRequiredParameters((nameof(serverName), serverName), (nameof(resourceGroup), resourceGroup), (nameof(subscription), subscription));
 
         try
         {
@@ -777,7 +777,7 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters(resourceGroup, subscription);
+        ValidateRequiredParameters((nameof(resourceGroup), resourceGroup), (nameof(subscription), subscription));
 
         try
         {
@@ -823,7 +823,7 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters(serverName, resourceGroup, subscription);
+        ValidateRequiredParameters((nameof(serverName), serverName), (nameof(resourceGroup), resourceGroup), (nameof(subscription), subscription));
 
         try
         {
@@ -875,7 +875,7 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters(serverName, databaseName, resourceGroup, subscription);
+        ValidateRequiredParameters((nameof(serverName), serverName), (nameof(databaseName), databaseName), (nameof(resourceGroup), resourceGroup), (nameof(subscription), subscription));
 
         try
         {

--- a/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
@@ -40,7 +40,7 @@ public class StorageService(
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters(subscription);
+    ValidateRequiredParameters((nameof(subscription), subscription));
 
         var accounts = new List<StorageAccountInfo>();
 
@@ -102,7 +102,11 @@ public class StorageService(
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(account, resourceGroup, location, subscription);
+        ValidateRequiredParameters(
+            (nameof(account), account),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(location), location),
+            (nameof(subscription), subscription));
 
         try
         {
@@ -176,7 +180,10 @@ public class StorageService(
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(account, container, subscription);
+        ValidateRequiredParameters(
+            (nameof(account), account),
+            (nameof(container), container),
+            (nameof(subscription), subscription));
 
         var blobServiceClient = await CreateBlobServiceClient(account, tenant, retryPolicy);
         var containerClient = blobServiceClient.GetBlobContainerClient(container);
@@ -262,7 +269,7 @@ public class StorageService(
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(account, subscription);
+    ValidateRequiredParameters((nameof(account), account), (nameof(subscription), subscription));
 
         var blobServiceClient = await CreateBlobServiceClient(account, tenant, retryPolicy);
         var containers = new List<ContainerInfo>();
@@ -334,7 +341,10 @@ public class StorageService(
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(account, container, subscription);
+        ValidateRequiredParameters(
+            (nameof(account), account),
+            (nameof(container), container),
+            (nameof(subscription), subscription));
 
         var blobServiceClient = await CreateBlobServiceClient(account, tenant, retryPolicy);
         var containerClient = blobServiceClient.GetBlobContainerClient(container);
@@ -418,7 +428,12 @@ public class StorageService(
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-        ValidateRequiredParameters(account, container, blob, localFilePath, subscription);
+        ValidateRequiredParameters(
+            (nameof(account), account),
+            (nameof(container), container),
+            (nameof(blob), blob),
+            (nameof(localFilePath), localFilePath),
+            (nameof(subscription), subscription));
 
         if (!File.Exists(localFilePath))
         {

--- a/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
@@ -40,7 +40,7 @@ public class StorageService(
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-    ValidateRequiredParameters((nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         var accounts = new List<StorageAccountInfo>();
 
@@ -269,7 +269,7 @@ public class StorageService(
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
-    ValidateRequiredParameters((nameof(account), account), (nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(account), account), (nameof(subscription), subscription));
 
         var blobServiceClient = await CreateBlobServiceClient(account, tenant, retryPolicy);
         var containers = new List<ContainerInfo>();

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Services/WorkbooksService.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Services/WorkbooksService.cs
@@ -23,7 +23,7 @@ public class WorkbooksService(ISubscriptionService _subscriptionService, ITenant
 
     public async Task<List<WorkbookInfo>> ListWorkbooks(string subscription, string resourceGroupName, WorkbookFilters? filters = null, RetryPolicyOptions? retryPolicy = null, string? tenant = null)
     {
-        ValidateRequiredParameters(subscription, resourceGroupName);
+    ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceGroupName), resourceGroupName));
 
         try
         {
@@ -206,7 +206,12 @@ public class WorkbooksService(ISubscriptionService _subscriptionService, ITenant
 
     public async Task<WorkbookInfo?> CreateWorkbook(string subscription, string resourceGroupName, string displayName, string serializedData, string sourceId, RetryPolicyOptions? retryPolicy = null, string? tenant = null)
     {
-        ValidateRequiredParameters(subscription, resourceGroupName, displayName, serializedData, sourceId);
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(resourceGroupName), resourceGroupName),
+            (nameof(displayName), displayName),
+            (nameof(serializedData), serializedData),
+            (nameof(sourceId), sourceId));
 
         try
         {
@@ -264,7 +269,7 @@ public class WorkbooksService(ISubscriptionService _subscriptionService, ITenant
 
     public async Task<bool> DeleteWorkbook(string workbookId, RetryPolicyOptions? retryPolicy = null, string? tenant = null)
     {
-        ValidateRequiredParameters(workbookId);
+    ValidateRequiredParameters((nameof(workbookId), workbookId));
 
         try
         {

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Services/WorkbooksService.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Services/WorkbooksService.cs
@@ -23,7 +23,7 @@ public class WorkbooksService(ISubscriptionService _subscriptionService, ITenant
 
     public async Task<List<WorkbookInfo>> ListWorkbooks(string subscription, string resourceGroupName, WorkbookFilters? filters = null, RetryPolicyOptions? retryPolicy = null, string? tenant = null)
     {
-    ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceGroupName), resourceGroupName));
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceGroupName), resourceGroupName));
 
         try
         {
@@ -269,7 +269,7 @@ public class WorkbooksService(ISubscriptionService _subscriptionService, ITenant
 
     public async Task<bool> DeleteWorkbook(string workbookId, RetryPolicyOptions? retryPolicy = null, string? tenant = null)
     {
-    ValidateRequiredParameters((nameof(workbookId), workbookId));
+        ValidateRequiredParameters((nameof(workbookId), workbookId));
 
         try
         {


### PR DESCRIPTION
## What does this PR do?
This PR updates all the `ValidateRequiredParameters` references to the new method signature introduced in https://github.com/microsoft/mcp/pull/575, which throws a better error message.

It also removes the old implementation: `ValidateRequiredParameters(params string?[] parameters)`

## GitHub issue number?
Fixes https://github.com/microsoft/mcp/issues/585

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
