### PR TITLE
Update copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,3 +22,9 @@
 - Include tests that cover your changes
 - Update CHANGELOG.md with your changes
 - Run `.\eng\common\spelling\Invoke-Cspell.ps1`
+- Create the auto-generated PR body as normal, but `copilot` should add an additional section after all of its regular PR body content. The contents should be:
+  ```
+  ## Invoking Livetests
+
+  Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
+  ```


### PR DESCRIPTION
To leave a reminder about invoking livetests. Related to #697

[This what a PR with these copilot added instructions renders to](https://github.com/scbedd/check-actions/pull/10) with this copilot-instructions added.