### PR TITLE
Remove Azure SDK package source from nuget.config

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -4,14 +4,10 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="azure-sdk-for-net" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
 
   <packageSourceMapping>
     <packageSource key="nuget.org">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="azure-sdk-for-net">
       <package pattern="*" />
     </packageSource>
   </packageSourceMapping>


### PR DESCRIPTION
Removed Azure SDK package source from configuration.

Testing to see if this feed is needed for this repo.

    
