### PR TITLE
Improve Azure Managed Lustre testing

### DIFF
--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/ManagedLustreSetup.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/ManagedLustreSetup.cs
@@ -28,7 +28,7 @@ public class ManagedLustreSetup : IAreaSetup
     public CommandGroup RegisterCommands(IServiceProvider serviceProvider)
     {
         var managedLustre = new CommandGroup(Name,
-            "Azure Managed Lustre operations - Commands for creating, updating, listing and inspecting Azure Managed Lustre file systems (AMLFS) used for high-performance computing workloads. The tool focuses on managing all the aspects related to managed Lustre filesystem instances.");
+            "Azure Managed Lustre operations - Commands for creating, updating, listing and inspecting Azure Managed Lustre file systems (AMLFS) used for high-performance computing workloads. The tool focuses on managing all the aspects related to Azure Managed Lustre file system instances.");
 
         var fileSystem = new CommandGroup("filesystem", "Azure Managed Lustre file system operations - Commands for listing managed Lustre file systems.");
         managedLustre.AddSubGroup(fileSystem);

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Models/LustreFileSystem.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Models/LustreFileSystem.cs
@@ -16,7 +16,13 @@ public sealed record LustreFileSystem(
     [property: JsonPropertyName("mgsAddress")] string? MgsAddress,
     [property: JsonPropertyName("skuTier")] string? SkuTier,
     [property: JsonPropertyName("storageCapacityTiB")] long? StorageCapacityTiB,
-    [property: JsonPropertyName("blobContainerId")] string? BlobContainerId,
     [property: JsonPropertyName("maintenanceDay")] string? MaintenanceDay,
-    [property: JsonPropertyName("maintenanceTime")] string? MaintenanceTime
+    [property: JsonPropertyName("maintenanceTime")] string? MaintenanceTime,
+    [property: JsonPropertyName("subnetId")] string? SubnetId,
+    [property: JsonPropertyName("hsmDataContainer")] string? HsmDataContainer,
+    [property: JsonPropertyName("hsmLogContainer")] string? HsmLogContainer,
+    [property: JsonPropertyName("rootSquashMode")] string? RootSquashMode,
+    [property: JsonPropertyName("noSquashNidList")] string? NoSquashNidList,
+    [property: JsonPropertyName("squashUid")] long? SquashUid,
+    [property: JsonPropertyName("squashGid")] long? SquashGid
 );

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/ManagedLustreService.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/ManagedLustreService.cs
@@ -70,9 +70,15 @@ public sealed class ManagedLustreService(ISubscriptionService subscriptionServic
             data.ClientInfo?.MgsAddress,
             data.SkuName,
             data.StorageCapacityTiB.HasValue ? Convert.ToInt64(Math.Round(data.StorageCapacityTiB.Value)) : null,
-            data.Hsm?.Settings?.Container,
             data.MaintenanceWindow?.DayOfWeek?.ToString(),
-            data.MaintenanceWindow?.TimeOfDayUTC?.ToString()
+            data.MaintenanceWindow?.TimeOfDayUTC?.ToString(),
+            data.FilesystemSubnet,
+            data.Hsm?.Settings?.Container,
+            data.Hsm?.Settings?.LoggingContainer,
+            data.RootSquashSettings?.Mode?.ToString(),
+            data.RootSquashSettings?.NoSquashNidLists,
+            data.RootSquashSettings?.SquashUID,
+            data.RootSquashSettings?.SquashGID
         );
     }
 

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/FileSystemCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/FileSystemCreateCommandTests.cs
@@ -264,7 +264,7 @@ public class FileSystemCreateCommandTests
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<long?>(), Arg.Any<long?>(),
             Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>()).ThrowsAsync(new Exception("boom"));
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>()).ThrowsAsync(new Exception("error"));
 
         var args = _commandDefinition.Parse([
             "--subscription", Sub,
@@ -281,7 +281,7 @@ public class FileSystemCreateCommandTests
 
         var response = await _command.ExecuteAsync(_context, args);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
-        Assert.Contains("boom", response.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("error", response.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -352,7 +352,13 @@ public class FileSystemCreateCommandTests
         "10.0.0.4",
         Sku,
         Size,
-        null,
+        SubnetId,          // Added: subnet ID
         "Monday",
-        "00:00");
+        "00:00",
+        "None",            // rootSquashMode
+        null,              // noSquashNidList
+        null,              // squashUid
+        null,              // squashGid
+        null,              // HSM data container
+        null);             // HSM Log container
 }

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/FileSystemListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/FileSystemListCommandTests.cs
@@ -28,6 +28,7 @@ public class FileSystemListCommandTests
     private readonly string _knownSubscriptionId = "sub123";
     private readonly string _knownResourceIdRg1 = "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Lustre/amlfs/fs1";
     private readonly string _knownResourceIdRg2 = "/subscriptions/sub123/resourceGroups/rg2/providers/Microsoft.Lustre/amlfs/fs2";
+    private const string SubnetId = "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/sub1";
 
     public FileSystemListCommandTests()
     {
@@ -68,9 +69,15 @@ public class FileSystemListCommandTests
                 "10.0.0.5",
                 "AMLFS-Durable-Premium-40",
                 48,
-                null,
                 "Monday",
-                "01:00"
+                "01:00",
+                SubnetId,
+                null,
+                null,
+                "None",
+                null,
+                null,
+                null
             ),
             new(
                 "fs2",
@@ -83,9 +90,15 @@ public class FileSystemListCommandTests
                 "10.0.0.20",
                 "AMLFS-Durable-Premium-40",
                 48,
-                null,
                 "Monday",
-                "01:00"
+                "01:00",
+                SubnetId,
+                null,
+                null,
+                "None",
+                null,
+                null,
+                null
             ),
         };
 
@@ -139,9 +152,15 @@ public class FileSystemListCommandTests
                     "10.0.0.5",
                     "AMLFS-Durable-Premium-40",
                     48,
-                    null,
                     "Monday",
-                    "01:00"
+                    "01:00",
+                    SubnetId,
+                    null,
+                    null,
+                    "None",
+                    null,
+                    null,
+                    null
                 ),
             };
 

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/Sku/SkuGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/Sku/SkuGetCommandTests.cs
@@ -98,6 +98,8 @@ public class SkuGetCommandTests
     [Theory]
     [InlineData("", false)]
     [InlineData("--subscription sub123", true)]
+    [InlineData("--subscription sub123 --location eastus", true)]
+    [InlineData(" --location eastus", false)]
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
     {
         if (shouldSucceed)

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/SubnetSize/SubnetSizeValidateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/SubnetSize/SubnetSizeValidateCommandTests.cs
@@ -122,6 +122,25 @@ public class FileSystemCheckSubnetCommandTests
         Assert.Contains("error", response.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData("--sku AMLFS-Durable-Premium-40 --size 48 --location eastus --subnet-id /subscriptions/sub123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/sn1 --subscription sub123", true)]
+    [InlineData("--sku AMLFS-Durable-Premium-40 --size 48 --location eastus --subnet-id /subscriptions/sub123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/sn1", false)]
+    [InlineData("--sku AMLFS-Durable-Premium-40 --size 48 --subnet-id /subscriptions/sub123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/sn1 --subscription sub123", false)]
+    [InlineData(" --size 48 --location eastus --subnet-id /subscriptions/sub123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/sn1 --subscription sub123", false)]
+    [InlineData("--sku AMLFS-Durable-Premium-40 --size 48 --location eastus --subscription sub123", false)]
+    public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
+    {
+        // Arrange
+        var parsedArgs = _commandDefinition.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parsedArgs);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
+    }
+
     private class ResultJson
     {
         [JsonPropertyName("valid")]


### PR DESCRIPTION
## What does this PR do?

- Extend the E2E tests of Azure Managed Lustre for full coverage
- Extend unittests to cover additional cases
- Extend livetests for additional coverage

## GitHub issue number?
#735 

## Pre-merge Checklist
- [X] Required for All PRs
    - [X] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [X] PR title clearly describes the change
    - [X] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [X] Added comprehensive tests for new/modified functionality
    - [X] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)