### PR TITLE
 Require non-null ITenantService parameter to BaseAzureService to ensure all derived types can make authenticated Azure calls always. Fixes product, live tests, and unit tests.

### DIFF
--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureResourceService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureResourceService.cs
@@ -11,7 +11,6 @@ using Azure.ResourceManager;
 using Azure.ResourceManager.ResourceGraph;
 using Azure.ResourceManager.ResourceGraph.Models;
 using Azure.ResourceManager.Resources;
-using Microsoft.Extensions.Logging;
 
 namespace Azure.Mcp.Core.Services.Azure;
 
@@ -21,11 +20,10 @@ namespace Azure.Mcp.Core.Services.Azure;
 /// </summary>
 public abstract class BaseAzureResourceService(
     ISubscriptionService subscriptionService,
-    ITenantService tenantService,
-    ILoggerFactory? loggerFactory = null) : BaseAzureService(tenantService, loggerFactory)
+    ITenantService tenantService)
+    : BaseAzureService(tenantService)
 {
     private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
-    private readonly ITenantService _tenantService = tenantService ?? throw new ArgumentNullException(nameof(tenantService));
 
     /// <summary>
     /// Gets the tenant resource for the specified subscription.
@@ -41,7 +39,7 @@ public abstract class BaseAzureResourceService(
         }
 
         // Get all tenants and find the matching one (GetTenants already has caching)
-        var allTenants = await _tenantService.GetTenants();
+        var allTenants = await TenantService.GetTenants();
         var tenantResource = allTenants.FirstOrDefault(t => t.Data.TenantId == tenantId.Value);
 
         if (tenantResource == null)

--- a/core/Azure.Mcp.Core/src/Services/Azure/ResourceGroup/ResourceGroupService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/ResourceGroup/ResourceGroupService.cs
@@ -10,8 +10,11 @@ using Azure.ResourceManager.Resources;
 
 namespace Azure.Mcp.Core.Services.Azure.ResourceGroup;
 
-public class ResourceGroupService(ICacheService cacheService, ISubscriptionService subscriptionService)
-    : BaseAzureService, IResourceGroupService
+public class ResourceGroupService(
+    ICacheService cacheService,
+    ISubscriptionService subscriptionService,
+    ITenantService tenantService)
+    : BaseAzureService(tenantService), IResourceGroupService
 {
     private readonly ICacheService _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
     private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Services/Azure/BaseAzureServiceTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Services/Azure/BaseAzureServiceTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Core;
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Core.Services.Azure.Tenant;
@@ -22,6 +23,10 @@ public class BaseAzureServiceTests
     {
         _azureService = new TestAzureService(_tenantService);
         _tenantService.GetTenantId(TenantName).Returns(TenantId);
+        _tenantService.GetTokenCredentialAsync(
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Substitute.For<TokenCredential>());
     }
 
     [Fact]
@@ -51,27 +56,21 @@ public class BaseAzureServiceTests
     }
 
     [Fact]
-    public async Task ResolveTenantIdAsync_ReturnsValueNoService()
+    public async Task ResolveTenantIdAsync_ReturnsNullOnNull()
     {
-        var testAzureService = new TestAzureService(null);
-
-        string? actual = await testAzureService.ResolveTenantId(TenantName);
-        Assert.Equal(TenantName, actual);
-
-        string? actual2 = await testAzureService.ResolveTenantId(null);
-        Assert.Null(actual2);
+        string? actual = await _azureService.ResolveTenantId(null);
+        Assert.Null(actual);
     }
 
     [Fact]
     public void EscapeKqlString_EscapesSingleQuotes()
     {
         // Arrange
-        var testAzureService = new TestAzureService();
         var input = "resource'with'quotes";
         var expected = "resource''with''quotes";
 
         // Act
-        var result = testAzureService.EscapeKqlStringTest(input);
+        var result = _azureService.EscapeKqlStringTest(input);
 
         // Assert
         Assert.Equal(expected, result);
@@ -81,12 +80,11 @@ public class BaseAzureServiceTests
     public void EscapeKqlString_EscapesBackslashes()
     {
         // Arrange
-        var testAzureService = new TestAzureService();
         var input = @"resource\with\backslashes";
         var expected = @"resource\\with\\backslashes";
 
         // Act
-        var result = testAzureService.EscapeKqlStringTest(input);
+        var result = _azureService.EscapeKqlStringTest(input);
 
         // Assert
         Assert.Equal(expected, result);
@@ -96,12 +94,11 @@ public class BaseAzureServiceTests
     public void EscapeKqlString_EscapesBothQuotesAndBackslashes()
     {
         // Arrange
-        var testAzureService = new TestAzureService();
         var input = @"resource\'with\'mixed";
         var expected = @"resource\\''with\\''mixed";
 
         // Act
-        var result = testAzureService.EscapeKqlStringTest(input);
+        var result = _azureService.EscapeKqlStringTest(input);
 
         // Assert
         Assert.Equal(expected, result);
@@ -110,29 +107,25 @@ public class BaseAzureServiceTests
     [Fact]
     public void EscapeKqlString_HandlesNullAndEmptyStrings()
     {
-        // Arrange
-        var testAzureService = new TestAzureService();
-
         // Act & Assert
-        Assert.Equal(string.Empty, testAzureService.EscapeKqlStringTest(null!));
-        Assert.Equal(string.Empty, testAzureService.EscapeKqlStringTest(string.Empty));
+        Assert.Equal(string.Empty, _azureService.EscapeKqlStringTest(null!));
+        Assert.Equal(string.Empty, _azureService.EscapeKqlStringTest(string.Empty));
     }
 
     [Fact]
     public void EscapeKqlString_HandlesRegularStringsWithoutEscaping()
     {
         // Arrange
-        var testAzureService = new TestAzureService();
         var input = "regular-resource-name";
 
         // Act
-        var result = testAzureService.EscapeKqlStringTest(input);
+        var result = _azureService.EscapeKqlStringTest(input);
 
         // Assert
         Assert.Equal(input, result);
     }
 
-    private sealed class TestAzureService(ITenantService? tenantService = null) : BaseAzureService(tenantService)
+    private sealed class TestAzureService(ITenantService tenantService) : BaseAzureService(tenantService)
     {
         public Task<ArmClient> GetArmClientAsync(string? tenant = null, RetryPolicyOptions? retryPolicy = null) =>
             CreateArmClientAsync(tenant, retryPolicy);

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using Azure.Core;
 using Azure.Data.AppConfiguration;
 using Azure.Mcp.Core.Models.Identity;
 using Azure.Mcp.Core.Options;
@@ -19,7 +18,6 @@ using ETag = Core.Models.ETag;
 public sealed class AppConfigService(ISubscriptionService subscriptionService, ITenantService tenantService, ILogger<AppConfigService> logger)
     : BaseAzureResourceService(subscriptionService, tenantService), IAppConfigService
 {
-    private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
     private readonly ILogger<AppConfigService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     public async Task<List<AppConfigurationAccount>> GetAppConfigAccounts(string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null)

--- a/tools/Azure.Mcp.Tools.AppLens/src/Services/AppLensService.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Services/AppLensService.cs
@@ -18,7 +18,7 @@ namespace Azure.Mcp.Tools.AppLens.Services;
 /// <summary>
 /// Service implementation for AppLens diagnostic operations.
 /// </summary>
-public class AppLensService(IHttpClientService httpClientService, ISubscriptionService subscriptionService, ITenantService? tenantService = null) : BaseAzureService(tenantService), IAppLensService
+public class AppLensService(IHttpClientService httpClientService, ISubscriptionService subscriptionService, ITenantService tenantService) : BaseAzureService(tenantService), IAppLensService
 {
     private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
     private readonly IHttpClientService _httpClientService = httpClientService ?? throw new ArgumentNullException(nameof(httpClientService));

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/ProfilerDataService.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/ProfilerDataService.cs
@@ -25,8 +25,8 @@ namespace Azure.Mcp.Tools.ApplicationInsights.Services;
 public class ProfilerDataService(
     IHttpClientService httpClientService,
     ILogger<ProfilerDataService> logger,
-    ITenantService? tenantService = null, ILoggerFactory? loggerFactory = null)
-    : BaseAzureService(tenantService, loggerFactory), IProfilerDataService
+    ITenantService tenantService)
+    : BaseAzureService(tenantService), IProfilerDataService
 {
     private const string Endpoint = "https://dataplane.diagnosticservices.azure.com/";
     private const string DefaultScope = "api://dataplane.diagnosticservices.azure.com/.default";

--- a/tools/Azure.Mcp.Tools.Authorization/src/Services/AuthorizationService.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Services/AuthorizationService.cs
@@ -16,7 +16,6 @@ namespace Azure.Mcp.Tools.Authorization.Services;
 public class AuthorizationService(ISubscriptionService subscriptionService, ITenantService tenantService, ILogger<AuthorizationService> logger)
     : BaseAzureResourceService(subscriptionService, tenantService), IAuthorizationService
 {
-    private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
     private readonly ILogger<AuthorizationService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     public async Task<List<RoleAssignment>> ListRoleAssignmentsAsync(

--- a/tools/Azure.Mcp.Tools.AzureIsv/src/Services/Datadog/DatadogService.cs
+++ b/tools/Azure.Mcp.Tools.AzureIsv/src/Services/Datadog/DatadogService.cs
@@ -10,7 +10,7 @@ namespace Azure.Mcp.Tools.AzureIsv.Services.Datadog;
 
 public partial class DatadogService : BaseAzureService, IDatadogService
 {
-    public DatadogService(ITenantService? tenantService = null) : base(tenantService)
+    public DatadogService(ITenantService tenantService) : base(tenantService)
     {
     }
 

--- a/tools/Azure.Mcp.Tools.BicepSchema/src/Services/BicepSchemaService.cs
+++ b/tools/Azure.Mcp.Tools.BicepSchema/src/Services/BicepSchemaService.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.BicepSchema.Services.ResourceProperties;
 using Azure.Mcp.Tools.BicepSchema.Services.ResourceProperties.Entities;
 using Azure.Mcp.Tools.BicepSchema.Services.Support;
@@ -9,7 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Azure.Mcp.Tools.BicepSchema.Services
 {
-    public class BicepSchemaService() : BaseAzureService, IBicepSchemaService
+    public class BicepSchemaService : IBicepSchemaService
     {
         public TypesDefinitionResult GetResourceTypeDefinitions(IServiceProvider serviceProvider, string resourceTypeName, string? apiVersion = null)
         {

--- a/tools/Azure.Mcp.Tools.Communication/src/Services/CommunicationService.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Services/CommunicationService.cs
@@ -3,8 +3,6 @@
 
 using Azure.Communication.Email;
 using Azure.Communication.Sms;
-using Azure.Core;
-using Azure.Mcp.Core.Exceptions;
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Core.Services.Azure.Subscription;
@@ -14,10 +12,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Azure.Mcp.Tools.Communication.Services;
 
-public class CommunicationService(ISubscriptionService subscriptionService, ITenantService tenantService, ILogger<CommunicationService> logger)
+public class CommunicationService(ITenantService tenantService, ILogger<CommunicationService> logger)
     : BaseAzureService(tenantService), ICommunicationService
 {
-    private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
     private readonly ILogger<CommunicationService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     public async Task<List<SmsResult>> SendSmsAsync(

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.UnitTests/Services/CommunicationServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.UnitTests/Services/CommunicationServiceTests.cs
@@ -1,16 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
-using Azure.Communication.Email;
-using Azure.Core;
-using Azure.Mcp.Core.Exceptions;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
-using Azure.Mcp.Tools.Communication.Models;
 using Azure.Mcp.Tools.Communication.Services;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -20,17 +11,15 @@ namespace Azure.Mcp.Tools.Communication.UnitTests.Services;
 
 public class CommunicationServiceTests
 {
-    private readonly ISubscriptionService _mockSubscriptionService;
     private readonly ITenantService _mockTenantService;
     private readonly ILogger<CommunicationService> _mockLogger;
     private readonly CommunicationService _service;
 
     public CommunicationServiceTests()
     {
-        _mockSubscriptionService = Substitute.For<ISubscriptionService>();
         _mockTenantService = Substitute.For<ITenantService>();
         _mockLogger = Substitute.For<ILogger<CommunicationService>>();
-        _service = new CommunicationService(_mockSubscriptionService, _mockTenantService, _mockLogger);
+        _service = new CommunicationService(_mockTenantService, _mockLogger);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Services/ConfidentialLedgerService.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Services/ConfidentialLedgerService.cs
@@ -1,23 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Buffers;
-using System.Collections.Generic;
-using System.Globalization;
 using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
-using Azure;
 using Azure.Core;
-using Azure.Identity;
 using Azure.Mcp.Core.Services.Azure;
+using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.ConfidentialLedger.Models;
 using Azure.Security.ConfidentialLedger;
 
 namespace Azure.Mcp.Tools.ConfidentialLedger.Services;
 
-public class ConfidentialLedgerService : BaseAzureService, IConfidentialLedgerService
+public class ConfidentialLedgerService(ITenantService tenantService)
+    : BaseAzureService(tenantService), IConfidentialLedgerService
 {
     // NOTE: We construct the data-plane endpoint from the ledger name.
     private static Uri BuildLedgerUri(string ledgerName) => new($"https://{ledgerName}.confidential-ledger.azure.com");

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/tests/Azure.Mcp.Tools.ConfidentialLedger.UnitTests/LedgerEntryGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/tests/Azure.Mcp.Tools.ConfidentialLedger.UnitTests/LedgerEntryGetCommandTests.cs
@@ -1,6 +1,6 @@
-using System.CommandLine;
 using System.Text.Json;
 using Azure.Mcp.Core.Models.Command;
+using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.ConfidentialLedger.Commands.Entries;
 using Azure.Mcp.Tools.ConfidentialLedger.Models;
 using Azure.Mcp.Tools.ConfidentialLedger.Services;
@@ -55,7 +55,7 @@ public sealed class LedgerEntryGetCommandTests
     [InlineData("ledgerName", " ")]
     public async Task GetLedgerEntryAsync_ThrowsArgumentNullException_WhenParametersInvalid(string? ledgerName, string? transactionId)
     {
-        var service = new ConfidentialLedgerService();
+        var service = new ConfidentialLedgerService(Substitute.For<ITenantService>());
         await Assert.ThrowsAsync<ArgumentException>(() =>
             service.GetLedgerEntryAsync(ledgerName!, transactionId!, null));
     }

--- a/tools/Azure.Mcp.Tools.Deploy/src/Services/DeployService.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/src/Services/DeployService.cs
@@ -3,13 +3,13 @@
 
 using Azure.Core;
 using Azure.Mcp.Core.Services.Azure;
+using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.Deploy.Services.Util;
 
 namespace Azure.Mcp.Tools.Deploy.Services;
 
-public class DeployService() : BaseAzureService, IDeployService
+public class DeployService(ITenantService tenantService) : BaseAzureService(tenantService), IDeployService
 {
-
     public async Task<string> GetAzdResourceLogsAsync(
          string workspaceFolder,
          string azdEnvName,

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
@@ -17,7 +17,6 @@ public class EventHubsService(ISubscriptionService subscriptionService, ITenantS
     : BaseAzureResourceService(subscriptionService, tenantService), IEventHubsService
 {
     private readonly ISubscriptionService _subscriptionService = subscriptionService;
-    private readonly ITenantService _tenantService = tenantService;
     private readonly ILogger<EventHubsService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     public async Task<List<Namespace>> GetNamespacesAsync(

--- a/tools/Azure.Mcp.Tools.Foundry/src/Services/FoundryService.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/src/Services/FoundryService.cs
@@ -5,8 +5,6 @@ using System.ClientModel;
 using System.Text;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization.Metadata;
-using System.Threading.Tasks.Dataflow;
-using Azure;
 using Azure.AI.Agents.Persistent;
 using Azure.AI.OpenAI;
 using Azure.AI.Projects;
@@ -19,16 +17,12 @@ using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Core.Services.Http;
 using Azure.Mcp.Tools.Foundry.Commands;
 using Azure.Mcp.Tools.Foundry.Models;
-using Azure.Mcp.Tools.Foundry.Services.Models;
 using Azure.ResourceManager;
 using Azure.ResourceManager.CognitiveServices;
-using Azure.ResourceManager.CognitiveServices.Models;
-using Azure.ResourceManager.Resources;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.AI.Evaluation;
 using Microsoft.Extensions.AI.Evaluation.Quality;
 using OpenAI.Chat;
-using OpenAI.Embeddings;
 
 #pragma warning disable AIEVAL001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
@@ -37,7 +31,8 @@ namespace Azure.Mcp.Tools.Foundry.Services;
 public class FoundryService(
     IHttpClientService httpClientService,
     ISubscriptionService subscriptionService,
-    ITenantService tenantService) : BaseAzureResourceService(subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService)), tenantService ?? throw new ArgumentNullException(nameof(tenantService))), IFoundryService
+    ITenantService tenantService)
+    : BaseAzureResourceService(subscriptionService, tenantService), IFoundryService
 {
     private static readonly Dictionary<string, Func<IEvaluator>> AgentEvaluatorDictionary = new()
     {

--- a/tools/Azure.Mcp.Tools.Grafana/src/Services/GrafanaService.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/src/Services/GrafanaService.cs
@@ -15,12 +15,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Azure.Mcp.Tools.Grafana.Services;
 
-public class GrafanaService(ISubscriptionService subscriptionService, ITenantService tenantService, ILogger<GrafanaService> logger)
+public class GrafanaService(ISubscriptionService subscriptionService, ITenantService tenantService)
     : BaseAzureResourceService(subscriptionService, tenantService), IGrafanaService
 {
-    private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
-    private readonly ILogger<GrafanaService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-
     public async Task<IEnumerable<GrafanaWorkspace>> ListWorkspacesAsync(
         string subscription,
         string? tenant = null,

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Services/KeyVaultService.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Services/KeyVaultService.cs
@@ -3,7 +3,6 @@
 
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Core.Services.Azure;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Security.KeyVault.Administration;
 using Azure.Security.KeyVault.Certificates;
@@ -12,9 +11,8 @@ using Azure.Security.KeyVault.Secrets;
 
 namespace Azure.Mcp.Tools.KeyVault.Services;
 
-public sealed class KeyVaultService(ISubscriptionService subscriptionService, ITenantService tenantService) : BaseAzureService(tenantService), IKeyVaultService
+public sealed class KeyVaultService(ITenantService tenantService) : BaseAzureService(tenantService), IKeyVaultService
 {
-    private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
     public async Task<List<string>> ListKeys(
         string vaultName,
         bool includeManagedKeys,

--- a/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoService.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoService.cs
@@ -21,7 +21,6 @@ public sealed class KustoService(
     IHttpClientService httpClientService,
     ILogger<KustoService> logger) : BaseAzureResourceService(subscriptionService, tenantService), IKustoService
 {
-    private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
     private readonly ICacheService _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
     private readonly IHttpClientService _httpClientService = httpClientService ?? throw new ArgumentNullException(nameof(httpClientService));
     private readonly ILogger<KustoService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Services/LoadTestingService.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Services/LoadTestingService.cs
@@ -6,6 +6,7 @@ using Azure.Developer.LoadTesting;
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.LoadTesting.Commands;
 using Azure.Mcp.Tools.LoadTesting.Models.LoadTest;
 using Azure.Mcp.Tools.LoadTesting.Models.LoadTestResource;
@@ -16,7 +17,10 @@ using Azure.ResourceManager.Resources;
 
 namespace Azure.Mcp.Tools.LoadTesting.Services;
 
-public class LoadTestingService(ISubscriptionService subscriptionService) : BaseAzureService, ILoadTestingService
+public class LoadTestingService(
+    ISubscriptionService subscriptionService,
+    ITenantService tenantService)
+    : BaseAzureService(tenantService), ILoadTestingService
 {
     ISubscriptionService _subscriptionService = subscriptionService;
     public async Task<List<TestResource>> GetLoadTestResourcesAsync(string subscription, string? resourceGroup = null, string? testResourceName = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null)

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorMetricsService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorMetricsService.cs
@@ -4,6 +4,7 @@
 using System.Xml;
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Core.Services.Azure;
+using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.Monitor.Models;
 using Azure.Monitor.Query;
 using Azure.Monitor.Query.Models;
@@ -13,8 +14,8 @@ using MetricResult = Azure.Mcp.Tools.Monitor.Models.MetricResult;
 
 namespace Azure.Mcp.Tools.Monitor.Services;
 
-public class MonitorMetricsService(IResourceResolverService resourceResolverService, IMetricsQueryClientService metricsQueryClientService)
-    : BaseAzureService(), IMonitorMetricsService
+public class MonitorMetricsService(IResourceResolverService resourceResolverService, IMetricsQueryClientService metricsQueryClientService, ITenantService tenantService)
+    : BaseAzureService(tenantService), IMonitorMetricsService
 {
     private readonly IResourceResolverService _resourceResolverService = resourceResolverService ?? throw new ArgumentNullException(nameof(resourceResolverService));
     private readonly IMetricsQueryClientService _metricsQueryClientService = metricsQueryClientService ?? throw new ArgumentNullException(nameof(metricsQueryClientService));

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.LiveTests/MonitorCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.LiveTests/MonitorCommandTests.cs
@@ -43,7 +43,7 @@ public class MonitorCommandTests(ITestOutputHelper output) : CommandTestsBase(ou
         var tokenProvider = new SingleIdentityTokenCredentialProvider(NullLoggerFactory.Instance);
         var tenantService = new TenantService(tokenProvider, cacheService);
         var subscriptionService = new SubscriptionService(cacheService, tenantService);
-        var resourceGroupService = new ResourceGroupService(cacheService, subscriptionService);
+        var resourceGroupService = new ResourceGroupService(cacheService, subscriptionService, tenantService);
         var resourceResolverService = new ResourceResolverService(subscriptionService, tenantService);
         var httpClientOptions = new HttpClientOptions();
         var httpClientService = new HttpClientService(Microsoft.Extensions.Options.Options.Create(httpClientOptions));

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Metrics/MonitorMetricsServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Metrics/MonitorMetricsServiceTests.cs
@@ -3,6 +3,7 @@
 
 using Azure.Core;
 using Azure.Mcp.Core.Options;
+using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.Monitor.Services;
 using Azure.Monitor.Query;
 using Azure.Monitor.Query.Models;
@@ -17,6 +18,7 @@ public class MonitorMetricsServiceTests
     private readonly IResourceResolverService _resourceResolverService;
     private readonly IMetricsQueryClientService _metricsQueryClientService;
     private readonly MetricsQueryClient _metricsQueryClient;
+    private readonly ITenantService _tenantService;
     private readonly MonitorMetricsService _service;
 
     private const string TestSubscription = "12345678-1234-1234-1234-123456789012";
@@ -31,7 +33,8 @@ public class MonitorMetricsServiceTests
         _resourceResolverService = Substitute.For<IResourceResolverService>();
         _metricsQueryClientService = Substitute.For<IMetricsQueryClientService>();
         _metricsQueryClient = Substitute.For<MetricsQueryClient>();
-        _service = new MonitorMetricsService(_resourceResolverService, _metricsQueryClientService);
+        _tenantService = Substitute.For<ITenantService>();
+        _service = new MonitorMetricsService(_resourceResolverService, _metricsQueryClientService, _tenantService);
 
         // Setup default behaviors
         _resourceResolverService.ResolveResourceIdAsync(
@@ -55,7 +58,7 @@ public class MonitorMetricsServiceTests
     public void Constructor_WithValidParameters_Succeeds()
     {
         // Act & Assert - Constructor should not throw
-        var service = new MonitorMetricsService(_resourceResolverService, _metricsQueryClientService);
+        var service = new MonitorMetricsService(_resourceResolverService, _metricsQueryClientService, _tenantService);
         Assert.NotNull(service);
     }
 
@@ -64,7 +67,7 @@ public class MonitorMetricsServiceTests
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
-            new MonitorMetricsService(null!, _metricsQueryClientService));
+            new MonitorMetricsService(null!, _metricsQueryClientService, _tenantService));
     }
 
     [Fact]
@@ -72,7 +75,7 @@ public class MonitorMetricsServiceTests
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
-            new MonitorMetricsService(_resourceResolverService, null!));
+            new MonitorMetricsService(_resourceResolverService, null!, _tenantService));
     }
 
     #endregion

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Services/MySqlServiceExecutionTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Services/MySqlServiceExecutionTests.cs
@@ -12,20 +12,6 @@ namespace Azure.Mcp.Tools.MySql.UnitTests.Services;
 
 public class MySqlServiceExecutionTests
 {
-    private readonly IResourceGroupService _resourceGroupService;
-    private readonly ITenantService _tenantService;
-    private readonly ILogger<MySqlService> _logger;
-    private readonly MySqlService _mysqlService;
-
-    public MySqlServiceExecutionTests()
-    {
-        _resourceGroupService = Substitute.For<IResourceGroupService>();
-        _tenantService = Substitute.For<ITenantService>();
-        _logger = Substitute.For<ILogger<MySqlService>>();
-
-        _mysqlService = new MySqlService(_resourceGroupService, _tenantService, _logger);
-    }
-
     [Fact]
     public void ValidateQuerySafety_WithNullQuery_ShouldThrowArgumentException()
     {

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Services/MySqlServiceQueryValidationTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Services/MySqlServiceQueryValidationTests.cs
@@ -12,20 +12,6 @@ namespace Azure.Mcp.Tools.MySql.UnitTests.Services;
 
 public class MySqlServiceQueryValidationTests
 {
-    private readonly IResourceGroupService _resourceGroupService;
-    private readonly ITenantService _tenantService;
-    private readonly ILogger<MySqlService> _logger;
-    private readonly MySqlService _mysqlService;
-
-    public MySqlServiceQueryValidationTests()
-    {
-        _resourceGroupService = Substitute.For<IResourceGroupService>();
-        _tenantService = Substitute.For<ITenantService>();
-        _logger = Substitute.For<ILogger<MySqlService>>();
-
-        _mysqlService = new MySqlService(_resourceGroupService, _tenantService, _logger);
-    }
-
     [Theory]
     [InlineData("SELECT * FROM users LIMIT 100")]
     [InlineData("SELECT COUNT(*) FROM products LIMIT 1")]

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Services/MySqlServiceRowLimitTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Services/MySqlServiceRowLimitTests.cs
@@ -12,20 +12,6 @@ namespace Azure.Mcp.Tools.MySql.UnitTests.Services;
 
 public class MySqlServiceRowLimitTests
 {
-    private readonly IResourceGroupService _resourceGroupService;
-    private readonly ITenantService _tenantService;
-    private readonly ILogger<MySqlService> _logger;
-    private readonly MySqlService _mysqlService;
-
-    public MySqlServiceRowLimitTests()
-    {
-        _resourceGroupService = Substitute.For<IResourceGroupService>();
-        _tenantService = Substitute.For<ITenantService>();
-        _logger = Substitute.For<ILogger<MySqlService>>();
-
-        _mysqlService = new MySqlService(_resourceGroupService, _tenantService, _logger);
-    }
-
     [Fact]
     public void ValidateQuerySafety_WithValidQuery_ShouldPassValidation()
     {

--- a/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
@@ -4,6 +4,7 @@
 using Azure.Core;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Core.Services.Azure.ResourceGroup;
+using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.ResourceManager.PostgreSql.FlexibleServers;
 using Npgsql;
 
@@ -15,7 +16,10 @@ public class PostgresService : BaseAzureService, IPostgresService
     private string? _cachedEntraIdAccessToken;
     private DateTime _tokenExpiryTime;
 
-    public PostgresService(IResourceGroupService resourceGroupService)
+    public PostgresService(
+        IResourceGroupService resourceGroupService,
+        ITenantService tenantService)
+        : base(tenantService)
     {
         _resourceGroupService = resourceGroupService ?? throw new ArgumentNullException(nameof(resourceGroupService));
     }

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Services/PostgresServiceParameterizedQueryTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Services/PostgresServiceParameterizedQueryTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Core.Services.Azure.ResourceGroup;
+using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.Postgres.Services;
 using NSubstitute;
 using Xunit;
@@ -20,7 +21,8 @@ public class PostgresServiceParameterizedQueryTests
     public PostgresServiceParameterizedQueryTests()
     {
         _resourceGroupService = Substitute.For<IResourceGroupService>();
-        _postgresService = new PostgresService(_resourceGroupService);
+        var tenantService = Substitute.For<ITenantService>();
+        _postgresService = new PostgresService(_resourceGroupService, tenantService);
     }
 
     [Theory]

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/QuotaService.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/QuotaService.cs
@@ -3,6 +3,7 @@
 
 using Azure.Core;
 using Azure.Mcp.Core.Services.Azure;
+using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Core.Services.Http;
 using Azure.Mcp.Tools.Quota.Models;
 using Azure.Mcp.Tools.Quota.Services.Util;
@@ -11,7 +12,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Azure.Mcp.Tools.Quota.Services;
 
-public class QuotaService(ILoggerFactory? loggerFactory = null, IHttpClientService? httpClientService = null) : BaseAzureService(loggerFactory: loggerFactory), IQuotaService
+public class QuotaService(
+    ITenantService tenantService,
+    ILoggerFactory loggerFactory,
+    IHttpClientService httpClientService)
+    : BaseAzureService(tenantService), IQuotaService
 {
     private readonly IHttpClientService _httpClientService = httpClientService ?? throw new ArgumentNullException(nameof(httpClientService));
 
@@ -26,7 +31,7 @@ public class QuotaService(ILoggerFactory? loggerFactory = null, IHttpClientServi
             resourceTypes,
             subscriptionId,
             location,
-            LoggerFactory,
+            loggerFactory,
             _httpClientService
             );
         return quotaByResourceTypes;
@@ -55,7 +60,7 @@ public class QuotaService(ILoggerFactory? loggerFactory = null, IHttpClientServi
             };
         }
 
-        var availableRegions = await AzureRegionService.GetAvailableRegionsForResourceTypesAsync(armClient, resourceTypes, subscriptionId, LoggerFactory, cognitiveServiceProperties);
+        var availableRegions = await AzureRegionService.GetAvailableRegionsForResourceTypesAsync(armClient, resourceTypes, subscriptionId, loggerFactory, cognitiveServiceProperties);
         var allRegions = availableRegions.Values
             .Where(regions => regions.Count > 0)
             .SelectMany(regions => regions)

--- a/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Core.Services.Caching;
 using Azure.Mcp.Tools.Search.Commands;
 using Azure.Mcp.Tools.Search.Models;
@@ -18,7 +19,11 @@ using Azure.Search.Documents.Models;
 
 namespace Azure.Mcp.Tools.Search.Services;
 
-public sealed class SearchService(ISubscriptionService subscriptionService, ICacheService cacheService) : BaseAzureService, ISearchService
+public sealed class SearchService(
+    ISubscriptionService subscriptionService,
+    ICacheService cacheService,
+    ITenantService tenantService)
+    : BaseAzureService(tenantService), ISearchService
 {
     private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
     private readonly ICacheService _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Services/ServiceBusService.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Services/ServiceBusService.cs
@@ -3,13 +3,14 @@
 
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Core.Services.Azure;
+using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.ServiceBus.Models;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 
 namespace Azure.Mcp.Tools.ServiceBus.Services;
 
-public class ServiceBusService : BaseAzureService, IServiceBusService
+public class ServiceBusService(ITenantService tenantService) : BaseAzureService(tenantService), IServiceBusService
 {
     public async Task<QueueDetails> GetQueueDetails(
         string namespaceName,

--- a/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.UnitTests/Services/SpeechServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.UnitTests/Services/SpeechServiceTests.cs
@@ -13,14 +13,11 @@ public class SpeechServiceTests
 {
     private readonly ITenantService _tenantService;
     private readonly ILogger<SpeechService> _logger;
-    private readonly SpeechService _speechService;
 
     public SpeechServiceTests()
     {
         _tenantService = Substitute.For<ITenantService>();
         _logger = Substitute.For<ILogger<SpeechService>>();
-
-        _speechService = new SpeechService(_tenantService, _logger);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
@@ -8,7 +8,6 @@ using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Core.Services.Azure.Models;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
-using Azure.Mcp.Core.Services.Caching;
 using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Services.Models;
@@ -22,16 +21,10 @@ namespace Azure.Mcp.Tools.Storage.Services;
 public class StorageService(
     ISubscriptionService subscriptionService,
     ITenantService tenantService,
-    ICacheService cacheService,
-    ILogger<StorageService> logger) : BaseAzureResourceService(subscriptionService, tenantService), IStorageService
+    ILogger<StorageService> logger)
+    : BaseAzureResourceService(subscriptionService, tenantService), IStorageService
 {
-    private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
-    private readonly ICacheService _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
     private readonly ILogger<StorageService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-
-    private const string CacheGroup = "storage";
-    private const string StorageAccountsCacheKey = "accounts";
-    private static readonly TimeSpan s_cacheDuration = TimeSpan.FromHours(1);
 
     public async Task<List<StorageAccountInfo>> GetAccountDetails(
         string? account,

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Services/WorkbooksService.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Services/WorkbooksService.cs
@@ -3,18 +3,17 @@
 
 using Azure.Core;
 using Azure.Mcp.Core.Options;
-using Azure.Mcp.Tools.Workbooks.Models;
-using Microsoft.Extensions.Logging;
-
-namespace Azure.Mcp.Tools.Workbooks.Services;
-
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
+using Azure.Mcp.Tools.Workbooks.Models;
 using Azure.ResourceManager.ApplicationInsights;
 using Azure.ResourceManager.ApplicationInsights.Models;
 using Azure.ResourceManager.ResourceGraph;
 using Azure.ResourceManager.ResourceGraph.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Mcp.Tools.Workbooks.Services;
 
 public class WorkbooksService(ISubscriptionService _subscriptionService, ITenantService tenantService, ILogger<WorkbooksService> logger) : BaseAzureService(tenantService), IWorkbooksService
 {


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

Makes `BaseAzureService` constructor for derived types provide `ITenantService` which is used for all Azure/Entra authentication.

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
