### PR TITLE
Fix for KB retrieve tool, stream not always at start in response

### DIFF
--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Service/SearchServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Service/SearchServiceTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using Azure.Mcp.Tools.Search.Services;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Search.UnitTests.Service;
+
+public class SearchServiceTests
+{
+    [Fact]
+    public async Task ProcessRetrieveResponse_IncludesResponseAndReferences_WhenAllPropertiesPresent()
+    {
+        var unfilteredJson = """
+            {
+              "response": [
+                {
+                  "content": []
+                }
+              ],
+              "activity": [
+                {
+                  "type": "modelQueryPlanning",
+                  "id": 0,
+                  "inputTokens": 1968,
+                  "outputTokens": 1822,
+                  "elapsedMs": 9308
+                }
+              ],
+              "references": [
+                {
+                  "type": "mcpTool",
+                  "id": "0",
+                  "activitySource": 2,
+                  "sourceData": {
+                    "title": "What is search?"
+                  },
+                  "rerankerScore": 3.5426497,
+                  "toolName": "myMcpServerTool"
+                }
+              ],
+              "other": "should be ignored"
+            }
+            """;
+
+        var result = await InvokeProcessRetrieveResponse(unfilteredJson);
+
+        Assert.Contains("\"response\"", result);
+        Assert.Contains("\"references\"", result);
+        Assert.DoesNotContain("\"activity\"", result);
+        Assert.DoesNotContain("\"other\"", result);
+    }
+
+    [Fact]
+    public async Task ProcessRetrieveResponse_IncludesOnlyResponse_WhenOnlyResponsePresent()
+    {
+        var unfilteredJson = """
+            {
+              "response": [
+                {
+                  "content": []
+                }
+              ],
+              "activity": [
+                {
+                  "type": "modelQueryPlanning"
+                }
+              ],
+              "other": "should be ignored"
+            }
+            """;
+
+        var result = await InvokeProcessRetrieveResponse(unfilteredJson);
+
+        Assert.Contains("\"response\"", result);
+        Assert.DoesNotContain("\"references\"", result);
+        Assert.DoesNotContain("\"activity\"", result);
+        Assert.DoesNotContain("\"other\"", result);
+    }
+
+    [Fact]
+    public async Task ProcessRetrieveResponse_ReturnsEmptyObject_WhenNoExpectedPropertiesPresent()
+    {
+        var unfilteredJson = """
+            {
+              "activity": [
+                {
+                  "type": "modelQueryPlanning"
+                }
+              ],
+              "other": "should be ignored"
+            }
+            """;
+
+        var result = await InvokeProcessRetrieveResponse(unfilteredJson);
+
+        Assert.Equal("{}", result);
+        Assert.DoesNotContain("\"activity\"", result);
+        Assert.DoesNotContain("\"other\"", result);
+    }
+
+    private static async Task<string> InvokeProcessRetrieveResponse(string json)
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        return await SearchService.ProcessRetrieveResponse(stream);
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Fixes the `retrieve` tool for search knowledge bases, where it looks like the response stream from the SDK could be not seeked at 0.

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [x] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
