### PR TITLE
Dispose json and http resources across services and tool loaders to eliminate retained buffers.

### DIFF
--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/BaseToolLoader.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/BaseToolLoader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
@@ -21,7 +22,15 @@ public abstract class BaseToolLoader(ILogger logger) : IToolLoader
     /// <summary>
     /// Cached empty JSON object to avoid repeated parsing.
     /// </summary>
-    protected static readonly JsonElement EmptyJsonObject = JsonDocument.Parse("{}").RootElement;
+    protected static readonly JsonElement EmptyJsonObject;
+
+    static BaseToolLoader()
+    {
+        using (var jsonDoc = JsonDocument.Parse("{}"))
+        {
+            EmptyJsonObject = jsonDoc.RootElement.Clone();
+        }
+    }
 
     private bool _disposed = false;
 

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
@@ -612,15 +612,15 @@ public sealed class NamespaceToolLoader(
 
             if (!string.IsNullOrEmpty(toolCallJson))
             {
-                var doc = JsonDocument.Parse(toolCallJson);
-                var root = doc.RootElement;
+                using var jsonDoc = JsonDocument.Parse(toolCallJson);
+                var root = jsonDoc.RootElement;
                 if (root.TryGetProperty("tool", out var toolProp) && toolProp.ValueKind == JsonValueKind.String)
                 {
                     commandName = toolProp.GetString();
                 }
                 if (root.TryGetProperty("parameters", out var parametersElem) && parametersElem.ValueKind == JsonValueKind.Object)
                 {
-                    parameters = parametersElem.EnumerateObject().ToDictionary(prop => prop.Name, prop => prop.Value) ?? new Dictionary<string, JsonElement>();
+                    parameters = parametersElem.EnumerateObject().ToDictionary(prop => prop.Name, prop => prop.Value.Clone()) ?? new Dictionary<string, JsonElement>();
                 }
             }
 

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
@@ -473,15 +473,15 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
             Dictionary<string, object?> parameters = [];
             if (!string.IsNullOrEmpty(toolCallJson))
             {
-                var doc = JsonDocument.Parse(toolCallJson);
-                var root = doc.RootElement;
+                using var jsonDoc = JsonDocument.Parse(toolCallJson);
+                var root = jsonDoc.RootElement;
                 if (root.TryGetProperty("tool", out var toolProp) && toolProp.ValueKind == JsonValueKind.String)
                 {
                     commandName = toolProp.GetString();
                 }
                 if (root.TryGetProperty("parameters", out var parametersElem) && parametersElem.ValueKind == JsonValueKind.Object)
                 {
-                    parameters = parametersElem.EnumerateObject().ToDictionary(prop => prop.Name, prop => (object?)prop.Value) ?? [];
+                    parameters = parametersElem.EnumerateObject().ToDictionary(prop => prop.Name, prop => (object?)prop.Value.Clone()) ?? [];
                 }
             }
             if (commandName != null && commandName != "Unknown")

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/SingleProxyToolLoader.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/SingleProxyToolLoader.cs
@@ -439,15 +439,15 @@ public sealed class SingleProxyToolLoader(IMcpDiscoveryStrategy discoveryStrateg
             Dictionary<string, object?> parameters = [];
             if (!string.IsNullOrEmpty(toolCallJson))
             {
-                var doc = JsonDocument.Parse(toolCallJson);
-                var root = doc.RootElement;
+                using var jsonDoc = JsonDocument.Parse(toolCallJson);
+                var root = jsonDoc.RootElement;
                 if (root.TryGetProperty("tool", out var toolProp) && toolProp.ValueKind == JsonValueKind.String)
                 {
                     commandName = toolProp.GetString();
                 }
                 if (root.TryGetProperty("parameters", out var paramsProp) && paramsProp.ValueKind == JsonValueKind.Object)
                 {
-                    parameters = paramsProp.EnumerateObject().ToDictionary(prop => prop.Name, prop => (object?)prop.Value);
+                    parameters = paramsProp.EnumerateObject().ToDictionary(prop => prop.Name, prop => (object?)prop.Value.Clone());
                 }
             }
             if (commandName != null && commandName != "Unknown")

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -9,6 +9,8 @@ The Azure MCP Server updates automatically by default whenever a new release com
 ### Breaking Changes
 
 ### Bugs Fixed
+- fix `azmcp_sql_db_rename`'s new database name binding bug [[#615](https://github.com/microsoft/mcp/issues/615)]
+- Fixed retained-buffer leaks across services (Kusto, EventGrid, AppLens, Speech, Cosmos, Foundry, NetworkResourceProvider) and tool loaders (BaseToolLoader, ServerToolLoader, NamespaceToolLoader, SingleProxyToolLoader) by disposing JsonDocument/HttpResponseMessage instances and cloning returned JsonElements. ([#817](https://github.com/microsoft/mcp/pull/817))
 
 ### Other Changes
 

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
@@ -203,7 +203,7 @@ public class CosmosService(ISubscriptionService subscriptionService, ITenantServ
             var iterator = client.GetDatabaseQueryStreamIterator();
             while (iterator.HasMoreResults)
             {
-                ResponseMessage dbResponse = await iterator.ReadNextAsync();
+                using ResponseMessage dbResponse = await iterator.ReadNextAsync();
                 if (!dbResponse.IsSuccessStatusCode)
                 {
                     throw new Exception(dbResponse.ErrorMessage);
@@ -258,7 +258,7 @@ public class CosmosService(ISubscriptionService subscriptionService, ITenantServ
             var iterator = database.GetContainerQueryStreamIterator();
             while (iterator.HasMoreResults)
             {
-                ResponseMessage containerRResponse = await iterator.ReadNextAsync();
+                using ResponseMessage containerRResponse = await iterator.ReadNextAsync();
                 if (!containerRResponse.IsSuccessStatusCode)
                 {
                     throw new Exception(containerRResponse.ErrorMessage);
@@ -314,7 +314,7 @@ public class CosmosService(ISubscriptionService subscriptionService, ITenantServ
 
             while (queryIterator.HasMoreResults)
             {
-                var response = await queryIterator.ReadNextAsync();
+                using ResponseMessage response = await queryIterator.ReadNextAsync();
                 using var document = JsonDocument.Parse(response.Content);
                 items.Add(document.RootElement.Clone());
             }

--- a/tools/Azure.Mcp.Tools.EventGrid/src/Services/EventGridService.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/src/Services/EventGridService.cs
@@ -175,7 +175,7 @@ public class EventGridService(ISubscriptionService subscriptionService, ITenantS
         try
         {
             // Parse the JSON data
-            var jsonDocument = JsonDocument.Parse(eventData);
+            using var jsonDocument = JsonDocument.Parse(eventData);
 
             IEnumerable<Models.EventGridEventSchema> events;
 

--- a/tools/Azure.Mcp.Tools.Foundry/src/Commands/OpenAiChatCompletionsCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/src/Commands/OpenAiChatCompletionsCreateCommand.cs
@@ -92,7 +92,7 @@ public sealed class OpenAiChatCompletionsCreateCommand : SubscriptionCommand<Ope
             var messages = new List<object>();
             if (!string.IsNullOrEmpty(options.MessageArray))
             {
-                var jsonDocument = JsonDocument.Parse(options.MessageArray);
+                using var jsonDocument = JsonDocument.Parse(options.MessageArray);
                 foreach (var element in jsonDocument.RootElement.EnumerateArray())
                 {
                     // Convert JsonElement to JsonObject for proper type matching in service

--- a/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoClient.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoClient.cs
@@ -7,7 +7,7 @@ using Azure.Mcp.Core.Services.Http;
 
 namespace Azure.Mcp.Tools.Kusto.Services;
 
-public class KustoClient(
+public sealed class KustoClient(
     string clusterUri,
     TokenCredential tokenCredential,
     string userAgent,

--- a/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoResult.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoResult.cs
@@ -1,18 +1,31 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net.Http;
+using System.Text.Json;
+
 namespace Azure.Mcp.Tools.Kusto.Services;
 
-public class KustoResult
+public sealed class KustoResult
 {
-    public JsonDocument? JsonDocument { get; private set; }
+    public JsonElement RootElement { get; }
+
+    private KustoResult(JsonElement rootElement)
+    {
+        RootElement = rootElement;
+    }
 
     public static KustoResult FromHttpResponseMessage(HttpResponseMessage response)
     {
-        var ret = new KustoResult();
-        var stream = response.Content.ReadAsStream();
-        var jsonDocument = JsonDocument.Parse(stream);
-        ret.JsonDocument = jsonDocument;
-        return ret;
+        using (response)
+        {
+            using (var content = response.Content.ReadAsStream())
+            {
+                using (var jsonDoc = JsonDocument.Parse(content))
+                {
+                    return new KustoResult(jsonDoc.RootElement.Clone());
+                }
+            }
+        }
     }
 }

--- a/tools/Azure.Mcp.Tools.Speech/src/Services/SpeechService.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Services/SpeechService.cs
@@ -415,9 +415,9 @@ public class SpeechService(ITenantService tenantService, ILogger<SpeechService> 
 
             if (!string.IsNullOrEmpty(jsonProperty))
             {
-                var jsonResult = JsonDocument.Parse(jsonProperty);
+                using var jsonDoc = JsonDocument.Parse(jsonProperty);
 
-                if (jsonResult.RootElement.TryGetProperty("NBest", out var nbestArray))
+                if (jsonDoc.RootElement.TryGetProperty("NBest", out var nbestArray))
                 {
                     foreach (var item in nbestArray.EnumerateArray())
                     {


### PR DESCRIPTION

## What does this PR do?
`[Provide a clear, concise description of the changes]`

Fixes retained-buffer leaks across services (Kusto, EventGrid, AppLens, Speech, Cosmos, Foundry, NetworkResourceProvider) and tool loaders (BaseToolLoader, ServerToolLoader, NamespaceToolLoader, SingleProxyToolLoader) by disposing JsonDocument/HttpResponseMessage instances and cloning returned JsonElements.

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
