### PR TITLE
Adhere to the latest server.json schema

### DIFF
--- a/eng/dnx/.mcp/server.json
+++ b/eng/dnx/.mcp/server.json
@@ -1,22 +1,24 @@
 {
-  "$schema": "https://modelcontextprotocol.io/schemas/draft/2025-07-09/server.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "description": "$(PackageDescription)",
-  "name": "io.github.microsoft/mcp/$(ServerName)",
+  "name": "com.microsoft/$(ServerName)",
+  "version": "$(PackageVersion)",
   "packages": [
     {
-      "registry_name": "nuget",
-      "name": "$(PackageId)",
+      "registryType": "nuget",
+      "identifier": "$(PackageId)",
       "version": "$(PackageVersion)",
-      "package_arguments": [
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
         {
           "type": "positional",
-          "value": "server",
-          "value_hint": "server"
+          "value": "server"
         },
         {
           "type": "positional",
-          "value": "start",
-          "value_hint": "start"
+          "value": "start"
         }
       ]
     }
@@ -24,8 +26,5 @@
   "repository": {
     "url": "$(RepositoryUrl)",
     "source": "github"
-  },
-  "version_detail": {
-    "version": "$(PackageVersion)"
   }
 }

--- a/eng/scripts/Pack-Nuget.ps1
+++ b/eng/scripts/Pack-Nuget.ps1
@@ -86,26 +86,27 @@ function ExportServerJson {
     )
 
     $output = [ordered]@{
-        '$schema' = "https://modelcontextprotocol.io/schemas/draft/2025-07-09/server.json"
+        '$schema' = "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json"
         description = $Description
-        name = "io.github.microsoft/mcp/$CommandName"
+        name = "com.microsoft/$CommandName"
+        version = $Version
         packages = @(
             [ordered]@{
-                registry_name = "nuget"
-                name = $PackageId
+                registryType = "nuget"
+                identifier = $PackageId
                 version = $Version
-                package_arguments = @(
-                    [ordered]@{ type = "positional"; value = "server"; value_hint = "server" },
-                    [ordered]@{ type = "positional"; value = "start"; value_hint = "start" }
+                transport = [ordered]@{
+                    type = "stdio"
+                }
+                packageArguments = @(
+                    [ordered]@{ type = "positional"; value = "server" },
+                    [ordered]@{ type = "positional"; value = "start" }
                 )
             }
         )
         repository = [ordered]@{
             url = $RepositoryUrl
             source = "github"
-        }
-        version_detail = [ordered]@{
-            version = $Version
         }
     }
 

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -15,6 +15,7 @@ The Azure MCP Server updates automatically by default whenever a new release com
 - Fixed the bug where user confirmation (elicitation) stopped working between versions 0.8.5 and 0.9.2. ([#824](https://github.com/microsoft/mcp/issues/824))
 - Fixed `IsServerCommandInvoked` always appearing to be true. [[#837](https://github.com/microsoft/mcp/pull/837)]
 - Fixed `ToolName` always showing up as the tool area even if an MCP tool was invoked. [[#837](https://github.com/microsoft/mcp/pull/837)]
+- Update the `server.json` in the NuGet distribution to match the 2025-09-29 server.json schema version (latest from the MCP Registry). [[#870](https://github.com/microsoft/mcp/pull/870)]
 
 ### Other Changes
 


### PR DESCRIPTION
## What does this PR do?

The server.json schema has changed a couple of times since the initial release to NuGet.org. This updates to the latest schema, now with a working `$schema` URL :).

Docs: https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md
Examples: https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md#examples
Template update: https://github.com/dotnet/extensions/pull/6888

NuGet.org is 

## GitHub issue number?

https://github.com/microsoft/mcp/issues/870

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] ~Added comprehensive tests for new/modified functionality~
    - [x] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
