### PR TITLE
Remove milestone property from bug bash report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_bash_mcp_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_bash_mcp_report.yml
@@ -3,7 +3,6 @@ description: "File a bug found during Bug Bash for the Azure MCP Server."
 title: "[BUGBASH] "
 labels: ["needs-triage", "server-Azure.Mcp", "Bug-Bash"]
 projects: ["Microsoft/1976"]
-milestone: 2025-10
 
 body:
   - type: markdown


### PR DESCRIPTION
Removed milestone date from bug report template, its not permitted.