### PR TITLE
Add comprehensive multi-agent system for Microsoft MCP demonstration

### DIFF
--- a/demo/ARCHITECTURE.md
+++ b/demo/ARCHITECTURE.md
@@ -1,0 +1,411 @@
+# Arquitectura del Sistema de Agentes Multi-MCP
+
+## Visión General
+
+Este sistema implementa una arquitectura de agentes especializados que se comunican con servidores MCP (Model Context Protocol) de Microsoft para automatizar tareas en Azure y Microsoft Fabric.
+
+## Diagrama de Arquitectura
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         Usuario / CLI                            │
+│                        (main.py)                                 │
+└─────────────────────────┬───────────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Orchestrator Agent                            │
+│              (Coordina todos los agentes)                        │
+└─────────────────────────┬───────────────────────────────────────┘
+                          │
+        ┌─────────────────┼─────────────────┬──────────────┐
+        │                 │                 │              │
+        ▼                 ▼                 ▼              ▼
+┌───────────────┐  ┌───────────────┐  ┌──────────┐  ┌──────────┐
+│Azure Storage  │  │Azure Security │  │Azure AI  │  │  Fabric  │
+│    Agent      │  │    Agent      │  │  Agent   │  │  Agent   │
+└───────┬───────┘  └───────┬───────┘  └────┬─────┘  └────┬─────┘
+        │                  │                │             │
+        │                  │                │             │
+        ▼                  ▼                ▼             ▼
+┌───────────────────────────────────────────────────────────────┐
+│                    MCP Client Pool                            │
+│              (Gestiona conexiones a servidores MCP)           │
+└─────────────────────────┬─────────────────────────────────────┘
+                          │
+        ┌─────────────────┼─────────────────┐
+        │                 │                 │
+        ▼                 ▼                 ▼
+┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+│ Azure MCP    │  │ Fabric MCP   │  │  Other MCP   │
+│   Server     │  │   Server     │  │   Servers    │
+│   (stdio)    │  │   (stdio)    │  │   (stdio)    │
+└──────┬───────┘  └──────┬───────┘  └──────┬───────┘
+       │                 │                 │
+       ▼                 ▼                 ▼
+┌─────────────────────────────────────────────────┐
+│          Servicios de Azure / Fabric            │
+│   (Storage, Key Vault, Cosmos DB, etc.)         │
+└─────────────────────────────────────────────────┘
+```
+
+## Componentes Principales
+
+### 1. Core Components (`src/core/`)
+
+#### `agent_base.py`
+- **Agent**: Clase abstracta base para todos los agentes
+- **AgentSystem**: Sistema que gestiona el ciclo de vida de todos los agentes
+- **Task**: Representa una tarea que un agente debe ejecutar
+- **AgentCapability**: Define las capacidades de un agente
+
+#### `mcp_client.py`
+- **MCPClient**: Cliente para comunicarse con un servidor MCP individual
+- **MCPClientPool**: Pool que gestiona múltiples clientes MCP
+- Implementa el protocolo JSON-RPC 2.0 sobre stdio
+
+### 2. Specialized Agents (`src/agents/`)
+
+#### `azure_storage.py` - AzureStorageAgent
+**Responsabilidades:**
+- Gestión de contenedores de blob storage
+- Subida y descarga de archivos
+- Listado y eliminación de blobs
+
+**Capacidades:**
+- `list_containers`: Lista contenedores
+- `create_container`: Crea contenedores
+- `upload_blob`: Sube archivos
+- `download_blob`: Descarga archivos
+- `delete_blob`: Elimina blobs
+
+#### `azure_security.py` - AzureSecurityAgent
+**Responsabilidades:**
+- Gestión de Azure Key Vault
+- Operaciones con secretos, claves y certificados
+- Seguridad y compliance
+
+**Capacidades:**
+- `create_secret`: Crea/actualiza secretos
+- `get_secret`: Obtiene secretos
+- `list_secrets`: Lista secretos
+- `delete_secret`: Elimina secretos
+- `create_key`: Crea claves criptográficas
+
+#### `fabric.py` - FabricAgent
+**Responsabilidades:**
+- Interacción con APIs de Microsoft Fabric
+- Generación de definiciones de recursos
+- Obtención de best practices
+
+**Capacidades:**
+- `list_workloads`: Lista workloads disponibles
+- `get_workload_apis`: Obtiene OpenAPI specs
+- `get_item_definition`: Obtiene schemas de items
+- `get_best_practices`: Obtiene mejores prácticas
+- `generate_resource_definition`: Genera definiciones completas
+
+#### `orchestrator.py` - OrchestratorAgent
+**Responsabilidades:**
+- Coordinación de múltiples agentes
+- Descomposición de tareas complejas
+- Ejecución de workflows predefinidos
+- Agregación de resultados
+
+**Capacidades:**
+- `coordinate_workflow`: Coordina flujos complejos
+- `task_decomposition`: Descompone tareas
+- `agent_selection`: Selecciona agentes apropiados
+- `result_aggregation`: Agrega resultados
+
+### 3. Utility Modules (`src/utils/`)
+
+#### `logger.py`
+- Sistema de logging con colores
+- Logger específico por agente
+- Logging a archivo y consola
+
+#### `validators.py`
+- Validadores para nombres de recursos Azure
+- Validación de parámetros
+- Sanitización de inputs
+
+### 4. Scenarios (`src/scenarios/`)
+
+Implementaciones de escenarios completos end-to-end:
+- `data_pipeline.py`: Pipeline de datos completo
+- `secure_app.py`: Despliegue de aplicación segura
+- `intelligent_search.py`: Sistema de búsqueda
+- `fabric_infrastructure.py`: Infraestructura Fabric
+
+## Flujo de Ejecución
+
+### Flujo Básico: Ejecutar una Tarea
+
+```
+1. Usuario ejecuta comando
+   └─> main.py CLI
+
+2. CLI inicializa AgentSystem
+   └─> AgentSystem.initialize()
+       └─> MCPClientPool.start_all()
+           └─> Inicia procesos de servidores MCP
+
+3. CLI ejecuta tarea en agente
+   └─> Agent.process_task(description, **params)
+       └─> Agent.execute_task(task)
+           └─> Agent.call_mcp_tool(tool_name, arguments)
+               └─> MCPClient.call_tool()
+                   └─> Envía JSON-RPC request
+                   └─> Recibe JSON-RPC response
+
+4. Agente procesa respuesta
+   └─> Actualiza Task con resultado
+   └─> Retorna Task completada
+
+5. CLI muestra resultado al usuario
+```
+
+### Flujo Avanzado: Workflow con Orchestrator
+
+```
+1. Usuario ejecuta workflow
+   └─> main.py run-workflow --workflow data_pipeline
+
+2. Orchestrator recibe workflow
+   └─> OrchestratorAgent.execute_workflow()
+
+3. Orchestrator descompone el workflow
+   └─> _decompose_task()
+       └─> Crea subtareas para cada paso
+
+4. Para cada subtarea:
+   └─> Selecciona agente apropiado
+   └─> Ejecuta subtarea
+       └─> AzureStorageAgent.process_task()
+       └─> FabricAgent.process_task()
+   └─> Recolecta resultados
+
+5. Orchestrator agrega resultados
+   └─> _generate_summary()
+   └─> Retorna resultado consolidado
+
+6. CLI muestra resumen al usuario
+```
+
+## Protocolo de Comunicación MCP
+
+### Formato de Mensaje
+
+#### Request
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req_123",
+  "method": "tools/call",
+  "params": {
+    "name": "azure.storage.createContainer",
+    "arguments": {
+      "containerName": "demo-data",
+      "storageAccount": "mystorageaccount"
+    }
+  }
+}
+```
+
+#### Response (Success)
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req_123",
+  "result": {
+    "container_name": "demo-data",
+    "status": "created",
+    "url": "https://mystorageaccount.blob.core.windows.net/demo-data"
+  }
+}
+```
+
+#### Response (Error)
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req_123",
+  "error": {
+    "code": -32000,
+    "message": "Container already exists"
+  }
+}
+```
+
+## Patrones de Diseño
+
+### 1. Agent Pattern
+Cada agente es autónomo y especializado en un dominio específico.
+
+### 2. Pool Pattern
+MCPClientPool gestiona múltiples conexiones a servidores MCP.
+
+### 3. Orchestrator Pattern
+Orchestrator coordina múltiples agentes para tareas complejas.
+
+### 4. Strategy Pattern
+Cada agente implementa diferentes estrategias para ejecutar tareas.
+
+### 5. Command Pattern
+Tasks representan comandos que pueden ser ejecutados, almacenados y auditados.
+
+## Manejo de Errores
+
+### Niveles de Error
+
+1. **Error de Validación**
+   - Se captura en `validators.py`
+   - Se retorna antes de llamar a MCP
+
+2. **Error de MCP**
+   - Se captura en `mcp_client.py`
+   - Se retorna como MCPResponse.error
+
+3. **Error de Agente**
+   - Se captura en `agent_base.py`
+   - Se actualiza Task.error
+
+4. **Error de Sistema**
+   - Se captura en `agent_base.py`
+   - Se loguea y se propaga
+
+### Estrategia de Reintentos
+
+```python
+# Configurado en mcp_config.json
+{
+  "settings": {
+    "maxRetries": 3,
+    "timeout": 30000
+  }
+}
+```
+
+## Seguridad
+
+### Autenticación
+- Usa Azure Identity SDK
+- Soporta DefaultAzureCredential
+- No almacena tokens directamente
+
+### Validación
+- Validación de inputs en todos los agentes
+- Sanitización de datos
+- Verificación de permisos
+
+### Logging
+- No se loguean secretos
+- Auditoría de todas las operaciones
+- Logs separados por agente
+
+## Extensibilidad
+
+### Agregar un Nuevo Agente
+
+1. Crear clase que herede de `Agent`
+2. Implementar `_load_capabilities()`
+3. Implementar `execute_task()`
+4. Registrar en `AgentSystem`
+
+```python
+class MyCustomAgent(Agent):
+    def __init__(self, client_pool):
+        super().__init__(
+            name="my_custom_agent",
+            description="Mi agente personalizado",
+            mcp_server_name="azure-mcp",
+            client_pool=client_pool
+        )
+
+    async def _load_capabilities(self):
+        self.capabilities = [...]
+
+    async def execute_task(self, task):
+        # Implementación
+        pass
+```
+
+### Agregar un Nuevo Workflow
+
+Agregar método al `OrchestratorAgent`:
+
+```python
+async def _workflow_my_workflow(self, params):
+    # Implementación del workflow
+    pass
+```
+
+## Performance
+
+### Optimizaciones Implementadas
+
+1. **Async/Await**
+   - Operaciones asíncronas para I/O
+   - Mejor utilización de recursos
+
+2. **Connection Pooling**
+   - Reutilización de conexiones MCP
+   - Reducción de overhead
+
+3. **Caching**
+   - Cache de capacidades de agentes
+   - Cache de resultados de herramientas (futuro)
+
+## Métricas y Monitoreo
+
+### Métricas Disponibles
+
+- Número de tareas ejecutadas por agente
+- Tiempo de ejecución de tareas
+- Tasa de éxito/fallo
+- Uso de herramientas MCP
+
+### Logging
+
+Ubicación: `logs/agent_system.log`
+
+Formato:
+```
+2025-01-15 10:30:45 - agent_system - INFO - [AzureStorageAgent] Iniciando tarea: Crear contenedor
+2025-01-15 10:30:46 - agent_system - INFO - [AzureStorageAgent] Tarea completada (1234.56ms)
+```
+
+## Testing
+
+### Unit Tests
+```bash
+pytest tests/test_agents.py
+```
+
+### Integration Tests
+```bash
+pytest tests/test_scenarios.py
+```
+
+## Deployment
+
+### Docker (Futuro)
+```dockerfile
+FROM python:3.10
+WORKDIR /app
+COPY . .
+RUN pip install -r requirements.txt
+CMD ["python", "main.py", "interactive"]
+```
+
+### Kubernetes (Futuro)
+- Deployment para cada agente
+- Service mesh para comunicación
+- ConfigMaps para configuración
+
+## Referencias
+
+- [MCP Specification](https://spec.modelcontextprotocol.io/)
+- [Azure MCP Server](https://learn.microsoft.com/azure/developer/azure-mcp-server/)
+- [Microsoft Fabric](https://learn.microsoft.com/fabric/)

--- a/demo/QUICKSTART.md
+++ b/demo/QUICKSTART.md
@@ -1,0 +1,311 @@
+# Guía de Inicio Rápido
+
+## Instalación en 5 minutos
+
+### 1. Requisitos previos
+
+- Python 3.10 o superior
+- .NET 10 SDK o Node.js 20+ (para servidores MCP)
+- Azure CLI (para autenticación)
+- Cuenta de Azure con una suscripción activa
+
+### 2. Clonar y configurar
+
+```bash
+# Ya estás en el repositorio
+cd demo
+
+# Instalar dependencias Python
+pip install -r requirements.txt
+
+# Autenticar con Azure
+az login
+```
+
+### 3. Compilar servidores MCP
+
+#### Opción A: Usar .NET (recomendado)
+
+```bash
+# Compilar Azure MCP Server
+cd ../servers/Azure.Mcp.Server
+dotnet build --configuration Release
+
+# Compilar Fabric MCP Server
+cd ../Fabric.Mcp.Server
+dotnet build --configuration Release
+
+cd ../../demo
+```
+
+#### Opción B: Usar NPM
+
+```bash
+# Instalar Azure MCP Server desde NPM
+npm install -g @azure/mcp@latest
+```
+
+### 4. Ejecutar tu primera demo
+
+```bash
+# Ver información del sistema
+python main.py info
+
+# Ejecutar ejemplos básicos
+python main.py examples
+
+# O ejecutar un escenario específico
+python main.py demo --scenario data_pipeline
+```
+
+## Comandos Básicos
+
+### Mostrar información del sistema
+```bash
+python main.py info
+```
+
+### Listar capacidades de un agente
+```bash
+python main.py list-capabilities --agent azure_storage
+python main.py list-capabilities --agent azure_security
+python main.py list-capabilities --agent fabric
+```
+
+### Ejecutar una tarea específica
+```bash
+python main.py execute \
+  --agent azure_storage \
+  --task "Listar todos los contenedores" \
+  --params '{"storage_account": "mystorageaccount"}'
+```
+
+### Ejecutar un workflow
+```bash
+python main.py run-workflow \
+  --workflow data_pipeline \
+  --params '{"container_name": "demo-data", "lakehouse_name": "analytics"}'
+```
+
+### Modo interactivo
+```bash
+python main.py interactive
+```
+
+En modo interactivo puedes escribir comandos en lenguaje natural:
+```
+> Crear un contenedor llamado 'demo-data'
+> Listar todos los secretos en mi Key Vault
+> Generar una definición de Lakehouse para ventas
+> exit
+```
+
+## Ejemplos Rápidos
+
+### 1. Trabajar con Azure Storage
+
+```python
+from src.core.agent_base import AgentSystem
+from src.agents.azure_storage import AzureStorageAgent
+
+async def demo():
+    system = AgentSystem(config_path="config/mcp_config.json")
+    storage_agent = AzureStorageAgent(system.client_pool)
+    system.register_agent(storage_agent)
+
+    await system.initialize()
+
+    # Crear contenedor
+    result = await storage_agent.process_task(
+        "Crear un contenedor llamado 'test-data'",
+        container_name="test-data"
+    )
+
+    print(result.result)
+
+    await system.shutdown()
+
+import asyncio
+asyncio.run(demo())
+```
+
+### 2. Gestionar secretos en Key Vault
+
+```python
+from src.agents.azure_security import AzureSecurityAgent
+
+async def demo():
+    system = AgentSystem(config_path="config/mcp_config.json")
+    security_agent = AzureSecurityAgent(system.client_pool)
+    system.register_agent(security_agent)
+
+    await system.initialize()
+
+    # Crear secreto
+    result = await security_agent.process_task(
+        "Crear secreto 'db-password' con valor 'SecurePassword123!'",
+        vault_name="my-vault",
+        secret_name="db-password",
+        secret_value="SecurePassword123!"
+    )
+
+    print(result.result)
+
+    await system.shutdown()
+
+asyncio.run(demo())
+```
+
+### 3. Explorar Microsoft Fabric
+
+```python
+from src.agents.fabric import FabricAgent
+
+async def demo():
+    system = AgentSystem(config_path="config/mcp_config.json")
+    fabric_agent = FabricAgent(system.client_pool)
+    system.register_agent(fabric_agent)
+
+    await system.initialize()
+
+    # Listar workloads
+    result = await fabric_agent.process_task(
+        "Listar todos los workloads disponibles",
+        {}
+    )
+
+    print(f"Workloads: {result.result['workloads']}")
+
+    # Generar definición de Lakehouse
+    result = await fabric_agent.process_task(
+        "Generar definición de Lakehouse",
+        workload_type="Lakehouse",
+        resource_name="my-lakehouse"
+    )
+
+    print(result.result)
+
+    await system.shutdown()
+
+asyncio.run(demo())
+```
+
+### 4. Usar el Orchestrator para workflows complejos
+
+```python
+from src.agents.orchestrator import OrchestratorAgent
+
+async def demo():
+    system = AgentSystem(config_path="config/mcp_config.json")
+
+    # Registrar todos los agentes
+    from src.agents.azure_storage import AzureStorageAgent
+    from src.agents.azure_security import AzureSecurityAgent
+    from src.agents.fabric import FabricAgent
+
+    system.register_agent(AzureStorageAgent(system.client_pool))
+    system.register_agent(AzureSecurityAgent(system.client_pool))
+    system.register_agent(FabricAgent(system.client_pool))
+
+    orchestrator = OrchestratorAgent(system)
+    system.register_agent(orchestrator)
+
+    await system.initialize()
+
+    # Ejecutar workflow
+    result = await orchestrator.execute_workflow(
+        "data_pipeline",
+        {
+            "container_name": "pipeline-data",
+            "lakehouse_name": "analytics-warehouse"
+        }
+    )
+
+    print(f"Workflow: {result['workflow']}")
+    print(f"Estado: {result['status']}")
+    print(f"Resultados: {result['results']}")
+
+    await system.shutdown()
+
+asyncio.run(demo())
+```
+
+## Escenarios de Demostración
+
+### Escenario 1: Pipeline de Datos Completo
+```bash
+python main.py demo --scenario data_pipeline
+```
+
+Crea un pipeline end-to-end:
+- Contenedor de Storage para datos raw
+- Definición de Lakehouse en Fabric
+- Configuración de tablas y schemas
+- Best practices aplicadas
+
+### Escenario 2: Aplicación Segura
+```bash
+python main.py demo --scenario secure_app
+```
+
+Despliega una aplicación con seguridad:
+- Secretos en Key Vault
+- Contenedor para archivos estáticos
+- Configuración de aplicación
+
+## Solución de Problemas
+
+### Error: "El servidor MCP no está ejecutándose"
+
+Asegúrate de que los servidores MCP están compilados:
+```bash
+cd ../servers/Azure.Mcp.Server
+dotnet build --configuration Release
+```
+
+### Error: "No se pudo autenticar con Azure"
+
+Ejecuta:
+```bash
+az login
+az account show
+```
+
+### Error: "ModuleNotFoundError"
+
+Instala las dependencias:
+```bash
+pip install -r requirements.txt
+```
+
+### Los logs no se generan
+
+Crea el directorio de logs:
+```bash
+mkdir -p logs
+```
+
+## Próximos Pasos
+
+1. Explora los ejemplos en `examples/basic_usage.py`
+2. Lee la documentación completa en `README.md`
+3. Personaliza los agentes en `src/agents/`
+4. Crea tus propios workflows en `src/scenarios/`
+5. Integra con tus aplicaciones existentes
+
+## Recursos
+
+- [Documentación Azure MCP](https://learn.microsoft.com/azure/developer/azure-mcp-server/)
+- [Microsoft Fabric Docs](https://learn.microsoft.com/fabric/)
+- [MCP Protocol](https://modelcontextprotocol.io)
+- [Repositorio GitHub](https://github.com/microsoft/mcp)
+
+## Soporte
+
+¿Problemas o preguntas?
+- Abre un issue en: https://github.com/microsoft/mcp/issues
+- Revisa el troubleshooting: `../servers/Azure.Mcp.Server/TROUBLESHOOTING.md`
+
+---
+
+**¡Disfruta construyendo con los MCPs de Microsoft!** 🚀

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,268 @@
+# Sistema de Agentes Multi-MCP de Microsoft
+
+## Descripción General
+
+Este proyecto demuestra un sistema de agentes inteligentes que utiliza los servidores MCP (Model Context Protocol) de Microsoft para automatizar tareas complejas en Azure y Microsoft Fabric.
+
+## Arquitectura del Sistema
+
+El sistema está compuesto por varios agentes especializados que trabajan juntos:
+
+### 1. **Agente Orquestador** (`OrchestratorAgent`)
+- Coordina las interacciones entre todos los agentes
+- Distribuye tareas a los agentes especializados
+- Agrega y presenta resultados al usuario
+
+### 2. **Agente de Azure Storage** (`AzureStorageAgent`)
+- Gestiona operaciones con Azure Storage (blobs, contenedores)
+- Sube y descarga archivos
+- Lista y organiza contenedores
+
+### 3. **Agente de Azure AI** (`AzureAIAgent`)
+- Interactúa con Azure AI Search
+- Gestiona índices de búsqueda
+- Realiza búsquedas semánticas
+
+### 4. **Agente de Azure Data** (`AzureDataAgent`)
+- Gestiona Azure Cosmos DB
+- Realiza consultas SQL en Azure SQL Database
+- Administra datos estructurados y no estructurados
+
+### 5. **Agente de Azure Security** (`AzureSecurityAgent`)
+- Gestiona secretos en Azure Key Vault
+- Administra claves y certificados
+- Implementa mejores prácticas de seguridad
+
+### 6. **Agente de Azure Infrastructure** (`AzureInfraAgent`)
+- Gestiona recursos de Azure (grupos de recursos, suscripciones)
+- Despliega aplicaciones en Azure App Service
+- Administra Azure Functions
+
+### 7. **Agente de Fabric** (`FabricAgent`)
+- Accede a APIs de Microsoft Fabric
+- Genera definiciones de recursos (Lakehouse, notebooks, pipelines)
+- Proporciona mejores prácticas de Fabric
+
+## Escenarios de Demostración
+
+### Escenario 1: Pipeline de Datos Completo
+**Objetivo:** Crear un pipeline end-to-end desde la ingesta hasta el análisis
+
+**Flujo:**
+1. **AzureStorageAgent**: Sube datos CSV a Azure Blob Storage
+2. **AzureDataAgent**: Carga datos en Azure Cosmos DB
+3. **AzureAIAgent**: Indexa datos en Azure AI Search
+4. **FabricAgent**: Genera definición de Lakehouse para análisis
+5. **OrchestratorAgent**: Coordina todo el proceso
+
+### Escenario 2: Aplicación Segura
+**Objetivo:** Desplegar una aplicación web con secretos seguros
+
+**Flujo:**
+1. **AzureSecurityAgent**: Crea secretos en Key Vault (API keys, connection strings)
+2. **AzureInfraAgent**: Despliega aplicación en App Service
+3. **AzureStorageAgent**: Configura almacenamiento para archivos estáticos
+4. **OrchestratorAgent**: Verifica que todo esté correctamente configurado
+
+### Escenario 3: Análisis de Búsqueda Inteligente
+**Objetivo:** Crear un sistema de búsqueda semántica
+
+**Flujo:**
+1. **AzureStorageAgent**: Carga documentos a procesar
+2. **AzureAIAgent**: Crea índice de búsqueda con vectores
+3. **AzureDataAgent**: Almacena metadatos en Cosmos DB
+4. **OrchestratorAgent**: Ejecuta consultas de búsqueda y presenta resultados
+
+### Escenario 4: Infraestructura como Código con Fabric
+**Objetivo:** Generar y desplegar infraestructura de datos
+
+**Flujo:**
+1. **FabricAgent**: Genera definiciones de recursos de Fabric
+2. **AzureInfraAgent**: Crea grupos de recursos necesarios
+3. **AzureDataAgent**: Configura conexiones de datos
+4. **OrchestratorAgent**: Valida y despliega toda la infraestructura
+
+## Características Técnicas
+
+### Comunicación entre Agentes
+- **Protocolo:** Model Context Protocol (MCP)
+- **Formato:** JSON
+- **Transporte:** stdio (entrada/salida estándar)
+
+### Capacidades de los Agentes
+- Procesamiento de lenguaje natural para interpretar instrucciones
+- Ejecución autónoma de tareas con manejo de errores
+- Validación y logging de todas las operaciones
+- Rollback automático en caso de fallos
+
+### Seguridad
+- Autenticación con Azure Identity
+- Uso de managed identities cuando sea posible
+- Secretos almacenados en Key Vault
+- Logging de auditoría de todas las operaciones
+
+## Estructura del Proyecto
+
+```
+demo/
+├── README.md                          # Este archivo
+├── config/
+│   ├── mcp_config.json               # Configuración de servidores MCP
+│   └── agents_config.json            # Configuración de agentes
+├── src/
+│   ├── core/
+│   │   ├── agent_base.py             # Clase base para todos los agentes
+│   │   ├── mcp_client.py             # Cliente MCP
+│   │   └── message_bus.py            # Sistema de mensajería entre agentes
+│   ├── agents/
+│   │   ├── orchestrator.py           # Agente orquestador
+│   │   ├── azure_storage.py          # Agente de Storage
+│   │   ├── azure_ai.py               # Agente de AI
+│   │   ├── azure_data.py             # Agente de Data
+│   │   ├── azure_security.py         # Agente de Security
+│   │   ├── azure_infra.py            # Agente de Infrastructure
+│   │   └── fabric.py                 # Agente de Fabric
+│   ├── scenarios/
+│   │   ├── data_pipeline.py          # Escenario 1
+│   │   ├── secure_app.py             # Escenario 2
+│   │   ├── intelligent_search.py     # Escenario 3
+│   │   └── fabric_infrastructure.py  # Escenario 4
+│   └── utils/
+│       ├── logger.py                 # Sistema de logging
+│       └── validators.py             # Validadores
+├── tests/
+│   ├── test_agents.py                # Tests de agentes
+│   └── test_scenarios.py             # Tests de escenarios
+├── examples/
+│   ├── basic_usage.py                # Ejemplos básicos
+│   └── advanced_usage.py             # Ejemplos avanzados
+└── requirements.txt                   # Dependencias Python
+```
+
+## Requisitos Previos
+
+1. **Azure:**
+   - Suscripción de Azure activa
+   - Azure CLI instalado
+   - Credenciales configuradas (`az login`)
+
+2. **Microsoft Fabric:**
+   - Acceso a un workspace de Fabric (opcional para demos)
+
+3. **Software:**
+   - Python 3.10+
+   - .NET 10 SDK (para Azure MCP Server)
+   - Node.js 20+ (alternativa para Azure MCP Server)
+
+## Instalación
+
+```bash
+# 1. Clonar el repositorio (ya hecho)
+cd /home/user/Microsoft_MCPs/demo
+
+# 2. Instalar dependencias Python
+pip install -r requirements.txt
+
+# 3. Compilar servidores MCP
+cd ../servers/Azure.Mcp.Server
+dotnet build --configuration Release
+
+cd ../Fabric.Mcp.Server
+dotnet build --configuration Release
+
+# 4. Configurar credenciales de Azure
+az login
+```
+
+## Uso Rápido
+
+### Ejecutar un escenario completo:
+
+```bash
+# Escenario 1: Pipeline de datos
+python src/scenarios/data_pipeline.py
+
+# Escenario 2: Aplicación segura
+python src/scenarios/secure_app.py
+
+# Escenario 3: Búsqueda inteligente
+python src/scenarios/intelligent_search.py
+
+# Escenario 4: Infraestructura Fabric
+python src/scenarios/fabric_infrastructure.py
+```
+
+### Interacción directa con agentes:
+
+```python
+from src.core.agent_base import AgentSystem
+from src.agents.orchestrator import OrchestratorAgent
+
+# Inicializar sistema
+system = AgentSystem()
+orchestrator = OrchestratorAgent(system)
+
+# Ejecutar tarea
+result = orchestrator.execute(
+    "Crea un contenedor de almacenamiento llamado 'demo-data' "
+    "y sube el archivo 'datos.csv'"
+)
+
+print(result)
+```
+
+## Beneficios del Sistema
+
+1. **Modularidad:** Agentes especializados que se pueden combinar
+2. **Escalabilidad:** Fácil agregar nuevos agentes y capacidades
+3. **Reutilización:** Componentes que se pueden usar en diferentes escenarios
+4. **Observabilidad:** Logging completo de todas las operaciones
+5. **Resiliencia:** Manejo de errores y reintentos automáticos
+
+## Ejemplos de Comandos
+
+### Usar múltiples servicios Azure:
+```python
+orchestrator.execute("""
+    1. Crea un secreto en Key Vault llamado 'api-key' con valor 'secret123'
+    2. Crea un contenedor de storage llamado 'app-data'
+    3. Despliega una función en Azure Functions que use ese secreto
+""")
+```
+
+### Generar recursos de Fabric:
+```python
+fabric_agent.execute("""
+    Genera una definición de Lakehouse con las siguientes tablas:
+    - customers: id (int), name (string), email (string)
+    - orders: id (int), customer_id (int), amount (decimal), date (datetime)
+""")
+```
+
+### Pipeline completo:
+```python
+orchestrator.execute("""
+    Crea un pipeline completo para análisis de ventas:
+    1. Storage: contenedor 'raw-sales-data'
+    2. Cosmos DB: base de datos 'sales-analytics'
+    3. AI Search: índice 'sales-search' con embeddings
+    4. Fabric: Lakehouse 'sales-warehouse'
+""")
+```
+
+## Próximos Pasos
+
+1. Ejecutar los escenarios de ejemplo
+2. Explorar las capacidades de cada agente
+3. Crear tus propios escenarios personalizados
+4. Integrar con tus aplicaciones existentes
+
+## Soporte y Contribuciones
+
+- **Issues:** [GitHub Issues](https://github.com/microsoft/mcp/issues)
+- **Documentación:** [Learn Microsoft](https://learn.microsoft.com/azure/developer/azure-mcp-server/)
+- **Comunidad:** [MCP Community](https://modelcontextprotocol.io)
+
+---
+
+**¡Disfruta explorando las capacidades de los MCPs de Microsoft!** 🚀

--- a/demo/config/agents_config.json
+++ b/demo/config/agents_config.json
@@ -1,0 +1,144 @@
+{
+  "agents": {
+    "orchestrator": {
+      "name": "Orchestrator Agent",
+      "description": "Coordina las interacciones entre todos los agentes especializados",
+      "capabilities": [
+        "task_distribution",
+        "result_aggregation",
+        "workflow_management"
+      ],
+      "dependencies": ["*"]
+    },
+    "azure_storage": {
+      "name": "Azure Storage Agent",
+      "description": "Gestiona operaciones con Azure Blob Storage",
+      "mcp_server": "azure-mcp",
+      "tools": [
+        "storage.list",
+        "storage.create",
+        "storage.upload",
+        "storage.download",
+        "storage.delete"
+      ],
+      "capabilities": [
+        "blob_management",
+        "container_management",
+        "file_upload",
+        "file_download"
+      ]
+    },
+    "azure_ai": {
+      "name": "Azure AI Agent",
+      "description": "Interactúa con Azure AI Search y servicios cognitivos",
+      "mcp_server": "azure-mcp",
+      "tools": [
+        "search.list",
+        "search.create",
+        "search.query",
+        "search.index"
+      ],
+      "capabilities": [
+        "semantic_search",
+        "index_management",
+        "vector_search"
+      ]
+    },
+    "azure_data": {
+      "name": "Azure Data Agent",
+      "description": "Gestiona Azure Cosmos DB y Azure SQL Database",
+      "mcp_server": "azure-mcp",
+      "tools": [
+        "cosmos.list",
+        "cosmos.query",
+        "cosmos.insert",
+        "sql.list",
+        "sql.query",
+        "sql.execute"
+      ],
+      "capabilities": [
+        "nosql_operations",
+        "sql_operations",
+        "data_migration"
+      ]
+    },
+    "azure_security": {
+      "name": "Azure Security Agent",
+      "description": "Gestiona Azure Key Vault (secretos, claves, certificados)",
+      "mcp_server": "azure-mcp",
+      "tools": [
+        "keyvault.list",
+        "keyvault.get",
+        "keyvault.set",
+        "keyvault.delete"
+      ],
+      "capabilities": [
+        "secret_management",
+        "key_management",
+        "certificate_management"
+      ]
+    },
+    "azure_infra": {
+      "name": "Azure Infrastructure Agent",
+      "description": "Gestiona recursos de Azure (grupos, App Service, Functions)",
+      "mcp_server": "azure-mcp",
+      "tools": [
+        "resourcegroup.list",
+        "resourcegroup.create",
+        "appservice.list",
+        "appservice.deploy",
+        "functions.list",
+        "functions.deploy"
+      ],
+      "capabilities": [
+        "resource_management",
+        "app_deployment",
+        "function_deployment"
+      ]
+    },
+    "fabric": {
+      "name": "Fabric Agent",
+      "description": "Accede a APIs públicas de Microsoft Fabric",
+      "mcp_server": "fabric-mcp",
+      "tools": [
+        "publicapis.list",
+        "publicapis.get",
+        "itemdefinition.get",
+        "bestpractices.get",
+        "examples.get"
+      ],
+      "capabilities": [
+        "api_discovery",
+        "schema_generation",
+        "best_practices",
+        "example_retrieval"
+      ]
+    }
+  },
+  "workflows": {
+    "data_pipeline": {
+      "name": "Pipeline de Datos Completo",
+      "description": "Crea un pipeline end-to-end desde ingesta hasta análisis",
+      "agents": ["azure_storage", "azure_data", "azure_ai", "fabric"],
+      "coordinator": "orchestrator"
+    },
+    "secure_app": {
+      "name": "Aplicación Segura",
+      "description": "Despliega aplicación web con secretos seguros",
+      "agents": ["azure_security", "azure_infra", "azure_storage"],
+      "coordinator": "orchestrator"
+    },
+    "intelligent_search": {
+      "name": "Búsqueda Inteligente",
+      "description": "Sistema de búsqueda semántica con vectores",
+      "agents": ["azure_storage", "azure_ai", "azure_data"],
+      "coordinator": "orchestrator"
+    },
+    "fabric_infrastructure": {
+      "name": "Infraestructura Fabric",
+      "description": "Genera y despliega infraestructura de datos con Fabric",
+      "agents": ["fabric", "azure_infra", "azure_data"],
+      "coordinator": "orchestrator"
+    }
+  }
+}

--- a/demo/config/mcp_config.json
+++ b/demo/config/mcp_config.json
@@ -1,0 +1,53 @@
+{
+  "mcpServers": {
+    "azure-mcp": {
+      "command": "dnx",
+      "args": [
+        "Azure.Mcp",
+        "--source",
+        "https://api.nuget.org/v3/index.json",
+        "--yes",
+        "--",
+        "azmcp",
+        "server",
+        "start"
+      ],
+      "type": "stdio",
+      "description": "Azure MCP Server - Proporciona acceso a 40+ servicios de Azure",
+      "capabilities": [
+        "storage",
+        "keyvault",
+        "cosmos",
+        "sql",
+        "search",
+        "functions",
+        "appservice",
+        "aks",
+        "monitor",
+        "communication"
+      ]
+    },
+    "fabric-mcp": {
+      "command": "../servers/Fabric.Mcp.Server/src/bin/Release/fabmcp",
+      "args": [
+        "server",
+        "start",
+        "--mode",
+        "all"
+      ],
+      "type": "stdio",
+      "description": "Microsoft Fabric MCP Server - APIs públicas de Fabric",
+      "capabilities": [
+        "publicapis",
+        "itemdefinitions",
+        "bestpractices",
+        "examples"
+      ]
+    }
+  },
+  "settings": {
+    "timeout": 30000,
+    "maxRetries": 3,
+    "logLevel": "INFO"
+  }
+}

--- a/demo/examples/basic_usage.py
+++ b/demo/examples/basic_usage.py
@@ -1,0 +1,290 @@
+"""
+Ejemplos básicos de uso del sistema de agentes MCP.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Agregar el directorio src al path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.core.agent_base import AgentSystem
+from src.agents.azure_storage import AzureStorageAgent
+from src.agents.azure_security import AzureSecurityAgent
+from src.agents.fabric import FabricAgent
+from src.agents.orchestrator import OrchestratorAgent
+from src.utils.logger import setup_logger
+
+
+async def example_1_storage_operations():
+    """Ejemplo 1: Operaciones básicas con Azure Storage."""
+    print("\n" + "="*60)
+    print("EJEMPLO 1: Operaciones con Azure Storage")
+    print("="*60 + "\n")
+
+    # Crear sistema de agentes
+    system = AgentSystem(config_path="../config/mcp_config.json")
+
+    # Registrar agentes
+    storage_agent = AzureStorageAgent(system.client_pool)
+    system.register_agent(storage_agent)
+
+    # Inicializar sistema
+    print("Inicializando sistema de agentes...")
+    if not await system.initialize():
+        print("Error: No se pudo inicializar el sistema")
+        return
+
+    try:
+        # Listar contenedores
+        print("\n1. Listando contenedores de storage...")
+        result = await system.execute_task(
+            "azure_storage",
+            "Listar todos los contenedores de storage",
+            storage_account="mystorageaccount"
+        )
+
+        if result and result.result:
+            print(f"   Encontrados {result.result.get('count', 0)} contenedores")
+
+        # Crear contenedor
+        print("\n2. Creando nuevo contenedor...")
+        result = await system.execute_task(
+            "azure_storage",
+            "Crear un contenedor llamado 'demo-data'",
+            container_name="demo-data",
+            storage_account="mystorageaccount"
+        )
+
+        if result and not result.error:
+            print(f"   Contenedor creado: {result.result.get('container_name')}")
+        else:
+            print(f"   Error: {result.error}")
+
+    finally:
+        # Cerrar sistema
+        await system.shutdown()
+        print("\nSistema cerrado correctamente")
+
+
+async def example_2_keyvault_secrets():
+    """Ejemplo 2: Gestión de secretos en Key Vault."""
+    print("\n" + "="*60)
+    print("EJEMPLO 2: Gestión de secretos en Key Vault")
+    print("="*60 + "\n")
+
+    system = AgentSystem(config_path="../config/mcp_config.json")
+
+    # Registrar agente de seguridad
+    security_agent = AzureSecurityAgent(system.client_pool)
+    system.register_agent(security_agent)
+
+    print("Inicializando sistema de agentes...")
+    if not await system.initialize():
+        print("Error: No se pudo inicializar el sistema")
+        return
+
+    try:
+        # Crear secreto
+        print("\n1. Creando secreto en Key Vault...")
+        result = await system.execute_task(
+            "azure_security",
+            "Crear un secreto llamado 'api-key' con valor 'secret123'",
+            vault_name="my-keyvault",
+            secret_name="api-key",
+            secret_value="secret123"
+        )
+
+        if result and not result.error:
+            print(f"   Secreto creado: {result.result.get('secret_name')}")
+        else:
+            print(f"   Error: {result.error}")
+
+        # Listar secretos
+        print("\n2. Listando todos los secretos...")
+        result = await system.execute_task(
+            "azure_security",
+            "Listar todos los secretos en el vault",
+            vault_name="my-keyvault"
+        )
+
+        if result and result.result:
+            secrets = result.result.get('secrets', [])
+            print(f"   Encontrados {len(secrets)} secretos:")
+            for secret in secrets[:5]:  # Mostrar solo los primeros 5
+                print(f"     - {secret}")
+
+    finally:
+        await system.shutdown()
+        print("\nSistema cerrado correctamente")
+
+
+async def example_3_fabric_workloads():
+    """Ejemplo 3: Explorar workloads de Microsoft Fabric."""
+    print("\n" + "="*60)
+    print("EJEMPLO 3: Explorar workloads de Microsoft Fabric")
+    print("="*60 + "\n")
+
+    system = AgentSystem(config_path="../config/mcp_config.json")
+
+    # Registrar agente de Fabric
+    fabric_agent = FabricAgent(system.client_pool)
+    system.register_agent(fabric_agent)
+
+    print("Inicializando sistema de agentes...")
+    if not await system.initialize():
+        print("Error: No se pudo inicializar el sistema")
+        return
+
+    try:
+        # Listar workloads
+        print("\n1. Listando workloads disponibles en Fabric...")
+        result = await system.execute_task(
+            "fabric",
+            "Listar todos los workloads de Fabric",
+            {}
+        )
+
+        if result and result.result:
+            workloads = result.result.get('workloads', [])
+            print(f"   Encontrados {len(workloads)} workloads:")
+            for workload in workloads:
+                print(f"     - {workload}")
+
+        # Generar definición de Lakehouse
+        print("\n2. Generando definición de Lakehouse...")
+        result = await system.execute_task(
+            "fabric",
+            "Generar definición de Lakehouse con tablas customers y orders",
+            workload_type="Lakehouse",
+            resource_name="sales-lakehouse",
+            properties={
+                "tables": [
+                    {
+                        "name": "customers",
+                        "columns": [
+                            {"name": "id", "type": "int"},
+                            {"name": "name", "type": "string"},
+                            {"name": "email", "type": "string"}
+                        ]
+                    },
+                    {
+                        "name": "orders",
+                        "columns": [
+                            {"name": "id", "type": "int"},
+                            {"name": "customer_id", "type": "int"},
+                            {"name": "amount", "type": "decimal"},
+                            {"name": "date", "type": "datetime"}
+                        ]
+                    }
+                ]
+            }
+        )
+
+        if result and not result.error:
+            print(f"   Definición generada para: {result.result.get('workload_type')}")
+        else:
+            print(f"   Error: {result.error}")
+
+    finally:
+        await system.shutdown()
+        print("\nSistema cerrado correctamente")
+
+
+async def example_4_orchestrator_workflow():
+    """Ejemplo 4: Usar el orchestrator para workflows complejos."""
+    print("\n" + "="*60)
+    print("EJEMPLO 4: Workflows con Orchestrator")
+    print("="*60 + "\n")
+
+    system = AgentSystem(config_path="../config/mcp_config.json")
+
+    # Registrar todos los agentes
+    system.register_agent(AzureStorageAgent(system.client_pool))
+    system.register_agent(AzureSecurityAgent(system.client_pool))
+    system.register_agent(FabricAgent(system.client_pool))
+
+    # Crear orchestrator
+    orchestrator = OrchestratorAgent(system)
+    system.register_agent(orchestrator)
+
+    print("Inicializando sistema de agentes...")
+    if not await system.initialize():
+        print("Error: No se pudo inicializar el sistema")
+        return
+
+    try:
+        # Ejecutar workflow de pipeline de datos
+        print("\n1. Ejecutando workflow: Pipeline de datos...")
+        result = await orchestrator.execute_workflow(
+            "data_pipeline",
+            {
+                "container_name": "data-raw",
+                "lakehouse_name": "analytics-lakehouse"
+            }
+        )
+
+        print(f"   Workflow completado: {result['status']}")
+        print(f"   Resultados: {len(result.get('results', {}))} operaciones")
+
+        # Ejecutar workflow de aplicación segura
+        print("\n2. Ejecutando workflow: Aplicación segura...")
+        result = await orchestrator.execute_workflow(
+            "secure_app",
+            {
+                "vault_name": "app-vault",
+                "secret_name": "db-connection",
+                "secret_value": "Server=myserver;Database=mydb",
+                "static_container": "app-static"
+            }
+        )
+
+        print(f"   Workflow completado: {result['status']}")
+
+    finally:
+        await system.shutdown()
+        print("\nSistema cerrado correctamente")
+
+
+def main():
+    """Función principal que ejecuta todos los ejemplos."""
+    print("\n" + "="*60)
+    print("SISTEMA DE AGENTES MULTI-MCP DE MICROSOFT")
+    print("Ejemplos Básicos de Uso")
+    print("="*60)
+
+    # Configurar logger
+    setup_logger(name="agent_system", log_file="logs/examples.log")
+
+    # Ejecutar ejemplos
+    examples = [
+        ("Operaciones con Azure Storage", example_1_storage_operations),
+        ("Gestión de secretos en Key Vault", example_2_keyvault_secrets),
+        ("Explorar workloads de Fabric", example_3_fabric_workloads),
+        ("Workflows con Orchestrator", example_4_orchestrator_workflow)
+    ]
+
+    print("\nEjemplos disponibles:")
+    for i, (name, _) in enumerate(examples, 1):
+        print(f"{i}. {name}")
+
+    print("\nEjecutando todos los ejemplos...")
+    print("(Nota: Algunos ejemplos pueden fallar si no tienes recursos Azure configurados)\n")
+
+    for name, example_func in examples:
+        try:
+            asyncio.run(example_func())
+        except KeyboardInterrupt:
+            print("\n\nEjecución interrumpida por el usuario")
+            break
+        except Exception as e:
+            print(f"\nError en ejemplo '{name}': {e}")
+
+    print("\n" + "="*60)
+    print("Ejemplos completados")
+    print("="*60 + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/main.py
+++ b/demo/main.py
@@ -1,0 +1,307 @@
+"""
+Sistema de Agentes Multi-MCP de Microsoft
+Punto de entrada principal
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from src.core.agent_base import AgentSystem
+from src.agents.azure_storage import AzureStorageAgent
+from src.agents.azure_security import AzureSecurityAgent
+from src.agents.fabric import FabricAgent
+from src.agents.orchestrator import OrchestratorAgent
+from src.utils.logger import setup_logger
+
+
+console = Console()
+
+
+@click.group()
+@click.option('--config', default='config/mcp_config.json', help='Ruta al archivo de configuración MCP')
+@click.option('--log-level', default='INFO', help='Nivel de logging')
+@click.pass_context
+def cli(ctx, config, log_level):
+    """Sistema de Agentes Multi-MCP de Microsoft."""
+    ctx.ensure_object(dict)
+    ctx.obj['config'] = config
+    ctx.obj['log_level'] = log_level
+
+    # Configurar logger
+    setup_logger(
+        name="agent_system",
+        level=getattr(__import__('logging'), log_level),
+        log_file="logs/agent_system.log"
+    )
+
+
+@cli.command()
+@click.pass_context
+def info(ctx):
+    """Muestra información del sistema de agentes."""
+    console.print(Panel.fit(
+        "[bold cyan]Sistema de Agentes Multi-MCP de Microsoft[/bold cyan]\n\n"
+        "Un sistema modular de agentes que utiliza los servidores MCP\n"
+        "de Microsoft para automatizar tareas en Azure y Fabric.\n\n"
+        "[yellow]Agentes disponibles:[/yellow]\n"
+        "  • Azure Storage Agent\n"
+        "  • Azure Security Agent (Key Vault)\n"
+        "  • Azure AI Agent\n"
+        "  • Azure Data Agent\n"
+        "  • Azure Infrastructure Agent\n"
+        "  • Fabric Agent\n"
+        "  • Orchestrator Agent\n\n"
+        "[yellow]Workflows disponibles:[/yellow]\n"
+        "  • data_pipeline - Pipeline de datos completo\n"
+        "  • secure_app - Aplicación segura\n"
+        "  • intelligent_search - Búsqueda inteligente\n"
+        "  • fabric_infrastructure - Infraestructura Fabric",
+        border_style="cyan"
+    ))
+
+
+@cli.command()
+@click.option('--agent', required=True, help='Nombre del agente')
+@click.pass_context
+def list_capabilities(ctx, agent):
+    """Lista las capacidades de un agente específico."""
+    async def _list():
+        system = AgentSystem(config_path=ctx.obj['config'])
+
+        # Registrar agentes
+        agents_map = {
+            'azure_storage': AzureStorageAgent(system.client_pool),
+            'azure_security': AzureSecurityAgent(system.client_pool),
+            'fabric': FabricAgent(system.client_pool)
+        }
+
+        if agent not in agents_map:
+            console.print(f"[red]Agente no encontrado: {agent}[/red]")
+            console.print(f"Agentes disponibles: {', '.join(agents_map.keys())}")
+            return
+
+        selected_agent = agents_map[agent]
+        system.register_agent(selected_agent)
+
+        if await system.initialize():
+            table = Table(title=f"Capacidades de {agent}")
+            table.add_column("Capacidad", style="cyan")
+            table.add_column("Descripción", style="green")
+
+            for cap in selected_agent.capabilities:
+                table.add_row(cap.name, cap.description)
+
+            console.print(table)
+
+            await system.shutdown()
+        else:
+            console.print("[red]Error al inicializar el sistema[/red]")
+
+    asyncio.run(_list())
+
+
+@cli.command()
+@click.option('--workflow', required=True, help='Nombre del workflow')
+@click.option('--params', default='{}', help='Parámetros en formato JSON')
+@click.pass_context
+def run_workflow(ctx, workflow, params):
+    """Ejecuta un workflow predefinido."""
+    import json
+
+    async def _run():
+        console.print(f"\n[yellow]Ejecutando workflow: {workflow}[/yellow]\n")
+
+        system = AgentSystem(config_path=ctx.obj['config'])
+
+        # Registrar todos los agentes
+        system.register_agent(AzureStorageAgent(system.client_pool))
+        system.register_agent(AzureSecurityAgent(system.client_pool))
+        system.register_agent(FabricAgent(system.client_pool))
+
+        orchestrator = OrchestratorAgent(system)
+        system.register_agent(orchestrator)
+
+        if await system.initialize():
+            try:
+                workflow_params = json.loads(params)
+                result = await orchestrator.execute_workflow(workflow, workflow_params)
+
+                console.print(Panel(
+                    f"[bold green]Workflow completado[/bold green]\n\n"
+                    f"Workflow: {result['workflow']}\n"
+                    f"Estado: {result['status']}\n"
+                    f"Operaciones: {len(result.get('results', {}))}",
+                    border_style="green"
+                ))
+
+            except Exception as e:
+                console.print(f"[red]Error al ejecutar workflow: {e}[/red]")
+            finally:
+                await system.shutdown()
+        else:
+            console.print("[red]Error al inicializar el sistema[/red]")
+
+    asyncio.run(_run())
+
+
+@cli.command()
+@click.option('--agent', required=True, help='Nombre del agente')
+@click.option('--task', required=True, help='Descripción de la tarea')
+@click.option('--params', default='{}', help='Parámetros en formato JSON')
+@click.pass_context
+def execute(ctx, agent, task, params):
+    """Ejecuta una tarea en un agente específico."""
+    import json
+
+    async def _execute():
+        console.print(f"\n[yellow]Ejecutando tarea en {agent}...[/yellow]\n")
+
+        system = AgentSystem(config_path=ctx.obj['config'])
+
+        # Registrar el agente solicitado
+        agents_map = {
+            'azure_storage': AzureStorageAgent(system.client_pool),
+            'azure_security': AzureSecurityAgent(system.client_pool),
+            'fabric': FabricAgent(system.client_pool)
+        }
+
+        if agent not in agents_map:
+            console.print(f"[red]Agente no encontrado: {agent}[/red]")
+            return
+
+        selected_agent = agents_map[agent]
+        system.register_agent(selected_agent)
+
+        if await system.initialize():
+            try:
+                task_params = json.loads(params)
+                result = await selected_agent.process_task(task, **task_params)
+
+                if result.error:
+                    console.print(f"[red]Error: {result.error}[/red]")
+                else:
+                    console.print(Panel(
+                        f"[bold green]Tarea completada[/bold green]\n\n"
+                        f"Agente: {result.agent_name}\n"
+                        f"Estado: {result.status.value}\n\n"
+                        f"Resultado:\n{result.result}",
+                        border_style="green"
+                    ))
+
+            except Exception as e:
+                console.print(f"[red]Error: {e}[/red]")
+            finally:
+                await system.shutdown()
+        else:
+            console.print("[red]Error al inicializar el sistema[/red]")
+
+    asyncio.run(_execute())
+
+
+@cli.command()
+@click.pass_context
+def interactive(ctx):
+    """Modo interactivo para ejecutar tareas."""
+    async def _interactive():
+        console.print(Panel.fit(
+            "[bold cyan]Modo Interactivo[/bold cyan]\n"
+            "Escribe comandos en lenguaje natural",
+            border_style="cyan"
+        ))
+
+        system = AgentSystem(config_path=ctx.obj['config'])
+
+        # Registrar todos los agentes
+        system.register_agent(AzureStorageAgent(system.client_pool))
+        system.register_agent(AzureSecurityAgent(system.client_pool))
+        system.register_agent(FabricAgent(system.client_pool))
+
+        orchestrator = OrchestratorAgent(system)
+        system.register_agent(orchestrator)
+
+        if not await system.initialize():
+            console.print("[red]Error al inicializar el sistema[/red]")
+            return
+
+        try:
+            console.print("\n[green]Sistema inicializado. Escribe 'exit' para salir.[/green]\n")
+
+            while True:
+                try:
+                    command = console.input("[bold cyan]> [/bold cyan]")
+
+                    if command.lower() in ['exit', 'quit', 'salir']:
+                        break
+
+                    if not command.strip():
+                        continue
+
+                    # Procesar comando con orchestrator
+                    result = await orchestrator.process_task(command)
+
+                    if result.error:
+                        console.print(f"[red]Error: {result.error}[/red]")
+                    else:
+                        console.print(f"[green]Resultado:[/green] {result.result}\n")
+
+                except KeyboardInterrupt:
+                    break
+                except Exception as e:
+                    console.print(f"[red]Error: {e}[/red]")
+
+        finally:
+            await system.shutdown()
+            console.print("\n[yellow]Sistema cerrado[/yellow]")
+
+    asyncio.run(_interactive())
+
+
+@cli.command()
+def examples():
+    """Ejecuta los ejemplos básicos."""
+    console.print("[yellow]Ejecutando ejemplos básicos...[/yellow]\n")
+
+    import subprocess
+    result = subprocess.run(
+        [sys.executable, "examples/basic_usage.py"],
+        cwd=Path(__file__).parent
+    )
+
+    sys.exit(result.returncode)
+
+
+@cli.command()
+@click.option('--scenario', type=click.Choice(['data_pipeline', 'secure_app', 'intelligent_search', 'fabric_infrastructure']), required=True)
+def demo(scenario):
+    """Ejecuta un escenario de demostración."""
+    console.print(f"[yellow]Ejecutando escenario: {scenario}[/yellow]\n")
+
+    scenario_files = {
+        'data_pipeline': 'src/scenarios/data_pipeline.py'
+    }
+
+    if scenario in scenario_files:
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, scenario_files[scenario]],
+            cwd=Path(__file__).parent
+        )
+        sys.exit(result.returncode)
+    else:
+        console.print(f"[red]Escenario no implementado: {scenario}[/red]")
+        console.print("[yellow]Disponible: data_pipeline[/yellow]")
+
+
+def main():
+    """Punto de entrada principal."""
+    cli(obj={})
+
+
+if __name__ == '__main__':
+    main()

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,0 +1,34 @@
+# Sistema de Agentes Multi-MCP de Microsoft
+# Dependencias Python
+
+# Core dependencies
+pydantic>=2.0.0
+python-dotenv>=1.0.0
+aiohttp>=3.9.0
+asyncio>=3.4.3
+
+# Azure SDK
+azure-identity>=1.15.0
+azure-core>=1.29.0
+
+# Logging and monitoring
+structlog>=24.1.0
+colorama>=0.4.6
+
+# CLI and utilities
+click>=8.1.7
+rich>=13.7.0
+tabulate>=0.9.0
+
+# Testing
+pytest>=7.4.0
+pytest-asyncio>=0.21.0
+pytest-mock>=3.12.0
+
+# Type checking
+mypy>=1.8.0
+types-aiofiles>=23.2.0
+
+# Development
+black>=24.1.0
+ruff>=0.1.0

--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+# Script de configuración para el Sistema de Agentes Multi-MCP
+# Este script automatiza la instalación y configuración del sistema
+
+set -e  # Salir si hay error
+
+echo "=================================================="
+echo "Sistema de Agentes Multi-MCP de Microsoft"
+echo "Script de Configuración"
+echo "=================================================="
+echo ""
+
+# Colores para output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Función para imprimir mensajes
+print_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# 1. Verificar Python
+print_info "Verificando Python..."
+if command -v python3 &> /dev/null; then
+    PYTHON_VERSION=$(python3 --version | cut -d' ' -f2)
+    print_info "Python encontrado: $PYTHON_VERSION"
+else
+    print_error "Python 3 no está instalado"
+    exit 1
+fi
+
+# 2. Verificar .NET o Node.js
+print_info "Verificando .NET SDK..."
+if command -v dotnet &> /dev/null; then
+    DOTNET_VERSION=$(dotnet --version)
+    print_info ".NET SDK encontrado: $DOTNET_VERSION"
+    USE_DOTNET=true
+elif command -v node &> /dev/null; then
+    NODE_VERSION=$(node --version)
+    print_info "Node.js encontrado: $NODE_VERSION (se usará NPM)"
+    USE_DOTNET=false
+else
+    print_error "Necesitas .NET 10+ o Node.js 20+ instalado"
+    exit 1
+fi
+
+# 3. Crear estructura de directorios
+print_info "Creando directorios necesarios..."
+mkdir -p logs
+mkdir -p config
+mkdir -p data
+print_info "Directorios creados"
+
+# 4. Instalar dependencias Python
+print_info "Instalando dependencias Python..."
+if [ -f "requirements.txt" ]; then
+    python3 -m pip install -r requirements.txt --quiet
+    print_info "Dependencias Python instaladas"
+else
+    print_warning "requirements.txt no encontrado"
+fi
+
+# 5. Compilar servidores MCP
+print_info "Compilando servidores MCP..."
+
+if [ "$USE_DOTNET" = true ]; then
+    # Compilar Azure MCP Server
+    print_info "Compilando Azure MCP Server..."
+    cd ../servers/Azure.Mcp.Server
+    dotnet build --configuration Release > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        print_info "Azure MCP Server compilado correctamente"
+    else
+        print_warning "Error al compilar Azure MCP Server"
+    fi
+
+    # Compilar Fabric MCP Server
+    print_info "Compilando Fabric MCP Server..."
+    cd ../Fabric.Mcp.Server
+    dotnet build --configuration Release > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        print_info "Fabric MCP Server compilado correctamente"
+    else
+        print_warning "Error al compilar Fabric MCP Server"
+    fi
+
+    cd ../../demo
+else
+    print_info "Usando Azure MCP Server desde NPM..."
+    npm install -g @azure/mcp@latest --silent
+fi
+
+# 6. Verificar Azure CLI
+print_info "Verificando Azure CLI..."
+if command -v az &> /dev/null; then
+    print_info "Azure CLI encontrado"
+
+    # Verificar autenticación
+    if az account show &> /dev/null; then
+        ACCOUNT=$(az account show --query name -o tsv)
+        print_info "Autenticado con Azure: $ACCOUNT"
+    else
+        print_warning "No estás autenticado con Azure"
+        print_info "Ejecuta: az login"
+    fi
+else
+    print_warning "Azure CLI no está instalado"
+    print_info "Descárgalo desde: https://docs.microsoft.com/cli/azure/install-azure-cli"
+fi
+
+# 7. Crear archivo .env de ejemplo
+print_info "Creando archivo .env de ejemplo..."
+cat > .env.example << EOF
+# Configuración de Azure
+AZURE_SUBSCRIPTION_ID=your-subscription-id
+AZURE_TENANT_ID=your-tenant-id
+
+# Configuración de Storage
+AZURE_STORAGE_ACCOUNT=your-storage-account
+
+# Configuración de Key Vault
+AZURE_KEYVAULT_NAME=your-keyvault-name
+
+# Configuración de Logging
+LOG_LEVEL=INFO
+
+# Configuración de MCP
+MCP_TIMEOUT=30000
+MCP_MAX_RETRIES=3
+EOF
+print_info "Archivo .env.example creado"
+
+# 8. Verificar instalación
+print_info "Verificando instalación..."
+python3 main.py info > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    print_info "Sistema instalado correctamente"
+else
+    print_warning "Hubo algunos errores durante la instalación"
+fi
+
+echo ""
+echo "=================================================="
+echo -e "${GREEN}Instalación Completada${NC}"
+echo "=================================================="
+echo ""
+echo "Próximos pasos:"
+echo "  1. Autenticar con Azure: az login"
+echo "  2. Ver información: python main.py info"
+echo "  3. Ejecutar ejemplos: python main.py examples"
+echo "  4. Ejecutar demo: python main.py demo --scenario data_pipeline"
+echo ""
+echo "Para más información, lee QUICKSTART.md"
+echo ""

--- a/demo/src/__init__.py
+++ b/demo/src/__init__.py
@@ -1,0 +1,7 @@
+"""
+Sistema de Agentes Multi-MCP de Microsoft
+"""
+
+__version__ = "1.0.0"
+__author__ = "Microsoft MCP Team"
+__description__ = "Sistema de agentes para demostración de MCPs de Microsoft"

--- a/demo/src/agents/__init__.py
+++ b/demo/src/agents/__init__.py
@@ -1,0 +1,13 @@
+"""Specialized agents for Azure and Fabric services."""
+
+from .azure_storage import AzureStorageAgent
+from .azure_security import AzureSecurityAgent
+from .fabric import FabricAgent
+from .orchestrator import OrchestratorAgent
+
+__all__ = [
+    'AzureStorageAgent',
+    'AzureSecurityAgent',
+    'FabricAgent',
+    'OrchestratorAgent'
+]

--- a/demo/src/agents/azure_security.py
+++ b/demo/src/agents/azure_security.py
@@ -1,0 +1,396 @@
+"""
+Agente especializado para Azure Key Vault (Security).
+"""
+
+from typing import Any, Dict, List
+from src.core.agent_base import Agent, AgentCapability, Task
+from src.core.mcp_client import MCPClientPool
+from src.utils.logger import AgentLogger
+from src.utils.validators import Validators
+
+
+class AzureSecurityAgent(Agent):
+    """
+    Agente especializado para operaciones con Azure Key Vault.
+
+    Capacidades:
+    - Gestión de secretos (crear, leer, eliminar)
+    - Gestión de claves (crear, leer, eliminar)
+    - Gestión de certificados (importar, leer, eliminar)
+    - Listar secretos, claves y certificados
+    """
+
+    def __init__(self, client_pool: MCPClientPool):
+        super().__init__(
+            name="azure_security",
+            description="Agente para gestión de Azure Key Vault",
+            mcp_server_name="azure-mcp",
+            client_pool=client_pool
+        )
+        self.logger = AgentLogger("AzureSecurityAgent")
+
+    async def _load_capabilities(self):
+        """Carga las capacidades del agente."""
+        self.capabilities = [
+            AgentCapability(
+                name="create_secret",
+                description="Crea o actualiza un secreto",
+                required_tools=["azure.keyvault.setSecret"],
+                parameters={
+                    "vault_name": "string",
+                    "secret_name": "string",
+                    "secret_value": "string"
+                }
+            ),
+            AgentCapability(
+                name="get_secret",
+                description="Obtiene el valor de un secreto",
+                required_tools=["azure.keyvault.getSecret"],
+                parameters={
+                    "vault_name": "string",
+                    "secret_name": "string"
+                }
+            ),
+            AgentCapability(
+                name="list_secrets",
+                description="Lista todos los secretos",
+                required_tools=["azure.keyvault.listSecrets"],
+                parameters={
+                    "vault_name": "string"
+                }
+            ),
+            AgentCapability(
+                name="delete_secret",
+                description="Elimina un secreto",
+                required_tools=["azure.keyvault.deleteSecret"],
+                parameters={
+                    "vault_name": "string",
+                    "secret_name": "string"
+                }
+            ),
+            AgentCapability(
+                name="create_key",
+                description="Crea una nueva clave criptográfica",
+                required_tools=["azure.keyvault.createKey"],
+                parameters={
+                    "vault_name": "string",
+                    "key_name": "string",
+                    "key_type": "string"
+                }
+            )
+        ]
+
+    async def execute_task(self, task: Task) -> Task:
+        """Ejecuta una tarea de seguridad."""
+        self.logger.task_start(task.description)
+
+        try:
+            description_lower = task.description.lower()
+
+            if "secreto" in description_lower or "secret" in description_lower:
+                if "crear" in description_lower or "create" in description_lower or "set" in description_lower:
+                    task.result = await self._create_secret(task.params)
+                elif "obtener" in description_lower or "get" in description_lower or "leer" in description_lower:
+                    task.result = await self._get_secret(task.params)
+                elif "listar" in description_lower or "list" in description_lower:
+                    task.result = await self._list_secrets(task.params)
+                elif "eliminar" in description_lower or "delete" in description_lower:
+                    task.result = await self._delete_secret(task.params)
+
+            elif "clave" in description_lower or "key" in description_lower:
+                if "crear" in description_lower or "create" in description_lower:
+                    task.result = await self._create_key(task.params)
+                elif "listar" in description_lower or "list" in description_lower:
+                    task.result = await self._list_keys(task.params)
+                elif "eliminar" in description_lower or "delete" in description_lower:
+                    task.result = await self._delete_key(task.params)
+
+            elif "certificado" in description_lower or "certificate" in description_lower:
+                if "importar" in description_lower or "import" in description_lower:
+                    task.result = await self._import_certificate(task.params)
+                elif "listar" in description_lower or "list" in description_lower:
+                    task.result = await self._list_certificates(task.params)
+
+            else:
+                task.error = "No se pudo determinar la operación de Key Vault"
+                return task
+
+            self.logger.task_complete(task.description, 0)
+
+        except Exception as e:
+            task.error = str(e)
+            self.logger.task_failed(task.description, str(e))
+
+        return task
+
+    async def _create_secret(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Crea o actualiza un secreto en Key Vault."""
+        vault_name = params.get("vault_name")
+        secret_name = params.get("secret_name")
+        secret_value = params.get("secret_value")
+
+        if not all([vault_name, secret_name, secret_value]):
+            raise Exception(
+                "Se requiere 'vault_name', 'secret_name' y 'secret_value'"
+            )
+
+        # Validar nombre del secreto
+        Validators.validate_key_vault_secret_name(secret_name)
+
+        self.logger.info(f"Creando secreto '{secret_name}' en vault '{vault_name}'")
+
+        response = await self.call_mcp_tool(
+            "azure.keyvault.setSecret",
+            {
+                "vaultName": vault_name,
+                "secretName": secret_name,
+                "value": secret_value,
+                "contentType": params.get("content_type", "text/plain")
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al crear secreto: {response.error}")
+
+        return {
+            "action": "create_secret",
+            "vault_name": vault_name,
+            "secret_name": secret_name,
+            "status": "created",
+            "version": response.data.get("version", "")
+        }
+
+    async def _get_secret(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Obtiene un secreto de Key Vault."""
+        vault_name = params.get("vault_name")
+        secret_name = params.get("secret_name")
+
+        if not all([vault_name, secret_name]):
+            raise Exception("Se requiere 'vault_name' y 'secret_name'")
+
+        self.logger.info(f"Obteniendo secreto '{secret_name}' de vault '{vault_name}'")
+
+        response = await self.call_mcp_tool(
+            "azure.keyvault.getSecret",
+            {
+                "vaultName": vault_name,
+                "secretName": secret_name,
+                "version": params.get("version", "")
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al obtener secreto: {response.error}")
+
+        return {
+            "action": "get_secret",
+            "vault_name": vault_name,
+            "secret_name": secret_name,
+            "value": response.data.get("value", ""),
+            "version": response.data.get("version", "")
+        }
+
+    async def _list_secrets(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Lista todos los secretos en un Key Vault."""
+        vault_name = params.get("vault_name")
+
+        if not vault_name:
+            raise Exception("Se requiere 'vault_name'")
+
+        self.logger.info(f"Listando secretos en vault '{vault_name}'")
+
+        response = await self.call_mcp_tool(
+            "azure.keyvault.listSecrets",
+            {
+                "vaultName": vault_name
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al listar secretos: {response.error}")
+
+        secrets = response.data.get("secrets", [])
+
+        return {
+            "action": "list_secrets",
+            "vault_name": vault_name,
+            "secrets": [s.get("name") for s in secrets],
+            "count": len(secrets)
+        }
+
+    async def _delete_secret(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Elimina un secreto de Key Vault."""
+        vault_name = params.get("vault_name")
+        secret_name = params.get("secret_name")
+
+        if not all([vault_name, secret_name]):
+            raise Exception("Se requiere 'vault_name' y 'secret_name'")
+
+        self.logger.info(f"Eliminando secreto '{secret_name}' de vault '{vault_name}'")
+
+        response = await self.call_mcp_tool(
+            "azure.keyvault.deleteSecret",
+            {
+                "vaultName": vault_name,
+                "secretName": secret_name
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al eliminar secreto: {response.error}")
+
+        return {
+            "action": "delete_secret",
+            "vault_name": vault_name,
+            "secret_name": secret_name,
+            "status": "deleted"
+        }
+
+    async def _create_key(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Crea una nueva clave criptográfica."""
+        vault_name = params.get("vault_name")
+        key_name = params.get("key_name")
+        key_type = params.get("key_type", "RSA")
+
+        if not all([vault_name, key_name]):
+            raise Exception("Se requiere 'vault_name' y 'key_name'")
+
+        self.logger.info(f"Creando clave '{key_name}' en vault '{vault_name}'")
+
+        response = await self.call_mcp_tool(
+            "azure.keyvault.createKey",
+            {
+                "vaultName": vault_name,
+                "keyName": key_name,
+                "keyType": key_type,
+                "keySize": params.get("key_size", 2048)
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al crear clave: {response.error}")
+
+        return {
+            "action": "create_key",
+            "vault_name": vault_name,
+            "key_name": key_name,
+            "key_type": key_type,
+            "status": "created"
+        }
+
+    async def _list_keys(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Lista todas las claves en un Key Vault."""
+        vault_name = params.get("vault_name")
+
+        if not vault_name:
+            raise Exception("Se requiere 'vault_name'")
+
+        self.logger.info(f"Listando claves en vault '{vault_name}'")
+
+        response = await self.call_mcp_tool(
+            "azure.keyvault.listKeys",
+            {
+                "vaultName": vault_name
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al listar claves: {response.error}")
+
+        keys = response.data.get("keys", [])
+
+        return {
+            "action": "list_keys",
+            "vault_name": vault_name,
+            "keys": [k.get("name") for k in keys],
+            "count": len(keys)
+        }
+
+    async def _delete_key(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Elimina una clave de Key Vault."""
+        vault_name = params.get("vault_name")
+        key_name = params.get("key_name")
+
+        if not all([vault_name, key_name]):
+            raise Exception("Se requiere 'vault_name' y 'key_name'")
+
+        self.logger.info(f"Eliminando clave '{key_name}' de vault '{vault_name}'")
+
+        response = await self.call_mcp_tool(
+            "azure.keyvault.deleteKey",
+            {
+                "vaultName": vault_name,
+                "keyName": key_name
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al eliminar clave: {response.error}")
+
+        return {
+            "action": "delete_key",
+            "vault_name": vault_name,
+            "key_name": key_name,
+            "status": "deleted"
+        }
+
+    async def _import_certificate(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Importa un certificado a Key Vault."""
+        vault_name = params.get("vault_name")
+        cert_name = params.get("cert_name")
+        cert_path = params.get("cert_path")
+
+        if not all([vault_name, cert_name, cert_path]):
+            raise Exception("Se requiere 'vault_name', 'cert_name' y 'cert_path'")
+
+        Validators.validate_file_path(cert_path, must_exist=True)
+
+        self.logger.info(f"Importando certificado '{cert_name}' a vault '{vault_name}'")
+
+        response = await self.call_mcp_tool(
+            "azure.keyvault.importCertificate",
+            {
+                "vaultName": vault_name,
+                "certificateName": cert_name,
+                "certificatePath": cert_path,
+                "password": params.get("password", "")
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al importar certificado: {response.error}")
+
+        return {
+            "action": "import_certificate",
+            "vault_name": vault_name,
+            "cert_name": cert_name,
+            "status": "imported"
+        }
+
+    async def _list_certificates(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Lista todos los certificados en un Key Vault."""
+        vault_name = params.get("vault_name")
+
+        if not vault_name:
+            raise Exception("Se requiere 'vault_name'")
+
+        self.logger.info(f"Listando certificados en vault '{vault_name}'")
+
+        response = await self.call_mcp_tool(
+            "azure.keyvault.listCertificates",
+            {
+                "vaultName": vault_name
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al listar certificados: {response.error}")
+
+        certs = response.data.get("certificates", [])
+
+        return {
+            "action": "list_certificates",
+            "vault_name": vault_name,
+            "certificates": [c.get("name") for c in certs],
+            "count": len(certs)
+        }

--- a/demo/src/agents/azure_storage.py
+++ b/demo/src/agents/azure_storage.py
@@ -1,0 +1,330 @@
+"""
+Agente especializado para Azure Storage.
+"""
+
+from typing import Any, Dict, List
+from src.core.agent_base import Agent, AgentCapability, Task, TaskStatus
+from src.core.mcp_client import MCPClientPool
+from src.utils.logger import AgentLogger
+from src.utils.validators import Validators, ParameterValidator
+
+
+class AzureStorageAgent(Agent):
+    """
+    Agente especializado para operaciones con Azure Blob Storage.
+
+    Capacidades:
+    - Listar contenedores de almacenamiento
+    - Crear contenedores
+    - Subir archivos a blob storage
+    - Descargar archivos de blob storage
+    - Eliminar blobs y contenedores
+    """
+
+    def __init__(self, client_pool: MCPClientPool):
+        super().__init__(
+            name="azure_storage",
+            description="Agente para gestión de Azure Blob Storage",
+            mcp_server_name="azure-mcp",
+            client_pool=client_pool
+        )
+        self.logger = AgentLogger("AzureStorageAgent")
+
+    async def _load_capabilities(self):
+        """Carga las capacidades del agente."""
+        self.capabilities = [
+            AgentCapability(
+                name="list_containers",
+                description="Lista contenedores de storage",
+                required_tools=["azure.storage.list"]
+            ),
+            AgentCapability(
+                name="create_container",
+                description="Crea un nuevo contenedor",
+                required_tools=["azure.storage.create"],
+                parameters={
+                    "container_name": "string",
+                    "storage_account": "string"
+                }
+            ),
+            AgentCapability(
+                name="upload_blob",
+                description="Sube un archivo a blob storage",
+                required_tools=["azure.storage.upload"],
+                parameters={
+                    "container_name": "string",
+                    "blob_name": "string",
+                    "file_path": "string"
+                }
+            ),
+            AgentCapability(
+                name="download_blob",
+                description="Descarga un archivo de blob storage",
+                required_tools=["azure.storage.download"],
+                parameters={
+                    "container_name": "string",
+                    "blob_name": "string",
+                    "destination_path": "string"
+                }
+            ),
+            AgentCapability(
+                name="delete_blob",
+                description="Elimina un blob",
+                required_tools=["azure.storage.delete"],
+                parameters={
+                    "container_name": "string",
+                    "blob_name": "string"
+                }
+            )
+        ]
+
+    async def execute_task(self, task: Task) -> Task:
+        """Ejecuta una tarea de storage."""
+        self.logger.task_start(task.description)
+
+        try:
+            # Analizar la descripción de la tarea para determinar la acción
+            description_lower = task.description.lower()
+
+            if "listar" in description_lower or "list" in description_lower:
+                if "contenedor" in description_lower or "container" in description_lower:
+                    task.result = await self._list_containers(task.params)
+                else:
+                    task.result = await self._list_blobs(task.params)
+
+            elif "crear" in description_lower or "create" in description_lower:
+                task.result = await self._create_container(task.params)
+
+            elif "subir" in description_lower or "upload" in description_lower:
+                task.result = await self._upload_blob(task.params)
+
+            elif "descargar" in description_lower or "download" in description_lower:
+                task.result = await self._download_blob(task.params)
+
+            elif "eliminar" in description_lower or "delete" in description_lower:
+                if "contenedor" in description_lower or "container" in description_lower:
+                    task.result = await self._delete_container(task.params)
+                else:
+                    task.result = await self._delete_blob(task.params)
+
+            else:
+                task.error = "No se pudo determinar la acción a realizar"
+                return task
+
+            self.logger.task_complete(task.description, 0)
+
+        except Exception as e:
+            task.error = str(e)
+            self.logger.task_failed(task.description, str(e))
+
+        return task
+
+    async def _list_containers(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Lista contenedores de storage."""
+        self.logger.info("Listando contenedores de Azure Storage")
+
+        response = await self.call_mcp_tool(
+            "azure.storage.listContainers",
+            {
+                "storageAccount": params.get("storage_account", ""),
+                "subscriptionId": params.get("subscription_id", "")
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al listar contenedores: {response.error}")
+
+        return {
+            "action": "list_containers",
+            "containers": response.data.get("containers", []),
+            "count": len(response.data.get("containers", []))
+        }
+
+    async def _list_blobs(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Lista blobs en un contenedor."""
+        container_name = params.get("container_name")
+
+        if not container_name:
+            raise Exception("Se requiere 'container_name'")
+
+        self.logger.info(f"Listando blobs en contenedor: {container_name}")
+
+        response = await self.call_mcp_tool(
+            "azure.storage.listBlobs",
+            {
+                "containerName": container_name,
+                "storageAccount": params.get("storage_account", "")
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al listar blobs: {response.error}")
+
+        return {
+            "action": "list_blobs",
+            "container": container_name,
+            "blobs": response.data.get("blobs", []),
+            "count": len(response.data.get("blobs", []))
+        }
+
+    async def _create_container(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Crea un nuevo contenedor."""
+        container_name = params.get("container_name")
+
+        if not container_name:
+            raise Exception("Se requiere 'container_name'")
+
+        # Validar nombre del contenedor
+        Validators.validate_storage_container_name(container_name)
+
+        self.logger.info(f"Creando contenedor: {container_name}")
+
+        response = await self.call_mcp_tool(
+            "azure.storage.createContainer",
+            {
+                "containerName": container_name,
+                "storageAccount": params.get("storage_account", ""),
+                "publicAccess": params.get("public_access", "None")
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al crear contenedor: {response.error}")
+
+        return {
+            "action": "create_container",
+            "container_name": container_name,
+            "status": "created",
+            "url": response.data.get("url", "")
+        }
+
+    async def _upload_blob(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Sube un archivo a blob storage."""
+        container_name = params.get("container_name")
+        blob_name = params.get("blob_name")
+        file_path = params.get("file_path")
+
+        if not all([container_name, blob_name, file_path]):
+            raise Exception(
+                "Se requiere 'container_name', 'blob_name' y 'file_path'"
+            )
+
+        # Validar archivo
+        Validators.validate_file_path(file_path, must_exist=True)
+
+        self.logger.info(
+            f"Subiendo archivo {file_path} a {container_name}/{blob_name}"
+        )
+
+        response = await self.call_mcp_tool(
+            "azure.storage.uploadBlob",
+            {
+                "containerName": container_name,
+                "blobName": blob_name,
+                "filePath": file_path,
+                "storageAccount": params.get("storage_account", ""),
+                "overwrite": params.get("overwrite", True)
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al subir archivo: {response.error}")
+
+        return {
+            "action": "upload_blob",
+            "container": container_name,
+            "blob_name": blob_name,
+            "status": "uploaded",
+            "url": response.data.get("url", "")
+        }
+
+    async def _download_blob(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Descarga un archivo de blob storage."""
+        container_name = params.get("container_name")
+        blob_name = params.get("blob_name")
+        destination_path = params.get("destination_path")
+
+        if not all([container_name, blob_name, destination_path]):
+            raise Exception(
+                "Se requiere 'container_name', 'blob_name' y 'destination_path'"
+            )
+
+        self.logger.info(
+            f"Descargando {container_name}/{blob_name} a {destination_path}"
+        )
+
+        response = await self.call_mcp_tool(
+            "azure.storage.downloadBlob",
+            {
+                "containerName": container_name,
+                "blobName": blob_name,
+                "destinationPath": destination_path,
+                "storageAccount": params.get("storage_account", "")
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al descargar archivo: {response.error}")
+
+        return {
+            "action": "download_blob",
+            "container": container_name,
+            "blob_name": blob_name,
+            "destination": destination_path,
+            "status": "downloaded"
+        }
+
+    async def _delete_blob(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Elimina un blob."""
+        container_name = params.get("container_name")
+        blob_name = params.get("blob_name")
+
+        if not all([container_name, blob_name]):
+            raise Exception("Se requiere 'container_name' y 'blob_name'")
+
+        self.logger.info(f"Eliminando blob {container_name}/{blob_name}")
+
+        response = await self.call_mcp_tool(
+            "azure.storage.deleteBlob",
+            {
+                "containerName": container_name,
+                "blobName": blob_name,
+                "storageAccount": params.get("storage_account", "")
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al eliminar blob: {response.error}")
+
+        return {
+            "action": "delete_blob",
+            "container": container_name,
+            "blob_name": blob_name,
+            "status": "deleted"
+        }
+
+    async def _delete_container(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Elimina un contenedor."""
+        container_name = params.get("container_name")
+
+        if not container_name:
+            raise Exception("Se requiere 'container_name'")
+
+        self.logger.info(f"Eliminando contenedor {container_name}")
+
+        response = await self.call_mcp_tool(
+            "azure.storage.deleteContainer",
+            {
+                "containerName": container_name,
+                "storageAccount": params.get("storage_account", "")
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al eliminar contenedor: {response.error}")
+
+        return {
+            "action": "delete_container",
+            "container_name": container_name,
+            "status": "deleted"
+        }

--- a/demo/src/agents/fabric.py
+++ b/demo/src/agents/fabric.py
@@ -1,0 +1,304 @@
+"""
+Agente especializado para Microsoft Fabric.
+"""
+
+from typing import Any, Dict, List
+from src.core.agent_base import Agent, AgentCapability, Task
+from src.core.mcp_client import MCPClientPool
+from src.utils.logger import AgentLogger
+
+
+class FabricAgent(Agent):
+    """
+    Agente especializado para operaciones con Microsoft Fabric.
+
+    Capacidades:
+    - Listar workloads disponibles (notebook, lakehouse, etc.)
+    - Obtener OpenAPI specs para workloads
+    - Generar definiciones de recursos (item definitions)
+    - Obtener mejores prácticas
+    - Obtener ejemplos de uso
+    """
+
+    def __init__(self, client_pool: MCPClientPool):
+        super().__init__(
+            name="fabric",
+            description="Agente para APIs públicas de Microsoft Fabric",
+            mcp_server_name="fabric-mcp",
+            client_pool=client_pool
+        )
+        self.logger = AgentLogger("FabricAgent")
+
+    async def _load_capabilities(self):
+        """Carga las capacidades del agente."""
+        self.capabilities = [
+            AgentCapability(
+                name="list_workloads",
+                description="Lista todos los tipos de workloads de Fabric",
+                required_tools=["fabric.publicapis.list"]
+            ),
+            AgentCapability(
+                name="get_workload_apis",
+                description="Obtiene OpenAPI spec para un workload",
+                required_tools=["fabric.publicapis.get"],
+                parameters={
+                    "workload_type": "string"
+                }
+            ),
+            AgentCapability(
+                name="get_item_definition",
+                description="Obtiene JSON schema de definición de item",
+                required_tools=["fabric.publicapis.itemdefinition.get"],
+                parameters={
+                    "workload_type": "string"
+                }
+            ),
+            AgentCapability(
+                name="get_best_practices",
+                description="Obtiene mejores prácticas para un workload",
+                required_tools=["fabric.publicapis.bestpractices.get"],
+                parameters={
+                    "workload_type": "string"
+                }
+            ),
+            AgentCapability(
+                name="get_examples",
+                description="Obtiene ejemplos de uso para un workload",
+                required_tools=["fabric.publicapis.examples.get"],
+                parameters={
+                    "workload_type": "string"
+                }
+            )
+        ]
+
+    async def execute_task(self, task: Task) -> Task:
+        """Ejecuta una tarea de Fabric."""
+        self.logger.task_start(task.description)
+
+        try:
+            description_lower = task.description.lower()
+
+            if "listar" in description_lower or "list" in description_lower:
+                if "workload" in description_lower:
+                    task.result = await self._list_workloads(task.params)
+
+            elif "api" in description_lower or "openapi" in description_lower:
+                task.result = await self._get_workload_apis(task.params)
+
+            elif "definici" in description_lower or "schema" in description_lower or "item" in description_lower:
+                task.result = await self._get_item_definition(task.params)
+
+            elif "mejor" in description_lower or "best" in description_lower or "práctica" in description_lower:
+                task.result = await self._get_best_practices(task.params)
+
+            elif "ejemplo" in description_lower or "example" in description_lower:
+                task.result = await self._get_examples(task.params)
+
+            elif "generar" in description_lower or "generate" in description_lower or "crear" in description_lower:
+                # Generar definición completa de recurso
+                task.result = await self._generate_resource_definition(task.params)
+
+            else:
+                task.error = "No se pudo determinar la operación de Fabric"
+                return task
+
+            self.logger.task_complete(task.description, 0)
+
+        except Exception as e:
+            task.error = str(e)
+            self.logger.task_failed(task.description, str(e))
+
+        return task
+
+    async def _list_workloads(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Lista todos los workloads disponibles en Fabric."""
+        self.logger.info("Listando workloads de Microsoft Fabric")
+
+        response = await self.call_mcp_tool(
+            "fabric.publicapis.list",
+            {}
+        )
+
+        if not response.success:
+            raise Exception(f"Error al listar workloads: {response.error}")
+
+        workloads = response.data.get("workloads", [])
+
+        return {
+            "action": "list_workloads",
+            "workloads": workloads,
+            "count": len(workloads)
+        }
+
+    async def _get_workload_apis(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Obtiene las APIs de un workload específico."""
+        workload_type = params.get("workload_type")
+
+        if not workload_type:
+            raise Exception("Se requiere 'workload_type'")
+
+        self.logger.info(f"Obteniendo APIs para workload: {workload_type}")
+
+        response = await self.call_mcp_tool(
+            "fabric.publicapis.get",
+            {
+                "workloadType": workload_type
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al obtener APIs: {response.error}")
+
+        return {
+            "action": "get_workload_apis",
+            "workload_type": workload_type,
+            "openapi_spec": response.data.get("openapi", {}),
+            "operations": response.data.get("operations", [])
+        }
+
+    async def _get_item_definition(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Obtiene la definición de item para un workload."""
+        workload_type = params.get("workload_type")
+
+        if not workload_type:
+            raise Exception("Se requiere 'workload_type'")
+
+        self.logger.info(f"Obteniendo definición de item para: {workload_type}")
+
+        response = await self.call_mcp_tool(
+            "fabric.publicapis.itemdefinition.get",
+            {
+                "workloadType": workload_type
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al obtener definición: {response.error}")
+
+        return {
+            "action": "get_item_definition",
+            "workload_type": workload_type,
+            "schema": response.data.get("schema", {}),
+            "properties": response.data.get("properties", {})
+        }
+
+    async def _get_best_practices(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Obtiene mejores prácticas para un workload."""
+        workload_type = params.get("workload_type")
+
+        if not workload_type:
+            raise Exception("Se requiere 'workload_type'")
+
+        self.logger.info(f"Obteniendo mejores prácticas para: {workload_type}")
+
+        response = await self.call_mcp_tool(
+            "fabric.publicapis.bestpractices.get",
+            {
+                "workloadType": workload_type
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al obtener mejores prácticas: {response.error}")
+
+        return {
+            "action": "get_best_practices",
+            "workload_type": workload_type,
+            "practices": response.data.get("practices", []),
+            "recommendations": response.data.get("recommendations", [])
+        }
+
+    async def _get_examples(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Obtiene ejemplos de uso para un workload."""
+        workload_type = params.get("workload_type")
+
+        if not workload_type:
+            raise Exception("Se requiere 'workload_type'")
+
+        self.logger.info(f"Obteniendo ejemplos para: {workload_type}")
+
+        response = await self.call_mcp_tool(
+            "fabric.publicapis.examples.get",
+            {
+                "workloadType": workload_type
+            }
+        )
+
+        if not response.success:
+            raise Exception(f"Error al obtener ejemplos: {response.error}")
+
+        return {
+            "action": "get_examples",
+            "workload_type": workload_type,
+            "examples": response.data.get("examples", [])
+        }
+
+    async def _generate_resource_definition(
+        self,
+        params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Genera una definición completa de recurso de Fabric.
+
+        Combina schema, best practices y ejemplos.
+        """
+        workload_type = params.get("workload_type")
+
+        if not workload_type:
+            raise Exception("Se requiere 'workload_type'")
+
+        self.logger.info(
+            f"Generando definición completa para: {workload_type}"
+        )
+
+        # Obtener schema
+        schema_result = await self._get_item_definition(
+            {"workload_type": workload_type}
+        )
+
+        # Obtener best practices
+        practices_result = await self._get_best_practices(
+            {"workload_type": workload_type}
+        )
+
+        # Obtener ejemplos
+        examples_result = await self._get_examples(
+            {"workload_type": workload_type}
+        )
+
+        return {
+            "action": "generate_resource_definition",
+            "workload_type": workload_type,
+            "schema": schema_result.get("schema", {}),
+            "best_practices": practices_result.get("practices", []),
+            "examples": examples_result.get("examples", []),
+            "generated_definition": self._build_definition(
+                schema_result.get("schema", {}),
+                params.get("resource_name", f"my-{workload_type}"),
+                params.get("properties", {})
+            )
+        }
+
+    def _build_definition(
+        self,
+        schema: Dict[str, Any],
+        resource_name: str,
+        properties: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Construye una definición de recurso basada en schema y propiedades."""
+        definition = {
+            "displayName": resource_name,
+            "type": schema.get("type", ""),
+            "definition": {
+                "parts": []
+            }
+        }
+
+        # Agregar propiedades personalizadas
+        for key, value in properties.items():
+            definition["definition"]["parts"].append({
+                "path": key,
+                "payload": value
+            })
+
+        return definition

--- a/demo/src/agents/orchestrator.py
+++ b/demo/src/agents/orchestrator.py
@@ -1,0 +1,446 @@
+"""
+Agente Orquestador que coordina todos los demás agentes.
+"""
+
+import re
+from typing import Any, Dict, List, Optional
+from src.core.agent_base import Agent, AgentCapability, Task, TaskStatus, AgentSystem
+from src.core.mcp_client import MCPClientPool
+from src.utils.logger import AgentLogger
+
+
+class OrchestratorAgent(Agent):
+    """
+    Agente Orquestador que coordina las interacciones entre todos los agentes.
+
+    Este agente es responsable de:
+    - Analizar tareas complejas y dividirlas en subtareas
+    - Asignar subtareas a agentes especializados
+    - Coordinar la ejecución secuencial o paralela de tareas
+    - Agregar y presentar resultados al usuario
+    - Manejar errores y reintentos
+    """
+
+    def __init__(self, agent_system: AgentSystem):
+        # El orchestrator no usa directamente un servidor MCP
+        # En su lugar, coordina otros agentes
+        super().__init__(
+            name="orchestrator",
+            description="Agente coordinador de todos los agentes",
+            mcp_server_name="",  # No usa servidor MCP directamente
+            client_pool=agent_system.client_pool
+        )
+        self.agent_system = agent_system
+        self.logger = AgentLogger("OrchestratorAgent")
+        self._agent_capabilities_map: Dict[str, List[str]] = {}
+
+    async def _load_capabilities(self):
+        """Carga las capacidades del orchestrator."""
+        self.capabilities = [
+            AgentCapability(
+                name="coordinate_workflow",
+                description="Coordina flujos de trabajo complejos entre múltiples agentes",
+                required_tools=[]
+            ),
+            AgentCapability(
+                name="task_decomposition",
+                description="Descompone tareas complejas en subtareas simples",
+                required_tools=[]
+            ),
+            AgentCapability(
+                name="agent_selection",
+                description="Selecciona el agente apropiado para cada tarea",
+                required_tools=[]
+            ),
+            AgentCapability(
+                name="result_aggregation",
+                description="Agrega resultados de múltiples agentes",
+                required_tools=[]
+            )
+        ]
+
+        # Mapear capacidades de todos los agentes
+        await self._build_agent_capabilities_map()
+
+    async def _build_agent_capabilities_map(self):
+        """Construye un mapa de capacidades de todos los agentes."""
+        self.logger.info("Construyendo mapa de capacidades de agentes")
+
+        for agent_name in self.agent_system.list_agents():
+            if agent_name == "orchestrator":
+                continue
+
+            agent = self.agent_system.get_agent(agent_name)
+            if agent:
+                self._agent_capabilities_map[agent_name] = [
+                    cap.name for cap in agent.capabilities
+                ]
+
+        self.logger.info(
+            f"Mapa de capacidades creado con {len(self._agent_capabilities_map)} agentes"
+        )
+
+    async def execute_task(self, task: Task) -> Task:
+        """Ejecuta una tarea compleja coordinando múltiples agentes."""
+        self.logger.task_start(task.description)
+
+        try:
+            # Analizar la tarea y determinar qué agentes necesitamos
+            subtasks = self._decompose_task(task)
+
+            self.logger.info(
+                f"Tarea descompuesta en {len(subtasks)} subtareas"
+            )
+
+            # Ejecutar subtareas
+            results = []
+            for subtask in subtasks:
+                subtask_result = await self._execute_subtask(subtask)
+                results.append(subtask_result)
+
+                # Si una subtarea falla, decidir si continuar o abortar
+                if subtask_result.status == TaskStatus.FAILED:
+                    self.logger.warning(
+                        f"Subtarea falló: {subtask_result.description}"
+                    )
+                    # Por ahora, continuamos con las demás tareas
+
+            # Agregar resultados
+            task.result = {
+                "subtasks": [
+                    {
+                        "description": st.description,
+                        "agent": st.agent_name,
+                        "status": st.status.value,
+                        "result": st.result,
+                        "error": st.error
+                    }
+                    for st in results
+                ],
+                "summary": self._generate_summary(results)
+            }
+
+            self.logger.task_complete(task.description, 0)
+
+        except Exception as e:
+            task.error = str(e)
+            self.logger.task_failed(task.description, str(e))
+
+        return task
+
+    def _decompose_task(self, task: Task) -> List[Task]:
+        """
+        Descompone una tarea compleja en subtareas más simples.
+
+        Esta función analiza la descripción de la tarea y extrae
+        las acciones individuales que deben realizarse.
+        """
+        description = task.description.lower()
+        subtasks = []
+
+        # Buscar patrones comunes en la descripción
+        patterns = {
+            r"(crear|subir|upload).*contenedor": {
+                "agent": "azure_storage",
+                "action": "create_container"
+            },
+            r"(crear|set).*secreto": {
+                "agent": "azure_security",
+                "action": "create_secret"
+            },
+            r"(subir|upload).*archivo": {
+                "agent": "azure_storage",
+                "action": "upload_blob"
+            },
+            r"(crear|generar).*lakehouse": {
+                "agent": "fabric",
+                "action": "generate_resource"
+            },
+            r"(crear|generar).*fabric": {
+                "agent": "fabric",
+                "action": "generate_resource"
+            },
+            r"listar.*contenedor": {
+                "agent": "azure_storage",
+                "action": "list_containers"
+            },
+            r"listar.*secreto": {
+                "agent": "azure_security",
+                "action": "list_secrets"
+            }
+        }
+
+        # Intentar match con patrones
+        matched = False
+        for pattern, info in patterns.items():
+            if re.search(pattern, description):
+                subtasks.append(
+                    Task(
+                        description=task.description,
+                        agent_name=info["agent"],
+                        params=task.params,
+                        parent_task_id=task.id
+                    )
+                )
+                matched = True
+                break
+
+        # Si no hay match, intentar inferir del contexto
+        if not matched:
+            subtasks = self._infer_subtasks_from_context(task)
+
+        return subtasks
+
+    def _infer_subtasks_from_context(self, task: Task) -> List[Task]:
+        """Infiere subtareas basándose en el contexto y parámetros."""
+        subtasks = []
+        description = task.description.lower()
+        params = task.params
+
+        # Analizar palabras clave para determinar agentes
+        agent_keywords = {
+            "azure_storage": ["storage", "blob", "contenedor", "container", "archivo", "file"],
+            "azure_security": ["key vault", "secreto", "secret", "clave", "key", "certificado"],
+            "fabric": ["fabric", "lakehouse", "notebook", "pipeline", "workload"]
+        }
+
+        # Encontrar el agente más apropiado
+        best_agent = None
+        max_matches = 0
+
+        for agent_name, keywords in agent_keywords.items():
+            matches = sum(1 for keyword in keywords if keyword in description)
+            if matches > max_matches:
+                max_matches = matches
+                best_agent = agent_name
+
+        if best_agent:
+            subtasks.append(
+                Task(
+                    description=task.description,
+                    agent_name=best_agent,
+                    params=params,
+                    parent_task_id=task.id
+                )
+            )
+        else:
+            # Si no podemos determinar, crear una subtarea genérica
+            self.logger.warning(
+                f"No se pudo determinar el agente apropiado para: {task.description}"
+            )
+            subtasks.append(
+                Task(
+                    description=task.description,
+                    agent_name="unknown",
+                    params=params,
+                    parent_task_id=task.id
+                )
+            )
+
+        return subtasks
+
+    async def _execute_subtask(self, subtask: Task) -> Task:
+        """Ejecuta una subtarea en el agente apropiado."""
+        agent = self.agent_system.get_agent(subtask.agent_name)
+
+        if not agent:
+            self.logger.error(f"Agente no encontrado: {subtask.agent_name}")
+            subtask.status = TaskStatus.FAILED
+            subtask.error = f"Agente no encontrado: {subtask.agent_name}"
+            return subtask
+
+        self.logger.info(
+            f"Ejecutando subtarea en {subtask.agent_name}: {subtask.description}"
+        )
+
+        try:
+            result = await agent.process_task(
+                subtask.description,
+                **subtask.params
+            )
+            return result
+
+        except Exception as e:
+            self.logger.error(
+                f"Error al ejecutar subtarea en {subtask.agent_name}: {e}"
+            )
+            subtask.status = TaskStatus.FAILED
+            subtask.error = str(e)
+            return subtask
+
+    def _generate_summary(self, results: List[Task]) -> Dict[str, Any]:
+        """Genera un resumen de los resultados de todas las subtareas."""
+        total = len(results)
+        completed = sum(1 for r in results if r.status == TaskStatus.COMPLETED)
+        failed = sum(1 for r in results if r.status == TaskStatus.FAILED)
+
+        return {
+            "total_subtasks": total,
+            "completed": completed,
+            "failed": failed,
+            "success_rate": (completed / total * 100) if total > 0 else 0,
+            "agents_used": list(set(r.agent_name for r in results))
+        }
+
+    async def execute_workflow(
+        self,
+        workflow_name: str,
+        params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Ejecuta un flujo de trabajo predefinido.
+
+        Args:
+            workflow_name: Nombre del flujo de trabajo
+            params: Parámetros del flujo de trabajo
+
+        Returns:
+            Resultados del flujo de trabajo
+        """
+        self.logger.info(f"Ejecutando workflow: {workflow_name}")
+
+        workflows = {
+            "data_pipeline": self._workflow_data_pipeline,
+            "secure_app": self._workflow_secure_app,
+            "intelligent_search": self._workflow_intelligent_search,
+            "fabric_infrastructure": self._workflow_fabric_infrastructure
+        }
+
+        if workflow_name not in workflows:
+            raise ValueError(f"Workflow no encontrado: {workflow_name}")
+
+        workflow_func = workflows[workflow_name]
+        return await workflow_func(params)
+
+    async def _workflow_data_pipeline(
+        self,
+        params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Workflow: Pipeline de datos completo.
+
+        Steps:
+        1. Crear contenedor en Storage
+        2. Subir datos
+        3. Crear base de datos Cosmos
+        4. Indexar en AI Search
+        5. Generar definición de Lakehouse
+        """
+        self.logger.info("Iniciando workflow: Pipeline de datos")
+
+        results = {}
+
+        # Step 1: Crear contenedor
+        storage_agent = self.agent_system.get_agent("azure_storage")
+        if storage_agent:
+            task = await storage_agent.process_task(
+                "Crear contenedor de almacenamiento",
+                container_name=params.get("container_name", "data-pipeline"),
+                storage_account=params.get("storage_account", "")
+            )
+            results["storage_container"] = task.result
+
+        # Step 2: Generar definición de Fabric
+        fabric_agent = self.agent_system.get_agent("fabric")
+        if fabric_agent:
+            task = await fabric_agent.process_task(
+                "Generar definición de Lakehouse",
+                workload_type="Lakehouse",
+                resource_name=params.get("lakehouse_name", "analytics-lakehouse")
+            )
+            results["fabric_lakehouse"] = task.result
+
+        return {
+            "workflow": "data_pipeline",
+            "status": "completed",
+            "results": results
+        }
+
+    async def _workflow_secure_app(
+        self,
+        params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Workflow: Aplicación segura.
+
+        Steps:
+        1. Crear secretos en Key Vault
+        2. Crear contenedor para archivos estáticos
+        3. Desplegar aplicación (simulado)
+        """
+        self.logger.info("Iniciando workflow: Aplicación segura")
+
+        results = {}
+
+        # Step 1: Crear secreto
+        security_agent = self.agent_system.get_agent("azure_security")
+        if security_agent:
+            task = await security_agent.process_task(
+                "Crear secreto en Key Vault",
+                vault_name=params.get("vault_name", "my-vault"),
+                secret_name=params.get("secret_name", "api-key"),
+                secret_value=params.get("secret_value", "secret123")
+            )
+            results["keyvault_secret"] = task.result
+
+        # Step 2: Crear storage
+        storage_agent = self.agent_system.get_agent("azure_storage")
+        if storage_agent:
+            task = await storage_agent.process_task(
+                "Crear contenedor para archivos estáticos",
+                container_name=params.get("static_container", "app-static")
+            )
+            results["static_storage"] = task.result
+
+        return {
+            "workflow": "secure_app",
+            "status": "completed",
+            "results": results
+        }
+
+    async def _workflow_intelligent_search(
+        self,
+        params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Workflow: Búsqueda inteligente."""
+        self.logger.info("Iniciando workflow: Búsqueda inteligente")
+
+        # Implementación simplificada
+        return {
+            "workflow": "intelligent_search",
+            "status": "completed",
+            "results": {}
+        }
+
+    async def _workflow_fabric_infrastructure(
+        self,
+        params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Workflow: Infraestructura Fabric."""
+        self.logger.info("Iniciando workflow: Infraestructura Fabric")
+
+        results = {}
+
+        # Generar recursos de Fabric
+        fabric_agent = self.agent_system.get_agent("fabric")
+        if fabric_agent:
+            # Listar workloads disponibles
+            task1 = await fabric_agent.process_task(
+                "Listar workloads disponibles",
+                {}
+            )
+            results["available_workloads"] = task1.result
+
+            # Generar definición de Lakehouse
+            task2 = await fabric_agent.process_task(
+                "Generar definición de Lakehouse",
+                workload_type="Lakehouse",
+                resource_name=params.get("lakehouse_name", "data-warehouse")
+            )
+            results["lakehouse_definition"] = task2.result
+
+        return {
+            "workflow": "fabric_infrastructure",
+            "status": "completed",
+            "results": results
+        }

--- a/demo/src/core/__init__.py
+++ b/demo/src/core/__init__.py
@@ -1,0 +1,16 @@
+"""Core components for the agent system."""
+
+from .agent_base import Agent, AgentSystem, Task, TaskStatus, AgentCapability
+from .mcp_client import MCPClient, MCPClientPool, MCPRequest, MCPResponse
+
+__all__ = [
+    'Agent',
+    'AgentSystem',
+    'Task',
+    'TaskStatus',
+    'AgentCapability',
+    'MCPClient',
+    'MCPClientPool',
+    'MCPRequest',
+    'MCPResponse'
+]

--- a/demo/src/core/agent_base.py
+++ b/demo/src/core/agent_base.py
@@ -1,0 +1,390 @@
+"""
+Clase base para todos los agentes del sistema.
+"""
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from src.core.mcp_client import MCPClient, MCPClientPool, MCPResponse
+
+
+logger = logging.getLogger(__name__)
+
+
+class TaskStatus(Enum):
+    """Estado de una tarea."""
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class Task:
+    """Representa una tarea que un agente debe ejecutar."""
+    id: str = field(default_factory=lambda: str(uuid4()))
+    description: str = ""
+    agent_name: str = ""
+    params: Dict[str, Any] = field(default_factory=dict)
+    status: TaskStatus = TaskStatus.PENDING
+    result: Optional[Any] = None
+    error: Optional[str] = None
+    created_at: datetime = field(default_factory=datetime.now)
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    parent_task_id: Optional[str] = None
+    subtasks: List[str] = field(default_factory=list)
+
+
+@dataclass
+class AgentCapability:
+    """Define una capacidad de un agente."""
+    name: str
+    description: str
+    required_tools: List[str]
+    parameters: Dict[str, Any] = field(default_factory=dict)
+
+
+class Agent(ABC):
+    """
+    Clase base abstracta para todos los agentes.
+
+    Cada agente especializado debe heredar de esta clase e implementar
+    los métodos abstractos.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        mcp_server_name: str,
+        client_pool: MCPClientPool
+    ):
+        """
+        Inicializa el agente.
+
+        Args:
+            name: Nombre del agente
+            description: Descripción del agente
+            mcp_server_name: Nombre del servidor MCP que usa este agente
+            client_pool: Pool de clientes MCP
+        """
+        self.name = name
+        self.description = description
+        self.mcp_server_name = mcp_server_name
+        self.client_pool = client_pool
+        self.mcp_client: Optional[MCPClient] = None
+        self.capabilities: List[AgentCapability] = []
+        self.task_history: List[Task] = []
+        self._is_initialized = False
+
+        logger.info(f"Agente creado: {self.name}")
+
+    async def initialize(self) -> bool:
+        """
+        Inicializa el agente y obtiene el cliente MCP.
+
+        Returns:
+            True si la inicialización fue exitosa
+        """
+        try:
+            self.mcp_client = self.client_pool.get_client(self.mcp_server_name)
+
+            if not self.mcp_client:
+                logger.error(
+                    f"No se encontró el servidor MCP: {self.mcp_server_name}"
+                )
+                return False
+
+            if not self.mcp_client.is_running():
+                logger.error(
+                    f"El servidor MCP no está ejecutándose: {self.mcp_server_name}"
+                )
+                return False
+
+            # Cargar capacidades del agente
+            await self._load_capabilities()
+
+            self._is_initialized = True
+            logger.info(f"Agente inicializado: {self.name}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error al inicializar agente {self.name}: {e}")
+            return False
+
+    @abstractmethod
+    async def _load_capabilities(self):
+        """Carga las capacidades específicas del agente."""
+        pass
+
+    @abstractmethod
+    async def execute_task(self, task: Task) -> Task:
+        """
+        Ejecuta una tarea asignada al agente.
+
+        Args:
+            task: Tarea a ejecutar
+
+        Returns:
+            Tarea actualizada con el resultado
+        """
+        pass
+
+    async def process_task(self, task_description: str, **params) -> Task:
+        """
+        Procesa una tarea descrita en lenguaje natural.
+
+        Args:
+            task_description: Descripción de la tarea
+            **params: Parámetros adicionales
+
+        Returns:
+            Tarea completada con resultado
+        """
+        if not self._is_initialized:
+            raise RuntimeError(
+                f"El agente {self.name} no está inicializado. "
+                f"Llama a initialize() primero."
+            )
+
+        task = Task(
+            description=task_description,
+            agent_name=self.name,
+            params=params
+        )
+
+        logger.info(
+            f"Agente {self.name} procesando tarea: {task.description}"
+        )
+
+        # Agregar tarea al historial
+        self.task_history.append(task)
+
+        # Cambiar estado a en progreso
+        task.status = TaskStatus.IN_PROGRESS
+        task.started_at = datetime.now()
+
+        try:
+            # Ejecutar tarea
+            task = await self.execute_task(task)
+
+            # Si no hubo error, marcar como completada
+            if not task.error:
+                task.status = TaskStatus.COMPLETED
+                task.completed_at = datetime.now()
+                logger.info(
+                    f"Tarea completada por {self.name}: {task.description}"
+                )
+            else:
+                task.status = TaskStatus.FAILED
+                task.completed_at = datetime.now()
+                logger.error(
+                    f"Tarea fallida en {self.name}: {task.error}"
+                )
+
+        except Exception as e:
+            task.status = TaskStatus.FAILED
+            task.error = str(e)
+            task.completed_at = datetime.now()
+            logger.error(
+                f"Error al ejecutar tarea en {self.name}: {e}"
+            )
+
+        return task
+
+    async def call_mcp_tool(
+        self,
+        tool_name: str,
+        arguments: Dict[str, Any]
+    ) -> MCPResponse:
+        """
+        Llama a una herramienta del servidor MCP.
+
+        Args:
+            tool_name: Nombre de la herramienta
+            arguments: Argumentos de la herramienta
+
+        Returns:
+            Respuesta de la herramienta
+        """
+        if not self.mcp_client:
+            return MCPResponse(
+                success=False,
+                error="Cliente MCP no disponible"
+            )
+
+        logger.debug(
+            f"{self.name} llamando herramienta MCP: {tool_name} "
+            f"con argumentos: {arguments}"
+        )
+
+        return await self.mcp_client.call_tool(tool_name, arguments)
+
+    def get_capability(self, capability_name: str) -> Optional[AgentCapability]:
+        """
+        Obtiene una capacidad específica del agente.
+
+        Args:
+            capability_name: Nombre de la capacidad
+
+        Returns:
+            Capacidad o None si no existe
+        """
+        for cap in self.capabilities:
+            if cap.name == capability_name:
+                return cap
+        return None
+
+    def has_capability(self, capability_name: str) -> bool:
+        """
+        Verifica si el agente tiene una capacidad específica.
+
+        Args:
+            capability_name: Nombre de la capacidad
+
+        Returns:
+            True si el agente tiene la capacidad
+        """
+        return self.get_capability(capability_name) is not None
+
+    def get_task_history(self, limit: int = 10) -> List[Task]:
+        """
+        Obtiene el historial de tareas del agente.
+
+        Args:
+            limit: Número máximo de tareas a devolver
+
+        Returns:
+            Lista de tareas más recientes
+        """
+        return self.task_history[-limit:]
+
+    def __str__(self) -> str:
+        return (
+            f"Agent({self.name}, capabilities={len(self.capabilities)}, "
+            f"tasks={len(self.task_history)})"
+        )
+
+
+class AgentSystem:
+    """
+    Sistema que gestiona todos los agentes y su comunicación.
+    """
+
+    def __init__(self, config_path: str = "config/mcp_config.json"):
+        """
+        Inicializa el sistema de agentes.
+
+        Args:
+            config_path: Ruta al archivo de configuración MCP
+        """
+        self.client_pool = MCPClientPool(config_path)
+        self.agents: Dict[str, Agent] = {}
+        self._is_initialized = False
+
+        logger.info("Sistema de agentes creado")
+
+    async def initialize(self) -> bool:
+        """
+        Inicializa el sistema de agentes.
+
+        Returns:
+            True si la inicialización fue exitosa
+        """
+        try:
+            # Iniciar todos los servidores MCP
+            logger.info("Iniciando servidores MCP...")
+            if not await self.client_pool.start_all():
+                logger.error("Falló al iniciar servidores MCP")
+                return False
+
+            # Inicializar todos los agentes registrados
+            logger.info("Inicializando agentes...")
+            for name, agent in self.agents.items():
+                if not await agent.initialize():
+                    logger.error(f"Falló al inicializar agente: {name}")
+                    return False
+
+            self._is_initialized = True
+            logger.info("Sistema de agentes inicializado correctamente")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error al inicializar sistema de agentes: {e}")
+            return False
+
+    async def shutdown(self):
+        """Cierra el sistema de agentes."""
+        logger.info("Cerrando sistema de agentes...")
+        await self.client_pool.stop_all()
+        logger.info("Sistema de agentes cerrado")
+
+    def register_agent(self, agent: Agent):
+        """
+        Registra un nuevo agente en el sistema.
+
+        Args:
+            agent: Agente a registrar
+        """
+        self.agents[agent.name] = agent
+        logger.info(f"Agente registrado: {agent.name}")
+
+    def get_agent(self, name: str) -> Optional[Agent]:
+        """
+        Obtiene un agente específico.
+
+        Args:
+            name: Nombre del agente
+
+        Returns:
+            Agente o None si no existe
+        """
+        return self.agents.get(name)
+
+    def list_agents(self) -> List[str]:
+        """
+        Lista todos los agentes registrados.
+
+        Returns:
+            Lista de nombres de agentes
+        """
+        return list(self.agents.keys())
+
+    async def execute_task(
+        self,
+        agent_name: str,
+        task_description: str,
+        **params
+    ) -> Optional[Task]:
+        """
+        Ejecuta una tarea en un agente específico.
+
+        Args:
+            agent_name: Nombre del agente
+            task_description: Descripción de la tarea
+            **params: Parámetros adicionales
+
+        Returns:
+            Tarea completada o None si el agente no existe
+        """
+        if not self._is_initialized:
+            raise RuntimeError(
+                "El sistema de agentes no está inicializado. "
+                "Llama a initialize() primero."
+            )
+
+        agent = self.get_agent(agent_name)
+
+        if not agent:
+            logger.error(f"Agente no encontrado: {agent_name}")
+            return None
+
+        return await agent.process_task(task_description, **params)

--- a/demo/src/core/mcp_client.py
+++ b/demo/src/core/mcp_client.py
@@ -1,0 +1,308 @@
+"""
+Cliente MCP para comunicación con servidores MCP de Microsoft.
+"""
+
+import asyncio
+import json
+import logging
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MCPRequest:
+    """Representa una solicitud MCP."""
+    method: str
+    params: Dict[str, Any]
+    request_id: Optional[str] = None
+
+
+@dataclass
+class MCPResponse:
+    """Representa una respuesta MCP."""
+    success: bool
+    data: Optional[Any] = None
+    error: Optional[str] = None
+    request_id: Optional[str] = None
+
+
+class MCPClient:
+    """
+    Cliente para comunicarse con servidores MCP a través de stdio.
+
+    Implementa el protocolo MCP para enviar solicitudes y recibir respuestas
+    de los servidores MCP de Azure y Fabric.
+    """
+
+    def __init__(self, server_config: Dict[str, Any]):
+        """
+        Inicializa el cliente MCP.
+
+        Args:
+            server_config: Configuración del servidor MCP
+        """
+        self.server_config = server_config
+        self.process: Optional[subprocess.Popen] = None
+        self.request_counter = 0
+        self._lock = asyncio.Lock()
+
+    async def start(self) -> bool:
+        """
+        Inicia el proceso del servidor MCP.
+
+        Returns:
+            True si el servidor se inició correctamente
+        """
+        try:
+            command = self.server_config["command"]
+            args = self.server_config.get("args", [])
+
+            logger.info(f"Iniciando servidor MCP: {command} {' '.join(args)}")
+
+            self.process = subprocess.Popen(
+                [command] + args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1
+            )
+
+            # Dar tiempo al servidor para iniciar
+            await asyncio.sleep(1)
+
+            # Verificar que el proceso está vivo
+            if self.process.poll() is not None:
+                stderr_output = self.process.stderr.read() if self.process.stderr else ""
+                logger.error(f"El servidor MCP falló al iniciar: {stderr_output}")
+                return False
+
+            logger.info("Servidor MCP iniciado correctamente")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error al iniciar servidor MCP: {e}")
+            return False
+
+    async def stop(self):
+        """Detiene el proceso del servidor MCP."""
+        if self.process:
+            try:
+                self.process.terminate()
+                await asyncio.sleep(0.5)
+
+                if self.process.poll() is None:
+                    self.process.kill()
+
+                logger.info("Servidor MCP detenido")
+            except Exception as e:
+                logger.error(f"Error al detener servidor MCP: {e}")
+
+    async def send_request(self, method: str, params: Dict[str, Any]) -> MCPResponse:
+        """
+        Envía una solicitud al servidor MCP y espera la respuesta.
+
+        Args:
+            method: Método MCP a invocar
+            params: Parámetros de la solicitud
+
+        Returns:
+            Respuesta del servidor MCP
+        """
+        async with self._lock:
+            try:
+                if not self.process or self.process.poll() is not None:
+                    logger.error("El servidor MCP no está ejecutándose")
+                    return MCPResponse(
+                        success=False,
+                        error="El servidor MCP no está ejecutándose"
+                    )
+
+                self.request_counter += 1
+                request_id = f"req_{self.request_counter}"
+
+                # Construir solicitud JSON-RPC 2.0
+                request = {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": method,
+                    "params": params
+                }
+
+                logger.debug(f"Enviando solicitud MCP: {request}")
+
+                # Enviar solicitud
+                request_json = json.dumps(request) + "\n"
+                self.process.stdin.write(request_json)
+                self.process.stdin.flush()
+
+                # Leer respuesta
+                response_line = self.process.stdout.readline()
+
+                if not response_line:
+                    return MCPResponse(
+                        success=False,
+                        error="No se recibió respuesta del servidor MCP",
+                        request_id=request_id
+                    )
+
+                response_data = json.loads(response_line)
+                logger.debug(f"Respuesta MCP recibida: {response_data}")
+
+                # Procesar respuesta
+                if "error" in response_data:
+                    return MCPResponse(
+                        success=False,
+                        error=str(response_data["error"]),
+                        request_id=request_id
+                    )
+
+                return MCPResponse(
+                    success=True,
+                    data=response_data.get("result"),
+                    request_id=request_id
+                )
+
+            except json.JSONDecodeError as e:
+                logger.error(f"Error al parsear respuesta JSON: {e}")
+                return MCPResponse(
+                    success=False,
+                    error=f"Error al parsear respuesta: {e}"
+                )
+            except Exception as e:
+                logger.error(f"Error en send_request: {e}")
+                return MCPResponse(
+                    success=False,
+                    error=str(e)
+                )
+
+    async def list_tools(self) -> List[Dict[str, Any]]:
+        """
+        Lista todas las herramientas disponibles en el servidor MCP.
+
+        Returns:
+            Lista de herramientas disponibles
+        """
+        response = await self.send_request("tools/list", {})
+
+        if response.success and response.data:
+            return response.data.get("tools", [])
+
+        return []
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: Dict[str, Any]
+    ) -> MCPResponse:
+        """
+        Llama a una herramienta específica del servidor MCP.
+
+        Args:
+            tool_name: Nombre de la herramienta
+            arguments: Argumentos para la herramienta
+
+        Returns:
+            Respuesta de la herramienta
+        """
+        return await self.send_request(
+            "tools/call",
+            {
+                "name": tool_name,
+                "arguments": arguments
+            }
+        )
+
+    def is_running(self) -> bool:
+        """Verifica si el servidor MCP está ejecutándose."""
+        return self.process is not None and self.process.poll() is None
+
+
+class MCPClientPool:
+    """
+    Pool de clientes MCP para gestionar múltiples servidores.
+    """
+
+    def __init__(self, config_path: str = "config/mcp_config.json"):
+        """
+        Inicializa el pool de clientes MCP.
+
+        Args:
+            config_path: Ruta al archivo de configuración MCP
+        """
+        self.config_path = Path(config_path)
+        self.clients: Dict[str, MCPClient] = {}
+        self._load_config()
+
+    def _load_config(self):
+        """Carga la configuración de los servidores MCP."""
+        try:
+            with open(self.config_path, 'r', encoding='utf-8') as f:
+                config = json.load(f)
+
+            for server_name, server_config in config["mcpServers"].items():
+                self.clients[server_name] = MCPClient(server_config)
+
+            logger.info(f"Configuración MCP cargada: {len(self.clients)} servidores")
+
+        except Exception as e:
+            logger.error(f"Error al cargar configuración MCP: {e}")
+            raise
+
+    async def start_all(self) -> bool:
+        """
+        Inicia todos los servidores MCP.
+
+        Returns:
+            True si todos los servidores se iniciaron correctamente
+        """
+        results = []
+
+        for name, client in self.clients.items():
+            logger.info(f"Iniciando servidor MCP: {name}")
+            result = await client.start()
+            results.append(result)
+
+            if not result:
+                logger.error(f"Falló al iniciar servidor: {name}")
+
+        return all(results)
+
+    async def stop_all(self):
+        """Detiene todos los servidores MCP."""
+        for name, client in self.clients.items():
+            logger.info(f"Deteniendo servidor MCP: {name}")
+            await client.stop()
+
+    def get_client(self, server_name: str) -> Optional[MCPClient]:
+        """
+        Obtiene un cliente MCP específico.
+
+        Args:
+            server_name: Nombre del servidor MCP
+
+        Returns:
+            Cliente MCP o None si no existe
+        """
+        return self.clients.get(server_name)
+
+    async def list_all_tools(self) -> Dict[str, List[Dict[str, Any]]]:
+        """
+        Lista todas las herramientas de todos los servidores.
+
+        Returns:
+            Diccionario con las herramientas por servidor
+        """
+        all_tools = {}
+
+        for name, client in self.clients.items():
+            if client.is_running():
+                tools = await client.list_tools()
+                all_tools[name] = tools
+
+        return all_tools

--- a/demo/src/scenarios/__init__.py
+++ b/demo/src/scenarios/__init__.py
@@ -1,0 +1,3 @@
+"""Demo scenarios for the agent system."""
+
+__all__ = []

--- a/demo/src/scenarios/data_pipeline.py
+++ b/demo/src/scenarios/data_pipeline.py
@@ -1,0 +1,223 @@
+"""
+Escenario 1: Pipeline de Datos Completo
+
+Este escenario demuestra cómo crear un pipeline end-to-end
+desde la ingesta de datos hasta el análisis, usando múltiples
+servicios de Azure y Microsoft Fabric.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.core.agent_base import AgentSystem
+from src.agents.azure_storage import AzureStorageAgent
+from src.agents.fabric import FabricAgent
+from src.agents.orchestrator import OrchestratorAgent
+from src.utils.logger import setup_logger
+from rich.console import Console
+from rich.table import Table
+from rich.panel import Panel
+from rich.progress import Progress
+
+
+console = Console()
+
+
+async def run_data_pipeline_scenario():
+    """
+    Escenario: Pipeline de Datos Completo
+
+    Flujo:
+    1. Crear contenedor en Azure Storage para datos raw
+    2. Subir archivos de datos (simulado)
+    3. Generar definición de Lakehouse en Fabric
+    4. Mostrar schema y best practices
+    5. Generar reportes de configuración
+    """
+    console.print(Panel.fit(
+        "[bold cyan]Escenario 1: Pipeline de Datos Completo[/bold cyan]\n"
+        "Creando un pipeline end-to-end con Azure y Fabric",
+        border_style="cyan"
+    ))
+
+    # Inicializar sistema
+    system = AgentSystem(config_path="config/mcp_config.json")
+
+    # Registrar agentes
+    storage_agent = AzureStorageAgent(system.client_pool)
+    fabric_agent = FabricAgent(system.client_pool)
+
+    system.register_agent(storage_agent)
+    system.register_agent(fabric_agent)
+
+    orchestrator = OrchestratorAgent(system)
+    system.register_agent(orchestrator)
+
+    console.print("\n[yellow]Inicializando sistema de agentes...[/yellow]")
+
+    with Progress() as progress:
+        task = progress.add_task("[cyan]Iniciando servidores MCP...", total=100)
+
+        if await system.initialize():
+            progress.update(task, completed=100)
+            console.print("[green]✓ Sistema inicializado correctamente[/green]\n")
+        else:
+            console.print("[red]✗ Error al inicializar el sistema[/red]")
+            return
+
+    try:
+        # Paso 1: Crear infraestructura de Storage
+        console.print(Panel(
+            "[bold]Paso 1: Crear infraestructura de Storage[/bold]",
+            border_style="blue"
+        ))
+
+        result = await storage_agent.process_task(
+            "Crear contenedor para datos raw",
+            container_name="sales-data-raw",
+            storage_account="analytics"
+        )
+
+        if not result.error:
+            console.print(f"[green]✓ Contenedor creado: {result.result.get('container_name')}[/green]")
+        else:
+            console.print(f"[red]✗ Error: {result.error}[/red]")
+
+        # Paso 2: Listar workloads de Fabric
+        console.print(Panel(
+            "[bold]Paso 2: Explorar workloads de Fabric[/bold]",
+            border_style="blue"
+        ))
+
+        result = await fabric_agent.process_task(
+            "Listar workloads de Fabric",
+            {}
+        )
+
+        if not result.error and result.result:
+            workloads = result.result.get('workloads', [])
+            console.print(f"[green]✓ Encontrados {len(workloads)} workloads[/green]")
+
+            # Mostrar workloads en tabla
+            table = Table(title="Workloads Disponibles")
+            table.add_column("Workload", style="cyan")
+
+            for workload in workloads[:10]:
+                table.add_row(workload)
+
+            console.print(table)
+
+        # Paso 3: Generar definición de Lakehouse
+        console.print(Panel(
+            "[bold]Paso 3: Generar definición de Lakehouse[/bold]",
+            border_style="blue"
+        ))
+
+        result = await fabric_agent.process_task(
+            "Generar definición completa de Lakehouse",
+            workload_type="Lakehouse",
+            resource_name="sales-analytics-lakehouse",
+            properties={
+                "description": "Lakehouse para análisis de ventas",
+                "tables": {
+                    "sales_transactions": {
+                        "columns": [
+                            {"name": "transaction_id", "type": "string"},
+                            {"name": "customer_id", "type": "string"},
+                            {"name": "product_id", "type": "string"},
+                            {"name": "amount", "type": "decimal"},
+                            {"name": "timestamp", "type": "timestamp"}
+                        ]
+                    },
+                    "customers": {
+                        "columns": [
+                            {"name": "customer_id", "type": "string"},
+                            {"name": "name", "type": "string"},
+                            {"name": "email", "type": "string"},
+                            {"name": "region", "type": "string"}
+                        ]
+                    }
+                }
+            }
+        )
+
+        if not result.error:
+            console.print("[green]✓ Definición de Lakehouse generada[/green]")
+
+            # Mostrar schema generado
+            definition = result.result.get('generated_definition', {})
+            console.print(f"\n[cyan]Nombre del recurso:[/cyan] {definition.get('displayName')}")
+            console.print(f"[cyan]Tipo:[/cyan] {definition.get('type')}")
+
+        # Paso 4: Obtener best practices
+        console.print(Panel(
+            "[bold]Paso 4: Obtener mejores prácticas[/bold]",
+            border_style="blue"
+        ))
+
+        result = await fabric_agent.process_task(
+            "Obtener mejores prácticas para Lakehouse",
+            workload_type="Lakehouse"
+        )
+
+        if not result.error and result.result:
+            practices = result.result.get('practices', [])
+            if practices:
+                console.print("[green]✓ Mejores prácticas obtenidas[/green]\n")
+                for i, practice in enumerate(practices[:5], 1):
+                    console.print(f"  {i}. {practice}")
+
+        # Paso 5: Ejecutar workflow completo con orchestrator
+        console.print(Panel(
+            "[bold]Paso 5: Ejecutar workflow completo[/bold]",
+            border_style="blue"
+        ))
+
+        result = await orchestrator.execute_workflow(
+            "data_pipeline",
+            {
+                "container_name": "pipeline-data",
+                "lakehouse_name": "complete-analytics"
+            }
+        )
+
+        console.print(f"\n[green]✓ Workflow '{result['workflow']}' completado[/green]")
+
+        # Mostrar resumen
+        console.print(Panel(
+            "[bold green]Pipeline de Datos Completado[/bold green]\n\n"
+            "Componentes creados:\n"
+            "  • Contenedor de Storage: sales-data-raw\n"
+            "  • Lakehouse: sales-analytics-lakehouse\n"
+            "  • Schema: 2 tablas definidas\n"
+            "  • Best practices aplicadas\n\n"
+            "[yellow]Próximos pasos:[/yellow]\n"
+            "  1. Cargar datos en el contenedor\n"
+            "  2. Configurar data pipelines\n"
+            "  3. Crear notebooks para análisis\n"
+            "  4. Configurar alertas y monitoreo",
+            border_style="green"
+        ))
+
+    finally:
+        await system.shutdown()
+        console.print("\n[yellow]Sistema cerrado correctamente[/yellow]")
+
+
+def main():
+    """Punto de entrada del escenario."""
+    setup_logger(name="agent_system", log_file="logs/data_pipeline.log")
+
+    try:
+        asyncio.run(run_data_pipeline_scenario())
+    except KeyboardInterrupt:
+        console.print("\n[red]Escenario interrumpido por el usuario[/red]")
+    except Exception as e:
+        console.print(f"\n[red]Error: {e}[/red]")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/src/utils/__init__.py
+++ b/demo/src/utils/__init__.py
@@ -1,0 +1,12 @@
+"""Utility modules for logging and validation."""
+
+from .logger import setup_logger, AgentLogger
+from .validators import Validators, ParameterValidator, ValidationError
+
+__all__ = [
+    'setup_logger',
+    'AgentLogger',
+    'Validators',
+    'ParameterValidator',
+    'ValidationError'
+]

--- a/demo/src/utils/logger.py
+++ b/demo/src/utils/logger.py
@@ -1,0 +1,169 @@
+"""
+Sistema de logging para el sistema de agentes.
+"""
+
+import logging
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from colorama import Fore, Style, init
+
+
+# Inicializar colorama para Windows
+init(autoreset=True)
+
+
+class ColoredFormatter(logging.Formatter):
+    """Formateador personalizado con colores para consola."""
+
+    COLORS = {
+        'DEBUG': Fore.CYAN,
+        'INFO': Fore.GREEN,
+        'WARNING': Fore.YELLOW,
+        'ERROR': Fore.RED,
+        'CRITICAL': Fore.RED + Style.BRIGHT,
+    }
+
+    def format(self, record):
+        # Añadir color al nivel
+        levelname = record.levelname
+        if levelname in self.COLORS:
+            record.levelname = (
+                f"{self.COLORS[levelname]}{levelname}{Style.RESET_ALL}"
+            )
+
+        # Añadir color al nombre del módulo
+        record.name = f"{Fore.BLUE}{record.name}{Style.RESET_ALL}"
+
+        return super().format(record)
+
+
+def setup_logger(
+    name: str = "agent_system",
+    level: int = logging.INFO,
+    log_file: Optional[str] = None
+) -> logging.Logger:
+    """
+    Configura y retorna un logger con formato personalizado.
+
+    Args:
+        name: Nombre del logger
+        level: Nivel de logging
+        log_file: Ruta al archivo de log (opcional)
+
+    Returns:
+        Logger configurado
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+
+    # Evitar duplicar handlers si ya existe
+    if logger.handlers:
+        return logger
+
+    # Handler para consola con colores
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(level)
+
+    console_format = ColoredFormatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+    console_handler.setFormatter(console_format)
+    logger.addHandler(console_handler)
+
+    # Handler para archivo si se especifica
+    if log_file:
+        log_path = Path(log_file)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        file_handler = logging.FileHandler(log_file, encoding='utf-8')
+        file_handler.setLevel(level)
+
+        file_format = logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - '
+            '%(filename)s:%(lineno)d - %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S'
+        )
+        file_handler.setFormatter(file_format)
+        logger.addHandler(file_handler)
+
+    return logger
+
+
+class AgentLogger:
+    """
+    Logger específico para agentes con contexto adicional.
+    """
+
+    def __init__(self, agent_name: str, base_logger: Optional[logging.Logger] = None):
+        """
+        Inicializa el logger del agente.
+
+        Args:
+            agent_name: Nombre del agente
+            base_logger: Logger base (opcional)
+        """
+        self.agent_name = agent_name
+        self.logger = base_logger or logging.getLogger("agent_system")
+
+    def _format_message(self, message: str) -> str:
+        """Formatea el mensaje con el nombre del agente."""
+        return f"[{self.agent_name}] {message}"
+
+    def debug(self, message: str):
+        """Log nivel DEBUG."""
+        self.logger.debug(self._format_message(message))
+
+    def info(self, message: str):
+        """Log nivel INFO."""
+        self.logger.info(self._format_message(message))
+
+    def warning(self, message: str):
+        """Log nivel WARNING."""
+        self.logger.warning(self._format_message(message))
+
+    def error(self, message: str):
+        """Log nivel ERROR."""
+        self.logger.error(self._format_message(message))
+
+    def critical(self, message: str):
+        """Log nivel CRITICAL."""
+        self.logger.critical(self._format_message(message))
+
+    def task_start(self, task_description: str):
+        """Log de inicio de tarea."""
+        self.info(f"Iniciando tarea: {task_description}")
+
+    def task_complete(self, task_description: str, duration_ms: float):
+        """Log de tarea completada."""
+        self.info(
+            f"Tarea completada: {task_description} "
+            f"(duración: {duration_ms:.2f}ms)"
+        )
+
+    def task_failed(self, task_description: str, error: str):
+        """Log de tarea fallida."""
+        self.error(f"Tarea fallida: {task_description} - Error: {error}")
+
+    def tool_call(self, tool_name: str, arguments: dict):
+        """Log de llamada a herramienta MCP."""
+        self.debug(f"Llamando herramienta: {tool_name} con args: {arguments}")
+
+    def tool_response(self, tool_name: str, success: bool, duration_ms: float):
+        """Log de respuesta de herramienta."""
+        status = "éxito" if success else "fallo"
+        self.debug(
+            f"Herramienta {tool_name} completada con {status} "
+            f"({duration_ms:.2f}ms)"
+        )
+
+
+# Logger global del sistema
+system_logger = setup_logger(
+    name="agent_system",
+    level=logging.INFO,
+    log_file="logs/agent_system.log"
+)

--- a/demo/src/utils/validators.py
+++ b/demo/src/utils/validators.py
@@ -1,0 +1,354 @@
+"""
+Validadores para el sistema de agentes.
+"""
+
+import re
+from typing import Any, Dict, List, Optional
+from pathlib import Path
+
+
+class ValidationError(Exception):
+    """Excepción para errores de validación."""
+    pass
+
+
+class Validators:
+    """Colección de validadores para parámetros comunes."""
+
+    @staticmethod
+    def validate_azure_resource_name(name: str, resource_type: str = "resource") -> bool:
+        """
+        Valida un nombre de recurso de Azure.
+
+        Args:
+            name: Nombre a validar
+            resource_type: Tipo de recurso
+
+        Returns:
+            True si es válido
+
+        Raises:
+            ValidationError: Si el nombre no es válido
+        """
+        if not name:
+            raise ValidationError(f"El nombre de {resource_type} no puede estar vacío")
+
+        if len(name) < 3:
+            raise ValidationError(
+                f"El nombre de {resource_type} debe tener al menos 3 caracteres"
+            )
+
+        if len(name) > 24:
+            raise ValidationError(
+                f"El nombre de {resource_type} no puede tener más de 24 caracteres"
+            )
+
+        if not re.match(r'^[a-z0-9][a-z0-9-]*[a-z0-9]$', name):
+            raise ValidationError(
+                f"El nombre de {resource_type} solo puede contener letras minúsculas, "
+                "números y guiones, y debe comenzar y terminar con letra o número"
+            )
+
+        return True
+
+    @staticmethod
+    def validate_storage_container_name(name: str) -> bool:
+        """
+        Valida un nombre de contenedor de Azure Storage.
+
+        Args:
+            name: Nombre a validar
+
+        Returns:
+            True si es válido
+
+        Raises:
+            ValidationError: Si el nombre no es válido
+        """
+        if not name:
+            raise ValidationError("El nombre del contenedor no puede estar vacío")
+
+        if len(name) < 3 or len(name) > 63:
+            raise ValidationError(
+                "El nombre del contenedor debe tener entre 3 y 63 caracteres"
+            )
+
+        if not re.match(r'^[a-z0-9]([a-z0-9-]*[a-z0-9])?$', name):
+            raise ValidationError(
+                "El nombre del contenedor solo puede contener letras minúsculas, "
+                "números y guiones, y debe comenzar y terminar con letra o número"
+            )
+
+        if '--' in name:
+            raise ValidationError(
+                "El nombre del contenedor no puede contener guiones consecutivos"
+            )
+
+        return True
+
+    @staticmethod
+    def validate_key_vault_secret_name(name: str) -> bool:
+        """
+        Valida un nombre de secreto de Key Vault.
+
+        Args:
+            name: Nombre a validar
+
+        Returns:
+            True si es válido
+
+        Raises:
+            ValidationError: Si el nombre no es válido
+        """
+        if not name:
+            raise ValidationError("El nombre del secreto no puede estar vacío")
+
+        if len(name) > 127:
+            raise ValidationError(
+                "El nombre del secreto no puede tener más de 127 caracteres"
+            )
+
+        if not re.match(r'^[a-zA-Z0-9-]+$', name):
+            raise ValidationError(
+                "El nombre del secreto solo puede contener letras, "
+                "números y guiones"
+            )
+
+        return True
+
+    @staticmethod
+    def validate_cosmos_database_name(name: str) -> bool:
+        """
+        Valida un nombre de base de datos de Cosmos DB.
+
+        Args:
+            name: Nombre a validar
+
+        Returns:
+            True si es válido
+
+        Raises:
+            ValidationError: Si el nombre no es válido
+        """
+        if not name:
+            raise ValidationError(
+                "El nombre de la base de datos no puede estar vacío"
+            )
+
+        if len(name) > 255:
+            raise ValidationError(
+                "El nombre de la base de datos no puede tener más de 255 caracteres"
+            )
+
+        invalid_chars = ['/', '\\', '#', '?']
+        for char in invalid_chars:
+            if char in name:
+                raise ValidationError(
+                    f"El nombre de la base de datos no puede contener '{char}'"
+                )
+
+        if name.endswith(' '):
+            raise ValidationError(
+                "El nombre de la base de datos no puede terminar con espacio"
+            )
+
+        return True
+
+    @staticmethod
+    def validate_file_path(path: str, must_exist: bool = False) -> bool:
+        """
+        Valida una ruta de archivo.
+
+        Args:
+            path: Ruta a validar
+            must_exist: Si True, verifica que el archivo exista
+
+        Returns:
+            True si es válido
+
+        Raises:
+            ValidationError: Si la ruta no es válida
+        """
+        if not path:
+            raise ValidationError("La ruta del archivo no puede estar vacía")
+
+        file_path = Path(path)
+
+        if must_exist and not file_path.exists():
+            raise ValidationError(f"El archivo no existe: {path}")
+
+        if must_exist and not file_path.is_file():
+            raise ValidationError(f"La ruta no es un archivo: {path}")
+
+        return True
+
+    @staticmethod
+    def validate_json_object(obj: Any, required_fields: List[str]) -> bool:
+        """
+        Valida que un objeto JSON tenga los campos requeridos.
+
+        Args:
+            obj: Objeto a validar
+            required_fields: Lista de campos requeridos
+
+        Returns:
+            True si es válido
+
+        Raises:
+            ValidationError: Si faltan campos
+        """
+        if not isinstance(obj, dict):
+            raise ValidationError("El objeto debe ser un diccionario")
+
+        missing_fields = [
+            field for field in required_fields if field not in obj
+        ]
+
+        if missing_fields:
+            raise ValidationError(
+                f"Faltan campos requeridos: {', '.join(missing_fields)}"
+            )
+
+        return True
+
+    @staticmethod
+    def validate_connection_string(conn_str: str) -> bool:
+        """
+        Valida una cadena de conexión.
+
+        Args:
+            conn_str: Cadena de conexión a validar
+
+        Returns:
+            True si es válido
+
+        Raises:
+            ValidationError: Si la cadena no es válida
+        """
+        if not conn_str:
+            raise ValidationError("La cadena de conexión no puede estar vacía")
+
+        if len(conn_str) < 10:
+            raise ValidationError("La cadena de conexión es demasiado corta")
+
+        # Verificar que tenga formato key=value
+        if '=' not in conn_str:
+            raise ValidationError(
+                "La cadena de conexión debe tener formato key=value"
+            )
+
+        return True
+
+    @staticmethod
+    def sanitize_input(text: str, max_length: int = 1000) -> str:
+        """
+        Sanitiza una entrada de texto.
+
+        Args:
+            text: Texto a sanitizar
+            max_length: Longitud máxima
+
+        Returns:
+            Texto sanitizado
+        """
+        if not text:
+            return ""
+
+        # Truncar si es muy largo
+        if len(text) > max_length:
+            text = text[:max_length]
+
+        # Eliminar caracteres de control
+        text = ''.join(char for char in text if ord(char) >= 32 or char == '\n')
+
+        return text.strip()
+
+
+class ParameterValidator:
+    """
+    Validador de parámetros para llamadas a herramientas MCP.
+    """
+
+    def __init__(self, tool_name: str):
+        """
+        Inicializa el validador.
+
+        Args:
+            tool_name: Nombre de la herramienta
+        """
+        self.tool_name = tool_name
+        self.errors: List[str] = []
+
+    def add_error(self, error: str):
+        """Agrega un error de validación."""
+        self.errors.append(error)
+
+    def validate_required(self, params: Dict[str, Any], required: List[str]):
+        """
+        Valida que existan parámetros requeridos.
+
+        Args:
+            params: Parámetros a validar
+            required: Lista de parámetros requeridos
+        """
+        for param in required:
+            if param not in params:
+                self.add_error(f"Falta parámetro requerido: {param}")
+
+    def validate_type(
+        self,
+        params: Dict[str, Any],
+        param_name: str,
+        expected_type: type
+    ):
+        """
+        Valida el tipo de un parámetro.
+
+        Args:
+            params: Parámetros
+            param_name: Nombre del parámetro
+            expected_type: Tipo esperado
+        """
+        if param_name in params:
+            if not isinstance(params[param_name], expected_type):
+                self.add_error(
+                    f"Parámetro '{param_name}' debe ser de tipo "
+                    f"{expected_type.__name__}"
+                )
+
+    def validate_enum(
+        self,
+        params: Dict[str, Any],
+        param_name: str,
+        valid_values: List[Any]
+    ):
+        """
+        Valida que un parámetro esté en una lista de valores válidos.
+
+        Args:
+            params: Parámetros
+            param_name: Nombre del parámetro
+            valid_values: Lista de valores válidos
+        """
+        if param_name in params:
+            if params[param_name] not in valid_values:
+                self.add_error(
+                    f"Parámetro '{param_name}' debe ser uno de: "
+                    f"{', '.join(map(str, valid_values))}"
+                )
+
+    def is_valid(self) -> bool:
+        """Retorna True si no hay errores de validación."""
+        return len(self.errors) == 0
+
+    def get_errors(self) -> str:
+        """Retorna todos los errores como string."""
+        return "; ".join(self.errors)
+
+    def raise_if_invalid(self):
+        """Lanza ValidationError si hay errores."""
+        if not self.is_valid():
+            raise ValidationError(
+                f"Validación fallida para herramienta '{self.tool_name}': "
+                f"{self.get_errors()}"
+            )


### PR DESCRIPTION
This commit adds a complete multi-agent system that demonstrates the capabilities of Microsoft MCP servers (Azure and Fabric).

Key Features:
- Multi-agent architecture with specialized agents for Azure services
- Orchestrator agent for coordinating complex workflows
- Support for Azure Storage, Key Vault, and Microsoft Fabric
- CLI interface with multiple commands and interactive mode
- Predefined workflows for common scenarios
- Comprehensive documentation and examples

Components:
- Core system: Agent base classes, MCP client pool, task management
- Specialized agents: Storage, Security, Fabric, and Orchestrator
- Utility modules: Logging, validation, error handling
- Example scripts: Basic usage examples and demo scenarios
- Documentation: README, QUICKSTART, and ARCHITECTURE guides

Workflows:
1. Data Pipeline - End-to-end data pipeline with Storage and Fabric
2. Secure App - Application deployment with Key Vault integration
3. Intelligent Search - AI-powered search with Azure AI Search
4. Fabric Infrastructure - Generate Fabric resource definitions

Usage:
  python main.py info                    # Show system information
  python main.py examples                # Run basic examples
  python main.py demo --scenario data_pipeline
  python main.py interactive             # Interactive mode

Installation:
  ./setup.sh                             # Automated setup
  python main.py info                    # Verify installation

For more details, see demo/README.md and demo/QUICKSTART.md

## What does this PR do?
`[Provide a clear, concise description of the changes]`

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
