### PR TITLE
Fix CI pipeline tests failure

### DIFF
--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -24,9 +24,10 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 ### Bugs Fixed
 
+- Fixed test failures in CI for SQL commands for `BaseSqlCommand` (--server option) and `BaseDatabaseCommand` (--database option) by using `.AsRequired()` extension method for consistent validation. [[#943](https://github.com/microsoft/mcp/issues/943), [#1013](https://github.com/microsoft/mcp/issues/1013)]
 - Avoid spawning child processes per namespace for consolidated mode [[#1002](https://github.com/microsoft/mcp/pull/1002)]
 - Improvement to learning experience by ignoring `command` parameter, which resulted in neither learning nor a tool call to happen. Learning is now always invoked when `learn=true` is passed. [[#1057](https://github.com/microsoft/mcp/pull/1057)]
-- Adds descriptions to the tools metadata, to ensure enough information is present in the cli to generate docs for metadata. [[#1043](https://github.com/microsoft/mcp/pull/1043)] 
+- Adds descriptions to the tools metadata, to ensure enough information is present in the cli to generate docs for metadata. [[#1043](https://github.com/microsoft/mcp/pull/1043)]
 
 ### Other Changes
 

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/BaseDatabaseCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/BaseDatabaseCommand.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Extensions;
+using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Sql.Options;
 using Microsoft.Extensions.Logging;
 
@@ -16,7 +17,7 @@ public abstract class BaseDatabaseCommand<
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
-        command.Options.Add(SqlOptionDefinitions.Database);
+        command.Options.Add(SqlOptionDefinitions.Database.AsRequired());
     }
 
     protected override TOptions BindOptions(ParseResult parseResult)

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/BaseSqlCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/BaseSqlCommand.cs
@@ -21,7 +21,7 @@ public abstract class BaseSqlCommand<
     {
         base.RegisterOptions(command);
         command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsRequired());
-        command.Options.Add(SqlOptionDefinitions.Server.AsRequired());
+        command.Options.Add(SqlOptionDefinitions.Server);
     }
 
     protected override TOptions BindOptions(ParseResult parseResult)

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/BaseSqlCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/BaseSqlCommand.cs
@@ -21,7 +21,7 @@ public abstract class BaseSqlCommand<
     {
         base.RegisterOptions(command);
         command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsRequired());
-        command.Options.Add(SqlOptionDefinitions.Server);
+        command.Options.Add(SqlOptionDefinitions.Server.AsRequired());
     }
 
     protected override TOptions BindOptions(ParseResult parseResult)


### PR DESCRIPTION
## What does this PR do?

Fix the following tests failure in CI pipeline:

`Azure.Mcp.Tools.Sql.UnitTests.EntraAdmin.EntraAdminListCommandTests.ExecuteAsync_ValidatesInputCorrectly`

`Azure.Mcp.Tools.Sql.UnitTests.Database.DatabaseUpdateCommandTests.ExecuteAsync_ValidatesRequiredParameters`

## GitHub issue number?

#943 
#1013 

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [x] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [x] 👉 For Community (non-Microsoft team member) PRs:
        - [x] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [x] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
