### PR TITLE
Remove xunit trait attributes and update new-command documentation

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.LiveTests/Services/Telemetry/LinuxInformationProviderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.LiveTests/Services/Telemetry/LinuxInformationProviderTests.cs
@@ -14,7 +14,6 @@ namespace Azure.Mcp.Core.LiveTests.Services.Telemetry;
 public class LinuxInformationProviderTests
 {
     [Fact]
-    [Trait("Category", "Live")]
     public async Task GetOrCreateDeviceId_WorksCorrectly()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Linux),

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.LiveTests/Services/Telemetry/MacOSXInformationProviderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.LiveTests/Services/Telemetry/MacOSXInformationProviderTests.cs
@@ -14,7 +14,6 @@ namespace Azure.Mcp.Core.LiveTests.Services.Telemetry;
 public class MacOSXInformationProviderTests
 {
     [Fact]
-    [Trait("Category", "Live")]
     public async Task GetOrCreateDeviceId_WorksCorrectly()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Linux),

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.LiveTests/Services/Telemetry/WindowsInformationProviderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.LiveTests/Services/Telemetry/WindowsInformationProviderTests.cs
@@ -14,7 +14,6 @@ namespace Azure.Mcp.Core.LiveTests.Services.Telemetry;
 public class WindowsInformationProviderTests
 {
     [Fact]
-    [Trait("Category", "Live")]
     public async Task GetOrCreateDeviceId_WorksCorrectly()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),

--- a/servers/Azure.Mcp.Server/docs/new-command.md
+++ b/servers/Azure.Mcp.Server/docs/new-command.md
@@ -1068,6 +1068,14 @@ Guidelines:
    - ❌ Bad: `_service.{Operation}(Arg.Is<T>(t => t == value)).Returns(return)`
 - CancellationToken in mocks: Always use `Arg.Any<CancellationToken>()` for CancellationToken parameters when setting up mocks
 - CancellationToken in product code invocation: When invoking real product code objects in unit tests, use `TestContext.Current.CancellationToken` for the CancellationToken parameter
+- If any test mutates environment variables, to prevent conflicts between tests, the test project must:
+  - Reference project `$(RepoRoot)core\Azure.Mcp.Core\tests\Azure.Mcp.Tests\Azure.Mcp.Tests.csproj`
+  - Include an `AssemblyAttributes.cs` file with the following contents :
+    ```csharp
+    [assembly: Azure.Mcp.Tests.Helpers.ClearEnvironmentVariablesBeforeTest]
+    [assembly: Xunit.CollectionBehavior(Xunit.CollectionBehavior.CollectionPerAssembly)]
+    ```
+
 ### 7. Integration Tests
 
 Integration tests inherit from `CommandTestsBase` and use test fixtures:
@@ -1506,8 +1514,6 @@ catch {
 Integration tests should use the deployed infrastructure:
 
 ```csharp
-[Trait("Toolset", "{Toolset}")]
-[Trait("Category", "Live")]
 public class {Toolset}CommandTests( ITestOutputHelper output)
     : CommandTestsBase(output)
 {

--- a/tools/Azure.Mcp.Tools.Acr/tests/Azure.Mcp.Tools.Acr.LiveTests/AcrCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Acr/tests/Azure.Mcp.Tools.Acr.LiveTests/AcrCommandTests.cs
@@ -9,8 +9,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Acr.LiveTests;
 
-[Trait("Area", "Acr")]
-[Trait("Category", "Live")]
 public class AcrCommandTests(ITestOutputHelper output)
     : CommandTestsBase(output)
 {

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.LiveTests/AppConfigCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.LiveTests/AppConfigCommandTests.cs
@@ -336,7 +336,6 @@ public class AppConfigCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_set_and_get_appconfig_kv_with_content_type()
     {
         // arrange
@@ -392,7 +391,6 @@ public class AppConfigCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_set_and_get_content_type_directly_using_service()
     {
         // arrange
@@ -423,7 +421,6 @@ public class AppConfigCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_set_kv_with_single_tag()
     {
         // arrange
@@ -455,7 +452,6 @@ public class AppConfigCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_set_kv_with_multiple_tags()
     {
         // arrange
@@ -492,7 +488,6 @@ public class AppConfigCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_set_kv_with_tags_containing_spaces()
     {
         // arrange

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/Account/AccountListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/Account/AccountListCommandTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.AppConfig.UnitTests.Account;
 
-[Trait("Area", "AppConfig")]
 public class AccountListCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueDeleteCommandTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.AppConfig.UnitTests.KeyValue;
 
-[Trait("Area", "AppConfig")]
 public class KeyValueDeleteCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueGetCommandTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.AppConfig.UnitTests.KeyValue;
 
-[Trait("Area", "AppConfig")]
 public class KeyValueGetCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueSetCommandTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.AppConfig.UnitTests.KeyValue;
 
-[Trait("Area", "AppConfig")]
 public class KeyValueSetCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.AppConfig.UnitTests.KeyValue.Lock;
 
-[Trait("Area", "AppConfig")]
 public class KeyValueLockSetCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/Services/AppConfigServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/Services/AppConfigServiceTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.AppConfig.UnitTests.Services;
 
-[Trait("Area", "AppConfig")]
 public class AppConfigServiceTests
 {
     /// <summary>

--- a/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.UnitTests/Resource/ResourceDiagnoseCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.UnitTests/Resource/ResourceDiagnoseCommandTests.cs
@@ -15,7 +15,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.AppLens.UnitTests.Resource;
 
-[Trait("Area", "AppLens")]
 public class ResourceDiagnoseCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Database/DatabaseAddCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Database/DatabaseAddCommandLiveTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.AppService.LiveTests.Database;
 
-[Trait("Area", "AppService")]
 [Trait("Command", "DatabaseAddCommand")]
 public class DatabaseAddCommandLiveTests(ITestOutputHelper output) : CommandTestsBase(output)
 {

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Database/DatabaseAddCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Database/DatabaseAddCommandTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.AppService.UnitTests.Commands.Database;
 
-[Trait("Area", "AppService")]
 [Trait("Command", "DatabaseAdd")]
 public class DatabaseAddCommandTests
 {

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.LiveTests/CommunicationCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.LiveTests/CommunicationCommandTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Communication.LiveTests;
 
-[Trait("Area", "Communication")]
 [Trait("Command", "SmsSendCommand")]
 public class CommunicationCommandTests : CommandTestsBase
 {

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.LiveTests/Email/EmailSendCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.LiveTests/Email/EmailSendCommandLiveTests.cs
@@ -13,7 +13,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Communication.LiveTests.Email;
 
-[Trait("Area", "Communication")]
 [Trait("Command", "EmailSendCommand")]
 public class EmailSendCommandLiveTests : CommandTestsBase
 {

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.UnitTests/Sms/SmsSendCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.UnitTests/Sms/SmsSendCommandTests.cs
@@ -13,8 +13,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Communication.UnitTests.Sms;
 
-[Trait("Area", "Communication")]
-[Trait("Category", "Unit")]
 public class SmsSendCommandTests
 {
     [Fact]

--- a/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.LiveTests/EventGridCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.LiveTests/EventGridCommandTests.cs
@@ -8,8 +8,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.EventGrid.LiveTests;
 
-[Trait("Area", "EventGrid")]
-[Trait("Category", "Live")]
 public class EventGridCommandTests(ITestOutputHelper output)
     : CommandTestsBase(output)
 {

--- a/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Events/EventsPublishCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Events/EventsPublishCommandTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.EventGrid.UnitTests.Events;
 
-[Trait("Area", "EventGrid")]
 public class EventsPublishCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Subscription/SubscriptionListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Subscription/SubscriptionListCommandTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.EventGrid.UnitTests.Subscription;
 
-[Trait("Area", "EventGrid")]
 public class SubscriptionListCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Topic/TopicListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Topic/TopicListCommandTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.EventGrid.UnitTests.Topic;
 
-[Trait("Area", "EventGrid")]
 public class TopicListCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.Foundry/tests/Azure.Mcp.Tools.Foundry.LiveTests/FoundryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/tests/Azure.Mcp.Tools.Foundry.LiveTests/FoundryCommandTests.cs
@@ -426,7 +426,6 @@ public class FoundryCommandTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_create_agent()
     {
         var projectName = $"{Settings.ResourceBaseName}-ai-projects";
@@ -457,7 +456,6 @@ public class FoundryCommandTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_connect_agent()
     {
         var projectName = $"{Settings.ResourceBaseName}-ai-projects";
@@ -488,7 +486,6 @@ public class FoundryCommandTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_list_agents()
     {
         var projectName = $"{Settings.ResourceBaseName}-ai-projects";
@@ -513,7 +510,6 @@ public class FoundryCommandTests(ITestOutputHelper output)
     [InlineData("task_adherence", "Task Adherence")]
     [InlineData("tool_call_accuracy", "Tool Call Accuracy")]
     [InlineData("intent_resolution", "Intent Resolution")]
-    [Trait("Category", "Live")]
     public async Task Should_query_and_evaluate_agent(string evaluatorName, string evaluationMetric)
     {
         // to be filled in
@@ -565,7 +561,6 @@ public class FoundryCommandTests(ITestOutputHelper output)
     [InlineData("task_adherence", "Task Adherence")]
     [InlineData("tool_call_accuracy", "Tool Call Accuracy")]
     [InlineData("intent_resolution", "Intent Resolution")]
-    [Trait("Category", "Live")]
     public async Task Should_evaluate_agent(string evaluatorName, string evaluationMetric)
     {
         // to be filled in
@@ -1040,7 +1035,6 @@ public class FoundryCommandTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_create_thread()
     {
         var projectName = $"{Settings.ResourceBaseName}-ai-projects";
@@ -1061,7 +1055,6 @@ public class FoundryCommandTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_list_threads()
     {
         var projectName = $"{Settings.ResourceBaseName}-ai-projects";
@@ -1078,7 +1071,6 @@ public class FoundryCommandTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_get_messages()
     {
         var projectName = $"{Settings.ResourceBaseName}-ai-projects";

--- a/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.LiveTests/ProductGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.LiveTests/ProductGetCommandTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Marketplace.LiveTests;
 
-[Trait("Area", "Marketplace")]
 public class ProductGetCommandTests : CommandTestsBase
 {
     private const string ProductKey = "product";
@@ -33,7 +32,6 @@ public class ProductGetCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_get_marketplace_product()
     {
         var result = await CallToolAsync(
@@ -53,7 +51,6 @@ public class ProductGetCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_get_marketplace_product_with_language_option()
     {
         var result = await CallToolAsync(
@@ -74,7 +71,6 @@ public class ProductGetCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_get_marketplace_product_with_market_option()
     {
         var result = await CallToolAsync(
@@ -95,7 +91,6 @@ public class ProductGetCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_get_marketplace_product_with_multiple_options()
     {
         var result = await CallToolAsync(

--- a/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.LiveTests/ProductListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.LiveTests/ProductListCommandTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Marketplace.LiveTests;
 
-[Trait("Area", "Marketplace")]
 public class ProductListCommandTests : CommandTestsBase
 {
     private const string ProductsKey = "products";
@@ -31,7 +30,6 @@ public class ProductListCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_list_marketplace_products()
     {
         var result = await CallToolAsync(
@@ -53,7 +51,6 @@ public class ProductListCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_list_marketplace_products_with_language_option()
     {
         var result = await CallToolAsync(
@@ -73,7 +70,6 @@ public class ProductListCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_list_marketplace_products_with_french_language_option()
     {
         var result = await CallToolAsync(
@@ -93,7 +89,6 @@ public class ProductListCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_list_marketplace_products_with_language_and_search_options()
     {
         var result = await CallToolAsync(
@@ -115,7 +110,6 @@ public class ProductListCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_list_marketplace_products_with_search_option()
     {
         var result = await CallToolAsync(
@@ -136,7 +130,6 @@ public class ProductListCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_list_marketplace_products_with_multiple_options()
     {
         var result = await CallToolAsync(
@@ -157,7 +150,6 @@ public class ProductListCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_list_marketplace_products_with_filter_option()
     {
         var result = await CallToolAsync(
@@ -177,7 +169,6 @@ public class ProductListCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_list_marketplace_products_with_orderby_option()
     {
         var result = await CallToolAsync(
@@ -197,7 +188,6 @@ public class ProductListCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_list_marketplace_products_with_select_option()
     {
         var result = await CallToolAsync(
@@ -222,7 +212,6 @@ public class ProductListCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_list_marketplace_products_with_multiple_odata_options()
     {
         var result = await CallToolAsync(

--- a/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.UnitTests/Product/ProductGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.UnitTests/Product/ProductGetCommandTests.cs
@@ -16,7 +16,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Marketplace.UnitTests.Product;
 
-[Trait("Area", "Marketplace")]
 public class ProductGetCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.UnitTests/Product/ProductListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.UnitTests/Product/ProductListCommandTests.cs
@@ -16,7 +16,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Marketplace.UnitTests.Product;
 
-[Trait("Area", "Marketplace")]
 public class ProductListCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/ActivityLog/ActivityLogListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/ActivityLog/ActivityLogListCommandTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.ActivityLog;
 
-[Trait("Area", "Monitor")]
 public sealed class ActivityLogListCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Log/ResourceLogQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Log/ResourceLogQueryCommandTests.cs
@@ -15,7 +15,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.Log;
 
-[Trait("Area", "Monitor")]
 public sealed class ResourceLogQueryCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Log/WorkspaceLogQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Log/WorkspaceLogQueryCommandTests.cs
@@ -15,7 +15,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.Log;
 
-[Trait("Area", "Monitor")]
 public sealed class WorkspaceLogQueryCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Table/TableListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Table/TableListCommandTests.cs
@@ -16,7 +16,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.Table;
 
-[Trait("Area", "Monitor")]
 public sealed class TableListCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/TableType/TableTypeListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/TableType/TableTypeListCommandTests.cs
@@ -16,7 +16,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.TableType;
 
-[Trait("Area", "Monitor")]
 public sealed class TableTypeListCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Workspace/WorkspaceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Workspace/WorkspaceListCommandTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.Workspace;
 
-[Trait("Area", "Monitor")]
 public sealed class WorkspaceListCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.LiveTests/QuotaCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.LiveTests/QuotaCommandTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Quota.LiveTests;
 
-[Trait("Area", "Quota")]
 public class QuotaCommandTests : CommandTestsBase
 {
     public QuotaCommandTests(ITestOutputHelper output) : base(output)
@@ -16,7 +15,6 @@ public class QuotaCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_check_azure_quota()
     {
         // act
@@ -65,7 +63,6 @@ public class QuotaCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_check_azure_regions()
     {
         // act
@@ -99,7 +96,6 @@ public class QuotaCommandTests : CommandTestsBase
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_check_regions_with_cognitive_services()
     {
         // act

--- a/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.UnitTests/Commands/Region/AvailabilityListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.UnitTests/Commands/Region/AvailabilityListCommandTests.cs
@@ -16,7 +16,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Quota.UnitTests.Commands.Region;
 
-[Trait("Area", "Quota")]
 public sealed class AvailabilityListCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.UnitTests/Commands/Usage/CheckCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.UnitTests/Commands/Usage/CheckCommandTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Quota.UnitTests.Commands.Usage;
 
-[Trait("Area", "Quota")]
 public sealed class CheckCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.UnitTests/Topic/SubscriptionDetailsCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.UnitTests/Topic/SubscriptionDetailsCommandTests.cs
@@ -19,7 +19,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.ServiceBus.UnitTests.Topic;
 
-[Trait("Area", "ServiceBus")]
 public class SubscriptionDetailsCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.LiveTests/SpeechCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.LiveTests/SpeechCommandTests.cs
@@ -10,8 +10,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.Speech.LiveTests;
 
-[Trait("Toolset", "Speech")]
-[Trait("Category", "Live")]
 public class SpeechCommandTests(ITestOutputHelper output) : CommandTestsBase(output)
 {
     #region SpeechToText Tests

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.LiveTests/VirtualDesktopCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.LiveTests/VirtualDesktopCommandTests.cs
@@ -8,11 +8,9 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.VirtualDesktop.LiveTests;
 
-[Trait("Area", "VirtualDesktop")]
 public class VirtualDesktopCommandTests(ITestOutputHelper output) : CommandTestsBase(output)
 {
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_ListHostpools_WithSubscriptionId()
     {
         var result = await CallToolAsync(
@@ -38,7 +36,6 @@ public class VirtualDesktopCommandTests(ITestOutputHelper output) : CommandTests
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_ListHostpools_WithSubscriptionName()
     {
         var result = await CallToolAsync(
@@ -64,7 +61,6 @@ public class VirtualDesktopCommandTests(ITestOutputHelper output) : CommandTests
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_ListHostpools_WithResourceGroup_WithSubscriptionId()
     {
         // First get all hostpools to find one with a resource group
@@ -108,7 +104,6 @@ public class VirtualDesktopCommandTests(ITestOutputHelper output) : CommandTests
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_ListHostpools_WithResourceGroup_WithSubscriptionName()
     {
         // First get all hostpools to find one with a resource group
@@ -152,7 +147,6 @@ public class VirtualDesktopCommandTests(ITestOutputHelper output) : CommandTests
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_ListHostpools_WithNonExistentResourceGroup()
     {
         // Test with a non-existent resource group name
@@ -170,7 +164,6 @@ public class VirtualDesktopCommandTests(ITestOutputHelper output) : CommandTests
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_ListSessionHosts_WithSubscriptionId()
     {
         // First get available hostpools
@@ -209,7 +202,6 @@ public class VirtualDesktopCommandTests(ITestOutputHelper output) : CommandTests
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_ListSessionHosts_WithSubscriptionName()
     {
         // First get available hostpools
@@ -248,7 +240,6 @@ public class VirtualDesktopCommandTests(ITestOutputHelper output) : CommandTests
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_ListUserSessions_WithSubscriptionId()
     {
         // First get available hostpools
@@ -307,7 +298,6 @@ public class VirtualDesktopCommandTests(ITestOutputHelper output) : CommandTests
     }
 
     [Fact]
-    [Trait("Category", "Live")]
     public async Task Should_ListUserSessions_WithSubscriptionName()
     {
         // First get available hostpools

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.UnitTests/Hostpool/HostpoolListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.UnitTests/Hostpool/HostpoolListCommandTests.cs
@@ -15,7 +15,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.VirtualDesktop.UnitTests.Hostpool;
 
-[Trait("Area", "VirtualDesktop")]
 public class HostpoolListCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.UnitTests/SessionHost/SessionHostListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.UnitTests/SessionHost/SessionHostListCommandTests.cs
@@ -15,7 +15,6 @@ using SessionHostModel = Azure.Mcp.Tools.VirtualDesktop.Models.SessionHost;
 
 namespace Azure.Mcp.Tools.VirtualDesktop.UnitTests.SessionHost;
 
-[Trait("Area", "VirtualDesktop")]
 public class SessionHostListCommandTests
 {
     private readonly IServiceProvider _serviceProvider;

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.UnitTests/SessionHost/SessionHostUserSessionListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.UnitTests/SessionHost/SessionHostUserSessionListCommandTests.cs
@@ -16,7 +16,6 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.VirtualDesktop.UnitTests.SessionHost;
 
-[Trait("Area", "VirtualDesktop")]
 public class SessionHostUserSessionListCommandTests
 {
     private readonly IServiceProvider _serviceProvider;


### PR DESCRIPTION
## What does this PR do?
In the migration to `servers/` and `tools/`, the use of `[Trait()]` attributes to separate tests for different tools and differentiate live tests from unit tests was replaced with simpler project path matching.  The documentation was never updated to reflect this and the traits were gradually added back to some test classes.   This PR removes the traits and updates the docs.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
