### PR TITLE
Update ExecuteSingleResourceQueryAsync references to include parameter names

### DIFF
--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -26,7 +26,7 @@ The Azure MCP Server updates automatically by default whenever a new release com
 - Added validation for the Cosmos query command `azmcp_cosmos_database_container_item_query`.[[#524](https://github.com/microsoft/mcp/pull/524)]
 - Fixed the construction of Azure Resource Graph queries for App Configuration in the `FindAppConfigStore` method. The name filter is now correctly passed via the `additionalFilter` parameter instead of `tableName`, resolving "ExactlyOneStartingOperatorRequired" and "BadRequest" errors when setting key-value pairs. [[#670](https://github.com/microsoft/mcp/pull/670)]
 - Updated the description of the Monitor tool and corrected the prompt for command `monitor_healthmodels_entity_gethealth` to ensure that the LLM picks up the correct tool. [[#630](https://github.com/microsoft/mcp/pull/630)]
-- Fixed BadRequest error in Azure Containter Registry to get a registry, and in EventHubs to get a namespace. [[#729](https://github.com/microsoft/mcp/pull/729)]
+- Fixed BadRequest error in Azure Container Registry to get a registry, and in EventHubs to get a namespace. [[#729](https://github.com/microsoft/mcp/pull/729)]
 
 ### Other Changes
 

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -26,7 +26,7 @@ The Azure MCP Server updates automatically by default whenever a new release com
 - Added validation for the Cosmos query command `azmcp_cosmos_database_container_item_query`.[[#524](https://github.com/microsoft/mcp/pull/524)]
 - Fixed the construction of Azure Resource Graph queries for App Configuration in the `FindAppConfigStore` method. The name filter is now correctly passed via the `additionalFilter` parameter instead of `tableName`, resolving "ExactlyOneStartingOperatorRequired" and "BadRequest" errors when setting key-value pairs. [[#670](https://github.com/microsoft/mcp/pull/670)]
 - Updated the description of the Monitor tool and corrected the prompt for command `monitor_healthmodels_entity_gethealth` to ensure that the LLM picks up the correct tool. [[#630](https://github.com/microsoft/mcp/pull/630)]
-- Fixed BadRequest error in Azure Containter Registry to get a registry, and in EventHubs to get a namespace.
+- Fixed BadRequest error in Azure Containter Registry to get a registry, and in EventHubs to get a namespace. [[#729](https://github.com/microsoft/mcp/pull/729)]
 
 ### Other Changes
 

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -25,7 +25,8 @@ The Azure MCP Server updates automatically by default whenever a new release com
 - Improved error message for macOS users when interactive browser authentication fails due to broker threading requirements. The error now provides clear guidance to use Azure CLI, Azure PowerShell, or Azure Developer CLI for authentication instead.[[#684](https://github.com/microsoft/mcp/pull/684)]
 - Added validation for the Cosmos query command `azmcp_cosmos_database_container_item_query`.[[#524](https://github.com/microsoft/mcp/pull/524)]
 - Fixed the construction of Azure Resource Graph queries for App Configuration in the `FindAppConfigStore` method. The name filter is now correctly passed via the `additionalFilter` parameter instead of `tableName`, resolving "ExactlyOneStartingOperatorRequired" and "BadRequest" errors when setting key-value pairs. [[#670](https://github.com/microsoft/mcp/pull/670)]
-- Updated the description of the Monitor tool and corrected the prompt for command `monitor_healthmodels_entity_gethealth` to ensure that the LLM picks up the correct tool. [[#630](https://github.com/microsoft/mcp/pull/630)]  
+- Updated the description of the Monitor tool and corrected the prompt for command `monitor_healthmodels_entity_gethealth` to ensure that the LLM picks up the correct tool. [[#630](https://github.com/microsoft/mcp/pull/630)]
+- Fixed BadRequest error in Azure Containter Registry to get a registry, and in EventHubs to get a namespace.
 
 ### Other Changes
 

--- a/tools/Azure.Mcp.Tools.Acr/src/Services/AcrService.cs
+++ b/tools/Azure.Mcp.Tools.Acr/src/Services/AcrService.cs
@@ -61,7 +61,7 @@ public sealed class AcrService(ISubscriptionService subscriptionService, ITenant
                         subscription,
                         retryPolicy,
                         ConvertToAcrRegistryInfoModel,
-                        $"name =~ '{EscapeKqlString(registry)}'");
+                        additionalFilter: $"name =~ '{EscapeKqlString(registry)}'");
             if (registrie == null)
             {
                 throw new KeyNotFoundException($"Container registry '{registry}' not found for subscription '{subscription}'.");

--- a/tools/Azure.Mcp.Tools.Acr/src/Services/AcrService.cs
+++ b/tools/Azure.Mcp.Tools.Acr/src/Services/AcrService.cs
@@ -57,10 +57,10 @@ public sealed class AcrService(ISubscriptionService subscriptionService, ITenant
         {
             var registrie = await ExecuteSingleResourceQueryAsync(
                         "Microsoft.ContainerRegistry/registries",
-                        resourceGroup,
-                        subscription,
-                        retryPolicy,
-                        ConvertToAcrRegistryInfoModel,
+                        resourceGroup: resourceGroup,
+                        subscription: subscription,
+                        retryPolicy: retryPolicy,
+                        converter: ConvertToAcrRegistryInfoModel,
                         additionalFilter: $"name =~ '{EscapeKqlString(registry)}'");
             if (registrie == null)
             {

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
@@ -165,9 +165,9 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
             var account = await ExecuteSingleResourceQueryAsync(
                         "Microsoft.AppConfiguration/configurationStores",
                         resourceGroup: null, // all resource groups
-                        subscription,
-                        retryPolicy,
-                        ConvertToAppConfigurationAccountModel,
+                        subscription: subscription,
+                        retryPolicy: retryPolicy,
+                        converter: ConvertToAppConfigurationAccountModel,
                         additionalFilter: $"name =~ '{EscapeKqlString(accountName)}'");
 
             if (account == null)

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
@@ -94,10 +94,10 @@ public class EventHubsService(ISubscriptionService subscriptionService, ITenantS
         {
             var namespaceDetails = await ExecuteSingleResourceQueryAsync(
                             "Microsoft.EventHub/namespaces",
-                            resourceGroup,
-                            subscription,
-                            retryPolicy,
-                            ConvertToNamespace,
+                            resourceGroup: resourceGroup,
+                            subscription: subscription,
+                            retryPolicy: retryPolicy,
+                            converter: ConvertToNamespace,
                             additionalFilter: $"name =~ '{EscapeKqlString(namespaceName)}'");
 
             if (namespaceDetails == null)

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
@@ -98,7 +98,7 @@ public class EventHubsService(ISubscriptionService subscriptionService, ITenantS
                             subscription,
                             retryPolicy,
                             ConvertToNamespace,
-                            $"name =~ '{EscapeKqlString(namespaceName)}'");
+                            additionalFilter: $"name =~ '{EscapeKqlString(namespaceName)}'");
 
             if (namespaceDetails == null)
             {

--- a/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoService.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoService.cs
@@ -73,9 +73,9 @@ public sealed class KustoService(
             var cluster = await ExecuteSingleResourceQueryAsync(
                         "Microsoft.Kusto/clusters",
                         resourceGroup: null, // all resource groups
-                        subscriptionId,
-                        retryPolicy,
-                        ConvertToClusterModel,
+                        subscription: subscriptionId,
+                        retryPolicy: retryPolicy,
+                        converter: ConvertToClusterModel,
                         additionalFilter: $"name =~ '{EscapeKqlString(clusterName)}'");
 
             if (cluster == null)

--- a/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
@@ -43,10 +43,10 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         {
             var result = await ExecuteSingleResourceQueryAsync(
                 "Microsoft.Sql/servers/databases",
-                resourceGroup,
-                subscription,
-                retryPolicy,
-                ConvertToSqlDatabaseModel,
+                resourceGroup: resourceGroup,
+                subscription: subscription,
+                retryPolicy: retryPolicy,
+                converter: ConvertToSqlDatabaseModel,
                 additionalFilter: $"name =~ '{EscapeKqlString(databaseName)}'",
                 cancellationToken: cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
@@ -69,10 +69,10 @@ public class StorageService(
             {
                 var storageAccount = await ExecuteSingleResourceQueryAsync(
                     "Microsoft.Storage/storageAccounts",
-                    null,
-                    subscription,
-                    retryPolicy,
-                    ConvertToAccountInfoModel,
+                    resourceGroup: null,
+                    subscription: subscription,
+                    retryPolicy: retryPolicy,
+                    converter: ConvertToAccountInfoModel,
                     additionalFilter: $"name =~ '{EscapeKqlString(account)}'");
 
                 if (storageAccount == null)


### PR DESCRIPTION
## What does this PR do?
This PR fixes a problem for EventHubs and ACR where the `additionalFilter` value was being passed as `tableName` after this last parameter was introduced in [PR #607](https://github.com/microsoft/mcp/pull/607/files#diff-90873735813f341180ede934ed060e63a185c05391f34dfe13efc4f38ffc4dacR89).

I explicitly specified all parameter names as well, to prevent these references from breaking in the future if new parameters are added.

## GitHub issue number?
Fixes https://github.com/microsoft/mcp/issues/727

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
