### PR TITLE
Add remote HTTP server mode with OAuth authentication and downstream token acquisition.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,6 +68,9 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Identity.Abstractions" Version="9.5.0" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="4.0.1" />
+    <PackageVersion Include="Microsoft.Identity.Web.Azure" Version="4.0.1" />
     <PackageVersion Include="Microsoft.HybridRow" Version="1.1.0-preview3" />
     <PackageVersion Include="Microsoft.Azure.Cosmos.Aot" Version="0.1.4-preview.2" />
     <PackageVersion Include="Microsoft.Azure.Mcp.AzTypes.Internal.Compact" Version="0.2.802" />
@@ -78,7 +81,7 @@
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-rc.1.25451.107" />
     <PackageVersion Include="System.Formats.Asn1" Version="9.0.9" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.11.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.0-rc.1.25451.107" />
     <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.0-rc.1.25451.107" />
     <PackageVersion Include="System.Numerics.Tensors" Version="9.0.0" />

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
@@ -64,14 +64,7 @@ public static class AzureMcpServiceCollectionExtensions
 
         // Register tool loader strategies
         services.AddSingleton<CommandFactoryToolLoader>();
-        services.AddSingleton(sp =>
-        {
-            return new RegistryToolLoader(
-                sp.GetRequiredService<RegistryDiscoveryStrategy>(),
-                sp.GetRequiredService<IOptions<ToolLoaderOptions>>(),
-                sp.GetRequiredService<ILogger<RegistryToolLoader>>()
-            );
-        });
+        services.AddSingleton<RegistryToolLoader>();
 
         services.AddSingleton<SingleProxyToolLoader>();
         services.AddSingleton<CompositeToolLoader>();
@@ -216,7 +209,7 @@ public static class AzureMcpServiceCollectionExtensions
 
         var mcpServerBuilder = services.AddMcpServer();
 
-        if (serviceStartOptions.EnableInsecureTransports)
+        if (serviceStartOptions.EnableInsecureTransports || serviceStartOptions.RunAsRemoteHttpService)
         {
             mcpServerBuilder.WithHttpTransport();
         }

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ServiceStartCommand.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ServiceStartCommand.cs
@@ -3,15 +3,21 @@
 
 using System.CommandLine.Parsing;
 using System.Net;
+using Azure.Mcp.Core.Areas.Server.Models;
 using Azure.Mcp.Core.Areas.Server.Options;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Helpers;
+using Azure.Mcp.Core.Services.Azure.Authentication;
 using Azure.Mcp.Core.Services.Telemetry;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Web;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
@@ -69,6 +75,8 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
         command.Options.Add(ServiceOptionDefinitions.Debug);
         command.Options.Add(ServiceOptionDefinitions.EnableInsecureTransports);
         command.Options.Add(ServiceOptionDefinitions.InsecureDisableElicitation);
+        command.Options.Add(ServiceOptionDefinitions.RunAsRemoteHttpService);
+        command.Options.Add(ServiceOptionDefinitions.OutgoingAuthStrategy);
         command.Validators.Add(commandResult =>
         {
             ValidateMode(commandResult.GetValueOrDefault(ServiceOptionDefinitions.Mode), commandResult);
@@ -77,6 +85,10 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
             ValidateNamespaceAndToolMutualExclusion(
                 commandResult.GetValueOrDefault<string[]?>(ServiceOptionDefinitions.Namespace.Name),
                 commandResult.GetValueOrDefault<string[]?>(ServiceOptionDefinitions.Tool.Name),
+                commandResult);
+            ValidateOutgoingAuthStrategy(
+                commandResult.GetValueOrDefault<bool>(ServiceOptionDefinitions.RunAsRemoteHttpService.Name),
+                commandResult.GetValueOrDefault<OutgoingAuthStrategy>(ServiceOptionDefinitions.OutgoingAuthStrategy.Name),
                 commandResult);
         });
     }
@@ -97,6 +109,17 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
             mode = ModeTypes.All;
         }
 
+        var runAsRemoteHttpService = parseResult.GetValueOrDefault<bool>(ServiceOptionDefinitions.RunAsRemoteHttpService.Name);
+        var outgoingAuthStrategy = parseResult.GetValueOrDefault<OutgoingAuthStrategy>(ServiceOptionDefinitions.OutgoingAuthStrategy.Name);
+
+        // Apply safe defaults for outgoing authentication strategy based on hosting mode
+        if (outgoingAuthStrategy == OutgoingAuthStrategy.NotSet)
+        {
+            outgoingAuthStrategy = runAsRemoteHttpService
+                ? OutgoingAuthStrategy.UseOnBehalfOf
+                : OutgoingAuthStrategy.UseHostingEnvironmentIdentity;
+        }
+
         var options = new ServiceStartOptions
         {
             Transport = parseResult.GetValueOrDefault<string>(ServiceOptionDefinitions.Transport.Name) ?? TransportTypes.StdIo,
@@ -106,7 +129,9 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
             ReadOnly = parseResult.GetValueOrDefault<bool?>(ServiceOptionDefinitions.ReadOnly.Name),
             Debug = parseResult.GetValueOrDefault<bool>(ServiceOptionDefinitions.Debug.Name),
             EnableInsecureTransports = parseResult.GetValueOrDefault<bool>(ServiceOptionDefinitions.EnableInsecureTransports.Name),
-            InsecureDisableElicitation = parseResult.GetValueOrDefault<bool>(ServiceOptionDefinitions.InsecureDisableElicitation.Name)
+            InsecureDisableElicitation = parseResult.GetValueOrDefault<bool>(ServiceOptionDefinitions.InsecureDisableElicitation.Name),
+            RunAsRemoteHttpService = runAsRemoteHttpService,
+            OutgoingAuthStrategy = outgoingAuthStrategy
         };
         return options;
     }
@@ -246,6 +271,26 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
     }
 
     /// <summary>
+    /// Validates that the outgoing authentication strategy is compatible with the hosting mode.
+    /// </summary>
+    /// <param name="runAsRemoteHttpService">Whether the server is running as a remote HTTP service.</param>
+    /// <param name="outgoingAuthStrategy">The outgoing authentication strategy.</param>
+    /// <param name="commandResult">Command result to update on failure.</param>
+    private static void ValidateOutgoingAuthStrategy(
+        bool runAsRemoteHttpService,
+        OutgoingAuthStrategy outgoingAuthStrategy,
+        CommandResult commandResult)
+    {
+        // UseOnBehalfOf is only valid when running as a remote HTTP service
+        if (!runAsRemoteHttpService && outgoingAuthStrategy == OutgoingAuthStrategy.UseOnBehalfOf)
+        {
+            commandResult.AddError($"The {OutgoingAuthStrategy.UseOnBehalfOf} outgoing authentication" +
+                $" strategy is only valid when running as a remote HTTP service " +
+                $"(--{ServiceOptionDefinitions.RunAsRemoteHttpServiceName}).");
+        }
+    }
+
+    /// <summary>
     /// Provides custom error messages for specific exception types to improve user experience.
     /// </summary>
     /// <param name="ex">The exception to format an error message for.</param>
@@ -258,6 +303,8 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
             "Invalid mode option specified. Use --mode single, namespace, or all for the supported modes.",
         ArgumentException argEx when argEx.Message.Contains("--namespace and --tool options cannot be used together") =>
             "Configuration error: The --namespace and --tool options are mutually exclusive. Use either one or the other to filter available tools.",
+        ArgumentException argEx when argEx.Message.Contains($"{OutgoingAuthStrategy.UseOnBehalfOf} outgoing authentication strategy") =>
+            $"Configuration error: The {OutgoingAuthStrategy.UseOnBehalfOf} authentication strategy requires --{ServiceOptionDefinitions.RunAsRemoteHttpServiceName} to be enabled.",
         InvalidOperationException invOpEx when invOpEx.Message.Contains("Using --enable-insecure-transport") =>
             "Insecure transport configuration error. Ensure proper authentication configured with Managed Identity or Workload Identity.",
         _ => base.GetErrorMessage(ex)
@@ -270,7 +317,7 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
     /// <returns>An IHost instance configured for the MCP server.</returns>
     private IHost CreateHost(ServiceStartOptions serverOptions)
     {
-        if (serverOptions.EnableInsecureTransports)
+        if (serverOptions.EnableInsecureTransports || serverOptions.RunAsRemoteHttpService)
         {
             return CreateHttpHost(serverOptions);
         }
@@ -315,6 +362,9 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
             })
             .ConfigureServices(services =>
             {
+                // Configure the outgoing authentication strategy.
+                services.AddSingleIdentityTokenCredentialProvider();
+
                 ConfigureServices(services);
                 ConfigureMcpServer(services, serverOptions);
             })
@@ -328,48 +378,190 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
     /// <returns>An IHost instance configured for HTTP transport.</returns>
     private IHost CreateHttpHost(ServiceStartOptions serverOptions)
     {
-        return Host.CreateDefaultBuilder()
-            .ConfigureLogging(logging =>
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+
+        InitializeListingUrls(builder, serverOptions);
+
+        // Configure logging
+        builder.Logging.ClearProviders();
+        builder.Logging.ConfigureOpenTelemetryLogger();
+        builder.Logging.AddEventSourceLogger();
+        builder.Logging.AddConsole();
+
+        IServiceCollection services = builder.Services;
+
+        // Configure outgoing and incoming (if needed) authentication and authorization.
+        if (serverOptions.RunAsRemoteHttpService)
+        {
+            // Configure incoming authentication and authorization.
+            MicrosoftIdentityWebApiAuthenticationBuilderWithConfiguration authBuilder = services
+                .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddMicrosoftIdentityWebApi(builder.Configuration);
+
+            // Configure incoming auth JWT Bearer events for OAuth protected resource metadata.
+            services.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
             {
-                logging.ClearProviders();
-                logging.ConfigureOpenTelemetryLogger();
-                logging.AddEventSourceLogger();
-                logging.AddConsole();
-            })
-            .ConfigureWebHostDefaults(webBuilder =>
-            {
-                webBuilder.ConfigureServices(services =>
+                options.Events = new JwtBearerEvents
                 {
-                    services.AddCors(options =>
+                    OnChallenge = context =>
                     {
-                        options.AddPolicy("AllowAll", policy =>
+                        // Add resource_metadata parameter to WWW-Authenticate header
+                        if (!context.Response.HasStarted)
                         {
-                            policy.AllowAnyOrigin()
-                                  .AllowAnyMethod()
-                                  .AllowAnyHeader();
-                        });
-                    });
+                            HttpRequest request = context.Request;
+                            string resourceMetadataUrl = $"{request.Scheme}://{request.Host}/.well-known/oauth-protected-resource";
 
-                    ConfigureServices(services);
-                    ConfigureMcpServer(services, serverOptions);
-                });
+                            // Modify the WWW-Authenticate header to include resource_metadata
+                            context.Response.Headers.WWWAuthenticate =
+                                $"Bearer realm=\"{request.Host}\", resource_metadata=\"{resourceMetadataUrl}\"";
+                        }
+                        return Task.CompletedTask;
+                    }
+                };
+            });
 
-                webBuilder.Configure(app =>
+            // Configure authorization policy for MCP access.
+            services.AddAuthorizationBuilder()
+                .SetFallbackPolicy(null)
+                .AddPolicy("McpAccess", policy =>
                 {
-                    app.UseCors("AllowAll");
-                    app.UseRouting();
-                    app.UseEndpoints(endpoints =>
-                    {
-                        endpoints.MapMcp();
-                    });
+                    policy.RequireAuthenticatedUser();
+
+                    // Naming conventions used based on well-known Microsoft services, like MS Graph:
+                    // - Scopes for delegated permissions: Mcp.Tools.Verb
+                    // - App roles for application permissions: Mcp.Tools.Verb.All
+                    // As of Oct 2025, we only have ReadWrite as a verb, but this can be extended
+                    // in the future as needed. Other scenarios that aren't "MCP" or "Tools" can
+                    // also be added in the future as they become relevant.
+                    policy.RequireScopeOrAppPermission(
+                        allowedScopeValues: ["Mcp.Tools.ReadWrite"],
+                        allowedAppPermissionValues: ["Mcp.Tools.ReadWrite.All"]);
                 });
 
-                var url = GetSafeAspNetCoreUrl();
-                webBuilder.UseUrls(url);
-            })
-            .Build();
-    }
+            // Configure outgoing authentication strategy
+            if (serverOptions.OutgoingAuthStrategy == OutgoingAuthStrategy.UseOnBehalfOf)
+            {
+                services.AddHttpOnBehalfOfTokenCredentialProvider(authBuilder);
+            }
+            else
+            {
+                services.AddSingleIdentityTokenCredentialProvider();
+            }
+        }
+        else
+        {
+            // Not running as remote HTTP service, use single identity
+            services.AddSingleIdentityTokenCredentialProvider();
+        }
 
+        // Configure non-MCP controllers/endpoints/routes/etc.
+        if (serverOptions.RunAsRemoteHttpService)
+        {
+            services.AddHealthChecks();
+        }
+
+        // Configure CORS
+        // We're allowing all origins, methods, and headers to support any web
+        // browser clients.
+        // Non-browser clients are unaffected by CORS.
+        services.AddCors(options =>
+        {
+            options.AddPolicy("AllowAll", policy =>
+            {
+                policy.AllowAnyOrigin()
+                    .AllowAnyMethod()
+                    .AllowAnyHeader();
+            });
+        });
+
+        // Configure services
+        ConfigureServices(services); // Our static callback hook
+        ConfigureMcpServer(services, serverOptions);
+
+        WebApplication app = builder.Build();
+
+        // Configure middleware pipeline
+        app.UseCors("AllowAll");
+        app.UseRouting();
+
+        // Add OAuth protected resource metadata middleware
+        if (serverOptions.RunAsRemoteHttpService)
+        {
+            app.Use(async (context, next) =>
+            {
+                if (context.Request.Path == "/.well-known/oauth-protected-resource" &&
+                    context.Request.Method == "GET")
+                {
+                    IOptionsMonitor<MicrosoftIdentityOptions> azureAdOptionsMonitor = context
+                        .RequestServices
+                        .GetRequiredService<IOptionsMonitor<MicrosoftIdentityOptions>>();
+                    MicrosoftIdentityOptions azureAdOptions = azureAdOptionsMonitor.Get(JwtBearerDefaults.AuthenticationScheme);
+                    HttpRequest request = context.Request;
+                    string baseUrl = $"{request.Scheme}://{request.Host}";
+                    string? clientId = azureAdOptions.ClientId;
+                    string? tenantId = azureAdOptions.TenantId;
+                    string instance = azureAdOptions.Instance?.TrimEnd('/') ?? "https://login.microsoftonline.com";
+
+                    var metadata = new OAuthProtectedResourceMetadata
+                    {
+                        Resource = baseUrl,
+                        AuthorizationServers = [$"{instance}/{tenantId}/v2.0"],
+
+                        // Only delegated permissions for user principal authorization is listed here.
+                        // Client with users send these scopes to the identity platform to acquire an
+                        // access token.
+                        // However, special to Entra, service principals are expected to always
+                        // request the special `app-id/.default` scope because service principals use
+                        // app roles/app permissions instead of scopes. At time of writing (Oct 2025),
+                        // we don't solve this problem here. Instead we expect any service principal
+                        // clients to be hardcoded to use the `app-id/.default` scope when requesting
+                        // access tokens for our endpoint and for the owners of the client and MCP
+                        // server's service principals to ensure the necessary app roles are assigned
+                        // upfront.
+                        ScopesSupported = [$"{clientId}/Mcp.Tools.ReadWrite"],
+                        BearerMethodsSupported = ["header"],
+
+                        // Intentionally pointing to MCP repo for documentation. Could eventually
+                        // have a dedicated usage doc page, potentially provided by this service itself.
+                        ResourceDocumentation = "https://github.com/Microsoft/mcp"
+                    };
+
+                    context.Response.ContentType = "application/json";
+                    await JsonSerializer.SerializeAsync(
+                        context.Response.Body,
+                        metadata,
+                        OAuthMetadataJsonContext.Default.OAuthProtectedResourceMetadata);
+                    return;
+                }
+
+                await next(context);
+            });
+        }
+
+        // AuthN/Z are always required in the remote HTTP service scenario.
+        if (serverOptions.RunAsRemoteHttpService)
+        {
+            app.UseAuthentication();
+            app.UseAuthorization();
+        }
+
+        IEndpointConventionBuilder mcpEndpointBuilder = app.MapMcp();
+        if (serverOptions.RunAsRemoteHttpService)
+        {
+            // All MCP endpoints require MCP.All scope or role
+            mcpEndpointBuilder.RequireAuthorization("McpAccess");
+        }
+
+        // Map non-MCP endpoints as needed.
+        if (serverOptions.RunAsRemoteHttpService)
+        {
+            // Health checks are anonymous (no authentication required)
+            app.MapHealthChecks("/health")
+                .AllowAnonymous();
+        }
+
+        return app;
+    }
     /// <summary>
     /// Configures the MCP server services.
     /// </summary>
@@ -381,11 +573,17 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
     }
 
     /// <summary>
-    /// Gets a safe ASP.NET Core URL with security validation.
+    /// Initializes the URL for ASP.NET Core to bind to.
     /// </summary>
-    /// <returns>A validated URL string for ASP.NET Core binding.</returns>
-    private static string GetSafeAspNetCoreUrl()
+    private static void InitializeListingUrls(WebApplicationBuilder builder, ServiceStartOptions options)
     {
+        if (options.RunAsRemoteHttpService)
+        {
+            // When running as a remote HTTP service, let the typical IConfiguration
+            // binding handle the ASPNETCORE_URLS value without additional validation.
+            return;
+        }
+
         string url = Environment.GetEnvironmentVariable("ASPNETCORE_URLS") ?? "http://127.0.0.1:5001";
 
         if (url.Contains(';'))
@@ -422,6 +620,6 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
                 $"Set ALLOW_INSECURE_EXTERNAL_BINDING=true if you intentionally want to bind beyond loopback.");
         }
 
-        return url;
+        builder.WebHost.UseUrls(url);
     }
 }

--- a/core/Azure.Mcp.Core/src/Areas/Server/Models/OAuthProtectedResourceMetadata.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Models/OAuthProtectedResourceMetadata.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Mcp.Core.Areas.Server.Models;
+
+/// <summary>
+/// OAuth 2.0 protected resource metadata response model. See https://datatracker.ietf.org/doc/rfc9728/.
+/// </summary>
+public sealed class OAuthProtectedResourceMetadata
+{
+    [JsonPropertyName("resource")]
+    public required string Resource { get; init; }
+
+    [JsonPropertyName("authorization_servers")]
+    public required string[] AuthorizationServers { get; init; }
+
+    [JsonPropertyName("scopes_supported")]
+    public required string[] ScopesSupported { get; init; }
+
+    [JsonPropertyName("bearer_methods_supported")]
+    public required string[] BearerMethodsSupported { get; init; }
+
+    [JsonPropertyName("resource_documentation")]
+    public required string ResourceDocumentation { get; init; }
+}
+
+/// <summary>
+/// JSON serializer context for AOT-safe serialization.
+/// </summary>
+[JsonSerializable(typeof(OAuthProtectedResourceMetadata))]
+internal partial class OAuthMetadataJsonContext : JsonSerializerContext
+{
+}

--- a/core/Azure.Mcp.Core/src/Areas/Server/Options/OutgoingAuthStrategy.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Options/OutgoingAuthStrategy.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Identity;
+
+namespace Azure.Mcp.Core.Areas.Server.Options;
+
+/// <summary>
+/// The strategy to use for authenticating outgoing requests to downstream services.
+/// </summary>
+public enum OutgoingAuthStrategy
+{
+    /// <summary>
+    /// The value is not set and is in a default state. A safe default will
+    /// be chosen based on other settings.
+    /// </summary>
+    NotSet = 0,
+
+    /// <summary>
+    /// Outgoing requests will use the hosting environment's identity resolving
+    /// in a similar way as <see cref="DefaultAzureCredential"/>. This is valid
+    /// for all hosting scenarios. This means all outgoing requests will use the
+    /// same identity regardless of the incoming authenticate request identity,
+    /// if any.
+    /// </summary>
+    UseHostingEnvironmentIdentity = 1,
+
+    /// <summary>
+    /// Outgoing requests will be authenticated based on exchanging the incoming
+    /// request's access token for a new access token valid for the downstream
+    /// service. This is only valid for remote MCP server scenarios.
+    /// </summary>
+    UseOnBehalfOf = 2
+}

--- a/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceOptionDefinitions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceOptionDefinitions.cs
@@ -13,6 +13,8 @@ public static class ServiceOptionDefinitions
     public const string DebugName = "debug";
     public const string EnableInsecureTransportsName = "enable-insecure-transports";
     public const string InsecureDisableElicitationName = "insecure-disable-elicitation";
+    public const string RunAsRemoteHttpServiceName = "run-as-remote-http-service";
+    public const string OutgoingAuthStrategyName = "outgoing-auth-strategy";
 
     public static readonly Option<string> Transport = new($"--{TransportName}")
     {
@@ -82,5 +84,21 @@ public static class ServiceOptionDefinitions
         Required = false,
         Description = "Disable elicitation (user confirmation) before allowing high risk commands to run, such as returning Secrets (passwords) from KeyVault.",
         DefaultValueFactory = _ => false
+    };
+
+    public static readonly Option<bool> RunAsRemoteHttpService = new(
+        $"--{RunAsRemoteHttpServiceName}")
+    {
+        Required = false,
+        Description = "Run the server as a remote HTTP service requiring authentication and authorization on incoming MCP requests.",
+        DefaultValueFactory = _ => false
+    };
+
+    public static readonly Option<OutgoingAuthStrategy> OutgoingAuthStrategy = new(
+        $"--{OutgoingAuthStrategyName}")
+    {
+        Required = false,
+        Description = "Outgoing authentication strategy for Azure service requests. Valid values: NotSet, UseHostingEnvironmentIdentity, UseOnBehalfOf.",
+        DefaultValueFactory = _ => Options.OutgoingAuthStrategy.NotSet
     };
 }

--- a/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceStartOptions.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Options/ServiceStartOptions.cs
@@ -64,4 +64,18 @@ public class ServiceStartOptions
     /// </summary>
     [JsonPropertyName("insecureDisableElicitation")]
     public bool InsecureDisableElicitation { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets whether the server should run as a remote HTTP service.
+    /// When true, the server will require authentication and authorization.
+    /// </summary>
+    [JsonPropertyName("runAsRemoteHttpService")]
+    public bool RunAsRemoteHttpService { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the outgoing authentication strategy for Azure service requests.
+    /// Determines whether to use hosting environment identity or on-behalf-of flow.
+    /// </summary>
+    [JsonPropertyName("outgoingAuthStrategy")]
+    public OutgoingAuthStrategy OutgoingAuthStrategy { get; set; } = OutgoingAuthStrategy.NotSet;
 }

--- a/core/Azure.Mcp.Core/src/Azure.Mcp.Core.csproj
+++ b/core/Azure.Mcp.Core/src/Azure.Mcp.Core.csproj
@@ -21,6 +21,9 @@
     <PackageReference Include="Azure.ResourceManager" />
     <PackageReference Include="Azure.ResourceManager.ResourceGraph" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
+    <PackageReference Include="Microsoft.Identity.Abstractions" />
+    <PackageReference Include="Microsoft.Identity.Web" />
+    <PackageReference Include="Microsoft.Identity.Web.Azure" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" />
     <PackageReference Include="System.Linq.AsyncEnumerable" />
   </ItemGroup>

--- a/core/Azure.Mcp.Core/src/Services/Azure/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Identity.Web;
+
+namespace Azure.Mcp.Core.Services.Azure.Authentication;
+
+/// <summary>
+/// Extension methods for configuring Azure authentication services.
+/// </summary>
+public static class AuthenticationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds <see cref="SingleIdentityTokenCredentialProvider"/> as a
+    /// <see cref="IAzureTokenCredentialProvider"/> with lifetime <see cref="ServiceLifetime.Singleton"/>
+    /// into the service collection.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method registers the single identity token credential provider which uses the hosting
+    /// environment's identity (e.g., a Managed Identity or a user principal using Azure CLI, Visual
+	/// Studio, etc.).
+    /// </para>
+    /// This method will not override any existing <see cref="IAzureTokenCredentialProvider"/>
+    /// registration. It can be overridden as needed for on-behalf-of web APIs using
+    /// <see cref="AddHttpOnBehalfOfTokenCredentialProvider"/>.
+    /// </remarks>
+    public static IServiceCollection AddSingleIdentityTokenCredentialProvider(this IServiceCollection services)
+    {
+        services.TryAddSingleton<IAzureTokenCredentialProvider, SingleIdentityTokenCredentialProvider>();
+        return services;
+    }
+
+    /// <summary>
+    /// Adds <see cref="HttpOnBehalfOfTokenCredentialProvider"/> as a
+    /// <see cref="IAzureTokenCredentialProvider"/> with lifetime <see cref="ServiceLifetime.Singleton"/>
+    /// into the service collection, along with all required dependencies.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="authBuilder">
+    /// The authentication builder from <see cref="MicrosoftIdentityWebApiAuthenticationBuilderExtensions.AddMicrosoftIdentityWebApi"/>
+    /// that will be used to enable token acquisition for downstream API calls.
+    /// </param>
+    /// <returns>The service collection.</returns>
+    /// <remarks>
+    /// This method will override any existing <see cref="IAzureTokenCredentialProvider"/> registration.
+    /// </remarks>
+    public static IServiceCollection AddHttpOnBehalfOfTokenCredentialProvider(
+        this IServiceCollection services,
+        MicrosoftIdentityWebApiAuthenticationBuilderWithConfiguration authBuilder)
+    {
+        // Dependencies - directly in constructor.
+        services.AddHttpContextAccessor();
+
+        // Dependencies - indirectly required to get MicrosoftIdentityTokenCredential.
+        authBuilder.EnableTokenAcquisitionToCallDownstreamApi()
+            .AddInMemoryTokenCaches();
+        services.AddMicrosoftIdentityAzureTokenCredential();
+
+        // Register the OBO token provider. This uses AddSingleton (not TryAdd) to override
+        // any default registration, since OBO is an explicit configuration choice.
+        services.AddSingleton<IAzureTokenCredentialProvider, HttpOnBehalfOfTokenCredentialProvider>();
+        return services;
+    }
+}

--- a/core/Azure.Mcp.Core/src/Services/Azure/Authentication/CustomChainedCredential.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Authentication/CustomChainedCredential.cs
@@ -15,20 +15,47 @@ namespace Azure.Mcp.Core.Services.Azure.Authentication;
 /// InteractiveBrowserCredential to provide a seamless authentication experience.
 /// </summary>
 /// <remarks>
+/// <para>
+/// DO NOT INSTANTIATE THIS CLASS DIRECTLY. Use dependency injection to get an instance of
+/// <see cref="TokenCredential"/> from <see cref="IAzureTokenCredentialProvider"/>.
+/// </para>
+/// <para>
 /// The credential chain behavior can be controlled via the AZURE_TOKEN_CREDENTIALS environment variable:
-/// - "dev": Visual Studio → Visual Studio Code → Azure CLI → Azure PowerShell → Azure Developer CLI
-/// - "prod": Environment → Workload Identity → Managed Identity
-/// - Specific credential name (e.g., "AzureCliCredential"): Only that credential
-/// - Not set or empty: Development chain (Environment → Visual Studio → Visual Studio Code → Azure CLI → Azure PowerShell → Azure Developer CLI)
-/// 
+/// </para>
+/// <list type="table">
+/// <listheader>
+/// <term>Value</term>
+/// <description>Behavior</description>
+/// </listheader>
+/// <item>
+/// <term>"dev"</term>
+/// <description>Visual Studio → Visual Studio Code → Azure CLI → Azure PowerShell → Azure Developer CLI</description>
+/// </item>
+/// <item>
+/// <term>"prod"</term>
+/// <description>Environment → Workload Identity → Managed Identity</description>
+/// </item>
+/// <item>
+/// <term>Specific credential name</term>
+/// <description>Only that credential (e.g., "AzureCliCredential")</description>
+/// </item>
+/// <item>
+/// <term>Not set or empty</term>
+/// <description>Development chain (Environment → Visual Studio → Visual Studio Code → Azure CLI → Azure PowerShell → Azure Developer CLI)</description>
+/// </item>
+/// </list>
+/// <para>
 /// By default, production credentials (Workload Identity and Managed Identity) are excluded unless explicitly requested via AZURE_TOKEN_CREDENTIALS="prod".
-/// 
+/// </para>
+/// <para>
 /// Special behavior: When running in VS Code context (VSCODE_PID environment variable is set) and AZURE_TOKEN_CREDENTIALS is not explicitly specified,
 /// Visual Studio Code credential is automatically prioritized first in the chain.
-/// 
+/// </para>
+/// <para>
 /// After the credential chain, Interactive Browser Authentication with Identity Broker is always added as the final fallback.
+/// </para>
 /// </remarks>
-public class CustomChainedCredential(string? tenantId = null, ILogger<CustomChainedCredential>? logger = null) : TokenCredential
+internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomChainedCredential>? logger = null) : TokenCredential
 {
     private TokenCredential? _credential;
     private readonly ILogger<CustomChainedCredential>? _logger = logger;

--- a/core/Azure.Mcp.Core/src/Services/Azure/Authentication/HttpOnBehalfOfTokenCredentialProvider.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Authentication/HttpOnBehalfOfTokenCredentialProvider.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Identity.Web;
+
+namespace Azure.Mcp.Core.Services.Azure.Authentication;
+
+public class HttpOnBehalfOfTokenCredentialProvider : IAzureTokenCredentialProvider
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<HttpOnBehalfOfTokenCredentialProvider> _logger;
+
+    public HttpOnBehalfOfTokenCredentialProvider(
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<HttpOnBehalfOfTokenCredentialProvider> logger)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public Task<TokenCredential> GetTokenCredentialAsync(string? tenantId, CancellationToken cancellationToken)
+    {
+        if (_httpContextAccessor.HttpContext is not HttpContext httpContext)
+        {
+            throw new InvalidOperationException("There is no ongoing HTTP request.");
+        }
+
+        if (httpContext.User.Identity?.IsAuthenticated != true)
+        {
+            throw new InvalidOperationException(
+                "The current HTTP request must be authenticated to make an on-behalf-of token request.");
+        }
+
+        if (tenantId is not null)
+        {
+            if (httpContext.User.FindFirst("tid")?.Value is string tidClaim
+                && tidClaim != tenantId)
+            {
+                _logger.LogWarning(
+                    "The requested token tenant '{GetTokenTenant}' does not match the tenant of the authenticated user '{TidClaim}'. Going to throw.",
+                    tenantId,
+                    tidClaim);
+
+                throw new InvalidOperationException(
+                    $"The requested token tenant '{tenantId}' does not match the tenant of the authenticated user '{tidClaim}'.");
+            }
+        }
+
+        // MicrosoftIdentityTokenCredential is registered as scoped, so we
+        // can get it from the request services to ensure we get the right instance.
+        MicrosoftIdentityTokenCredential tokenCredential = httpContext
+            .RequestServices
+            .GetRequiredService<MicrosoftIdentityTokenCredential>();
+        return Task.FromResult<TokenCredential>(tokenCredential);
+    }
+}

--- a/core/Azure.Mcp.Core/src/Services/Azure/Authentication/IAzureTokenCredentialProvider.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Authentication/IAzureTokenCredentialProvider.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Azure.Mcp.Core.Services.Azure.Tenant;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Mcp.Core.Services.Azure.Authentication;
+
+/// <summary>
+/// Providers instances of <see cref="TokenCredential"/> appropriate for the current environment.
+/// Implementations are expected to be of <see cref="ServiceLifetime.Singleton"/>, however, in
+/// multi-user enviornments using on-behalf-of downstream authentication, the implementation
+/// must return credentials within the context of the user in the current execution context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Callers</b> can either directly depend on this interface or indirectly depend on it through
+/// <see cref="ITenantService"/>.
+/// </para>
+/// <para>
+/// <b>Implementors</b> of this interface are responsible for generating, caching, and retrieving tokens
+/// that can be used for authentication or authorization purposes. The specific type of the
+/// <see cref="TokenCredential"/> is opaque to the caller of this interface as it will vary based
+/// on the environment and configured authentication.
+/// </para>
+/// </remarks>
+public interface IAzureTokenCredentialProvider
+{
+    /// <summary>
+    /// Gets an instance of <see cref="TokenCredential"/> applicable for the current environment
+    /// and downstream authentication configuration.
+    /// </summary>
+    /// <param name="tenantId">An optional tenant ID to use for the token request. Use of this may
+    /// cause <see cref="InvalidOperationException"/> to be thrown. See the exceptions section for
+    /// details.
+    /// </param>
+    /// <param name="cancellation">A cancellation token.</param>
+    /// <returns>
+    /// A task representing the asynchronous operation, with a value of <see cref="TokenCredential"/>.
+    /// </returns>
+    /// <exception cref="OperationCanceledException"
+    /// >Thrown when the operation has been cancelled.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a credential cannot be provided. This can happen for reasons that vary based on the
+    /// underlying implementation and authentication configuration of the environment. The
+    /// <see cref="Exception.Message"/> of the <see cref="InvalidOperationException"/> should include
+    /// additional details. For example, in multi-user environments using on-behalf-of will
+    /// throw if a non-<see langword="null"/> <paramref name="tenantId"/> is provided that does
+    /// not match the tenant of the authenticated user in the current execution context.
+    /// </exception>
+    Task<TokenCredential> GetTokenCredentialAsync(
+        string? tenantId,
+        CancellationToken cancellation);
+}

--- a/core/Azure.Mcp.Core/src/Services/Azure/Authentication/SingleIdentityTokenCredentialProvider.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Authentication/SingleIdentityTokenCredentialProvider.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Mcp.Core.Services.Azure.Authentication;
+
+/// <summary>
+/// Implementation of <see cref="IAzureTokenCredentialProvider"/> that uses and caches
+/// instances of <see cref="CustomChainedCredential"/>.
+/// </summary>
+public class SingleIdentityTokenCredentialProvider : IAzureTokenCredentialProvider
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly TokenCredential _credential;
+    private readonly Dictionary<string, TokenCredential> _tenantSpecificCredentials
+        = new(StringComparer.OrdinalIgnoreCase);
+
+    public SingleIdentityTokenCredentialProvider(ILoggerFactory loggerFactory)
+    {
+        _loggerFactory = loggerFactory;
+        _credential = new CustomChainedCredential(
+            null,
+            _loggerFactory.CreateLogger<CustomChainedCredential>()
+        );
+    }
+
+    /// <inheritdoc/>
+    public Task<TokenCredential> GetTokenCredentialAsync(
+        string? tenantId,
+        CancellationToken cancellation)
+    {
+        if (tenantId is null)
+        {
+            return Task.FromResult(_credential);
+        }
+
+        if (!_tenantSpecificCredentials.TryGetValue(tenantId, out TokenCredential? tenantCredential))
+        {
+            lock (_tenantSpecificCredentials)
+            {
+                if (!_tenantSpecificCredentials.TryGetValue(tenantId, out tenantCredential))
+                {
+                    tenantCredential = new CustomChainedCredential(
+                        tenantId,
+                        _loggerFactory.CreateLogger<CustomChainedCredential>()
+                    );
+                    _tenantSpecificCredentials[tenantId] = tenantCredential;
+                }
+            }
+        }
+
+        return Task.FromResult(tenantCredential);
+    }
+}

--- a/core/Azure.Mcp.Core/src/Services/Azure/ResourceGroup/ResourceGroupService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/ResourceGroup/ResourceGroupService.cs
@@ -4,6 +4,7 @@
 using Azure.Mcp.Core.Models.ResourceGroup;
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Core.Services.Caching;
 using Azure.ResourceManager.Resources;
 

--- a/core/Azure.Mcp.Core/src/Services/Azure/Tenant/ITenantService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Tenant/ITenantService.cs
@@ -1,15 +1,101 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Core;
+using Azure.Mcp.Core.Services.Azure.Authentication;
 using Azure.ResourceManager.Resources;
 
 namespace Azure.Mcp.Core.Services.Azure.Tenant;
 
+/// <summary>
+/// Provides operations for managing Azure tenants and tenant-scoped authentication.
+/// </summary>
 public interface ITenantService
 {
+    /// <summary>
+    /// Gets the list of all available Azure tenants.
+    /// </summary>
+    /// <returns>
+    /// A task representing the asynchronous operation, with a list of <see cref="TenantResource"/>
+    /// instances.
+    /// </returns>
     Task<List<TenantResource>> GetTenants();
-    Task<string?> GetTenantId(string tenant);
-    Task<string?> GetTenantIdByName(string tenantName);
-    Task<string?> GetTenantNameById(string tenantId);
-    bool IsTenantId(string tenant);
+
+    /// <summary>
+    /// Gets the tenant ID from either a tenant ID or tenant name.
+    /// </summary>
+    /// <param name="tenantIdOrName">The tenant ID or tenant name.</param>
+    /// <returns>
+    /// A task representing the asynchronous operation, with the tenant ID or <see langword="null"/>
+    /// if not found.
+    /// </returns>
+    /// <exception cref="Exception">
+    /// Thrown when a tenant with the specified name is not found.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the tenant has a <see langword="null"> TenantId.
+    /// </exception>
+    Task<string> GetTenantId(string tenantIdOrName);
+
+    /// <summary>
+    /// Gets the tenant ID by tenant name.
+    /// </summary>
+    /// <param name="tenantName">The tenant name.</param>
+    /// <returns>
+    /// A task representing the asynchronous operation, with the tenant ID or <see langword="null"/>
+    /// if not found.
+    /// </returns>
+    /// <exception cref="Exception">
+    /// Thrown when a tenant with the specified name is not found.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the tenant has a <see langword="null"> TenantId.
+    /// </exception>
+    Task<string> GetTenantIdByName(string tenantName);
+
+    /// <summary>
+    /// Gets the tenant name by tenant ID.
+    /// </summary>
+    /// <param name="tenantId">The tenant ID.</param>
+    /// <returns>
+    /// A task representing the asynchronous operation, with the tenant name or <see langword="null"/> if not found.
+    /// </returns>
+    /// <exception cref="Exception">
+    /// Thrown when a tenant with the specified ID is not found.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the tenant has a <see langword="null"> DisplayName.
+    /// </exception>
+    Task<string> GetTenantNameById(string tenantId);
+
+    /// <summary>
+    /// Determines whether the specified string is a valid tenant ID (GUID format).
+    /// </summary>
+    /// <param name="tenantId">The string to validate.</param>
+    /// <returns>
+    /// <see langword="true"/> if the string is a valid tenant ID; otherwise, <see langword="false"/>.
+    /// </returns>
+    bool IsTenantId(string tenantId);
+
+    /// <summary>
+    /// Gets an instance of <see cref="TokenCredential"/>.
+    /// </summary>
+    /// <param name="tenantId">Optional tenant ID. Use <see langword="null"/> in most cases.</param>
+    /// <param name="cancellation">A cancellation token.</param>
+    /// <returns>
+    /// A task representing the asynchronous operation, with a value of <see cref="TokenCredential"/>.
+    /// </returns>
+    /// <remarks>
+    /// Implementors of this method must use <see cref="IAzureTokenCredentialProvider"/> to obtain
+    /// the token credential.
+    /// </remarks>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when the operation has been cancelled.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a credential cannot be provided.
+    /// </exception>
+    Task<TokenCredential> GetTokenCredentialAsync(
+        string? tenantId,
+        CancellationToken cancellationToken);
 }

--- a/core/Azure.Mcp.Core/src/Services/Azure/Tenant/TenantService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Tenant/TenantService.cs
@@ -1,20 +1,32 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Core;
+using Azure.Mcp.Core.Services.Azure.Authentication;
 using Azure.Mcp.Core.Services.Caching;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
 
 namespace Azure.Mcp.Core.Services.Azure.Tenant;
 
-public class TenantService(ICacheService cacheService)
-    : BaseAzureService, ITenantService
+public class TenantService: BaseAzureService, ITenantService
 {
-    private readonly ICacheService _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
+    private readonly IAzureTokenCredentialProvider _credentialProvider;
+    private readonly ICacheService _cacheService;
     private const string CacheGroup = "tenant";
     private const string CacheKey = "tenants";
     private static readonly TimeSpan s_cacheDuration = TimeSpan.FromHours(12);
 
+    public TenantService(
+        IAzureTokenCredentialProvider credentialProvider,
+        ICacheService cacheService)
+    {
+        _credentialProvider = credentialProvider;
+        _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
+        TenantService = this;
+    }
+
+    /// <inheritdoc/>
     public async Task<List<TenantResource>> GetTenants()
     {
         // Try to get from cache first
@@ -40,42 +52,54 @@ public class TenantService(ICacheService cacheService)
         return results;
     }
 
-    public bool IsTenantId(string tenant)
+    /// <inheritdoc/>
+    public bool IsTenantId(string tenantId)
     {
-        return Guid.TryParse(tenant, out _);
+        return Guid.TryParse(tenantId, out _);
     }
 
-    public async Task<string?> GetTenantId(string tenant)
+    /// <inheritdoc/>
+    public async Task<string> GetTenantId(string tenantIdOrName)
     {
-        if (IsTenantId(tenant))
+        if (IsTenantId(tenantIdOrName))
         {
-            return tenant;
+            return tenantIdOrName;
         }
 
-        return await GetTenantIdByName(tenant);
+        return await GetTenantIdByName(tenantIdOrName);
     }
 
-    public async Task<string?> GetTenantIdByName(string tenantName)
+    /// <inheritdoc/>
+    public async Task<string> GetTenantIdByName(string tenantName)
     {
         var tenants = await GetTenants();
         var tenant = tenants.FirstOrDefault(t => t.Data.DisplayName?.Equals(tenantName, StringComparison.OrdinalIgnoreCase) == true) ??
             throw new Exception($"Could not find tenant with name {tenantName}");
 
-        if (tenant.Data.TenantId == null)
+        string? tenantId = tenant.Data.TenantId?.ToString();
+        if (tenantId == null)
             throw new InvalidOperationException($"Tenant {tenantName} has a null TenantId");
 
-        return tenant.Data.TenantId.ToString();
+        return tenantId.ToString();
     }
 
-    public async Task<string?> GetTenantNameById(string tenantId)
+    /// <inheritdoc/>
+    public async Task<string> GetTenantNameById(string tenantId)
     {
         var tenants = await GetTenants();
         var tenant = tenants.FirstOrDefault(t => t.Data.TenantId?.ToString().Equals(tenantId, StringComparison.OrdinalIgnoreCase) == true) ??
             throw new Exception($"Could not find tenant with ID {tenantId}");
 
-        if (tenant.Data.DisplayName == null)
+        string? tenantName = tenant.Data.DisplayName;
+        if (tenantName == null)
             throw new InvalidOperationException($"Tenant with ID {tenantId} has a null DisplayName");
 
-        return tenant.Data.DisplayName;
+        return tenantName;
+    }
+
+    /// <inheritdoc/>
+    public async Task<TokenCredential> GetTokenCredentialAsync(string? tenantId, CancellationToken cancellationToken)
+    {
+        return await _credentialProvider.GetTokenCredentialAsync(tenantId, cancellationToken);
     }
 }

--- a/core/Azure.Mcp.Core/src/Services/Azure/Tenant/TenantServiceCollectionExtensions.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Tenant/TenantServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Services.Azure.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Azure.Mcp.Core.Services.Azure.Tenant;
+
+/// <summary>
+/// Extension methods for configuring Azure tenant services.
+/// </summary>
+public static class TenantServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds <see cref="TenantService"/> as <see cref="ITenantService"/> with lifetime
+    /// <see cref="ServiceLifetime.Singleton"/> into the service collection.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method follows the dependency graph pattern by ensuring all dependencies of
+    /// <see cref="TenantService"/> are registered by calling their respective extension methods.
+    /// </para>
+    /// <para>
+    /// Dependencies registered:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>
+    /// <description>
+    /// <see cref="IAzureTokenCredentialProvider"/> via <see cref="Authentication.AuthenticationServiceCollectionExtensions.AddSingleIdentityTokenCredentialProvider"/>.
+    /// This can be overridden using <see cref="Authentication.AuthenticationServiceCollectionExtensions.AddAzureTokenCredentialProvider"/>
+    /// based on parsed command line arguments and environment variables.
+    /// </description>
+    /// </item>
+    /// </list>
+    /// </remarks>
+    public static IServiceCollection AddAzureTenantService(this IServiceCollection services)
+    {
+        // !!! HACK !!!
+        // Program.cs for the CLI servers have their own DI containers vs ServiceStartCommand.
+        // If the CLI is started to run a non-"server start" command, then we're assuming we should
+        // use the identity resolved from the host environment for downstream auth (e.g., Azure CLI
+        // or VS Code user). This will fulfill the DI container for those non-"server start" commands.
+        // Within ServiceStartCommand, when it has its own fully IHost with DI and IConfiguration,
+        // then it will need to call AddAzureTokenCredentialProvider for just the ServiceStartCommand
+        // container to be populated with the correct authentication strategy, such as OBO for
+        // running as a remote HTTP MCP service.
+        services.AddSingleIdentityTokenCredentialProvider();
+        
+        services.TryAddSingleton<ITenantService, TenantService>();
+        return services;
+    }
+}

--- a/servers/Azure.Mcp.Server/src/Program.cs
+++ b/servers/Azure.Mcp.Server/src/Program.cs
@@ -131,7 +131,7 @@ internal class Program
         services.AddSingleton<ICacheService, CacheService>();
         services.AddSingleton<IExternalProcessService, ExternalProcessService>();
         services.AddSingleton<IDateTimeProvider, DateTimeProvider>();
-        services.AddSingleton<ITenantService, TenantService>();
+        services.AddAzureTenantService();
         services.AddSingleton<IResourceGroupService, ResourceGroupService>();
         services.AddSingleton<ISubscriptionService, SubscriptionService>();
         services.AddSingleton<CommandFactory>();

--- a/servers/Azure.Mcp.Server/src/Properties/launchSettings.json
+++ b/servers/Azure.Mcp.Server/src/Properties/launchSettings.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json.schemastore.org/launchsettings.json",
+    "profiles": {
+        "debug-remotemcp": {
+            "commandName": "Project",
+            "commandLineArgs": "server start --run-as-remote-http-service --outgoing-auth-strategy UseHostingEnvironmentIdentity",
+            "dotnetRunMessages": true,
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "ASPNETCORE_URLS": "http://localhost:1031",
+                "AzureAd__TenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+                "AzureAd__ClientId": "ca1e0302-d50a-47d7-b5e6-7aff49884bce",
+                "AzureAd__Instance": "https://login.microsoftonline.com/"
+            }
+        }
+    }
+}

--- a/servers/Fabric.Mcp.Server/src/Program.cs
+++ b/servers/Fabric.Mcp.Server/src/Program.cs
@@ -87,7 +87,7 @@ internal class Program
         services.AddSingleton<ICacheService, CacheService>();
         services.AddSingleton<IExternalProcessService, ExternalProcessService>();
         services.AddSingleton<IDateTimeProvider, DateTimeProvider>();
-        services.AddSingleton<ITenantService, TenantService>();
+        services.AddAzureTenantService();
         services.AddSingleton<IResourceGroupService, ResourceGroupService>();
         services.AddSingleton<ISubscriptionService, SubscriptionService>();
         services.AddSingleton<CommandFactory>();

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.LiveTests/AppConfigCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.LiveTests/AppConfigCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
+using Azure.Mcp.Core.Services.Azure.Authentication;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Core.Services.Caching;
@@ -27,7 +28,8 @@ public class AppConfigCommandTests : CommandTestsBase
         _logger = NullLogger<AppConfigService>.Instance;
         var memoryCache = new MemoryCache(Microsoft.Extensions.Options.Options.Create(new MemoryCacheOptions()));
         var cacheService = new CacheService(memoryCache);
-        var tenantService = new TenantService(cacheService);
+        var tokenProvider = new SingleIdentityTokenCredentialProvider(NullLoggerFactory.Instance);
+        var tenantService = new TenantService(tokenProvider, cacheService);
         var subscriptionService = new SubscriptionService(cacheService, tenantService);
         _appConfigService = new AppConfigService(subscriptionService, tenantService, _logger);
     }

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.LiveTests/CosmosDbFixture.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.LiveTests/CosmosDbFixture.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 using Azure.Mcp.Core.Services.Azure.Authentication;
 using Azure.Mcp.Tests.Client.Helpers;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Cosmos.LiveTests;
@@ -19,9 +20,11 @@ public class CosmosDbFixture : IAsyncLifetime
         var settingsFixture = new LiveTestSettingsFixture();
         await settingsFixture.InitializeAsync();
 
+        var tokenProvider = new SingleIdentityTokenCredentialProvider(NullLoggerFactory.Instance);
+
         _client = new CosmosClient(
             accountEndpoint: $"https://{settingsFixture.Settings.ResourceBaseName}.documents.azure.com:443/",
-            tokenCredential: new CustomChainedCredential()
+            tokenCredential: await tokenProvider.GetTokenCredentialAsync(default, default)
         );
         Container container = _client.GetContainer("ToDoList", "Items");
         ToDoItem entry = new ToDoItem();

--- a/tools/Azure.Mcp.Tools.Extension/src/Services/CliGenerateService.cs
+++ b/tools/Azure.Mcp.Tools.Extension/src/Services/CliGenerateService.cs
@@ -9,16 +9,17 @@ using Azure.Mcp.Tools.Extension.Models;
 
 namespace Azure.Mcp.Tools.Extension.Services;
 
-internal class CliGenerateService(IHttpClientService httpClientService) : ICliGenerateService
+internal class CliGenerateService(IHttpClientService httpClientService, IAzureTokenCredentialProvider tokenCredentialProvider) : ICliGenerateService
 {
     private readonly IHttpClientService _httpClientService = httpClientService;
+    private readonly IAzureTokenCredentialProvider _tokenCredentialProvider = tokenCredentialProvider;
 
     public async Task<HttpResponseMessage> GenerateAzureCLICommandAsync(string intent)
     {
         // AzCli copilot 1P app scope
         const string apiScope = "a5ede409-60d3-4a6c-93e6-eb2e7271e8e3/.default";
 
-        var credential = new CustomChainedCredential();
+        var credential = await _tokenCredentialProvider.GetTokenCredentialAsync(tenantId: null, CancellationToken.None);
         var accessToken = await credential.GetTokenAsync(new TokenRequestContext([apiScope]), CancellationToken.None);
 
         // AzCli copilot API endpoint

--- a/tools/Azure.Mcp.Tools.Foundry/tests/Azure.Mcp.Tools.Foundry.LiveTests/FoundryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/tests/Azure.Mcp.Tools.Foundry.LiveTests/FoundryCommandTests.cs
@@ -6,6 +6,7 @@ using Azure.AI.Agents.Persistent;
 using Azure.Mcp.Core.Services.Azure.Authentication;
 using Azure.Mcp.Tests;
 using Azure.Mcp.Tests.Client;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Foundry.LiveTests;
@@ -1009,9 +1010,11 @@ public class FoundryCommandTests(ITestOutputHelper output)
 
     private async Task<string> CreateAgent(string agentName, string projectEndpoint, string deploymentName)
     {
+        var tokenProvider = new SingleIdentityTokenCredentialProvider(NullLoggerFactory.Instance);
+
         var client = new PersistentAgentsClient(
             projectEndpoint,
-            new CustomChainedCredential());
+            await tokenProvider.GetTokenCredentialAsync(default, default));
 
         var bingConnectionId = $"/subscriptions/{Settings.SubscriptionId}/resourceGroups/{Settings.ResourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{Settings.ResourceBaseName}/projects/{Settings.ResourceBaseName}-ai-projects/connections/{Settings.ResourceBaseName}-bing-connection";
 

--- a/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.LiveTests/ProductGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.LiveTests/ProductGetCommandTests.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
+using Azure.Mcp.Core.Services.Azure.Authentication;
 using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Core.Services.Caching;
 using Azure.Mcp.Tests;
 using Azure.Mcp.Tests.Client;
 using Azure.Mcp.Tools.Marketplace.Services;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Marketplace.LiveTests;
@@ -25,7 +27,8 @@ public class ProductGetCommandTests : CommandTestsBase
     {
         var memoryCache = new MemoryCache(Microsoft.Extensions.Options.Options.Create(new MemoryCacheOptions()));
         var cacheService = new CacheService(memoryCache);
-        var tenantService = new TenantService(cacheService);
+        var tokenProvider = new SingleIdentityTokenCredentialProvider(NullLoggerFactory.Instance);
+        var tenantService = new TenantService(tokenProvider, cacheService);
         _marketplaceService = new MarketplaceService(tenantService);
     }
 

--- a/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.LiveTests/ProductListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.LiveTests/ProductListCommandTests.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
+using Azure.Mcp.Core.Services.Azure.Authentication;
 using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Core.Services.Caching;
 using Azure.Mcp.Tests;
 using Azure.Mcp.Tests.Client;
 using Azure.Mcp.Tools.Marketplace.Services;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Marketplace.LiveTests;
@@ -23,7 +25,8 @@ public class ProductListCommandTests : CommandTestsBase
     {
         var memoryCache = new MemoryCache(Microsoft.Extensions.Options.Options.Create(new MemoryCacheOptions()));
         var cacheService = new CacheService(memoryCache);
-        var tenantService = new TenantService(cacheService);
+        var tokenProvider = new SingleIdentityTokenCredentialProvider(NullLoggerFactory.Instance);
+        var tenantService = new TenantService(tokenProvider, cacheService);
         _marketplaceService = new MarketplaceService(tenantService);
     }
 

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.LiveTests/MonitorCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.LiveTests/MonitorCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
+using Azure.Mcp.Core.Services.Azure.Authentication;
 using Azure.Mcp.Core.Services.Azure.ResourceGroup;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
@@ -11,6 +12,7 @@ using Azure.Mcp.Tests;
 using Azure.Mcp.Tests.Client;
 using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.LiveTests;
@@ -38,7 +40,8 @@ public class MonitorCommandTests(ITestOutputHelper output) : CommandTestsBase(ou
     {
         var memoryCache = new MemoryCache(Microsoft.Extensions.Options.Options.Create(new MemoryCacheOptions()));
         var cacheService = new CacheService(memoryCache);
-        var tenantService = new TenantService(cacheService);
+        var tokenProvider = new SingleIdentityTokenCredentialProvider(NullLoggerFactory.Instance);
+        var tenantService = new TenantService(tokenProvider, cacheService);
         var subscriptionService = new SubscriptionService(cacheService, tenantService);
         var resourceGroupService = new ResourceGroupService(cacheService, subscriptionService);
         var resourceResolverService = new ResourceResolverService(subscriptionService, tenantService);

--- a/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.LiveTests/ServiceBusCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.LiveTests/ServiceBusCommandTests.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
+using Azure.Core;
 using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Core.Services.Azure.Authentication;
 using Azure.Mcp.Tests;
 using Azure.Mcp.Tests.Client;
 using Azure.Mcp.Tools.ServiceBus.Options;
 using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.ServiceBus.LiveTests
@@ -118,7 +120,8 @@ namespace Azure.Mcp.Tools.ServiceBus.LiveTests
 
         private async Task SendTestMessages(string queueOrTopicName, int numberOfMessages)
         {
-            var credentials = new CustomChainedCredential(Settings.TenantId);
+            var tokenProvider = new SingleIdentityTokenCredentialProvider(NullLoggerFactory.Instance);
+            TokenCredential credentials = await tokenProvider.GetTokenCredentialAsync(Settings.TenantId, default);
             await using (var client = new ServiceBusClient($"{Settings.ResourceBaseName}.servicebus.windows.net", credentials))
             await using (var sender = client.CreateSender(queueOrTopicName))
             {


### PR DESCRIPTION


## What does this PR do?
`[Provide a clear, concise description of the changes]`

Add remote HTTP server mode with OAuth authentication and downstream token acquisition.

- Add RunAsRemoteHttpService and OutgoingAuthStrategy options to enable MCP server to run as a remote HTTP service
- Introduce ITokenProvider abstraction for dependency injection of downstream authentication tokens and credentials
- Add support for On-Behalf-Of (OBO) token flow and hosting environment identity modes for outgoing authentication
- Implement OAuth Protected Resource Metadata endpoint at /.well-known/oauth-protected-resource with WWW-Authenticate challenge
- Add Visual Studio launch profile for debugging remote MCP server with Microsoft.Identity.Web configuration
- Modernize HTTP host creation using WebApplicationBuilder with authentication and authorization middleware

`[Any additional context, screenshots, or information that helps reviewers]`

This is for our goals of allowing Microsoft customers self-hosting remote MCP servers.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [X] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [X] PR title clearly describes the change
    - [X] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
