### PR TITLE
Use build_info to construct the file names to sign

### DIFF
--- a/eng/pipelines/templates/jobs/sign-and-pack.yml
+++ b/eng/pipelines/templates/jobs/sign-and-pack.yml
@@ -26,10 +26,8 @@ jobs:
     parameters:
       SigningKeyCode: 'CP-230012' # MS Cert
       BinaryPath: $(Build.ArtifactStagingDirectory)/signed
-      # Note: Explicit binary patterns have been removed for maintainability.
-      # Signing patterns are now dynamically generated in Compress-ForSigning.ps1
-      # based on build_info.json cliName properties. See Compress-ForSigning.ps1 for details.
-      BinaryPattern: $(WindowsSigningPatterns)
+      # The CliName variable is produced in Compress-ForSigning.ps1 based on build_info.json cliName properties.
+      BinaryPattern: '**/windows-*/$(CliName).exe'
 
   - template: pipelines/steps/azd-cli-mac-signing.yml@azure-sdk-build-tools
     parameters:

--- a/eng/scripts/Compress-ForSigning.ps1
+++ b/eng/scripts/Compress-ForSigning.ps1
@@ -126,13 +126,15 @@ foreach ($server in $buildInfo.servers) {
 }
 
 if($isPipelineRun) {
-    $signingPatterns = $buildInfo.servers
-    | Select-Object -ExpandProperty cliName -Unique
-    | ForEach-Object { "**/windows-*/$_.dll", "**/windows-*/$_.exe" }
-    | ConvertTo-Json -AsArray -Compress
+    if ($buildInfo.servers.Count -ne 1) {
+        LogError "Compress-ForSigning.ps1 only supports single-server builds in a pipeline context."
+        exit 1
+    }
 
-    Write-Host "Setting WindowsSigningPatterns variable to:`n$signingPatterns"
-    Write-Host "##vso[task.setvariable variable=WindowsSigningPatterns]$signingPatterns"
+    $cliName = $buildInfo.servers[0].cliName
+
+    Write-Host "Setting CliName variable to:`n$cliName"
+    Write-Host "##vso[task.setvariable variable=CliName]$CliName"
 
     Write-Host "`n##[group] Output Path Contents:"
     Get-ChildItem -Path $OutputPath -File -Recurse | Select-Object -ExpandProperty FullName | Out-Host


### PR DESCRIPTION
## What does this PR do?
Instead of hard coding the list of files to sign, use the cliName properties from build_info.json to construct a signing pattern.

## GitHub issue number?
fixes #819

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
