### PR TITLE
Add fabric-mcp team as owners of the Fabric MCP code paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -251,3 +251,10 @@
 
 # ServiceLabel: %tools-ResourceHealth
 # ServiceOwners:                       @pkaza-msft @microsoft/azure-mcp
+
+##################
+# Fabric MCP
+##################
+/core/Microsoft.Fabric.Mcp.Core/      @microsoft/fabric-mcp
+/servers/Fabric.Mcp.Server/           @microsoft/fabric-mcp
+/tools/Fabric.Mcp.Tools.PublicApi/    @microsoft/fabric-mcp


### PR DESCRIPTION
## What does this PR do?
Add fabric-mcp team as owners of the Fabric MCP code paths