### PR TITLE
Use AzurePowerShellCredential for all live tests

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Tests/Client/Helpers/LiveTestSettings.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Tests/Client/Helpers/LiveTestSettings.cs
@@ -16,5 +16,6 @@ public class LiveTestSettings
     public string SettingsDirectory { get; set; } = string.Empty;
     public string TestPackage { get; set; } = string.Empty;
     public bool DebugOutput { get; set; }
-    public Dictionary<string, string> DeploymentOutputs { get; set; } = new();
+    public Dictionary<string, string> DeploymentOutputs { get; set; } = [];
+    public Dictionary<string, string> EnvironmentVariables { get; set; } = [];
 }

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Tests/Client/Helpers/LiveTestSettingsFixture.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Tests/Client/Helpers/LiveTestSettingsFixture.cs
@@ -26,6 +26,11 @@ namespace Azure.Mcp.Tests.Client.Helpers
                     Settings = JsonSerializer.Deserialize<LiveTestSettings>(content)
                         ?? throw new Exception("Unable to deserialize live test settings");
 
+                    foreach (var (key, value) in Settings.EnvironmentVariables)
+                    {
+                        Environment.SetEnvironmentVariable(key, value);
+                    }
+
                     Settings.SettingsDirectory = directory;
                     await SetPrincipalSettingsAsync();
 

--- a/eng/scripts/helpers/TestResourcesHelpers.ps1
+++ b/eng/scripts/helpers/TestResourcesHelpers.ps1
@@ -51,6 +51,11 @@ function New-TestSettings {
         SubscriptionName = $subscriptionName
         ResourceGroupName = $ResourceGroupName
         ResourceBaseName = $BaseName
+        EnvironmentVariables = [ordered]@{
+            # Live test resources are deployed using Azure PowerShell, so we know it's already in the correct tenant
+            # Force CustomChainedCredential to use AzurePowerShellCredential to avoid cross-tenant auth issues
+            "AZURE_TOKEN_CREDENTIALS" = "AzurePowerShellCredential"
+        }
     }
 
     # Add DeploymentOutputs if provided


### PR DESCRIPTION
## What does this PR do?
Azure PowerShell is used to deploy test resources. Our chained credential, like DefaultAzureCredential will pull a token from VS or VSCode before trying AZ PowerShelll or az CLI.  This causes cross tenant auth issues when VS or VS Code returns a token for a tenant other than the one used in the deployment.

For a consistent test experience, we'll now allow `.testsettings.json` files to set environment variables to be loaded by LiveTestSettingsFixture and we'll set .testsettings.json's `AZURE_TOKEN_CREDENTIALS` environment variable to `AzurePowerShellCredential` after deployment.  This will cause live tests with deployed resources and the mcp server they start to use only AzurePowerShellCredential for tokens.

## GitHub issue number?
none

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
