### PR TITLE
Live tests for PostgreSQL MCP client

### DIFF
--- a/AzureMcp.sln
+++ b/AzureMcp.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -546,6 +545,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{294AC723-70DA-F50A-2C7A-AC6C0AEA0A62}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fabric.Mcp.Tools.PublicApi.Tests", "tools\Fabric.Mcp.Tools.PublicApi\tests\Fabric.Mcp.Tools.PublicApi.Tests.csproj", "{D3F46C2D-3AFD-FD9C-9C6A-180B1514DD2F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Mcp.Tools.Postgres.LiveTests", "tools\Azure.Mcp.Tools.Postgres\tests\Azure.Mcp.Tools.Postgres.LiveTests\Azure.Mcp.Tools.Postgres.LiveTests.csproj", "{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -2069,6 +2070,18 @@ Global
 		{D3F46C2D-3AFD-FD9C-9C6A-180B1514DD2F}.Release|x64.Build.0 = Release|Any CPU
 		{D3F46C2D-3AFD-FD9C-9C6A-180B1514DD2F}.Release|x86.ActiveCfg = Release|Any CPU
 		{D3F46C2D-3AFD-FD9C-9C6A-180B1514DD2F}.Release|x86.Build.0 = Release|Any CPU
+		{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE}.Debug|x64.Build.0 = Debug|Any CPU
+		{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE}.Debug|x86.Build.0 = Debug|Any CPU
+		{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE}.Release|x64.ActiveCfg = Release|Any CPU
+		{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE}.Release|x64.Build.0 = Release|Any CPU
+		{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE}.Release|x86.ActiveCfg = Release|Any CPU
+		{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2342,6 +2355,9 @@ Global
 		{C031D592-96D6-44D0-BF31-33CCE5CAABA1} = {447CAF13-A1DE-A946-989B-DD6CAA0CDF92}
 		{294AC723-70DA-F50A-2C7A-AC6C0AEA0A62} = {9072C7AF-9EB2-E481-3974-77957587AC76}
 		{D3F46C2D-3AFD-FD9C-9C6A-180B1514DD2F} = {294AC723-70DA-F50A-2C7A-AC6C0AEA0A62}
+		{BF0354AE-3748-A8DC-F79D-B21FDDEDDFAE} = {37B0CE47-14C8-F5BF-BDDD-13EEBE580A88}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {926577F9-9246-44E4-BCE9-25DB003F1C51}
 	EndGlobalSection
 EndGlobal
-

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.LiveTests/Azure.Mcp.Tools.Postgres.LiveTests.csproj
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.LiveTests/Azure.Mcp.Tools.Postgres.LiveTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />
+    <ProjectReference Include="..\..\..\..\core\Azure.Mcp.Core\tests\Azure.Mcp.Tests\Azure.Mcp.Tests.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+</Project>

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.LiveTests/PostgresCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.LiveTests/PostgresCommandTests.cs
@@ -1,0 +1,513 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Mcp.Tests;
+using Azure.Mcp.Tests.Client;
+using ModelContextProtocol.Protocol;
+using Npgsql;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Postgres.LiveTests;
+
+public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(output)
+{
+    private string TestDatabaseName => Settings.DeploymentOutputs["TESTDATABASENAME"];
+    private string ServerName => Settings.DeploymentOutputs["POSTGRESSERVERNAME"];
+    private string ServerFqdn => Settings.DeploymentOutputs["POSTGRESSERVERFQDN"];
+    private string AdminUsername => Settings.PrincipalName ?? string.Empty;
+
+    private static bool _testDataInitialized = false;
+    private static readonly SemaphoreSlim _initLock = new(1, 1);
+
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        // Only initialize test data once for all tests
+        if (_testDataInitialized)
+        {
+            return;
+        }
+
+        await _initLock.WaitAsync();
+        try
+        {
+            if (_testDataInitialized)
+            {
+                return;
+            }
+
+            Output.WriteLine("Initializing test data...");
+            await CreateTestDataAsync();
+            _testDataInitialized = true;
+            Output.WriteLine("Test data initialized successfully");
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    private async Task CreateTestDataAsync()
+    {
+        Output.WriteLine($"ServerFqdn: {ServerFqdn}");
+        Output.WriteLine($"AdminUsername: {AdminUsername}");
+        Output.WriteLine($"TestDatabaseName: {TestDatabaseName}");
+
+        // Get Entra ID access token for PostgreSQL
+        var options = new DefaultAzureCredentialOptions
+        {
+            TenantId = Settings.TenantId,
+            ExcludeManagedIdentityCredential = true,  // We don't want to use ADO build server identity
+        };
+        var tokenCredential = new DefaultAzureCredential(options);
+        var tokenRequestContext = new TokenRequestContext(["https://ossrdbms-aad.database.windows.net/.default"], tenantId: Settings.TenantId);
+        AccessToken accessToken = await tokenCredential.GetTokenAsync(tokenRequestContext, CancellationToken.None);
+
+        string connectionString = $"Host={ServerFqdn};Database={TestDatabaseName};Username={AdminUsername};Password={accessToken.Token};SSL Mode=Require;Trust Server Certificate=true;";
+
+        Output.WriteLine($"Connecting to PostgreSQL...");
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        Output.WriteLine($"Connected successfully!");
+
+        // Create employees table
+        string createEmployeesTable = @"
+            CREATE TABLE IF NOT EXISTS employees (
+                id SERIAL PRIMARY KEY,
+                first_name VARCHAR(50) NOT NULL,
+                last_name VARCHAR(50) NOT NULL,
+                email VARCHAR(100) UNIQUE NOT NULL,
+                department VARCHAR(50),
+                salary DECIMAL(10, 2),
+                hire_date DATE DEFAULT CURRENT_DATE,
+                is_active BOOLEAN DEFAULT true
+            );";
+
+        await using (var cmd = new NpgsqlCommand(createEmployeesTable, connection))
+        {
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        // Insert employee data
+        string insertEmployees = @"
+            INSERT INTO employees (first_name, last_name, email, department, salary, hire_date, is_active)
+            VALUES 
+                ('John', 'Doe', 'john.doe@example.com', 'Engineering', 75000.00, '2023-01-15', true),
+                ('Jane', 'Smith', 'jane.smith@example.com', 'Marketing', 65000.00, '2023-02-20', true),
+                ('Bob', 'Johnson', 'bob.johnson@example.com', 'Sales', 70000.00, '2023-03-10', true),
+                ('Alice', 'Williams', 'alice.williams@example.com', 'Engineering', 80000.00, '2023-04-05', true),
+                ('Charlie', 'Brown', 'charlie.brown@example.com', 'HR', 60000.00, '2023-05-12', false)
+            ON CONFLICT (email) DO NOTHING;";
+
+        await using (var cmd = new NpgsqlCommand(insertEmployees, connection))
+        {
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        // Create departments table
+        string createDepartmentsTable = @"
+            CREATE TABLE IF NOT EXISTS departments (
+                dept_id SERIAL PRIMARY KEY,
+                dept_name VARCHAR(50) NOT NULL UNIQUE,
+                location VARCHAR(100),
+                budget DECIMAL(12, 2)
+            );";
+
+        await using (var cmd = new NpgsqlCommand(createDepartmentsTable, connection))
+        {
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        // Insert department data
+        string insertDepartments = @"
+            INSERT INTO departments (dept_name, location, budget)
+            VALUES 
+                ('Engineering', 'Seattle', 1000000.00),
+                ('Marketing', 'New York', 500000.00),
+                ('Sales', 'San Francisco', 750000.00),
+                ('HR', 'Austin', 300000.00)
+            ON CONFLICT (dept_name) DO NOTHING;";
+
+        await using (var cmd = new NpgsqlCommand(insertDepartments, connection))
+        {
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        Output.WriteLine("Test tables and data created successfully");
+    }
+
+    [Fact]
+    public async Task Should_ListDatabases_Successfully()
+    {
+        JsonElement? result = await CallToolAsync(
+            "azmcp_postgres_database_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "server", ServerName },
+                { "user", AdminUsername }
+            });
+
+        // Should successfully retrieve the list of databases
+        JsonElement databases = result.AssertProperty("Databases");
+        Assert.Equal(JsonValueKind.Array, databases.ValueKind);
+
+        // Should contain at least our test databases
+        List<JsonElement> databaseList = databases.EnumerateArray().ToList();
+        Assert.True(databaseList.Count >= 2, $"Should contain at least {TestDatabaseName} and postgres databases");
+
+        // Verify that our test databases exist
+        List<string?> testDbNames = databaseList.Select(db => db.GetString()).ToList();
+        Assert.Contains(TestDatabaseName, testDbNames);
+        Assert.Contains("postgres", testDbNames);
+    }
+
+    [Fact]
+    public async Task Should_ListTables_Successfully()
+    {
+        JsonElement? result = await CallToolAsync(
+            "azmcp_postgres_table_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "server", ServerName },
+                { "database", TestDatabaseName },
+                { "user", AdminUsername }
+            });
+
+        // Should successfully retrieve the list of tables
+        JsonElement tables = result.AssertProperty("Tables");
+        Assert.Equal(JsonValueKind.Array, tables.ValueKind);
+
+        // Should contain our test tables
+        List<JsonElement> tableList = tables.EnumerateArray().ToList();
+        Assert.True(tableList.Count >= 2, "Should contain at least employees and departments tables");
+
+        List<string?> tableNames = tableList.Select(t => t.GetString()).ToList();
+        Assert.Contains("employees", tableNames);
+        Assert.Contains("departments", tableNames);
+    }
+
+    [Fact]
+    public async Task Should_GetTableSchema_Successfully()
+    {
+        JsonElement? result = await CallToolAsync(
+            "azmcp_postgres_table_schema_get",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "server", ServerName },
+                { "database", TestDatabaseName },
+                { "user", AdminUsername },
+                { "table", "employees" }
+            });
+
+        // Should successfully retrieve the table schema
+        JsonElement schema = result.AssertProperty("Schema");
+        Assert.Equal(JsonValueKind.Array, schema.ValueKind);
+
+        // Should contain all columns from the employees table
+        List<JsonElement> schemaArray = schema.EnumerateArray().ToList();
+        Assert.True(schemaArray.Count >= 8, "Should contain at least 8 columns");
+
+        // Verify that key columns exist in the schema
+        string schemaJson = schema.ToString();
+        Assert.Contains("id", schemaJson);
+        Assert.Contains("first_name", schemaJson);
+        Assert.Contains("last_name", schemaJson);
+        Assert.Contains("email", schemaJson);
+        Assert.Contains("department", schemaJson);
+        Assert.Contains("salary", schemaJson);
+        Assert.Contains("hire_date", schemaJson);
+        Assert.Contains("is_active", schemaJson);
+    }
+
+    [Fact]
+    public async Task Should_ExecuteQuery_Successfully()
+    {
+        // Test a simple SELECT query
+        JsonElement? result = await CallToolAsync(
+            "azmcp_postgres_database_query",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "server", ServerName },
+                { "database", TestDatabaseName },
+                { "user", AdminUsername },
+                { "query", "SELECT first_name, last_name FROM employees WHERE department = 'Engineering';" }
+            });
+
+        // Should successfully execute the query
+        JsonElement queryResult = result.AssertProperty("QueryResult");
+        Assert.Equal(JsonValueKind.Array, queryResult.ValueKind);
+
+        // Should return at least the employees we inserted
+        List<JsonElement> resultList = queryResult.EnumerateArray().ToList();
+        Assert.True(resultList.Count >= 2, "Should return at least 2 Engineering employees");
+
+        // Verify the result contains expected data
+        string resultJson = queryResult.ToString();
+        Assert.Contains("John", resultJson);
+        Assert.Contains("Alice", resultJson);
+    }
+
+    [Fact]
+    public async Task Should_ExecuteQuery_WithAggregation_Successfully()
+    {
+        // Test a query with COUNT aggregation
+        JsonElement? result = await CallToolAsync(
+            "azmcp_postgres_database_query",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "server", ServerName },
+                { "database", TestDatabaseName },
+                { "user", AdminUsername },
+                { "query", "SELECT department, COUNT(*) as emp_count FROM employees GROUP BY department ORDER BY department;" }
+            });
+
+        // Should successfully execute the query
+        JsonElement queryResult = result.AssertProperty("QueryResult");
+        Assert.Equal(JsonValueKind.Array, queryResult.ValueKind);
+
+        // Should return aggregated results
+        List<JsonElement> resultArray = queryResult.EnumerateArray().ToList();
+        Assert.True(resultArray.Count >= 3, "Should return at least 3 departments");
+    }
+
+    [Fact]
+    public async Task Should_ExecuteQuery_WithJoin_Successfully()
+    {
+        // Test a query with JOIN
+        JsonElement? result = await CallToolAsync(
+            "azmcp_postgres_database_query",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "server", ServerName },
+                { "database", TestDatabaseName },
+                { "user", AdminUsername },
+                { "query", @"SELECT e.first_name, e.last_name, d.location 
+                             FROM employees e 
+                             JOIN departments d ON e.department = d.dept_name 
+                             WHERE d.location = 'Seattle';" }
+            });
+
+        // Should successfully execute the join query
+        JsonElement queryResult = result.AssertProperty("QueryResult");
+        Assert.Equal(JsonValueKind.Array, queryResult.ValueKind);
+
+        // Should return employees in Seattle
+        List<JsonElement> resultArray = queryResult.EnumerateArray().ToList();
+        Assert.True(resultArray.Count >= 1, "Should return at least 1 employee in Seattle");
+    }
+
+    [Fact]
+    public async Task Should_ListServerConfigs_Successfully()
+    {
+        JsonElement? result = await CallToolAsync(
+            "azmcp_postgres_server_config_get",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "server", ServerName },
+                { "user", AdminUsername },
+            });
+
+        // Should successfully retrieve server configurations
+        JsonElement config = result.AssertProperty("Configuration");
+        Assert.Equal(JsonValueKind.String, config.ValueKind);
+
+        string[] configLines = config
+            .GetString()?
+            .Trim()
+            .Split("\n") ?? Array.Empty<string>();
+
+        // Should contain multiple configuration parameters
+        Assert.True(configLines.Length > 0, "Should return at least one configuration parameter");
+
+        List<KeyValuePair<string, string>> configList = configLines
+            .Select(line =>
+            {
+                string[] parts = line.Split(":", 2);
+                return new KeyValuePair<string, string>(
+                    parts[0].Trim(),
+                    parts.Length > 1 ? parts[1].Trim() : string.Empty);
+            })
+            .ToList();
+
+        // Should contain at least the "Server Name" parameter
+        KeyValuePair<string, string> serverConfig = configList.FirstOrDefault(c => c.Key == "Server Name");
+        Assert.Equal("Server Name", serverConfig.Key);
+        Assert.Equal(ServerName, serverConfig.Value);
+    }
+
+    [Fact]
+    public async Task Should_GetServerParameter_Successfully()
+    {
+        // Get a specific server parameter (max_connections is a common one)
+        JsonElement? result = await CallToolAsync(
+            "azmcp_postgres_server_param_get",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "server", ServerName },
+                { "user", AdminUsername },
+                { "param", "max_connections" }
+            });
+
+        // Should successfully retrieve the parameter
+        JsonElement parameter = result.AssertProperty("ParameterValue");
+        Assert.Equal(JsonValueKind.String, parameter.ValueKind);
+
+        int maxConnections = int.Parse(parameter.GetString() ?? "0");
+        Assert.True(maxConnections > 0, "max_connections should be greater than 0");
+    }
+
+    [Fact]
+    public async Task Should_ListServers_Successfully()
+    {
+        JsonElement? result = await CallToolAsync(
+            "azmcp_postgres_server_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "user", AdminUsername },
+            });
+
+        // Should successfully retrieve the list of servers
+        List<string?> servers = result.AssertProperty("Servers")
+            .EnumerateArray()
+            .Select(s => s.GetString())
+            .ToList();
+        Assert.True(servers.Count >= 1, $"Should contain at least the {ServerName} server");
+
+        // Verify that our test server exists
+        Assert.Contains(ServerName, servers);
+    }
+
+    [Fact]
+    public async Task Should_RejectNonSelectQuery_WithValidationError()
+    {
+        JsonElement error = await this.CallToolAsyncWithErrorExpected("azmcp_postgres_database_query",
+            new()
+            {
+                    { "subscription", Settings.SubscriptionId },
+                    { "resource-group", Settings.ResourceGroupName },
+                    { "server", ServerName },
+                    { "database", TestDatabaseName },
+                    { "user", AdminUsername },
+                    { "query", "DELETE FROM employees WHERE id = 1;" }
+            });
+
+        int errorStatus = error.GetProperty("status").GetInt32();
+        Assert.Equal(400, errorStatus);
+
+        string errorMessage = error.GetProperty("message").GetString()!;
+        Assert.Equal("Only single read-only SELECT statements are allowed.", errorMessage);
+    }
+
+    [Fact]
+    public async Task Should_HandleInvalidServerName_Gracefully()
+    {
+        string serverName = Guid.NewGuid().ToString(); // <-- nonexistent_server
+
+        JsonElement error = await this.CallToolAsyncWithErrorExpected(
+                "azmcp_postgres_database_list",
+                new()
+                {
+                    { "subscription", Settings.SubscriptionId },
+                    { "resource-group", Settings.ResourceGroupName },
+                    { "server", serverName },
+                    { "database", TestDatabaseName },
+                    { "user", AdminUsername }
+                });
+
+        int errorStatus = error.GetProperty("status").GetInt32();
+        Assert.Equal(500, errorStatus);
+
+        string errorMessage = error.GetProperty("message").GetString()!;
+        bool isExpectedError =
+            errorMessage.Contains("No such host is known") ||
+            errorMessage.Contains("Name or service not known");
+        Assert.True(isExpectedError, $"Error message should indicate unknown host, but was: {errorMessage}");
+    }
+
+    [Fact]
+    public async Task Should_HandleInvalidDatabaseName_Gracefully()
+    {
+        string databaseName = Guid.NewGuid().ToString(); // <-- nonexistent_database
+
+        JsonElement error = await this.CallToolAsyncWithErrorExpected(
+                "azmcp_postgres_table_list",
+                new()
+                {
+                    { "subscription", Settings.SubscriptionId },
+                    { "resource-group", Settings.ResourceGroupName },
+                    { "server", ServerName },
+                    { "database", databaseName },
+                    { "user", AdminUsername }
+                });
+
+        int errorStatus = error.GetProperty("status").GetInt32();
+        Assert.Equal(500, errorStatus);
+
+        string errorMessage = error.GetProperty("message").GetString()!;
+        Assert.Contains($"\"{databaseName}\" does not exist", errorMessage);
+    }
+
+    [Fact]
+    public async Task Should_HandleInvalidTableName_Gracefully()
+    {
+        string tableName = Guid.NewGuid().ToString(); // <-- nonexistent_table
+
+        JsonElement? result = await CallToolAsync(
+            "azmcp_postgres_table_schema_get",
+            new()
+            {
+                    { "subscription", Settings.SubscriptionId },
+                    { "resource-group", Settings.ResourceGroupName },
+                    { "server", ServerName },
+                    { "database", TestDatabaseName },
+                    { "user", AdminUsername },
+                    { "table", tableName }
+            });
+
+        JsonElement schema = result.AssertProperty("Schema");
+        Assert.Equal(JsonValueKind.Array, schema.ValueKind);
+
+        // Schema should be empty for nonexistent table
+        List<JsonElement> schemaList = schema.EnumerateArray().ToList();
+        Assert.Empty(schemaList);
+    }
+
+    private async Task<JsonElement> CallToolAsyncWithErrorExpected(string command, Dictionary<string, object?> parameters)
+    {
+        CallToolResult result = await Client.CallToolAsync(command, parameters);
+        Assert.NotNull(result);
+        Assert.True(result.IsError, $"Command {command} should have failed but succeeded.");
+
+        Assert.NotNull(result.Content);
+        Assert.Single(result.Content);
+
+        var textContent = (TextContentBlock)result.Content.Single();
+        Assert.NotNull(textContent.Text);
+        Assert.NotEmpty(textContent.Text);
+
+        JsonElement errorContent = JsonSerializer.Deserialize<JsonElement>(textContent.Text);
+        return errorContent;
+    }
+}

--- a/tools/Azure.Mcp.Tools.Postgres/tests/test-resources-post.ps1
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/test-resources-post.ps1
@@ -1,0 +1,95 @@
+
+param(
+    [string] $TenantId,
+    [string] $TestApplicationId,
+    [string] $ResourceGroupName,
+    [string] $BaseName,
+    [hashtable] $DeploymentOutputs
+)
+
+$ErrorActionPreference = "Stop"
+
+. "$PSScriptRoot/../../../eng/common/scripts/common.ps1"
+. "$PSScriptRoot/../../../eng/scripts/helpers/TestResourcesHelpers.ps1"
+
+$testSettings = New-TestSettings @PSBoundParameters -OutputPath $PSScriptRoot
+
+$postgresServerName = "$($testSettings.ResourceBaseName)-postgres"
+
+Write-Host "Verifying PostgreSQL Server deployment: $postgresServerName" -ForegroundColor Yellow
+
+# Get the PostgreSQL server details to verify deployment
+try {
+    $postgresServer = Get-AzPostgreSqlFlexibleServer -ResourceGroupName $ResourceGroupName -Name $postgresServerName
+
+    if ($postgresServer) {
+        Write-Host "PostgreSQL Server '$postgresServerName' deployed successfully" -ForegroundColor Green
+        Write-Host "  Server: $($postgresServer.Name)" -ForegroundColor Gray
+        Write-Host "  FQDN: $($postgresServer.FullyQualifiedDomainName)" -ForegroundColor Gray
+        Write-Host "  Location: $($postgresServer.Location)" -ForegroundColor Gray
+        Write-Host "  Version: $($postgresServer.Version)" -ForegroundColor Gray
+        Write-Host "  State: $($postgresServer.State)" -ForegroundColor Gray
+
+        # List databases
+        try {
+            $databases = Get-AzPostgreSqlFlexibleServerDatabase -ResourceGroupName $ResourceGroupName -ServerName $postgresServerName
+            Write-Host "  Databases:" -ForegroundColor Gray
+            foreach ($db in $databases) {
+                Write-Host "    - $($db.Name) (Charset: $($db.Charset), Collation: $($db.Collation))" -ForegroundColor Gray
+            }
+        }
+        catch {
+            Write-Warning "Could not list databases: $($_.Exception.Message)"
+        }
+
+        # List firewall rules
+        try {
+            $firewallRules = Get-AzPostgreSqlFlexibleServerFirewallRule -ResourceGroupName $ResourceGroupName -ServerName $postgresServerName
+            Write-Host "  Firewall Rules:" -ForegroundColor Gray
+            foreach ($rule in $firewallRules) {
+                Write-Host "    - $($rule.Name): $($rule.StartIpAddress) - $($rule.EndIpAddress)" -ForegroundColor Gray
+            }
+        }
+        catch {
+            Write-Warning "Could not list firewall rules: $($_.Exception.Message)"
+        }
+
+        # Wait for server to be ready
+        Write-Host "Waiting for PostgreSQL server to be ready..." -ForegroundColor Yellow
+        $maxWaitTime = 300 # 5 minutes
+        $waitInterval = 15 # 15 seconds
+        $elapsedTime = 0
+
+        do {
+            Start-Sleep -Seconds $waitInterval
+            $elapsedTime += $waitInterval
+            $currentServer = Get-AzPostgreSqlFlexibleServer -ResourceGroupName $ResourceGroupName -Name $postgresServerName
+            Write-Host "  Server state: $($currentServer.State)" -ForegroundColor Gray
+            
+            if ($currentServer.State -eq "Ready") {
+                Write-Host "PostgreSQL server is ready!" -ForegroundColor Green
+                break
+            }
+            
+            if ($elapsedTime -ge $maxWaitTime) {
+                Write-Warning "Timeout waiting for PostgreSQL server to be ready. Current state: $($currentServer.State)"
+                break
+            }
+        } while ($currentServer.State -ne "Ready")
+
+        # Prepare test data
+        Write-Host "Preparing test data..." -ForegroundColor Yellow
+        
+        # The connection string and data preparation would typically be done here
+        # However, since we're using MCP tools for testing, the actual data preparation
+        # will be done as part of the live tests themselves
+        
+        Write-Host "PostgreSQL test resources setup completed successfully!" -ForegroundColor Green
+    } else {
+        Write-Error "PostgreSQL Server '$postgresServerName' not found"
+    }
+}
+catch {
+    Write-Error "Error verifying PostgreSQL Server deployment: $($_.Exception.Message)"
+    throw
+}

--- a/tools/Azure.Mcp.Tools.Postgres/tests/test-resources.bicep
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/test-resources.bicep
@@ -1,0 +1,104 @@
+@minLength(3)
+@maxLength(17)
+@description('The base resource name. PostgreSQL Server names have a max length restriction.')
+param baseName string = resourceGroup().name
+
+@description('The location of the resource. By default, this is the same as the resource group.')
+param location string = 'northeurope' // resourceGroup().location
+
+@description('The client OID to grant access to test resources.')
+param testApplicationOid string = '26ffb325-f480-419c-b7a9-2c8a018203a8' // azure-sdk-internal-devops-connections
+
+var testDbName string = 'testdb'
+
+resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2025-06-01-preview' = {
+  name: '${baseName}-postgres'
+  location: location
+  sku: {
+    name: 'Standard_B1ms'
+    tier: 'Burstable'
+  }
+  properties: {
+    version: '17'
+    storage: {
+      storageSizeGB: 32
+      iops: 120
+      tier: 'P4'
+    }
+    backup: {
+      geoRedundantBackup: 'Disabled'
+    }
+    highAvailability: {
+      mode: 'Disabled'
+    }
+    authConfig: {
+      activeDirectoryAuth: 'Enabled'
+      passwordAuth: 'Disabled'  // S360 compliant
+      tenantId: tenant().tenantId
+    }
+  }
+
+  resource firewallAzure 'firewallRules' = {
+    name: 'allow-all-azure-internal-IPs'
+    properties: {
+        startIpAddress: '0.0.0.0'
+        endIpAddress: '0.0.0.0'
+    }
+  }
+
+  resource firewallSingle 'firewallRules' = {
+    name: 'allow-all'
+    properties: {
+        startIpAddress: '0.0.0.0'
+        endIpAddress: '255.255.255.255'
+    }
+  }
+
+  resource postgresAdministrator 'administrators' = {
+    name: testApplicationOid
+    properties: {
+      principalType: testApplicationOid == '26ffb325-f480-419c-b7a9-2c8a018203a8' ? 'ServicePrincipal' : 'User'
+      principalName: testApplicationOid == '26ffb325-f480-419c-b7a9-2c8a018203a8' ? 'azure-sdk-internal-devops-connections' :  deployer().userPrincipalName
+      tenantId: tenant().tenantId
+    }
+    dependsOn: [
+      firewallAzure
+      firewallSingle
+    ]
+  }
+
+  resource testDatabase 'databases' = {
+    name: testDbName
+    properties: {
+      charset: 'utf8'
+      collation: 'en_US.utf8'
+    }
+  }
+}
+
+// PostgreSQL Contributor role definition
+resource postgresContributorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  scope: subscription()
+  // This is the PostgreSQL Contributor role
+  // Lets you manage PostgreSQL servers, but not access to them
+  // See https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#postgresql-contributor
+  name: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+}
+
+// Role assignment for test application
+resource appPostgresRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(postgresContributorRoleDefinition.id, testApplicationOid, postgresServer.id)
+  scope: postgresServer
+  properties: {
+    principalId: testApplicationOid
+    roleDefinitionId: postgresContributorRoleDefinition.id
+    description: 'PostgreSQL Contributor for testApplicationOid'
+  }
+}
+
+// Output values for tests
+output postgresServerName string = postgresServer.name
+output postgresServerFqdn string = postgresServer.properties.fullyQualifiedDomainName
+output testDatabaseName string = testDbName
+output entraIdAdminObjectId string = testApplicationOid
+output adminLogin string = testApplicationOid


### PR DESCRIPTION
## What does this PR do?
It adds live tests for PostgreSQL MCP client.

The `test-resources.bicep` and `test-resources-post.ps1` are used for provisioning the required flexible server where to do the tests, while `PostgresCommandTests.cs` conains the live tests it self.

Bicep file can be run from both local developer's machine and TME CI/CD pipeline. The identity for the TME pipeline is known and don't change, we use that information to determine the principalName and principal type ('User' or 'ServicePrinicipal')

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [x] For MCP tool changes:
    - [x] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
