### PR TITLE
Update contributing guide for HTTP mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,9 +205,52 @@ Build the project at the root directory of this repository:
 dotnet build
 ```
 
+#### Run the Azure MCP server in HTTP mode
+
+**Option 1: Using dotnet run (uses launchSettings.json)**
+
+```bash
+dotnet run --project servers/Azure.Mcp.Server/src/
+```
+
+> **Note:** Running `dotnet run` automatically uses the configuration in `servers/Azure.Mcp.Server/src/Properties/launchSettings.json`, which contains the necessary command line arguments and environment variables to run the server in HTTP mode at `http://localhost:1031` for easier debugging and testing.
+
+**Option 2: Using the built executable directly**
+
+Build the project first, then run the executable with the necessary environment variables:
+
+```bash
+# Set environment variables (PowerShell)
+$env:ASPNETCORE_ENVIRONMENT = "Development"
+$env:ASPNETCORE_URLS = "http://localhost:1031"
+$env:AzureAd__TenantId = "<your-tenant-id>"
+$env:AzureAd__ClientId = "<your-client-id>"
+$env:AzureAd__Instance = "https://login.microsoftonline.com/"
+
+# Run the executable
+./servers/Azure.Mcp.Server/src/bin/Debug/net9.0/azmcp.exe server start --run-as-remote-http-service --outgoing-auth-strategy UseHostingEnvironmentIdentity
+```
+
+```bash
+# Set environment variables (Bash)
+export ASPNETCORE_ENVIRONMENT="Development"
+export ASPNETCORE_URLS="http://localhost:1031"
+export AzureAd__TenantId="<your-tenant-id>"
+export AzureAd__ClientId="<your-client-id>"
+export AzureAd__Instance="https://login.microsoftonline.com/"
+
+# Run the executable
+./servers/Azure.Mcp.Server/src/bin/Debug/net9.0/azmcp server start --run-as-remote-http-service --outgoing-auth-strategy UseHostingEnvironmentIdentity
+```
+
+> **Note:** The environment variables listed above are taken from the `debug-remotemcp` profile in `launchSettings.json`. Replace `<your-tenant-id>` and `<your-client-id>` with your actual Azure AD tenant ID and client ID. These variables configure Azure AD authentication and the server endpoint for HTTP mode operation.
+
+
 #### Configure mcp.json
 
-Update your mcp.json to point to the locally built azmcp executable:
+Update your mcp.json to point to the locally built azmcp executable.
+
+**Stdio Mode:**
 
 ```json
 {
@@ -221,9 +264,23 @@ Update your mcp.json to point to the locally built azmcp executable:
 }
 ```
 
+**HTTP Mode:**
+
+```json
+{
+  "servers": {
+    "Azure MCP Server": {
+      "url": "http://localhost:1031/",
+      "type": "http"
+    }
+  }
+}
+```
+
 > [!NOTE]
-> Replace `<absolute-path-to>` with the full path to your built executable.
+> For stdio mode, replace `<absolute-path-to>` with the full path to your built executable.
 > On **Windows**, use `azmcp.exe`. On **macOS/Linux**, use `azmcp`.
+> For HTTP mode, ensure the server is running on the specified port before connecting (port 1031 is the default port configured in launchSettings.json).
 
 #### Server Modes
 

--- a/servers/Azure.Mcp.Server/TROUBLESHOOTING.md
+++ b/servers/Azure.Mcp.Server/TROUBLESHOOTING.md
@@ -881,10 +881,25 @@ To export telemetry to Azure Monitor, set the `APPLICATIONINSIGHTS_CONNECTION_ST
 
 ### Development in VS Code
 
+#### Running Azure MCP Server Locally for Development
+
+When developing or debugging the Azure MCP Server locally, you can use `dotnet run` which automatically uses the configuration in `Properties/launchSettings.json`:
+
+```bash
+dotnet run --project servers/Azure.Mcp.Server/src/
+```
+
+The `launchSettings.json` file automatically configures:
+- **Command line arguments:** `server start --run-as-remote-http-service --outgoing-auth-strategy UseHostingEnvironmentIdentity`
+- **Environment variables** for Azure AD authentication and ASP.NET Core settings
+- **HTTP endpoint:** `http://localhost:1031` for easier debugging and testing
+
+This is the recommended approach for local development as it sets up the server in HTTP mode with all necessary authentication and configuration automatically.
+
 #### Bring your own language model key
 
 [Bring your own language model key](https://code.visualstudio.com/docs/copilot/language-models#_bring-your-own-language-model-key)
-An existing API key from a language model provider can be used to access that provider’s models in VS Code chat, in addition to the built-in models available through Copilot. Supported providers include Anthropic, Azure, Google Gemini, Groq, Ollama, OpenAI, and OpenRouter.
+An existing API key from a language model provider can be used to access that provider's models in VS Code chat, in addition to the built-in models available through Copilot. Supported providers include Anthropic, Azure, Google Gemini, Groq, Ollama, OpenAI, and OpenRouter.
 
 
 ### Locating MCP Server Binaries in VS Code


### PR DESCRIPTION
This pull request adds detailed instructions for running the Azure MCP Server in HTTP mode and clarifies configuration steps for local development and testing. The documentation now covers both running the server via `dotnet run` and using the built executable, including necessary environment variables and configuration for Azure AD authentication. These improvements help streamline onboarding and troubleshooting for developers.

**Documentation improvements for running and configuring Azure MCP Server:**

* Added step-by-step instructions for running the Azure MCP Server in HTTP mode, including options for using `dotnet run` (leveraging `launchSettings.json`) and running the built executable directly, with clear details on required environment variables and command line arguments.
* Provided example `mcp.json` configuration for both stdio and HTTP modes, clarifying how to connect to the server and what values to update for each scenario.

**Developer experience and troubleshooting enhancements:**

* Updated `TROUBLESHOOTING.md` with a recommended workflow for local development, highlighting the use of `dotnet run` and the automatic configuration provided by `launchSettings.json` for HTTP mode operation.