### PR TITLE
Fix issue with Postgres live tests

### DIFF
--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.LiveTests/PostgresCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.LiveTests/PostgresCommandTests.cs
@@ -144,7 +144,7 @@ public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(o
     public async Task Should_ListDatabases_Successfully()
     {
         JsonElement? result = await CallToolAsync(
-            "azmcp_postgres_database_list",
+            "postgres_database_list",
             new()
             {
                 { "subscription", Settings.SubscriptionId },
@@ -171,7 +171,7 @@ public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(o
     public async Task Should_ListTables_Successfully()
     {
         JsonElement? result = await CallToolAsync(
-            "azmcp_postgres_table_list",
+            "postgres_table_list",
             new()
             {
                 { "subscription", Settings.SubscriptionId },
@@ -198,7 +198,7 @@ public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(o
     public async Task Should_GetTableSchema_Successfully()
     {
         JsonElement? result = await CallToolAsync(
-            "azmcp_postgres_table_schema_get",
+            "postgres_table_schema_get",
             new()
             {
                 { "subscription", Settings.SubscriptionId },
@@ -234,7 +234,7 @@ public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(o
     {
         // Test a simple SELECT query
         JsonElement? result = await CallToolAsync(
-            "azmcp_postgres_database_query",
+            "postgres_database_query",
             new()
             {
                 { "subscription", Settings.SubscriptionId },
@@ -264,7 +264,7 @@ public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(o
     {
         // Test a query with COUNT aggregation
         JsonElement? result = await CallToolAsync(
-            "azmcp_postgres_database_query",
+            "postgres_database_query",
             new()
             {
                 { "subscription", Settings.SubscriptionId },
@@ -289,7 +289,7 @@ public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(o
     {
         // Test a query with JOIN
         JsonElement? result = await CallToolAsync(
-            "azmcp_postgres_database_query",
+            "postgres_database_query",
             new()
             {
                 { "subscription", Settings.SubscriptionId },
@@ -316,7 +316,7 @@ public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(o
     public async Task Should_ListServerConfigs_Successfully()
     {
         JsonElement? result = await CallToolAsync(
-            "azmcp_postgres_server_config_get",
+            "postgres_server_config_get",
             new()
             {
                 { "subscription", Settings.SubscriptionId },
@@ -358,7 +358,7 @@ public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(o
     {
         // Get a specific server parameter (max_connections is a common one)
         JsonElement? result = await CallToolAsync(
-            "azmcp_postgres_server_param_get",
+            "postgres_server_param_get",
             new()
             {
                 { "subscription", Settings.SubscriptionId },
@@ -380,7 +380,7 @@ public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(o
     public async Task Should_ListServers_Successfully()
     {
         JsonElement? result = await CallToolAsync(
-            "azmcp_postgres_server_list",
+            "postgres_server_list",
             new()
             {
                 { "subscription", Settings.SubscriptionId },
@@ -402,7 +402,7 @@ public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(o
     [Fact]
     public async Task Should_RejectNonSelectQuery_WithValidationError()
     {
-        JsonElement error = await this.CallToolAsyncWithErrorExpected("azmcp_postgres_database_query",
+        JsonElement error = await this.CallToolAsyncWithErrorExpected("postgres_database_query",
             new()
             {
                     { "subscription", Settings.SubscriptionId },
@@ -426,7 +426,7 @@ public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(o
         string serverName = Guid.NewGuid().ToString(); // <-- nonexistent_server
 
         JsonElement error = await this.CallToolAsyncWithErrorExpected(
-                "azmcp_postgres_database_list",
+                "postgres_database_list",
                 new()
                 {
                     { "subscription", Settings.SubscriptionId },
@@ -452,7 +452,7 @@ public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(o
         string databaseName = Guid.NewGuid().ToString(); // <-- nonexistent_database
 
         JsonElement error = await this.CallToolAsyncWithErrorExpected(
-                "azmcp_postgres_table_list",
+                "postgres_table_list",
                 new()
                 {
                     { "subscription", Settings.SubscriptionId },
@@ -475,7 +475,7 @@ public class PostgresCommandTests(ITestOutputHelper output) : CommandTestsBase(o
         string tableName = Guid.NewGuid().ToString(); // <-- nonexistent_table
 
         JsonElement? result = await CallToolAsync(
-            "azmcp_postgres_table_schema_get",
+            "postgres_table_schema_get",
             new()
             {
                     { "subscription", Settings.SubscriptionId },


### PR DESCRIPTION
## What does this PR do?
Updates `PostgresCommandTests.cs` to stop using the `azmcp_` command prefix after it was removed.

## GitHub issue number?
N/A

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
