### PR TITLE
Increase TestTimeoutInMinutes from 10 to 30

### DIFF
--- a/eng/pipelines/templates/common.yml
+++ b/eng/pipelines/templates/common.yml
@@ -72,7 +72,7 @@ extends:
           SparseCheckout: false
           JobTemplatePath: /eng/pipelines/templates/jobs/build.yml
           AdditionalParameters:
-            TestTimeoutInMinutes: 10
+            TestTimeoutInMinutes: 30
             ServerName: ${{ parameters.ServerName }}
           MatrixConfigs:
             - Name: build_matrix


### PR DESCRIPTION
## What does this PR do?
Our pipelines currently have a 10-minute timeout for tests, which has been hit a few times lately during releases. [Here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5454613&view=logs&j=1e679852-4871-5dae-dd38-eb073eb853d4&t=51598406-2d78-56ba-c023-a1fb19c0bfbb&l=12770) is an example from today:

<img width="1316" height="661" alt="image" src="https://github.com/user-attachments/assets/f552a541-c0c8-47f5-9931-44656c47e7d1" />

This PR increases the test timeout to 30 mins for the time being.

## GitHub issue number?
N/A

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
