### PR TITLE
Add pipeline validation to prevent emojis in TOC

### DIFF
--- a/eng/scripts/Process-PackageReadMe.ps1
+++ b/eng/scripts/Process-PackageReadMe.ps1
@@ -234,11 +234,6 @@ function Validate-PackageReadme {
             
             $anchorLink = $title.ToLower() -replace '[^a-z0-9 ]', '' -replace ' ', '-'
             if ($headingValidationList.ContainsKey($title)) {
-                # Only check for emojis in headings that are actually in the TOC
-                if ($title -match $emojiPattern) {
-                    throw "Unicode emoji detected in heading: '$title'. This heading is in the TOC and emojis in TOC entries break NuGet packaging."
-                }
-                
                 $headingInfo = $headingValidationList[$title]
                 if ($headingInfo.Level -ne $level) {
                     Write-Host "Heading level mismatch for '$title'. TOC level: $($headingInfo.Level), Actual level: $level" -ForegroundColor Red
@@ -246,6 +241,12 @@ function Validate-PackageReadme {
                 if ($headingInfo.AnchorLink -ne $anchorLink) {
                     Write-Host "Anchor link mismatch for '$title'. TOC anchor: '$($headingInfo.AnchorLink)', Actual anchor: '$anchorLink'" -ForegroundColor Red
                 }
+                
+                # Check for emojis in headings after other validation to provide complete feedback
+                if ($title -match $emojiPattern) {
+                    throw "Unicode emoji detected in heading: '$title'. This heading is in the TOC and emojis in TOC entries break NuGet packaging."
+                }
+                
                 $headingValidationList.Remove($title) | Out-Null
             }
         }


### PR DESCRIPTION
## What does this PR do?
Modifies the `eng\scripts\Process-PackageReadMe.ps1` script to validate that TOC headers do not have any unicode emoji, since these break NuGet.

## GitHub issue number?
Related to: https://github.com/microsoft/mcp/pull/934

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
