### PR TITLE
Remove 'isOutput=true' from Docker image variables

### DIFF
--- a/eng/pipelines/templates/jobs/docker/release-docker.yml
+++ b/eng/pipelines/templates/jobs/docker/release-docker.yml
@@ -53,11 +53,11 @@ jobs:
 
         $imageName = $serverInfo.dockerImageName
         Write-Host "Setting variable DockerImageName to $imageName"
-        Write-Host "##vso[task.setvariable variable=DockerImageName;isOutput=true]$imageName"
+        Write-Host "##vso[task.setvariable variable=DockerImageName]$imageName"
 
         $version = $serverInfo.version
         Write-Host "Setting variable DockerImageVersion to $version"
-        Write-Host "##vso[task.setvariable variable=DockerImageVersion;isOutput=true]$version"
+        Write-Host "##vso[task.setvariable variable=DockerImageVersion]$version"
 
         $cliName = $serverInfo.cliName
         $extension = $serverInfo.extension


### PR DESCRIPTION
We are referencing these only by name and which doesn't work if isOuptut is set, but we don't need them to be output variables so removing that.