### PR TITLE
The Great Cancellation: Part 3 - Adding CancellationToken to many interfaces

### DIFF
--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/CommandGroupDiscoveryStrategy.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/CommandGroupDiscoveryStrategy.cs
@@ -26,11 +26,8 @@ public sealed class CommandGroupDiscoveryStrategy(CommandFactory commandFactory,
     /// </summary>
     public string? EntryPoint { get; set; } = null;
 
-    /// <summary>
-    /// Discovers available command groups and converts them to MCP server providers.
-    /// </summary>
-    /// <returns>A collection of command group server providers.</returns>
-    public override Task<IEnumerable<IMcpServerProvider>> DiscoverServersAsync()
+    /// <inheritdoc/>
+    public override Task<IEnumerable<IMcpServerProvider>> DiscoverServersAsync(CancellationToken cancellationToken)
     {
         var providers = _commandFactory.RootGroup.SubGroup
             .Where(group => !DiscoveryConstants.IgnoredCommandGroups.Contains(group.Name, StringComparer.OrdinalIgnoreCase))

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/CommandGroupServerProvider.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/CommandGroupServerProvider.cs
@@ -32,10 +32,8 @@ public sealed class CommandGroupServerProvider(CommandGroup commandGroup) : IMcp
     /// </summary>
     public bool ReadOnly { get; set; } = false;
 
-    /// <summary>
-    /// Creates an MCP client from a command group.
-    /// </summary>
-    public async Task<McpClient> CreateClientAsync(McpClientOptions clientOptions)
+    /// <inheritdoc/>
+    public async Task<McpClient> CreateClientAsync(McpClientOptions clientOptions, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(EntryPoint))
         {
@@ -52,7 +50,7 @@ public sealed class CommandGroupServerProvider(CommandGroup commandGroup) : IMcp
         };
 
         var clientTransport = new StdioClientTransport(transportOptions);
-        return await McpClient.CreateAsync(clientTransport, clientOptions);
+        return await McpClient.CreateAsync(clientTransport, clientOptions, cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/CompositeDiscoveryStrategy.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/CompositeDiscoveryStrategy.cs
@@ -36,13 +36,10 @@ public sealed class CompositeDiscoveryStrategy(IEnumerable<IMcpDiscoveryStrategy
         return strategyList;
     }
 
-    /// <summary>
-    /// Discovers available MCP servers from all combined discovery strategies.
-    /// </summary>
-    /// <returns>A collection of all discovered MCP server providers from all strategies.</returns>
-    public override async Task<IEnumerable<IMcpServerProvider>> DiscoverServersAsync()
+    /// <inheritdoc/>
+    public override async Task<IEnumerable<IMcpServerProvider>> DiscoverServersAsync(CancellationToken cancellationToken)
     {
-        var tasks = _strategies.Select(strategy => strategy.DiscoverServersAsync());
+        var tasks = _strategies.Select(strategy => strategy.DiscoverServersAsync(cancellationToken));
         var results = await Task.WhenAll(tasks);
 
         return results.SelectMany(result => result);

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategy.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategy.cs
@@ -215,11 +215,8 @@ public sealed class ConsolidatedToolDiscoveryStrategy(CommandFactory commandFact
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
     }
 
-    /// <summary>
-    /// Discovers available command groups and converts them to MCP server providers.
-    /// </summary>
-    /// <returns>A collection of command group server providers.</returns>
-    public override Task<IEnumerable<IMcpServerProvider>> DiscoverServersAsync()
+    /// <inheritdoc/>
+    public override Task<IEnumerable<IMcpServerProvider>> DiscoverServersAsync(CancellationToken cancellationToken)
     {
         return Task.FromResult<IEnumerable<IMcpServerProvider>>(new List<IMcpServerProvider>());
     }

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/ConsolidatedToolServerProvider.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/ConsolidatedToolServerProvider.cs
@@ -35,10 +35,8 @@ public sealed class ConsolidatedToolServerProvider(CommandGroup commandGroup) : 
     /// </summary>
     public bool ReadOnly { get; set; } = false;
 
-    /// <summary>
-    /// Creates an MCP client from a command group.
-    /// </summary>
-    public async Task<McpClient> CreateClientAsync(McpClientOptions clientOptions)
+    /// <inheritdoc/>
+    public async Task<McpClient> CreateClientAsync(McpClientOptions clientOptions, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(EntryPoint))
         {
@@ -55,7 +53,7 @@ public sealed class ConsolidatedToolServerProvider(CommandGroup commandGroup) : 
         };
 
         var clientTransport = new StdioClientTransport(transportOptions);
-        return await McpClient.CreateAsync(clientTransport, clientOptions);
+        return await McpClient.CreateAsync(clientTransport, clientOptions, cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/IDiscoveryStrategy.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/IDiscoveryStrategy.cs
@@ -10,24 +10,27 @@ public interface IMcpDiscoveryStrategy : IAsyncDisposable
     /// <summary>
     /// Discovers available MCP servers via this strategy.
     /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A collection of discovered MCP servers.</returns>
-    Task<IEnumerable<IMcpServerProvider>> DiscoverServersAsync();
+    Task<IEnumerable<IMcpServerProvider>> DiscoverServersAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Finds a server provider by name.
     /// </summary>
     /// <param name="name">The name of the server to find.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The server provider if found.</returns>
     /// <exception cref="KeyNotFoundException">Thrown when no server with the specified name is found.</exception>
-    Task<IMcpServerProvider> FindServerProviderAsync(string name);
+    Task<IMcpServerProvider> FindServerProviderAsync(string name, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets an MCP client for the specified server.
     /// </summary>
     /// <param name="name">The name of the server to get a client for.</param>
     /// <param name="clientOptions">Optional client configuration options. If null, default options are used.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>An MCP client that can communicate with the specified server.</returns>
     /// <exception cref="KeyNotFoundException">Thrown when no server with the specified name is found.</exception>
     /// <exception cref="ArgumentNullException">Thrown when the name parameter is null.</exception>
-    Task<McpClient> GetOrCreateClientAsync(string name, McpClientOptions? clientOptions = null);
+    Task<McpClient> GetOrCreateClientAsync(string name, McpClientOptions? clientOptions = null, CancellationToken cancellationToken = default);
 }

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/McpServerMetadata.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/McpServerMetadata.cs
@@ -55,6 +55,9 @@ public interface IMcpServerProvider
     /// Creates an MCP client that can communicate with this server.
     /// </summary>
     /// <param name="clientOptions">Options to configure the client behavior.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A configured MCP client ready for use.</returns>
-    Task<McpClient> CreateClientAsync(McpClientOptions clientOptions);
+    /// <exception cref="ArgumentException">Thrown when the server configuration doesn't specify a valid transport type (missing URL or stdio configuration).</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the server configuration is valid but client creation fails (e.g., missing command for stdio transport, dependency issues, or external process failures).</exception>
+    Task<McpClient> CreateClientAsync(McpClientOptions clientOptions, CancellationToken cancellationToken);
 }

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/RegistryDiscoveryStrategy.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/Discovery/RegistryDiscoveryStrategy.cs
@@ -18,11 +18,9 @@ namespace Azure.Mcp.Core.Areas.Server.Commands.Discovery;
 public sealed class RegistryDiscoveryStrategy(IOptions<ServiceStartOptions> options, ILogger<RegistryDiscoveryStrategy> logger) : BaseDiscoveryStrategy(logger)
 {
     private readonly IOptions<ServiceStartOptions> _options = options;
-    /// <summary>
-    /// Discovers available MCP servers from the embedded registry.
-    /// </summary>
-    /// <returns>A collection of server providers defined in the registry.</returns>
-    public override async Task<IEnumerable<IMcpServerProvider>> DiscoverServersAsync()
+
+    /// <inheritdoc/>
+    public override async Task<IEnumerable<IMcpServerProvider>> DiscoverServersAsync(CancellationToken cancellationToken)
     {
         var registryRoot = await LoadRegistryAsync();
         if (registryRoot == null)

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/RegistryToolLoader.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/RegistryToolLoader.cs
@@ -178,7 +178,7 @@ public sealed class RegistryToolLoader(
                 return;
             }
 
-            var serverList = await _serverDiscoveryStrategy.DiscoverServersAsync();
+            var serverList = await _serverDiscoveryStrategy.DiscoverServersAsync(cancellationToken);
 
             foreach (var server in serverList)
             {
@@ -186,7 +186,7 @@ public sealed class RegistryToolLoader(
                 McpClient? mcpClient;
                 try
                 {
-                    mcpClient = await _serverDiscoveryStrategy.GetOrCreateClientAsync(serverMetadata.Name, ClientOptions);
+                    mcpClient = await _serverDiscoveryStrategy.GetOrCreateClientAsync(serverMetadata.Name, ClientOptions, cancellationToken);
                 }
                 catch (InvalidOperationException ex)
                 {

--- a/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
@@ -63,7 +63,7 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
 
     public override async ValueTask<ListToolsResult> ListToolsHandler(RequestContext<ListToolsRequestParams> request, CancellationToken cancellationToken)
     {
-        var serverList = await _serverDiscoveryStrategy.DiscoverServersAsync();
+        var serverList = await _serverDiscoveryStrategy.DiscoverServersAsync(cancellationToken);
         var allToolsResponse = new ListToolsResult
         {
             Tools = new List<Tool>()
@@ -215,7 +215,7 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
         try
         {
             var clientOptions = CreateClientOptions(request.Server);
-            client = await _serverDiscoveryStrategy.GetOrCreateClientAsync(tool, clientOptions);
+            client = await _serverDiscoveryStrategy.GetOrCreateClientAsync(tool, clientOptions, cancellationToken);
             if (client == null)
             {
                 _logger.LogError("Failed to get provider client for tool: {Tool}", tool);
@@ -230,7 +230,7 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
 
         try
         {
-            var availableTools = await GetChildToolListAsync(request, tool);
+            var availableTools = await GetChildToolListAsync(request, tool, cancellationToken);
 
             // When the specified command is not available, we try to learn about the tool's capabilities
             // and infer the command and parameters from the users intent.
@@ -273,7 +273,7 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
 
                 if (textContent.Text.Contains("Missing required options", StringComparison.OrdinalIgnoreCase))
                 {
-                    var childToolSpecJson = await GetChildToolJsonAsync(request, tool, command);
+                    var childToolSpecJson = await GetChildToolJsonAsync(request, tool, command, cancellationToken);
 
                     _logger.LogWarning("Tool {Tool} command {Command} requires additional parameters.", tool, command);
                     var finalResponse = new CallToolResult
@@ -332,7 +332,7 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
     private async Task<CallToolResult> InvokeToolLearn(RequestContext<CallToolRequestParams> request, string? intent, string tool, CancellationToken cancellationToken)
     {
         Activity.Current?.SetTag(TagName.IsServerCommandInvoked, false);
-        var toolsJson = await GetChildToolListJsonAsync(request, tool);
+        var toolsJson = await GetChildToolListJsonAsync(request, tool, cancellationToken);
 
         var learnResponse = new CallToolResult
         {
@@ -352,7 +352,7 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
         var response = learnResponse;
         if (SupportsSampling(request.Server) && !string.IsNullOrWhiteSpace(intent))
         {
-            var availableTools = await GetChildToolListAsync(request, tool);
+            var availableTools = await GetChildToolListAsync(request, tool, cancellationToken);
             (string? commandName, Dictionary<string, object?> parameters) = await GetCommandAndParametersFromIntentAsync(request, intent, tool, availableTools, cancellationToken);
             if (commandName != null)
             {
@@ -368,7 +368,7 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
     /// <param name="request"></param>
     /// <param name="tool"></param>
     /// <returns></returns>
-    private async Task<List<Tool>> GetChildToolListAsync(RequestContext<CallToolRequestParams> request, string tool)
+    private async Task<List<Tool>> GetChildToolListAsync(RequestContext<CallToolRequestParams> request, string tool, CancellationToken cancellationToken)
     {
         if (_cachedToolLists.TryGetValue(tool, out var cachedList))
         {
@@ -381,13 +381,13 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
         }
 
         var clientOptions = CreateClientOptions(request.Server);
-        var client = await _serverDiscoveryStrategy.GetOrCreateClientAsync(request.Params.Name, clientOptions);
+        var client = await _serverDiscoveryStrategy.GetOrCreateClientAsync(request.Params.Name, clientOptions, cancellationToken);
         if (client == null)
         {
             return [];
         }
 
-        var listTools = await client.ListToolsAsync();
+        var listTools = await client.ListToolsAsync(cancellationToken: cancellationToken);
         if (listTools == null)
         {
             _logger.LogWarning("No tools found for tool: {Tool}", tool);
@@ -403,21 +403,21 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
         return list;
     }
 
-    private async Task<string> GetChildToolListJsonAsync(RequestContext<CallToolRequestParams> request, string tool)
+    private async Task<string> GetChildToolListJsonAsync(RequestContext<CallToolRequestParams> request, string tool, CancellationToken cancellationToken)
     {
-        var listTools = await GetChildToolListAsync(request, tool);
+        var listTools = await GetChildToolListAsync(request, tool, cancellationToken);
         return JsonSerializer.Serialize(listTools, ServerJsonContext.Default.ListTool);
     }
 
-    private async Task<Tool> GetChildToolAsync(RequestContext<CallToolRequestParams> request, string toolName, string commandName)
+    private async Task<Tool> GetChildToolAsync(RequestContext<CallToolRequestParams> request, string toolName, string commandName, CancellationToken cancellationToken)
     {
-        var tools = await GetChildToolListAsync(request, toolName);
+        var tools = await GetChildToolListAsync(request, toolName, cancellationToken);
         return tools.First(t => string.Equals(t.Name, commandName, StringComparison.OrdinalIgnoreCase));
     }
 
-    private async Task<string> GetChildToolJsonAsync(RequestContext<CallToolRequestParams> request, string toolName, string commandName)
+    private async Task<string> GetChildToolJsonAsync(RequestContext<CallToolRequestParams> request, string toolName, string commandName, CancellationToken cancellationToken)
     {
-        var tool = await GetChildToolAsync(request, toolName, commandName);
+        var tool = await GetChildToolAsync(request, toolName, commandName, cancellationToken);
         return JsonSerializer.Serialize(tool, ServerJsonContext.Default.Tool);
     }
 

--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureResourceService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureResourceService.cs
@@ -39,7 +39,7 @@ public abstract class BaseAzureResourceService(
         }
 
         // Get all tenants and find the matching one (GetTenants already has caching)
-        var allTenants = await TenantService.GetTenants();
+        var allTenants = await TenantService.GetTenants(cancellationToken);
         var tenantResource = allTenants.FirstOrDefault(t => t.Data.TenantId == tenantId.Value);
 
         if (tenantResource == null)

--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
@@ -129,23 +129,23 @@ public abstract class BaseAzureService
         return value.Replace("\\", "\\\\").Replace("'", "''");
     }
 
-    protected async Task<string?> ResolveTenantIdAsync(string? tenant)
+    protected async Task<string?> ResolveTenantIdAsync(string? tenant, CancellationToken cancellationToken)
     {
         if (tenant == null)
             return tenant;
-        return await TenantService.GetTenantId(tenant);
+        return await TenantService.GetTenantId(tenant, cancellationToken);
     }
 
-    protected async Task<TokenCredential> GetCredential(CancellationToken cancellationToken = default)
+    protected async Task<TokenCredential> GetCredential(CancellationToken cancellationToken)
     {
         // TODO @vukelich: separate PR for cancellationToken to be required, not optional default
         return await GetCredential(null, cancellationToken);
     }
 
-    protected async Task<TokenCredential> GetCredential(string? tenant, CancellationToken cancellationToken = default)
+    protected async Task<TokenCredential> GetCredential(string? tenant, CancellationToken cancellationToken)
     {
         // TODO @vukelich: separate PR for cancellationToken to be required, not optional default
-        var tenantId = string.IsNullOrEmpty(tenant) ? null : await ResolveTenantIdAsync(tenant);
+        var tenantId = string.IsNullOrEmpty(tenant) ? null : await ResolveTenantIdAsync(tenant, cancellationToken);
 
         try
         {
@@ -211,7 +211,7 @@ public abstract class BaseAzureService
         ArmClientOptions? armClientOptions = null,
         CancellationToken cancellationToken = default)
     {
-        var tenantId = await ResolveTenantIdAsync(tenantIdOrName);
+        var tenantId = await ResolveTenantIdAsync(tenantIdOrName, cancellationToken);
 
         try
         {

--- a/core/Azure.Mcp.Core/src/Services/Azure/ResourceGroup/ResourceGroupService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/ResourceGroup/ResourceGroupService.cs
@@ -31,7 +31,7 @@ public class ResourceGroupService(
 
         // Try to get from cache first
         var cacheKey = $"{CacheKey}_{subscriptionId}_{tenant ?? "default"}";
-        var cachedResults = await _cacheService.GetAsync<List<ResourceGroupInfo>>(CacheGroup, cacheKey, s_cacheDuration);
+        var cachedResults = await _cacheService.GetAsync<List<ResourceGroupInfo>>(CacheGroup, cacheKey, s_cacheDuration, cancellationToken);
         if (cachedResults != null)
         {
             return cachedResults;
@@ -49,7 +49,7 @@ public class ResourceGroupService(
                 .ToListAsync(cancellationToken: cancellationToken);
 
             // Cache the results
-            await _cacheService.SetAsync(CacheGroup, cacheKey, resourceGroups, s_cacheDuration);
+            await _cacheService.SetAsync(CacheGroup, cacheKey, resourceGroups, s_cacheDuration, cancellationToken);
 
             return resourceGroups;
         }
@@ -68,7 +68,7 @@ public class ResourceGroupService(
 
         // Try to get from cache first
         var cacheKey = $"{CacheKey}_{subscriptionId}_{tenant ?? "default"}";
-        var cachedResults = await _cacheService.GetAsync<List<ResourceGroupInfo>>(CacheGroup, cacheKey, s_cacheDuration);
+        var cachedResults = await _cacheService.GetAsync<List<ResourceGroupInfo>>(CacheGroup, cacheKey, s_cacheDuration, cancellationToken);
         if (cachedResults != null)
         {
             return cachedResults.FirstOrDefault(rg => rg.Name.Equals(resourceGroupName, StringComparison.OrdinalIgnoreCase));

--- a/core/Azure.Mcp.Core/src/Services/Azure/Subscription/SubscriptionService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Subscription/SubscriptionService.cs
@@ -21,7 +21,7 @@ public class SubscriptionService(ICacheService cacheService, ITenantService tena
     {
         // Try to get from cache first
         var cacheKey = string.IsNullOrEmpty(tenant) ? CacheKey : $"{CacheKey}_{tenant}";
-        var cachedResults = await _cacheService.GetAsync<List<SubscriptionData>>(CacheGroup, cacheKey, s_cacheDuration);
+        var cachedResults = await _cacheService.GetAsync<List<SubscriptionData>>(CacheGroup, cacheKey, s_cacheDuration, cancellationToken);
         if (cachedResults != null)
         {
             return cachedResults;
@@ -38,7 +38,7 @@ public class SubscriptionService(ICacheService cacheService, ITenantService tena
         }
 
         // Cache the results
-        await _cacheService.SetAsync(CacheGroup, cacheKey, results, s_cacheDuration);
+        await _cacheService.SetAsync(CacheGroup, cacheKey, results, s_cacheDuration, cancellationToken);
 
         return results;
     }
@@ -54,7 +54,7 @@ public class SubscriptionService(ICacheService cacheService, ITenantService tena
         var cacheKey = string.IsNullOrEmpty(tenant)
             ? $"{SubscriptionCacheKey}_{subscriptionId}"
             : $"{SubscriptionCacheKey}_{subscriptionId}_{tenant}";
-        var cachedSubscription = await _cacheService.GetAsync<SubscriptionResource>(CacheGroup, cacheKey, s_cacheDuration);
+        var cachedSubscription = await _cacheService.GetAsync<SubscriptionResource>(CacheGroup, cacheKey, s_cacheDuration, cancellationToken);
         if (cachedSubscription != null)
         {
             return cachedSubscription;
@@ -68,7 +68,7 @@ public class SubscriptionService(ICacheService cacheService, ITenantService tena
         }
 
         // Cache the result using subscription ID
-        await _cacheService.SetAsync(CacheGroup, cacheKey, response.Value, s_cacheDuration);
+        await _cacheService.SetAsync(CacheGroup, cacheKey, response.Value, s_cacheDuration, cancellationToken);
 
         return response.Value;
     }

--- a/core/Azure.Mcp.Core/src/Services/Azure/Tenant/ITenantService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Tenant/ITenantService.cs
@@ -15,16 +15,18 @@ public interface ITenantService
     /// <summary>
     /// Gets the list of all available Azure tenants.
     /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>
     /// A task representing the asynchronous operation, with a list of <see cref="TenantResource"/>
     /// instances.
     /// </returns>
-    Task<List<TenantResource>> GetTenants();
+    Task<List<TenantResource>> GetTenants(CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the tenant ID from either a tenant ID or tenant name.
     /// </summary>
     /// <param name="tenantIdOrName">The tenant ID or tenant name.</param>
+    /// <param name="cancellation">A cancellation token.</param>
     /// <returns>
     /// A task representing the asynchronous operation, with the tenant ID or <see langword="null"/>
     /// if not found.
@@ -35,12 +37,13 @@ public interface ITenantService
     /// <exception cref="InvalidOperationException">
     /// Thrown when the tenant has a <see langword="null"> TenantId.
     /// </exception>
-    Task<string> GetTenantId(string tenantIdOrName);
+    Task<string> GetTenantId(string tenantIdOrName, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the tenant ID by tenant name.
     /// </summary>
     /// <param name="tenantName">The tenant name.</param>
+    /// <param name="cancellation">A cancellation token.</param>
     /// <returns>
     /// A task representing the asynchronous operation, with the tenant ID or <see langword="null"/>
     /// if not found.
@@ -51,12 +54,13 @@ public interface ITenantService
     /// <exception cref="InvalidOperationException">
     /// Thrown when the tenant has a <see langword="null"> TenantId.
     /// </exception>
-    Task<string> GetTenantIdByName(string tenantName);
+    Task<string> GetTenantIdByName(string tenantName, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the tenant name by tenant ID.
     /// </summary>
     /// <param name="tenantId">The tenant ID.</param>
+    /// <param name="cancellation">A cancellation token.</param>
     /// <returns>
     /// A task representing the asynchronous operation, with the tenant name or <see langword="null"/> if not found.
     /// </returns>
@@ -66,7 +70,7 @@ public interface ITenantService
     /// <exception cref="InvalidOperationException">
     /// Thrown when the tenant has a <see langword="null"> DisplayName.
     /// </exception>
-    Task<string> GetTenantNameById(string tenantId);
+    Task<string> GetTenantNameById(string tenantId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Determines whether the specified string is a valid tenant ID (GUID format).

--- a/core/Azure.Mcp.Core/src/Services/Caching/HttpServiceCacheService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Caching/HttpServiceCacheService.cs
@@ -18,32 +18,32 @@
 // like Conditional Access on caching?
 public class HttpServiceCacheService : ICacheService
 {
-    public ValueTask ClearAsync()
+    public ValueTask ClearAsync(CancellationToken cancellationToken)
     {
         return ValueTask.CompletedTask;
     }
 
-    public ValueTask ClearGroupAsync(string group)
+    public ValueTask ClearGroupAsync(string group, CancellationToken cancellationToken)
     {
         return ValueTask.CompletedTask;
     }
 
-    public ValueTask DeleteAsync(string group, string key)
+    public ValueTask DeleteAsync(string group, string key, CancellationToken cancellationToken)
     {
         return ValueTask.CompletedTask;
     }
 
-    public ValueTask<T?> GetAsync<T>(string group, string key, TimeSpan? expiration = null)
+    public ValueTask<T?> GetAsync<T>(string group, string key, TimeSpan? expiration = null, CancellationToken cancellationToken = default)
     {
         return ValueTask.FromResult<T?>(default);
     }
 
-    public ValueTask<IEnumerable<string>> GetGroupKeysAsync(string group)
+    public ValueTask<IEnumerable<string>> GetGroupKeysAsync(string group, CancellationToken cancellationToken)
     {
         return ValueTask.FromResult<IEnumerable<string>>(Array.Empty<string>());
     }
 
-    public ValueTask SetAsync<T>(string group, string key, T data, TimeSpan? expiration = null)
+    public ValueTask SetAsync<T>(string group, string key, T data, TimeSpan? expiration = null, CancellationToken cancellationToken = default)
     {
         return ValueTask.CompletedTask;
     }

--- a/core/Azure.Mcp.Core/src/Services/Caching/ICacheService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Caching/ICacheService.cs
@@ -12,8 +12,9 @@ public interface ICacheService
     /// <param name="group">The group name.</param>
     /// <param name="key">The cache key within the group.</param>
     /// <param name="expiration">Optional expiration time.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>The cached value or default if not found.</returns>
-    ValueTask<T?> GetAsync<T>(string group, string key, TimeSpan? expiration = null);
+    ValueTask<T?> GetAsync<T>(string group, string key, TimeSpan? expiration = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Sets a value in the cache using a group and key.
@@ -23,32 +24,39 @@ public interface ICacheService
     /// <param name="key">The cache key within the group.</param>
     /// <param name="data">The data to cache.</param>
     /// <param name="expiration">Optional expiration time.</param>
-    ValueTask SetAsync<T>(string group, string key, T data, TimeSpan? expiration = null);
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A ValueTask representing the asynchronous operation.</returns>
+    ValueTask SetAsync<T>(string group, string key, T data, TimeSpan? expiration = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes a value from the cache using a group and key.
     /// </summary>
     /// <param name="group">The group name.</param>
     /// <param name="key">The cache key within the group.</param>
-    ValueTask DeleteAsync(string group, string key);
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A ValueTask representing the asynchronous operation.</returns>
+    ValueTask DeleteAsync(string group, string key, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets all keys in a specific group.
     /// </summary>
     /// <param name="group">The group name.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A collection of keys in the specified group.</returns>
-    ValueTask<IEnumerable<string>> GetGroupKeysAsync(string group);
+    ValueTask<IEnumerable<string>> GetGroupKeysAsync(string group, CancellationToken cancellationToken);
 
     /// <summary>
     /// Clears all items from the cache.
     /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A ValueTask representing the asynchronous operation.</returns>
-    ValueTask ClearAsync();
+    ValueTask ClearAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Clears all items from a specific group in the cache.
     /// </summary>
     /// <param name="group">The group name to clear.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A ValueTask representing the asynchronous operation.</returns>
-    ValueTask ClearGroupAsync(string group);
+    ValueTask ClearGroupAsync(string group, CancellationToken cancellationToken);
 }

--- a/core/Azure.Mcp.Core/src/Services/Caching/SingleUserCliCacheService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Caching/SingleUserCliCacheService.cs
@@ -23,13 +23,13 @@ public class SingleUserCliCacheService(IMemoryCache memoryCache) : ICacheService
     private readonly IMemoryCache _memoryCache = memoryCache;
     private static readonly ConcurrentDictionary<string, HashSet<string>> s_groupKeys = new();
 
-    public ValueTask<T?> GetAsync<T>(string group, string key, TimeSpan? expiration = null)
+    public ValueTask<T?> GetAsync<T>(string group, string key, TimeSpan? expiration = null, CancellationToken cancellationToken = default)
     {
         string cacheKey = GetGroupKey(group, key);
         return _memoryCache.TryGetValue(cacheKey, out T? value) ? new ValueTask<T?>(value) : default;
     }
 
-    public ValueTask SetAsync<T>(string group, string key, T data, TimeSpan? expiration = null)
+    public ValueTask SetAsync<T>(string group, string key, T data, TimeSpan? expiration = null, CancellationToken cancellationToken = default)
     {
         if (data == null)
             return default;
@@ -56,7 +56,7 @@ public class SingleUserCliCacheService(IMemoryCache memoryCache) : ICacheService
         return default;
     }
 
-    public ValueTask DeleteAsync(string group, string key)
+    public ValueTask DeleteAsync(string group, string key, CancellationToken cancellationToken)
     {
         string cacheKey = GetGroupKey(group, key);
         _memoryCache.Remove(cacheKey);
@@ -70,7 +70,7 @@ public class SingleUserCliCacheService(IMemoryCache memoryCache) : ICacheService
         return default;
     }
 
-    public ValueTask<IEnumerable<string>> GetGroupKeysAsync(string group)
+    public ValueTask<IEnumerable<string>> GetGroupKeysAsync(string group, CancellationToken cancellationToken)
     {
         if (s_groupKeys.TryGetValue(group, out var keys))
         {
@@ -80,7 +80,7 @@ public class SingleUserCliCacheService(IMemoryCache memoryCache) : ICacheService
         return new ValueTask<IEnumerable<string>>([]);
     }
 
-    public ValueTask ClearAsync()
+    public ValueTask ClearAsync(CancellationToken cancellationToken)
     {
         // Clear all items from the memory cache
         if (_memoryCache is MemoryCache memoryCache)
@@ -94,7 +94,7 @@ public class SingleUserCliCacheService(IMemoryCache memoryCache) : ICacheService
         return default;
     }
 
-    public ValueTask ClearGroupAsync(string group)
+    public ValueTask ClearGroupAsync(string group, CancellationToken cancellationToken)
     {
         // If this group doesn't exist, nothing to do
         if (!s_groupKeys.TryGetValue(group, out var keys))

--- a/core/Azure.Mcp.Core/src/Services/ProcessExecution/IExternalProcessService.cs
+++ b/core/Azure.Mcp.Core/src/Services/ProcessExecution/IExternalProcessService.cs
@@ -18,12 +18,14 @@ public interface IExternalProcessService
     /// <param name="arguments">Arguments to pass to the executable</param>
     /// <param name="timeoutSeconds">Timeout in seconds</param>
     /// <param name="customPaths">Optional additional paths to search for the executable</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>Process execution result containing exit code, output and error streams</returns>
     Task<ProcessResult> ExecuteAsync(
         string executableName,
         string arguments,
         int timeoutSeconds = 300,
-        IEnumerable<string>? customPaths = null);
+        IEnumerable<string>? customPaths = null,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Tries to parse the process output as JSON and return it as JsonElement

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.LiveTests/RecordingFramework/RecordedCommandTestsBaseTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.LiveTests/RecordingFramework/RecordedCommandTestsBaseTests.cs
@@ -37,7 +37,7 @@ public sealed class RecordedCommandTestsBaseTest : IAsyncLifetime
 
         Assert.True(File.Exists(RecordingFileLocation));
 
-        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(RecordingFileLocation, CancellationToken.None));
+        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(RecordingFileLocation, TestContext.Current.CancellationToken));
         Assert.True(document.RootElement.TryGetProperty("Variables", out var variablesElement));
         Assert.Equal("sampleValue", variablesElement.GetProperty("sampleKey").GetString());
     }

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/CommandGroupDiscoveryStrategyTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/CommandGroupDiscoveryStrategyTests.cs
@@ -130,7 +130,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -146,7 +146,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy(options: options);
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -162,7 +162,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy(options: options);
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -178,7 +178,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy(options: options);
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -194,7 +194,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy(entryPoint: customEntryPoint);
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -209,7 +209,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy(entryPoint: null);
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -231,7 +231,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy(entryPoint: "");
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -251,7 +251,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy(entryPoint: "   ");
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -271,7 +271,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var names = result.Select(p => p.CreateMetadata().Name).ToList();
@@ -290,7 +290,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var providers = result.ToList();
@@ -314,7 +314,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -328,7 +328,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var providers = result.ToList();
@@ -343,8 +343,8 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result1 = await strategy.DiscoverServersAsync();
-        var result2 = await strategy.DiscoverServersAsync();
+        var result1 = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
+        var result2 = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result1);
@@ -367,7 +367,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy(); // Uses real command factory
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var providers = result.ToList();
@@ -396,7 +396,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy(options: options, entryPoint: azmcpEntryPoint);
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -415,7 +415,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var names = result.Select(p => p.CreateMetadata().Name).ToList();
@@ -434,8 +434,8 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result1 = await strategy.DiscoverServersAsync();
-        var result2 = await strategy.DiscoverServersAsync();
+        var result1 = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
+        var result2 = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var count1 = result1.Count();
@@ -452,7 +452,7 @@ public class CommandGroupDiscoveryStrategyTests
         var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
         var logger = NSubstitute.Substitute.For<Microsoft.Extensions.Logging.ILogger<CommandGroupDiscoveryStrategy>>();
         var strategy = new CommandGroupDiscoveryStrategy(commandFactory, options, logger);
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(result);
     }
 
@@ -467,7 +467,7 @@ public class CommandGroupDiscoveryStrategyTests
         {
             EntryPoint = azmcpEntryPoint
         };
-        var result = (await strategy.DiscoverServersAsync()).ToList();
+        var result = (await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken)).ToList();
         Assert.NotEmpty(result);
         // Should not include ignored groups
         var ignored = DiscoveryConstants.IgnoredCommandGroups;
@@ -522,7 +522,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy(options: options);
 
         // Act
-        var servers = await strategy.DiscoverServersAsync();
+        var servers = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
         var serverNames = servers.Select(s => s.CreateMetadata().Name).ToList();
 
         // Assert
@@ -547,7 +547,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy(options: options);
 
         // Act
-        var servers = await strategy.DiscoverServersAsync();
+        var servers = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
         var serverNames = servers.Select(s => s.CreateMetadata().Name).ToList();
 
         // Assert
@@ -574,7 +574,7 @@ public class CommandGroupDiscoveryStrategyTests
         var strategy = CreateStrategy(options: options);
 
         // Act
-        var servers = await strategy.DiscoverServersAsync();
+        var servers = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
         var serverNames = servers.Select(s => s.CreateMetadata().Name).ToList();
 
         // Assert

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/CommandGroupServerProviderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/CommandGroupServerProviderTests.cs
@@ -51,7 +51,7 @@ public class CommandGroupServerProviderTests
         var options = new McpClientOptions();
 
         // Act
-        var client = await mcpCommandGroup.CreateClientAsync(options);
+        var client = await mcpCommandGroup.CreateClientAsync(options, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(client);

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/CompositeDiscoveryStrategyTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/CompositeDiscoveryStrategyTests.cs
@@ -12,7 +12,7 @@ public class CompositeDiscoveryStrategyTests
     private static IMcpDiscoveryStrategy CreateMockStrategy(params IMcpServerProvider[] providers)
     {
         var strategy = Substitute.For<IMcpDiscoveryStrategy>();
-        strategy.DiscoverServersAsync().Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(providers));
+        strategy.DiscoverServersAsync(TestContext.Current.CancellationToken).Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(providers));
         return strategy;
     }
 
@@ -92,7 +92,7 @@ public class CompositeDiscoveryStrategyTests
         var composite = CreateCompositeStrategy(new[] { strategy });
 
         // Act
-        var result = (await composite.DiscoverServersAsync()).ToList();
+        var result = (await composite.DiscoverServersAsync(TestContext.Current.CancellationToken)).ToList();
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -114,7 +114,7 @@ public class CompositeDiscoveryStrategyTests
         var composite = CreateCompositeStrategy(new[] { strategy1, strategy2 });
 
         // Act
-        var result = (await composite.DiscoverServersAsync()).ToList();
+        var result = (await composite.DiscoverServersAsync(TestContext.Current.CancellationToken)).ToList();
 
         // Assert
         Assert.Equal(4, result.Count);
@@ -136,7 +136,7 @@ public class CompositeDiscoveryStrategyTests
         var composite = CreateCompositeStrategy(new[] { activeStrategy, emptyStrategy1, emptyStrategy2 });
 
         // Act
-        var result = (await composite.DiscoverServersAsync()).ToList();
+        var result = (await composite.DiscoverServersAsync(TestContext.Current.CancellationToken)).ToList();
 
         // Assert
         Assert.Single(result);
@@ -152,7 +152,7 @@ public class CompositeDiscoveryStrategyTests
         var composite = CreateCompositeStrategy(new[] { emptyStrategy1, emptyStrategy2 });
 
         // Act
-        var result = await composite.DiscoverServersAsync();
+        var result = await composite.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -174,7 +174,7 @@ public class CompositeDiscoveryStrategyTests
         var composite = CreateCompositeStrategy(new[] { strategy1, strategy2, strategy3 });
 
         // Act
-        var result = (await composite.DiscoverServersAsync()).ToList();
+        var result = (await composite.DiscoverServersAsync(TestContext.Current.CancellationToken)).ToList();
 
         // Assert
         Assert.Equal(3, result.Count);
@@ -183,9 +183,9 @@ public class CompositeDiscoveryStrategyTests
         Assert.Contains(provider3, result);
 
         // Verify all strategies were called
-        await strategy1.Received(1).DiscoverServersAsync();
-        await strategy2.Received(1).DiscoverServersAsync();
-        await strategy3.Received(1).DiscoverServersAsync();
+        await strategy1.Received(1).DiscoverServersAsync(Arg.Any<CancellationToken>());
+        await strategy2.Received(1).DiscoverServersAsync(Arg.Any<CancellationToken>());
+        await strategy3.Received(1).DiscoverServersAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -203,7 +203,7 @@ public class CompositeDiscoveryStrategyTests
         var composite = CreateCompositeStrategy(new[] { strategy1, strategy2 });
 
         // Act
-        var result = (await composite.DiscoverServersAsync()).ToList();
+        var result = (await composite.DiscoverServersAsync(TestContext.Current.CancellationToken)).ToList();
 
         // Assert
         Assert.Equal(4, result.Count);
@@ -224,8 +224,8 @@ public class CompositeDiscoveryStrategyTests
         var composite = CreateCompositeStrategy(new[] { strategy });
 
         // Act
-        var result1 = (await composite.DiscoverServersAsync()).ToList();
-        var result2 = (await composite.DiscoverServersAsync()).ToList();
+        var result1 = (await composite.DiscoverServersAsync(TestContext.Current.CancellationToken)).ToList();
+        var result2 = (await composite.DiscoverServersAsync(TestContext.Current.CancellationToken)).ToList();
 
         // Assert
         Assert.Equal(result1.Count, result2.Count);
@@ -233,7 +233,7 @@ public class CompositeDiscoveryStrategyTests
         Assert.Equal(2, result2.Count);
 
         // Should call the underlying strategy each time
-        await strategy.Received(2).DiscoverServersAsync();
+        await strategy.Received(2).DiscoverServersAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -249,7 +249,7 @@ public class CompositeDiscoveryStrategyTests
         var composite = CreateCompositeStrategy(new[] { strategy1, strategy2 });
 
         // Act
-        var result = (await composite.DiscoverServersAsync()).ToList();
+        var result = (await composite.DiscoverServersAsync(TestContext.Current.CancellationToken)).ToList();
 
         // Assert
         // CompositeDiscoveryStrategy doesn't deduplicate - it includes all providers
@@ -269,7 +269,7 @@ public class CompositeDiscoveryStrategyTests
         Assert.IsAssignableFrom<BaseDiscoveryStrategy>(composite);
 
         // Should implement the base contract
-        var result = await composite.DiscoverServersAsync();
+        var result = await composite.DiscoverServersAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(result);
     }
 
@@ -281,10 +281,10 @@ public class CompositeDiscoveryStrategyTests
         var mockStrategy2 = Substitute.For<IMcpDiscoveryStrategy>();
         var provider1 = Substitute.For<IMcpServerProvider>();
         var provider2 = Substitute.For<IMcpServerProvider>();
-        mockStrategy1.DiscoverServersAsync().Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(new[] { provider1 }));
-        mockStrategy2.DiscoverServersAsync().Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(new[] { provider2 }));
+        mockStrategy1.DiscoverServersAsync(TestContext.Current.CancellationToken).Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(new[] { provider1 }));
+        mockStrategy2.DiscoverServersAsync(TestContext.Current.CancellationToken).Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(new[] { provider2 }));
         var composite = CreateCompositeStrategy(new[] { mockStrategy1, mockStrategy2 });
-        var result = await composite.DiscoverServersAsync();
+        var result = await composite.DiscoverServersAsync(TestContext.Current.CancellationToken);
         Assert.Contains(provider1, result);
         Assert.Contains(provider2, result);
     }
@@ -298,10 +298,10 @@ public class CompositeDiscoveryStrategyTests
         var provider2 = Substitute.For<IMcpServerProvider>();
         provider1.CreateMetadata().Returns(new McpServerMetadata { Id = "one", Name = "one", Description = "desc1" });
         provider2.CreateMetadata().Returns(new McpServerMetadata { Id = "two", Name = "two", Description = "desc2" });
-        mockStrategy1.DiscoverServersAsync().Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(new[] { provider1 }));
-        mockStrategy2.DiscoverServersAsync().Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(new[] { provider2 }));
+        mockStrategy1.DiscoverServersAsync(TestContext.Current.CancellationToken).Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(new[] { provider1 }));
+        mockStrategy2.DiscoverServersAsync(TestContext.Current.CancellationToken).Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(new[] { provider2 }));
         var composite = CreateCompositeStrategy(new[] { mockStrategy1, mockStrategy2 });
-        var result = (await composite.DiscoverServersAsync()).ToList();
+        var result = (await composite.DiscoverServersAsync(TestContext.Current.CancellationToken)).ToList();
         Assert.Equal(2, result.Count);
         Assert.Contains(result, p => p.CreateMetadata().Id == "one");
         Assert.Contains(result, p => p.CreateMetadata().Id == "two");
@@ -315,7 +315,7 @@ public class CompositeDiscoveryStrategyTests
         var composite = CreateCompositeStrategy(new[] { emptyStrategy });
 
         // Act
-        var result = await composite.DiscoverServersAsync();
+        var result = await composite.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategyTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategyTests.cs
@@ -37,7 +37,7 @@ public class ConsolidatedToolDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/RegistryDiscoveryStrategyTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/RegistryDiscoveryStrategyTests.cs
@@ -34,7 +34,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -47,7 +47,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = (await strategy.DiscoverServersAsync()).ToList();
+        var result = (await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken)).ToList();
 
         // Assert
         Assert.NotEmpty(result);
@@ -69,7 +69,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -83,7 +83,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var providers = result.ToList();
@@ -108,7 +108,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var providers = result.ToList();
@@ -123,8 +123,8 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result1 = await strategy.DiscoverServersAsync();
-        var result2 = await strategy.DiscoverServersAsync();
+        var result1 = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
+        var result2 = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result1);
@@ -147,8 +147,8 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result1 = await strategy.DiscoverServersAsync();
-        var result2 = await strategy.DiscoverServersAsync();
+        var result1 = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
+        var result2 = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var count1 = result1.Count();
@@ -164,7 +164,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         // Should successfully load from the embedded registry.json resource
@@ -182,7 +182,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
         var documentationProvider = result.FirstOrDefault(p => p.CreateMetadata().Name == "documentation");
 
         // Assert
@@ -206,7 +206,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -226,7 +226,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -249,7 +249,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
         var documentationProvider = result.FirstOrDefault(p => p.CreateMetadata().Name == "documentation");
 
         // Assert
@@ -272,7 +272,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy();
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -296,7 +296,7 @@ public class RegistryDiscoveryStrategyTests
         Assert.IsAssignableFrom<BaseDiscoveryStrategy>(strategy);
 
         // Should implement the base contract
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(result);
     }
 
@@ -305,7 +305,7 @@ public class RegistryDiscoveryStrategyTests
     public async Task ShouldDiscoverServers()
     {
         var strategy = CreateStrategy();
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
         Assert.NotNull(result);
     }
 
@@ -313,7 +313,7 @@ public class RegistryDiscoveryStrategyTests
     public async Task ShouldDiscoverServers_ReturnsExpectedProviders()
     {
         var strategy = CreateStrategy();
-        var result = (await strategy.DiscoverServersAsync()).ToList();
+        var result = (await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken)).ToList();
         Assert.NotEmpty(result);
         // Should contain the 'documentation' server from registry.json
         var documentationProvider = result.FirstOrDefault(p => p.CreateMetadata().Name == "documentation");
@@ -333,7 +333,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy(options);
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -350,7 +350,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy(options);
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(result);
@@ -367,7 +367,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy(options);
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var providers = result.ToList();
@@ -389,7 +389,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy(options);
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var providers = result.ToList();
@@ -404,7 +404,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy(options);
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var providers = result.ToList();
@@ -427,7 +427,7 @@ public class RegistryDiscoveryStrategyTests
         var strategy = CreateStrategy(options);
 
         // Act
-        var result = await strategy.DiscoverServersAsync();
+        var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         var providers = result.ToList();

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/RegistryServerProviderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/RegistryServerProviderTests.cs
@@ -113,7 +113,7 @@ public class RegistryServerProviderTests
 
     //     // Act & Assert
     //     var exception = await Assert.ThrowsAsync<HttpRequestException>(
-    //         () => provider.CreateClientAsync(new McpClientOptions()));
+    //         () => provider.CreateClientAsync(new McpClientOptions(), TestContext.Current.CancellationToken));
 
     //     Assert.Contains(((int)HttpStatusCode.NotFound).ToString(), exception.Message);
     // }
@@ -135,7 +135,7 @@ public class RegistryServerProviderTests
         // Act & Assert - Should throw InvalidOperationException for subprocess startup failure
         // since configuration is valid but external process fails to start properly
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => provider.CreateClientAsync(new McpClientOptions()));
+            () => provider.CreateClientAsync(new McpClientOptions(), TestContext.Current.CancellationToken));
 
         Assert.Contains($"Failed to create MCP client for registry server '{testId}'", exception.Message);
     }
@@ -161,7 +161,7 @@ public class RegistryServerProviderTests
         // Act & Assert - Should throw InvalidOperationException for subprocess startup failure
         // since configuration is valid but external process fails to start properly
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => provider.CreateClientAsync(new McpClientOptions()));
+            () => provider.CreateClientAsync(new McpClientOptions(), TestContext.Current.CancellationToken));
 
         Assert.Contains($"Failed to create MCP client for registry server '{testId}'", exception.Message);
     }
@@ -180,7 +180,7 @@ public class RegistryServerProviderTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(
-            () => provider.CreateClientAsync(new McpClientOptions()));
+            () => provider.CreateClientAsync(new McpClientOptions(), TestContext.Current.CancellationToken));
 
         Assert.Contains($"Registry server '{testId}' does not have a valid transport type.",
             exception.Message);
@@ -201,7 +201,7 @@ public class RegistryServerProviderTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => provider.CreateClientAsync(new McpClientOptions()));
+            () => provider.CreateClientAsync(new McpClientOptions(), TestContext.Current.CancellationToken));
 
         Assert.Contains($"Registry server '{testId}' does not have a valid command for stdio transport.",
             exception.Message);
@@ -225,7 +225,7 @@ public class RegistryServerProviderTests
 
         // Act & Assert - Should throw InvalidOperationException with install instructions
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => provider.CreateClientAsync(new McpClientOptions()));
+            () => provider.CreateClientAsync(new McpClientOptions(), TestContext.Current.CancellationToken));
 
         // Verify the exception message contains the install instructions
         Assert.Contains($"Failed to initialize the '{testId}' MCP tool.", exception.Message);

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/RegistryToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/RegistryToolLoaderTests.cs
@@ -56,7 +56,7 @@ public class RegistryToolLoaderTests
         var (toolLoader, mockDiscoveryStrategy) = CreateToolLoader();
         var request = CreateListToolsRequest();
 
-        mockDiscoveryStrategy.DiscoverServersAsync()
+        mockDiscoveryStrategy.DiscoverServersAsync(TestContext.Current.CancellationToken)
             .Returns(Task.FromResult(Enumerable.Empty<IMcpServerProvider>()));
 
         // Act

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/ServerToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/ServerToolLoaderTests.cs
@@ -91,7 +91,7 @@ public class ServerToolLoaderTests
         var (toolLoader, mockDiscoveryStrategy) = CreateToolLoader();
         var request = CreateRequest();
 
-        mockDiscoveryStrategy.DiscoverServersAsync()
+        mockDiscoveryStrategy.DiscoverServersAsync(TestContext.Current.CancellationToken)
             .Returns(Task.FromResult(Enumerable.Empty<IMcpServerProvider>()));
 
         // Act

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/SingleProxyToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/SingleProxyToolLoaderTests.cs
@@ -103,7 +103,7 @@ public class SingleProxyToolLoaderTests
         var request = CreateListToolsRequest();
 
         // Setup mock to return empty servers (SingleProxyToolLoader always returns the azure tool)
-        mockDiscoveryStrategy.DiscoverServersAsync()
+        mockDiscoveryStrategy.DiscoverServersAsync(TestContext.Current.CancellationToken)
             .Returns(Task.FromResult(Enumerable.Empty<IMcpServerProvider>()));
 
         // Act

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Services/Azure/BaseAzureServiceTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Services/Azure/BaseAzureServiceTests.cs
@@ -23,7 +23,7 @@ public class BaseAzureServiceTests
     public BaseAzureServiceTests()
     {
         _azureService = new TestAzureService(_tenantService);
-        _tenantService.GetTenantId(TenantName).Returns(TenantId);
+        _tenantService.GetTenantId(TenantName, Arg.Any<CancellationToken>()).Returns(TenantId);
         _tenantService.GetTokenCredentialAsync(
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
@@ -37,7 +37,7 @@ public class BaseAzureServiceTests
         var tenantName2 = "Other-Tenant-Name";
         var tenantId2 = "Other-Tenant-Id";
 
-        _tenantService.GetTenantId(tenantName2).Returns(tenantId2);
+        _tenantService.GetTenantId(tenantName2, Arg.Any<CancellationToken>()).Returns(tenantId2);
 
         var retryPolicyArgs = new RetryPolicyOptions
         {
@@ -63,7 +63,7 @@ public class BaseAzureServiceTests
     [Fact]
     public async Task ResolveTenantIdAsync_ReturnsNullOnNull()
     {
-        string? actual = await _azureService.ResolveTenantId(null);
+        string? actual = await _azureService.ResolveTenantId(null, TestContext.Current.CancellationToken);
         Assert.Null(actual);
     }
 
@@ -159,7 +159,8 @@ public class BaseAzureServiceTests
         public Task<ArmClient> GetArmClientAsync(string? tenant = null, RetryPolicyOptions? retryPolicy = null) =>
             CreateArmClientAsync(tenant, retryPolicy);
 
-        public Task<string?> ResolveTenantId(string? tenant) => ResolveTenantIdAsync(tenant);
+        // Expose the protected ResolveTenantIdAsync method for testing
+        public Task<string?> ResolveTenantId(string? tenant, CancellationToken cancellationToken) => ResolveTenantIdAsync(tenant, cancellationToken);
 
         public string EscapeKqlStringTest(string value) => EscapeKqlString(value);
 

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Services/Caching/CacheServiceTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Services/Caching/CacheServiceTests.cs
@@ -27,11 +27,11 @@ public class CacheServiceTests
         string value = "test-value";
 
         // Clear any existing cache data
-        await _cacheService.ClearAsync();
+        await _cacheService.ClearAsync(TestContext.Current.CancellationToken);
 
         // Act
-        await _cacheService.SetAsync(group, key, value);
-        var result = await _cacheService.GetAsync<string>(group, key);
+        await _cacheService.SetAsync(group, key, value, cancellationToken: TestContext.Current.CancellationToken);
+        var result = await _cacheService.GetAsync<string>(group, key, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(value, result);
@@ -46,11 +46,11 @@ public class CacheServiceTests
         string value = "test-value";
 
         // Clear any existing cache data
-        await _cacheService.ClearAsync();
+        await _cacheService.ClearAsync(TestContext.Current.CancellationToken);
 
         // Act
-        await _cacheService.SetAsync(group, key, value);
-        var result = await _cacheService.GetAsync<string>(group, key);
+        await _cacheService.SetAsync(group, key, value, cancellationToken: TestContext.Current.CancellationToken);
+        var result = await _cacheService.GetAsync<string>(group, key, cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(value, result);
@@ -67,12 +67,12 @@ public class CacheServiceTests
         string value2 = "test-value2";
 
         // Clear any existing cache data
-        await _cacheService.ClearAsync();
+        await _cacheService.ClearAsync(TestContext.Current.CancellationToken);
 
         // Act
-        await _cacheService.SetAsync(group, key1, value1);
-        await _cacheService.SetAsync(group, key2, value2);
-        var groupKeys = await _cacheService.GetGroupKeysAsync(group);
+        await _cacheService.SetAsync(group, key1, value1, cancellationToken: TestContext.Current.CancellationToken);
+        await _cacheService.SetAsync(group, key2, value2, cancellationToken: TestContext.Current.CancellationToken);
+        var groupKeys = await _cacheService.GetGroupKeysAsync(group, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, groupKeys.Count());
@@ -91,16 +91,18 @@ public class CacheServiceTests
         string value2 = "test-value2";
 
         // Clear any existing cache data
-        await _cacheService.ClearAsync();
+        await _cacheService.ClearAsync(TestContext.Current.CancellationToken);
 
         // Act
-        await _cacheService.SetAsync(group, key1, value1);
-        await _cacheService.SetAsync(group, key2, value2);
-        await _cacheService.DeleteAsync(group, key1);
+        await _cacheService.SetAsync(group, key1, value1, cancellationToken: TestContext.Current.CancellationToken);
+        await _cacheService.SetAsync(group, key2, value2, cancellationToken: TestContext.Current.CancellationToken);
+        await _cacheService.DeleteAsync(group, key1, TestContext.Current.CancellationToken);
 
-        var groupKeys = await _cacheService.GetGroupKeysAsync(group);
-        var result1 = await _cacheService.GetAsync<string>(group, key1);
-        var result2 = await _cacheService.GetAsync<string>(group, key2);        // Assert
+        var groupKeys = await _cacheService.GetGroupKeysAsync(group, TestContext.Current.CancellationToken);
+        var result1 = await _cacheService.GetAsync<string>(group, key1, cancellationToken: TestContext.Current.CancellationToken);
+        var result2 = await _cacheService.GetAsync<string>(group, key2, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
         Assert.Single(groupKeys);
         Assert.Contains(key2, groupKeys);
         Assert.Null(result1);
@@ -118,19 +120,19 @@ public class CacheServiceTests
         string value2 = "test-value2";
 
         // Clear any existing cache data first
-        await _cacheService.ClearAsync();
+        await _cacheService.ClearAsync(TestContext.Current.CancellationToken);
 
-        await _cacheService.SetAsync(group1, key1, value1);
-        await _cacheService.SetAsync(group2, key2, value2);
+        await _cacheService.SetAsync(group1, key1, value1, cancellationToken: TestContext.Current.CancellationToken);
+        await _cacheService.SetAsync(group2, key2, value2, cancellationToken: TestContext.Current.CancellationToken);
 
         // Act
-        await _cacheService.ClearAsync();
+        await _cacheService.ClearAsync(TestContext.Current.CancellationToken);
 
         // Assert
-        var group1Keys = await _cacheService.GetGroupKeysAsync(group1);
-        var group2Keys = await _cacheService.GetGroupKeysAsync(group2);
-        var result1 = await _cacheService.GetAsync<string>(group1, key1);
-        var result2 = await _cacheService.GetAsync<string>(group2, key2);
+        var group1Keys = await _cacheService.GetGroupKeysAsync(group1, TestContext.Current.CancellationToken);
+        var group2Keys = await _cacheService.GetGroupKeysAsync(group2, TestContext.Current.CancellationToken);
+        var result1 = await _cacheService.GetAsync<string>(group1, key1, cancellationToken: TestContext.Current.CancellationToken);
+        var result2 = await _cacheService.GetAsync<string>(group2, key2, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Empty(group1Keys);
         Assert.Empty(group2Keys);
@@ -150,19 +152,19 @@ public class CacheServiceTests
         string value2 = "test-value2";
 
         // Clear any existing cache data first
-        await _cacheService.ClearAsync();
+        await _cacheService.ClearAsync(TestContext.Current.CancellationToken);
 
-        await _cacheService.SetAsync(group1, key1, value1);
-        await _cacheService.SetAsync(group2, key2, value2);
+        await _cacheService.SetAsync(group1, key1, value1, cancellationToken: TestContext.Current.CancellationToken);
+        await _cacheService.SetAsync(group2, key2, value2, cancellationToken: TestContext.Current.CancellationToken);
 
         // Act
-        await _cacheService.ClearGroupAsync(group1);
+        await _cacheService.ClearGroupAsync(group1, TestContext.Current.CancellationToken);
 
         // Assert
-        var group1Keys = await _cacheService.GetGroupKeysAsync(group1);
-        var group2Keys = await _cacheService.GetGroupKeysAsync(group2);
-        var result1 = await _cacheService.GetAsync<string>(group1, key1);
-        var result2 = await _cacheService.GetAsync<string>(group2, key2);
+        var group1Keys = await _cacheService.GetGroupKeysAsync(group1, TestContext.Current.CancellationToken);
+        var group2Keys = await _cacheService.GetGroupKeysAsync(group2, TestContext.Current.CancellationToken);
+        var result1 = await _cacheService.GetAsync<string>(group1, key1, cancellationToken: TestContext.Current.CancellationToken);
+        var result2 = await _cacheService.GetAsync<string>(group2, key2, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Empty(group1Keys);
         Assert.Single(group2Keys);

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -20,6 +20,8 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 ### Other Changes
 
+- Added a `CancellationToken` parameter to async methods to more `I[SomeService]` interfaces. [[#1178](https://github.com/microsoft/mcp/pull/1178)]
+
 ## 2.0.0-beta.4 (2025-11-13)
 
 ### Features Added

--- a/servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.UnitTests/Infrastructure/CommandMetadataSyncTests.cs
+++ b/servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.UnitTests/Infrastructure/CommandMetadataSyncTests.cs
@@ -35,7 +35,7 @@ public class CommandMetadataSyncTests
         var pwshPath = FindPowerShellExecutable();
         var arguments = $"-NoProfile -ExecutionPolicy Bypass -File \"{updateScriptPath}\" -AzmcpPath \"{azmcpPath}\" -DocsPath \"{docsPath}\"";
 
-        var updateResult = await processService.ExecuteAsync(pwshPath, arguments);
+        var updateResult = await processService.ExecuteAsync(pwshPath, arguments, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(updateResult.ExitCode == 0,
             $"Update script failed with exit code {updateResult.ExitCode}. Output: {updateResult.Output}. Error: {updateResult.Error}");

--- a/tools/Azure.Mcp.Tools.Aks/src/Commands/Cluster/ClusterGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Aks/src/Commands/Cluster/ClusterGetCommand.cs
@@ -79,7 +79,8 @@ public sealed class ClusterGetCommand(ILogger<ClusterGetCommand> logger) : BaseA
                 options.ClusterName,
                 options.ResourceGroup,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(clusters ?? []), AksJsonContext.Default.ClusterGetCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Aks/src/Commands/Nodepool/NodepoolGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Aks/src/Commands/Nodepool/NodepoolGetCommand.cs
@@ -70,7 +70,8 @@ public sealed class NodepoolGetCommand(ILogger<NodepoolGetCommand> logger) : Bas
                 options.ClusterName!,
                 options.NodepoolName,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(nodePools ?? []), AksJsonContext.Default.NodepoolGetCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Aks/src/Services/IAksService.cs
+++ b/tools/Azure.Mcp.Tools.Aks/src/Services/IAksService.cs
@@ -13,7 +13,8 @@ public interface IAksService
         string? clusterName,
         string? resourceGroup,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<NodePool>> GetNodePools(
         string subscription,
@@ -21,5 +22,6 @@ public interface IAksService
         string clusterName,
         string? nodePoolName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.UnitTests/Cluster/ClusterGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.UnitTests/Cluster/ClusterGetCommandTests.cs
@@ -61,7 +61,8 @@ public class ClusterGetCommandTests
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>())
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
                 .Returns([]);
         }
 
@@ -99,7 +100,8 @@ public class ClusterGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedClusters);
 
         var context = new CommandContext(_serviceProvider);
@@ -118,7 +120,8 @@ public class ClusterGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>());
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
 
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize(json, AksJsonContext.Default.ClusterGetCommandResult);
@@ -211,7 +214,8 @@ public class ClusterGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([enriched]);
 
         var context = new CommandContext(_serviceProvider);
@@ -249,7 +253,8 @@ public class ClusterGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         var context = new CommandContext(_serviceProvider);
@@ -278,7 +283,8 @@ public class ClusterGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<List<Models.Cluster>>(new Exception("Test error")));
 
         var context = new CommandContext(_serviceProvider);
@@ -316,7 +322,7 @@ public class ClusterGetCommandTests
             AgentPoolProfiles = [new() { Name = "systempool", Count = 3 }]
         };
 
-        _aksService.GetClusters("test-subscription", "test-cluster", "test-rg", null, Arg.Any<RetryPolicyOptions>())
+        _aksService.GetClusters("test-subscription", "test-cluster", "test-rg", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns([expectedCluster]);
 
         var parseResult = _commandDefinition.Parse(["--subscription", "test-subscription", "--resource-group", "test-rg", "--cluster", "test-cluster"]);
@@ -335,7 +341,7 @@ public class ClusterGetCommandTests
     {
         // Arrange
         var notFoundException = new RequestFailedException((int)HttpStatusCode.NotFound, "AKS cluster not found");
-        _aksService.GetClusters(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _aksService.GetClusters(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<List<Models.Cluster>>(notFoundException));
 
         var parseResult = _commandDefinition.Parse(["--subscription", "test-subscription", "--resource-group", "test-rg", "--cluster", "test-cluster"]);
@@ -353,7 +359,7 @@ public class ClusterGetCommandTests
     {
         // Arrange
         var forbiddenException = new RequestFailedException((int)HttpStatusCode.Forbidden, "Authorization failed");
-        _aksService.GetClusters(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _aksService.GetClusters(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<List<Models.Cluster>>(forbiddenException));
 
         var parseResult = _commandDefinition.Parse(["--subscription", "test-subscription", "--resource-group", "test-rg", "--cluster", "test-cluster"]);

--- a/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.UnitTests/Nodepool/NodepoolGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.UnitTests/Nodepool/NodepoolGetCommandTests.cs
@@ -61,7 +61,8 @@ public sealed class NodepoolGetCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>())
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
                 .Returns([]);
         }
 
@@ -168,7 +169,8 @@ public sealed class NodepoolGetCommandTests
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedNodePools);
 
         var context = new CommandContext(_serviceProvider);
@@ -188,7 +190,8 @@ public sealed class NodepoolGetCommandTests
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>());
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
 
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize(json, AksJsonContext.Default.NodepoolGetCommandResult);
@@ -241,7 +244,8 @@ public sealed class NodepoolGetCommandTests
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         var context = new CommandContext(_serviceProvider);
@@ -271,7 +275,8 @@ public sealed class NodepoolGetCommandTests
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<List<Models.NodePool>>(new Exception("Test error")));
 
         var context = new CommandContext(_serviceProvider);
@@ -333,7 +338,7 @@ public sealed class NodepoolGetCommandTests
             PodSubnetId = "/subscriptions/s/rg/r/providers/Microsoft.Network/virtualNetworks/vnet/subnets/podsubnet",
             VnetSubnetId = "/subscriptions/s/rg/r/providers/Microsoft.Network/virtualNetworks/vnet/subnets/nodesubnet"
         };
-        _aksService.GetNodePools(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _aksService.GetNodePools(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns([expectedNodePool]);
 
         var context = new CommandContext(_serviceProvider);
@@ -346,7 +351,7 @@ public sealed class NodepoolGetCommandTests
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        await _aksService.Received(1).GetNodePools(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>());
+        await _aksService.Received(1).GetNodePools(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
 
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize(json, AksJsonContext.Default.NodepoolGetCommandResult);

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueDeleteCommand.cs
@@ -54,7 +54,8 @@ public sealed class KeyValueDeleteCommand(ILogger<KeyValueDeleteCommand> logger)
                 options.Subscription!,
                 options.Tenant,
                 options.RetryPolicy,
-                options.Label);
+                options.Label,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(options.Key, options.Label), AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueGetCommand.cs
@@ -89,7 +89,8 @@ public sealed class KeyValueGetCommand(ILogger<KeyValueGetCommand> logger) : Bas
                 options.KeyFilter,
                 options.LabelFilter,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(settings ?? []), AppConfigJsonContext.Default.KeyValueGetCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueSetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueSetCommand.cs
@@ -76,7 +76,8 @@ public sealed class KeyValueSetCommand(ILogger<KeyValueSetCommand> logger) : Bas
                 options.RetryPolicy,
                 options.Label,
                 options.ContentType,
-                options.Tags);
+                options.Tags,
+                cancellationToken);
             context.Response.Results = ResponseResult.Create(
                 new(options.Key, options.Value, options.Label, options.ContentType, options.Tags),
                 AppConfigJsonContext.Default.KeyValueSetCommandResult

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/Lock/KeyValueLockSetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/Lock/KeyValueLockSetCommand.cs
@@ -72,7 +72,8 @@ public sealed class KeyValueLockSetCommand(ILogger<KeyValueLockSetCommand> logge
                 options.Subscription!,
                 options.Tenant,
                 options.RetryPolicy,
-                options.Label);
+                options.Label,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(options.Key!, options.Label, options.Lock), AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/IAppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/IAppConfigService.cs
@@ -21,7 +21,8 @@ public interface IAppConfigService
         string? keyFilter = null,
         string? labelFilter = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
     Task SetKeyValueLockState(
         string accountName,
         string key,
@@ -29,7 +30,8 @@ public interface IAppConfigService
         string subscription,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
-        string? label = null);
+        string? label = null,
+        CancellationToken cancellationToken = default);
     Task SetKeyValue(
         string accountName,
         string key,
@@ -39,12 +41,14 @@ public interface IAppConfigService
         RetryPolicyOptions? retryPolicy = null,
         string? label = null,
         string? contentType = null,
-        string[]? tags = null);
+        string[]? tags = null,
+        CancellationToken cancellationToken = default);
     Task DeleteKeyValue(
         string accountName,
         string key,
         string subscription,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
-        string? label = null);
+        string? label = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.LiveTests/AppConfigCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.LiveTests/AppConfigCommandTests.cs
@@ -61,8 +61,18 @@ public class AppConfigCommandTests : CommandTestsBase
         const string key1 = "bar";
         const string value1 = "bar-value";
 
-        await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key0, value0, Settings.SubscriptionId);
-        await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key1, value1, Settings.SubscriptionId);
+        await _appConfigService.SetKeyValue(
+            Settings.ResourceBaseName,
+            key0,
+            value0,
+            Settings.SubscriptionId,
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _appConfigService.SetKeyValue(
+            Settings.ResourceBaseName,
+            key1,
+            value1,
+            Settings.SubscriptionId,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // act
         var result = await CallToolAsync(
@@ -93,7 +103,13 @@ public class AppConfigCommandTests : CommandTestsBase
         const string key = "foo1";
         const string value = "foo-value";
         const string label = "foobar";
-        await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, value, Settings.SubscriptionId, label: label);
+        await _appConfigService.SetKeyValue(
+            Settings.ResourceBaseName,
+            key,
+            value,
+            Settings.SubscriptionId,
+            label: label,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // act
         var result = await CallToolAsync(
@@ -127,13 +143,25 @@ public class AppConfigCommandTests : CommandTestsBase
         try
         {
             // if it exists, unlock it
-            await _appConfigService.SetKeyValueLockState(Settings.ResourceBaseName, key, false, Settings.SubscriptionId, label: label);
+            await _appConfigService.SetKeyValueLockState(
+                Settings.ResourceBaseName,
+                key,
+                false,
+                Settings.SubscriptionId,
+                label: label,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
         catch
         {
         }
         // make sure it exists
-        await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, value, Settings.SubscriptionId, label: label);
+        await _appConfigService.SetKeyValue(
+            Settings.ResourceBaseName,
+            key,
+            value,
+            Settings.SubscriptionId,
+            label: label,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // act
         var result = await CallToolAsync(
@@ -148,7 +176,13 @@ public class AppConfigCommandTests : CommandTestsBase
             });
 
         // assert
-        await Assert.ThrowsAnyAsync<Exception>(() => _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, newValue, Settings.SubscriptionId, label: label));
+        await Assert.ThrowsAnyAsync<Exception>(() => _appConfigService.SetKeyValue(
+            Settings.ResourceBaseName,
+            key,
+            newValue,
+            Settings.SubscriptionId,
+            label: label,
+            cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -161,13 +195,13 @@ public class AppConfigCommandTests : CommandTestsBase
         try
         {
             // if it exists, unlock it
-            await _appConfigService.SetKeyValueLockState(Settings.ResourceBaseName, key, false, Settings.SubscriptionId);
+            await _appConfigService.SetKeyValueLockState(Settings.ResourceBaseName, key, false, Settings.SubscriptionId, cancellationToken: TestContext.Current.CancellationToken);
         }
         catch
         {
         }
         // make sure it exists
-        await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, value, Settings.SubscriptionId);
+        await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, value, Settings.SubscriptionId, cancellationToken: TestContext.Current.CancellationToken);
 
         // act
         var result = await CallToolAsync(
@@ -181,7 +215,7 @@ public class AppConfigCommandTests : CommandTestsBase
             });
 
         // assert
-        await Assert.ThrowsAnyAsync<Exception>(() => _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, newValue, Settings.SubscriptionId));
+        await Assert.ThrowsAnyAsync<Exception>(() => _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, newValue, Settings.SubscriptionId, cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -195,14 +229,14 @@ public class AppConfigCommandTests : CommandTestsBase
         try
         {
             // if it exists, unlock it
-            await _appConfigService.SetKeyValueLockState(Settings.ResourceBaseName, key, false, Settings.SubscriptionId, label: label);
+            await _appConfigService.SetKeyValueLockState(Settings.ResourceBaseName, key, false, Settings.SubscriptionId, label: label, cancellationToken: TestContext.Current.CancellationToken);
         }
         catch
         {
         }
         // make sure it exists
-        await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, value, Settings.SubscriptionId, label: label);
-        await _appConfigService.SetKeyValueLockState(Settings.ResourceBaseName, key, true, Settings.SubscriptionId, label: label);
+        await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, value, Settings.SubscriptionId, label: label, cancellationToken: TestContext.Current.CancellationToken);
+        await _appConfigService.SetKeyValueLockState(Settings.ResourceBaseName, key, true, Settings.SubscriptionId, label: label, cancellationToken: TestContext.Current.CancellationToken);
 
         // act
         _ = await CallToolAsync(
@@ -219,7 +253,7 @@ public class AppConfigCommandTests : CommandTestsBase
         // assert
         try
         {
-            await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, newValue, Settings.SubscriptionId, label: label);
+            await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, newValue, Settings.SubscriptionId, label: label, cancellationToken: TestContext.Current.CancellationToken);
         }
         catch (Exception ex)
         {
@@ -237,14 +271,14 @@ public class AppConfigCommandTests : CommandTestsBase
         try
         {
             // if it exists, unlock it
-            await _appConfigService.SetKeyValueLockState(Settings.ResourceBaseName, key, false, Settings.SubscriptionId);
+            await _appConfigService.SetKeyValueLockState(Settings.ResourceBaseName, key, false, Settings.SubscriptionId, cancellationToken: TestContext.Current.CancellationToken);
         }
         catch
         {
         }
         // make sure it exists
-        await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, value, Settings.SubscriptionId);
-        await _appConfigService.SetKeyValueLockState(Settings.ResourceBaseName, key, true, Settings.SubscriptionId);
+        await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, value, Settings.SubscriptionId, cancellationToken: TestContext.Current.CancellationToken);
+        await _appConfigService.SetKeyValueLockState(Settings.ResourceBaseName, key, true, Settings.SubscriptionId, cancellationToken: TestContext.Current.CancellationToken);
 
         // act
         _ = await CallToolAsync(
@@ -260,7 +294,7 @@ public class AppConfigCommandTests : CommandTestsBase
         // assert
         try
         {
-            await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, newValue, Settings.SubscriptionId);
+            await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, newValue, Settings.SubscriptionId, cancellationToken: TestContext.Current.CancellationToken);
         }
         catch (Exception ex)
         {
@@ -275,7 +309,7 @@ public class AppConfigCommandTests : CommandTestsBase
         const string key = "foo6";
         const string value = "foo-value";
         const string label = "staging";
-        await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, value, Settings.SubscriptionId, label: label);
+        await _appConfigService.SetKeyValue(Settings.ResourceBaseName, key, value, Settings.SubscriptionId, label: label, cancellationToken: TestContext.Current.CancellationToken);
 
         // act
         var result = await CallToolAsync(
@@ -406,13 +440,15 @@ public class AppConfigCommandTests : CommandTestsBase
            key,
            value,
            Settings.SubscriptionId,
-           contentType: contentType);
+           contentType: contentType,
+           cancellationToken: TestContext.Current.CancellationToken);
 
         // act - get key-value to verify content type was preserved
         var settings = await _appConfigService.GetKeyValues(
             Settings.ResourceBaseName,
             Settings.SubscriptionId,
-            key);
+            key,
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // assert - verify content type was properly set and retrieved
         Assert.Single(settings);

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueDeleteCommandTests.cs
@@ -61,7 +61,8 @@ public class KeyValueDeleteCommandTests
             "sub123",
             null,
             Arg.Any<RetryPolicyOptions>(),
-            null);
+            null,
+            Arg.Any<CancellationToken>());
 
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize(json, AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
@@ -91,7 +92,8 @@ public class KeyValueDeleteCommandTests
             "my-key",
             "sub123", null,
             Arg.Any<RetryPolicyOptions>(),
-            "prod");
+            "prod",
+            Arg.Any<CancellationToken>());
 
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize(json, AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
@@ -111,7 +113,8 @@ public class KeyValueDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string>())
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Failed to delete key-value"));
 
         var args = _commandDefinition.Parse([

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueGetCommandTests.cs
@@ -58,7 +58,8 @@ public class KeyValueGetCommandTests
           Arg.Any<string?>(),
           Arg.Any<string?>(),
           Arg.Any<string?>(),
-          Arg.Any<RetryPolicyOptions>())
+          Arg.Any<RetryPolicyOptions>(),
+          Arg.Any<CancellationToken>())
           .Returns(expectedSettings);
 
         var args = _commandDefinition.Parse(["--subscription", "sub123", "--account", "account1"]);
@@ -95,7 +96,8 @@ public class KeyValueGetCommandTests
           "key1",
           Arg.Any<string?>(),
           Arg.Any<string?>(),
-          Arg.Any<RetryPolicyOptions>())
+          Arg.Any<RetryPolicyOptions>(),
+          Arg.Any<CancellationToken>())
           .Returns(expectedSettings);
 
         var args = _commandDefinition.Parse(["--subscription", "sub123", "--account", "account1", "--key-filter", "key1"]);
@@ -133,7 +135,8 @@ public class KeyValueGetCommandTests
           Arg.Any<string?>(),
           "prod",
           Arg.Any<string?>(),
-          Arg.Any<RetryPolicyOptions>())
+          Arg.Any<RetryPolicyOptions>(),
+          Arg.Any<CancellationToken>())
           .Returns(expectedSettings);
 
         var args = _commandDefinition.Parse(["--subscription", "sub123", "--account", "account1", "--label-filter", "prod"]);
@@ -175,7 +178,8 @@ public class KeyValueGetCommandTests
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([expectedSetting]);
 
         var args = _commandDefinition.Parse([
@@ -221,7 +225,8 @@ public class KeyValueGetCommandTests
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([expectedSetting]);
 
         var args = _commandDefinition.Parse([
@@ -258,7 +263,8 @@ public class KeyValueGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Setting not found"));
 
         var args = _commandDefinition.Parse([

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueSetCommandTests.cs
@@ -65,7 +65,8 @@ public class KeyValueSetCommandTests
             Arg.Any<RetryPolicyOptions>(),
             null,
             Arg.Any<string>(),
-            Arg.Any<string[]>());
+            Arg.Any<string[]>(),
+            Arg.Any<CancellationToken>());
 
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize(json, AppConfigJsonContext.Default.KeyValueSetCommandResult);
@@ -101,7 +102,8 @@ public class KeyValueSetCommandTests
             Arg.Any<RetryPolicyOptions>(),
             "prod",
             Arg.Any<string>(),
-            Arg.Any<string[]>());
+            Arg.Any<string[]>(),
+            Arg.Any<CancellationToken>());
 
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize(json, AppConfigJsonContext.Default.KeyValueSetCommandResult);
@@ -139,7 +141,8 @@ public class KeyValueSetCommandTests
             Arg.Any<RetryPolicyOptions>(),
             null,
             "application/json",
-            Arg.Is<string[]>(tags => tags.Contains("environment=prod") && tags.Contains("team=backend")));
+            Arg.Is<string[]>(tags => tags.Contains("environment=prod") && tags.Contains("team=backend")),
+            Arg.Any<CancellationToken>());
 
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize(json, AppConfigJsonContext.Default.KeyValueSetCommandResult);
@@ -166,7 +169,8 @@ public class KeyValueSetCommandTests
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<string[]>())
+            Arg.Any<string[]>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Failed to set key-value"));
 
         var args = _commandDefinition.Parse([

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
@@ -63,7 +63,8 @@ public class KeyValueLockSetCommandTests
             "sub123",
             null,
             Arg.Any<RetryPolicyOptions>(),
-            null);
+            null,
+            Arg.Any<CancellationToken>());
 
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize(json, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
@@ -97,7 +98,8 @@ public class KeyValueLockSetCommandTests
             "sub123",
             null,
             Arg.Any<RetryPolicyOptions>(),
-            "prod");
+            "prod",
+            Arg.Any<CancellationToken>());
 
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize(json, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
@@ -130,7 +132,8 @@ public class KeyValueLockSetCommandTests
             "sub123",
             null,
             Arg.Any<RetryPolicyOptions>(),
-            null);
+            null,
+            Arg.Any<CancellationToken>());
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize(json, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
 
@@ -162,7 +165,8 @@ public class KeyValueLockSetCommandTests
             "sub123",
             null,
             Arg.Any<RetryPolicyOptions>(),
-            "prod");
+            "prod",
+            Arg.Any<CancellationToken>());
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize(json, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
 
@@ -184,7 +188,8 @@ public class KeyValueLockSetCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string>())
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Failed to lock key-value"));
 
         var argsToParse = locked

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/Database/DatabaseAddCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/Database/DatabaseAddCommand.cs
@@ -77,7 +77,8 @@ public sealed class DatabaseAddCommand(ILogger<DatabaseAddCommand> logger) : Bas
                 options.ConnectionString ?? string.Empty, // connectionString - will be generated if not provided
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(
                 new Result(connectionInfo),

--- a/tools/Azure.Mcp.Tools.AppService/src/Services/IAppServiceService.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Services/IAppServiceService.cs
@@ -17,5 +17,6 @@ public interface IAppServiceService
         string connectionString,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Database/DatabaseAddCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Database/DatabaseAddCommandTests.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
-using System.CommandLine.Invocation;
-using System.CommandLine.Parsing;
-using System.Linq;
 using System.Net;
 using Azure.Mcp.Core.Models.Command;
 using Azure.Mcp.Core.Options;
@@ -14,6 +10,7 @@ using Azure.Mcp.Tools.AppService.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AppService.UnitTests.Commands.Database;
@@ -75,7 +72,8 @@ public class DatabaseAddCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>())
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
             .Returns(expectedConnection);
 
         // Test the service directly
@@ -88,7 +86,8 @@ public class DatabaseAddCommandTests
             connectionString ?? string.Empty,
             subscription,
             tenant,
-            new RetryPolicyOptions());
+            new RetryPolicyOptions(),
+            TestContext.Current.CancellationToken);
 
         // Verify the service returns expected data
         Assert.NotNull(connectionInfo);
@@ -106,7 +105,8 @@ public class DatabaseAddCommandTests
             Arg.Any<string>(),
             Arg.Is<string>(x => x == subscription),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>());
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -138,7 +138,8 @@ public class DatabaseAddCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>());
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -227,18 +228,18 @@ public class DatabaseAddCommandTests
         var databaseServer = "test-server.database.windows.net";
         var databaseName = "test-db";
 
-        _appServiceService
-            .When(x => x.AddDatabaseAsync(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>()))
-            .Do(x => throw new InvalidOperationException("Service error"));
+        _appServiceService.AddDatabaseAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Service error"));
 
         var command = new DatabaseAddCommand(_logger);
         var args = command.GetCommand().Parse([

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/src/Commands/Recommendation/RecommendationListCommand.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/src/Commands/Recommendation/RecommendationListCommand.cs
@@ -62,7 +62,8 @@ public sealed class RecommendationListCommand(ILogger<RecommendationListCommand>
                 options.Subscription!,
                 options.ResourceGroup,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = insights?.Count() > 0 ?
                 ResponseResult.Create(new RecommendationListCommandResult(insights), ApplicationInsightsJsonContext.Default.RecommendationListCommandResult) :

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/ApplicationInsightsService.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/ApplicationInsightsService.cs
@@ -26,23 +26,33 @@ public class ApplicationInsightsService(
     private readonly IProfilerDataService _profilerDataClient = profilerDataClient ?? throw new ArgumentNullException(nameof(profilerDataClient));
     private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-    public async Task<IEnumerable<JsonNode>> GetProfilerInsightsAsync(string subscription, string? resourceGroup = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
+    public async Task<IEnumerable<JsonNode>> GetProfilerInsightsAsync(
+        string subscription,
+        string? resourceGroup = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
-        IEnumerable<JsonNode> results = await GetProfilerInsightsImpAsync(subscription, resourceGroup, tenant, retryPolicy).ConfigureAwait(false);
+        IEnumerable<JsonNode> results = await GetProfilerInsightsImpAsync(subscription, resourceGroup, tenant, retryPolicy, cancellationToken).ConfigureAwait(false);
         return results.Take(MaxRecommendations);
     }
 
-    private async Task<IEnumerable<JsonNode>> GetProfilerInsightsImpAsync(string subscription, string? resourceGroup, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
+    private async Task<IEnumerable<JsonNode>> GetProfilerInsightsImpAsync(
+        string subscription,
+        string? resourceGroup,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
         List<JsonNode> results = [];
 
         try
         {
-            List<ApplicationInsightsComponentResource> components = await GetApplicationInsightsComponentsAsync(subscription, resourceGroup, tenant, retryPolicy).ConfigureAwait(false);
+            List<ApplicationInsightsComponentResource> components = await GetApplicationInsightsComponentsAsync(subscription, resourceGroup, tenant, retryPolicy, cancellationToken).ConfigureAwait(false);
 
-            IEnumerable<JsonNode> insights = await _profilerDataClient.GetInsightsAsync(resourceIds: components.Select(c => c.Id)).ConfigureAwait(false);
+            IEnumerable<JsonNode> insights = await _profilerDataClient.GetInsightsAsync(resourceIds: components.Select(c => c.Id), cancellationToken: cancellationToken).ConfigureAwait(false);
             results.AddRange(insights);
 
             // Return all results for this resource group (outer method enforces global max)
@@ -55,7 +65,12 @@ public class ApplicationInsightsService(
         }
     }
 
-    private async Task<List<ApplicationInsightsComponentResource>> GetApplicationInsightsComponentsAsync(string subscription, string? resourceGroup, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default)
+    private async Task<List<ApplicationInsightsComponentResource>> GetApplicationInsightsComponentsAsync(
+        string subscription,
+        string? resourceGroup,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(resourceGroup))
         {
@@ -69,7 +84,11 @@ public class ApplicationInsightsService(
         return await rgResource.GetApplicationInsightsComponents().GetAllAsync(cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<List<ApplicationInsightsComponentResource>> GetApplicationInsightsComponentsAsync(string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default)
+    private async Task<List<ApplicationInsightsComponentResource>> GetApplicationInsightsComponentsAsync(
+        string subscription,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
         SubscriptionResource targetSubscription = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken).ConfigureAwait(false);
         return await targetSubscription.GetApplicationInsightsComponentsAsync(cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false);

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/IApplicationInsightsService.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/IApplicationInsightsService.cs
@@ -12,5 +12,6 @@ public interface IApplicationInsightsService
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/tests/Azure.Mcp.Tools.ApplicationInsights.UnitTests/RecommendationListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/tests/Azure.Mcp.Tools.ApplicationInsights.UnitTests/RecommendationListCommandTests.cs
@@ -37,7 +37,12 @@ public class RecommendationListCommandTests
             JsonNode.Parse("{ \"id\": \"rec1\", \"type\": \"cpu\" }")!,
             JsonNode.Parse("{ \"id\": \"rec2\", \"type\": \"memory\" }")!
         };
-        _serviceMock.GetProfilerInsightsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+        _serviceMock.GetProfilerInsightsAsync(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IEnumerable<JsonNode>>(insights!));
         var args = _command.GetCommand().Parse(["--subscription", "sub1"]);
         await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
@@ -52,7 +57,12 @@ public class RecommendationListCommandTests
     [Fact]
     public async Task ExecuteAsync_WhenServiceReturnsNoInsights_NoResults()
     {
-        _serviceMock.GetProfilerInsightsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+        _serviceMock.GetProfilerInsightsAsync(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IEnumerable<JsonNode>>(Array.Empty<JsonNode>()));
         var args = _command.GetCommand().Parse(["--subscription", "sub1"]);
         await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);

--- a/tools/Azure.Mcp.Tools.AzureIsv/src/Commands/Datadog/MonitoredResourcesListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureIsv/src/Commands/Datadog/MonitoredResourcesListCommand.cs
@@ -71,7 +71,8 @@ public sealed class MonitoredResourcesListCommand(ILogger<MonitoredResourcesList
             List<string> results = await service.ListMonitoredResources(
                 options.ResourceGroup!,
                 options.Subscription!,
-                options.DatadogResource!);
+                options.DatadogResource!,
+                cancellationToken);
             context.Response.Results = results?.Count > 0
                 ? ResponseResult.Create(new(results), DatadogJsonContext.Default.MonitoredResourcesListResult)
                 : ResponseResult.Create(new(["No monitored resources found for the specified Datadog resource."]), DatadogJsonContext.Default.MonitoredResourcesListResult);

--- a/tools/Azure.Mcp.Tools.AzureIsv/src/Services/Datadog/DatadogService.cs
+++ b/tools/Azure.Mcp.Tools.AzureIsv/src/Services/Datadog/DatadogService.cs
@@ -14,18 +14,18 @@ public partial class DatadogService : BaseAzureService, IDatadogService
     {
     }
 
-    public async Task<List<string>> ListMonitoredResources(string resourceGroup, string subscription, string datadogResource)
+    public async Task<List<string>> ListMonitoredResources(string resourceGroup, string subscription, string datadogResource, CancellationToken cancellationToken = default)
     {
         try
         {
-            var tenantId = await ResolveTenantIdAsync(null);
-            var armClient = await CreateArmClientAsync(tenantIdOrName: tenantId, retryPolicy: null);
+            var tenantId = await ResolveTenantIdAsync(null, cancellationToken);
+            var armClient = await CreateArmClientAsync(tenantIdOrName: tenantId, retryPolicy: null, armClientOptions: null, cancellationToken);
 
             var resourceId = $"/subscriptions/{subscription}/resourceGroups/{resourceGroup}/providers/Microsoft.Datadog/monitors/{datadogResource}";
 
             ResourceIdentifier id = new ResourceIdentifier(resourceId);
             var datadogMonitorResource = armClient.GetDatadogMonitorResource(id);
-            var monitoredResources = datadogMonitorResource.GetMonitoredResources();
+            var monitoredResources = datadogMonitorResource.GetMonitoredResources(cancellationToken);
 
             var resourceList = new List<string>();
             foreach (var resource in monitoredResources)

--- a/tools/Azure.Mcp.Tools.AzureIsv/src/Services/IDatadogService.cs
+++ b/tools/Azure.Mcp.Tools.AzureIsv/src/Services/IDatadogService.cs
@@ -14,5 +14,5 @@ public interface IDatadogService
     /// <returns>A list of monitored resources.</returns>
     /// <exception cref="AuthenticationFailedException">Thrown when authentication fails.</exception>
     /// <exception cref="RequestFailedException">Thrown when the service request fails.</exception>
-    Task<List<string>> ListMonitoredResources(string resourceGroup, string subscription, string datadogResource);
+    Task<List<string>> ListMonitoredResources(string resourceGroup, string subscription, string datadogResource, CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.AzureIsv/tests/Azure.Mcp.Tools.AzureIsv.UnitTests/Datadog/MonitoredResourcesListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureIsv/tests/Azure.Mcp.Tools.AzureIsv.UnitTests/Datadog/MonitoredResourcesListCommandTests.cs
@@ -38,7 +38,7 @@ public class MonitoredResourcesListCommandTests
             "/subscriptions/1234/resourceGroups/rg-demo/providers/Microsoft.Datadog/monitors/app-demo-1",
             "/subscriptions/1234/resourceGroups/rg-demo/providers/Microsoft.Datadog/monitors/vm-demo-2"
         };
-        _datadogService.ListMonitoredResources(Arg.Is("rg1"), Arg.Is("sub123"), Arg.Is("datadog1"))
+        _datadogService.ListMonitoredResources(Arg.Is("rg1"), Arg.Is("sub123"), Arg.Is("datadog1"), Arg.Any<CancellationToken>())
             .Returns(expectedResources);
 
         var command = new MonitoredResourcesListCommand(_logger);
@@ -57,7 +57,7 @@ public class MonitoredResourcesListCommandTests
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoResources()
     {
         // Arrange
-        _datadogService.ListMonitoredResources("rg1", "sub123", "datadog1")
+        _datadogService.ListMonitoredResources("rg1", "sub123", "datadog1", Arg.Any<CancellationToken>())
             .Returns([]);
 
         var command = new MonitoredResourcesListCommand(_logger);
@@ -76,7 +76,7 @@ public class MonitoredResourcesListCommandTests
     {
         // Arrange
         var expectedError = "Missing required arguments: datadog-resource";
-        _datadogService.ListMonitoredResources("rg1", "sub123", "datadog1")
+        _datadogService.ListMonitoredResources("rg1", "sub123", "datadog1", Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         var command = new MonitoredResourcesListCommand(_logger);

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.UnitTests/Email/EmailSendCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.UnitTests/Email/EmailSendCommandTests.cs
@@ -22,6 +22,7 @@ using Azure.Mcp.Tools.Communication.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Communication.UnitTests.Email;
@@ -235,22 +236,21 @@ public class EmailSendCommandTests
         var parseResult = _commandDefinition.Parse(args);
 
         var expectedException = new RequestFailedException("Test error message");
-        _mockCommunicationService
-            .When(x => x.SendEmailAsync(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string[]>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<bool>(),
-                Arg.Any<string[]>(),
-                Arg.Any<string[]>(),
-                Arg.Any<string[]>(),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>()))
-            .Do(x => throw expectedException);
+        _mockCommunicationService.SendEmailAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string[]>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<bool>(),
+            Arg.Any<string[]>(),
+            Arg.Any<string[]>(),
+            Arg.Any<string[]>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(expectedException);
 
         // Act
         var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/Entries/LedgerEntryAppendCommand.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/Entries/LedgerEntryAppendCommand.cs
@@ -64,7 +64,7 @@ public sealed class LedgerEntryAppendCommand(IConfidentialLedgerService service,
 
         try
         {
-            var result = await _service.AppendEntryAsync(options.LedgerName!, options.Content!, options.CollectionId);
+            var result = await _service.AppendEntryAsync(options.LedgerName!, options.Content!, options.CollectionId, cancellationToken);
             context.Response.Results = ResponseResult.Create(result, ConfidentialLedgerJsonContext.Default.AppendEntryResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/Entries/LedgerEntryGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/Entries/LedgerEntryGetCommand.cs
@@ -64,7 +64,8 @@ public sealed class LedgerEntryGetCommand(IConfidentialLedgerService service, IL
             var result = await _service.GetLedgerEntryAsync(
                 options.LedgerName!,
                 options.TransactionId!,
-                options.CollectionId).ConfigureAwait(false);
+                options.CollectionId,
+                cancellationToken).ConfigureAwait(false);
 
             context.Response.Results = ResponseResult.Create(
                 result,

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Services/ConfidentialLedgerService.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Services/ConfidentialLedgerService.cs
@@ -34,13 +34,13 @@ public class ConfidentialLedgerService(ITenantService tenantService)
         return RequestContent.Create(binary);
     }
 
-    public async Task<AppendEntryResult> AppendEntryAsync(string ledgerName, string entryData, string? collectionId = null)
+    public async Task<AppendEntryResult> AppendEntryAsync(string ledgerName, string entryData, string? collectionId = null, CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
             (nameof(ledgerName), ledgerName),
             (nameof(entryData), entryData));
 
-        var credential = await GetCredential();
+        var credential = await GetCredential(cancellationToken);
 
         // Configure client (retry etc. could be extended later)
         ConfidentialLedgerClient client = new(BuildLedgerUri(ledgerName), credential);
@@ -57,7 +57,7 @@ public class ConfidentialLedgerService(ITenantService tenantService)
         };
     }
 
-    public async Task<LedgerEntryGetResult> GetLedgerEntryAsync(string ledgerName, string transactionId, string? collectionId = null)
+    public async Task<LedgerEntryGetResult> GetLedgerEntryAsync(string ledgerName, string transactionId, string? collectionId = null, CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
             (nameof(ledgerName), ledgerName),
@@ -73,7 +73,7 @@ public class ConfidentialLedgerService(ITenantService tenantService)
             throw new ArgumentException("Transaction ID cannot be empty or whitespace.", nameof(transactionId));
         }
 
-        var credential = await GetCredential();
+        var credential = await GetCredential(cancellationToken);
         ConfidentialLedgerClient client = new(BuildLedgerUri(ledgerName), credential);
 
         Response? getByCollectionResponse = null;

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Services/IConfidentialLedgerService.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Services/IConfidentialLedgerService.cs
@@ -7,6 +7,6 @@ namespace Azure.Mcp.Tools.ConfidentialLedger.Services;
 
 public interface IConfidentialLedgerService
 {
-    Task<AppendEntryResult> AppendEntryAsync(string ledgerName, string entryData, string? collectionId = null);
-    Task<LedgerEntryGetResult> GetLedgerEntryAsync(string ledgerName, string transactionId, string? collectionId = null);
+    Task<AppendEntryResult> AppendEntryAsync(string ledgerName, string entryData, string? collectionId = null, CancellationToken cancellationToken = default);
+    Task<LedgerEntryGetResult> GetLedgerEntryAsync(string ledgerName, string transactionId, string? collectionId = null, CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/tests/Azure.Mcp.Tools.ConfidentialLedger.UnitTests/LedgerEntryAppendCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/tests/Azure.Mcp.Tools.ConfidentialLedger.UnitTests/LedgerEntryAppendCommandTests.cs
@@ -21,7 +21,7 @@ public class LedgerEntryAppendCommandTests
     {
         var service = Substitute.For<IConfidentialLedgerService>();
         var logger = Substitute.For<ILogger<LedgerEntryAppendCommand>>();
-        service.AppendEntryAsync("ledger1", "data")
+        service.AppendEntryAsync("ledger1", "data", cancellationToken: Arg.Any<CancellationToken>())
             .Returns(new AppendEntryResult { TransactionId = "tx1", State = "Committed" });
 
         var provider = new ServiceCollection()

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/tests/Azure.Mcp.Tools.ConfidentialLedger.UnitTests/LedgerEntryGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/tests/Azure.Mcp.Tools.ConfidentialLedger.UnitTests/LedgerEntryGetCommandTests.cs
@@ -19,7 +19,7 @@ public sealed class LedgerEntryGetCommandTests
         var service = Substitute.For<IConfidentialLedgerService>();
         var logger = Substitute.For<ILogger<LedgerEntryGetCommand>>();
 
-        service.GetLedgerEntryAsync("ledger1", "2.199", null)
+        service.GetLedgerEntryAsync("ledger1", "2.199", null, Arg.Any<CancellationToken>())
             .Returns(new LedgerEntryGetResult
             {
                 LedgerName = "ledger1",
@@ -43,7 +43,7 @@ public sealed class LedgerEntryGetCommandTests
         Assert.NotNull(result);
         Assert.Equal("2.199", result!.TransactionId);
 
-        await service.Received(1).GetLedgerEntryAsync("ledger1", "2.199", null);
+        await service.Received(1).GetLedgerEntryAsync("ledger1", "2.199", null, Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -57,7 +57,7 @@ public sealed class LedgerEntryGetCommandTests
     {
         var service = new ConfidentialLedgerService(Substitute.For<ITenantService>());
         await Assert.ThrowsAsync<ArgumentException>(() =>
-            service.GetLedgerEntryAsync(ledgerName!, transactionId!, null));
+            service.GetLedgerEntryAsync(ledgerName!, transactionId!, null, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public sealed class LedgerEntryGetCommandTests
         var service = Substitute.For<IConfidentialLedgerService>();
         var logger = Substitute.For<ILogger<LedgerEntryGetCommand>>();
 
-        service.GetLedgerEntryAsync("ledger1", "2.199", "my-collection")
+        service.GetLedgerEntryAsync("ledger1", "2.199", "my-collection", Arg.Any<CancellationToken>())
             .Returns(new LedgerEntryGetResult
             {
                 LedgerName = "ledger1",
@@ -90,6 +90,6 @@ public sealed class LedgerEntryGetCommandTests
         Assert.NotNull(result);
         Assert.Equal("2.199", result!.TransactionId);
 
-        await service.Received(1).GetLedgerEntryAsync("ledger1", "2.199", "my-collection");
+        await service.Received(1).GetLedgerEntryAsync("ledger1", "2.199", "my-collection", Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/AccountListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/AccountListCommand.cs
@@ -50,7 +50,8 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger) : Sub
             var accounts = await cosmosService.GetCosmosAccounts(
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(accounts ?? []), CosmosJsonContext.Default.AccountListCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ContainerListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ContainerListCommand.cs
@@ -53,7 +53,8 @@ public sealed class ContainerListCommand(ILogger<ContainerListCommand> logger) :
                 options.Subscription!,
                 options.AuthMethod ?? AuthMethod.Credential,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(containers ?? []), CosmosJsonContext.Default.ContainerListCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/DatabaseListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/DatabaseListCommand.cs
@@ -51,7 +51,8 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
                 options.Subscription!,
                 options.AuthMethod ?? AuthMethod.Credential,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(databases ?? []), CosmosJsonContext.Default.DatabaseListCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ItemQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ItemQueryCommand.cs
@@ -75,7 +75,8 @@ public sealed class ItemQueryCommand(ILogger<ItemQueryCommand> logger) : BaseCon
                 options.Subscription!,
                 options.AuthMethod ?? AuthMethod.Credential,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(items ?? []), CosmosJsonContext.Default.ItemQueryCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Services/ICosmosService.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Services/ICosmosService.cs
@@ -10,14 +10,16 @@ public interface ICosmosService : IDisposable
     Task<List<string>> GetCosmosAccounts(
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<string>> ListDatabases(
         string accountName,
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<string>> ListContainers(
         string accountName,
@@ -25,7 +27,8 @@ public interface ICosmosService : IDisposable
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<JsonElement>> QueryItems(
         string accountName,
@@ -35,5 +38,6 @@ public interface ICosmosService : IDisposable
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/AccountListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/AccountListCommandTests.cs
@@ -44,7 +44,7 @@ public class AccountListCommandTests
     {
         // Arrange
         var expectedAccounts = new List<string> { "account1", "account2" };
-        _cosmosService.GetCosmosAccounts(Arg.Is("sub123"), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _cosmosService.GetCosmosAccounts(Arg.Is("sub123"), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedAccounts);
 
         var args = _commandDefinition.Parse(["--subscription", "sub123"]);
@@ -67,7 +67,7 @@ public class AccountListCommandTests
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoAccountsExist()
     {
         // Arrange
-        _cosmosService.GetCosmosAccounts("sub123", null, null)
+        _cosmosService.GetCosmosAccounts("sub123", null, null, Arg.Any<CancellationToken>())
             .Returns([]);
 
         var args = _commandDefinition.Parse(["--subscription", "sub123"]);
@@ -104,7 +104,7 @@ public class AccountListCommandTests
         var expectedError = "Test error";
         var subscriptionId = "sub123";
 
-        _cosmosService.GetCosmosAccounts(subscriptionId, null, Arg.Any<RetryPolicyOptions>())
+        _cosmosService.GetCosmosAccounts(subscriptionId, null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         var args = _commandDefinition.Parse(["--subscription", subscriptionId]);
@@ -123,8 +123,8 @@ public class AccountListCommandTests
     {
         // Arrange
         var subscriptionId = "sub123";
-        _cosmosService.GetCosmosAccounts(subscriptionId, null, Arg.Any<RetryPolicyOptions>())
-            .ThrowsAsync(new HttpRequestException("Service Unavailable", null, System.Net.HttpStatusCode.ServiceUnavailable));
+        _cosmosService.GetCosmosAccounts(subscriptionId, null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Service Unavailable", null, HttpStatusCode.ServiceUnavailable));
 
         var args = _commandDefinition.Parse(["--subscription", subscriptionId]);
 

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/ContainerListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/ContainerListCommandTests.cs
@@ -49,7 +49,8 @@ public class ContainerListCommandTests
             Arg.Is("sub123"),
             Arg.Any<AuthMethod>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedContainers);
 
         var args = _commandDefinition.Parse([
@@ -81,7 +82,8 @@ public class ContainerListCommandTests
             Arg.Is("sub123"),
             Arg.Any<AuthMethod>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         var args = _commandDefinition.Parse([
@@ -114,7 +116,8 @@ public class ContainerListCommandTests
             Arg.Is("sub123"),
             Arg.Any<AuthMethod>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         var args = _commandDefinition.Parse([

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/DatabaseListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/DatabaseListCommandTests.cs
@@ -48,7 +48,8 @@ public class DatabaseListCommandTests
             Arg.Is("sub123"),
             Arg.Any<AuthMethod>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedDatabases);
 
         var args = _commandDefinition.Parse([
@@ -78,7 +79,8 @@ public class DatabaseListCommandTests
             Arg.Is("sub123"),
             Arg.Any<AuthMethod>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         var args = _commandDefinition.Parse([
@@ -109,7 +111,8 @@ public class DatabaseListCommandTests
             Arg.Is("sub123"),
             Arg.Any<AuthMethod>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         var args = _commandDefinition.Parse([

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/ItemQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/ItemQueryCommandTests.cs
@@ -52,7 +52,10 @@ public class ItemQueryCommandTests
             Arg.Is("container123"),
             Arg.Is(query),
             Arg.Is("sub123"),
-            Arg.Any<AuthMethod>(), null, Arg.Any<RetryPolicyOptions>())
+            Arg.Any<AuthMethod>(),
+            null,
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(expectedItems));
 
         var args = _commandDefinition.Parse([
@@ -94,7 +97,8 @@ public class ItemQueryCommandTests
             Arg.Is("sub123"),
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(expectedItems));
 
         var args = _commandDefinition.Parse([
@@ -128,7 +132,8 @@ public class ItemQueryCommandTests
             Arg.Is<string>(s => s == "sub123"),
             Arg.Is<AuthMethod>(a => a == AuthMethod.Credential),
             Arg.Is<string?>(t => t == null),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         var args = _commandDefinition.Parse([
@@ -165,7 +170,8 @@ public class ItemQueryCommandTests
             Arg.Is("sub123"),
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         var args = _commandDefinition.Parse([

--- a/tools/Azure.Mcp.Tools.Deploy/src/Commands/App/LogsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/src/Commands/App/LogsGetCommand.cs
@@ -69,7 +69,7 @@ public sealed class LogsGetCommand(ILogger<LogsGetCommand> logger) : Subscriptio
                 options.WorkspaceFolder!,
                 options.AzdEnvName!,
                 options.Subscription!,
-                options.Limit);
+                options.Limit, cancellationToken);
 
             context.Response.Message = result;
         }

--- a/tools/Azure.Mcp.Tools.Deploy/src/Services/DeployService.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/src/Services/DeployService.cs
@@ -14,9 +14,10 @@ public class DeployService(ITenantService tenantService) : BaseAzureService(tena
          string workspaceFolder,
          string azdEnvName,
          string subscriptionId,
-         int? limit = null)
+         int? limit = null,
+         CancellationToken cancellationToken = default)
     {
-        TokenCredential credential = await GetCredential();
+        TokenCredential credential = await GetCredential(cancellationToken);
         string result = await AzdResourceLogService.GetAzdResourceLogsAsync(
             credential,
             workspaceFolder,

--- a/tools/Azure.Mcp.Tools.Deploy/src/Services/IDeployService.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/src/Services/IDeployService.cs
@@ -9,5 +9,5 @@ public interface IDeployService
         string workspaceFolder,
         string azdEnvName,
         string subscriptionId,
-        int? limit = null);
+        int? limit = null, CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/App/LogsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/App/LogsGetCommandTests.cs
@@ -46,7 +46,8 @@ public class LogsGetCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<int?>())
+            Arg.Any<int?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedLogs);
 
         var args = _commandDefinition.Parse([
@@ -77,7 +78,8 @@ public class LogsGetCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<int?>())
+            Arg.Any<int?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedLogs);
 
         var args = _commandDefinition.Parse([
@@ -105,7 +107,8 @@ public class LogsGetCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<int?>())
+            Arg.Any<int?>(),
+            Arg.Any<CancellationToken>())
             .Returns("No logs found.");
 
         var args = _commandDefinition.Parse([
@@ -133,7 +136,8 @@ public class LogsGetCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<int?>())
+            Arg.Any<int?>(),
+            Arg.Any<CancellationToken>())
             .Returns(errorMessage);
 
         var args = _commandDefinition.Parse([
@@ -161,7 +165,8 @@ public class LogsGetCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<int?>())
+            Arg.Any<int?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Failed to connect to Azure"));
 
         var args = _commandDefinition.Parse([

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupDeleteCommand.cs
@@ -81,7 +81,8 @@ public sealed class ConsumerGroupDeleteCommand(ILogger<ConsumerGroupDeleteComman
                 options.ResourceGroup!,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(deleted, options.ConsumerGroup!, options.EventHub!, options.Namespace!, options.ResourceGroup!), EventHubsJsonContext.Default.ConsumerGroupDeleteCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupGetCommand.cs
@@ -87,7 +87,8 @@ public sealed class ConsumerGroupGetCommand(ILogger<ConsumerGroupGetCommand> log
                     options.ResourceGroup!,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
 
                 var singleResult = consumerGroup != null ? new List<Models.ConsumerGroup> { consumerGroup } : new List<Models.ConsumerGroup>();
                 context.Response.Results = ResponseResult.Create(new(singleResult), EventHubsJsonContext.Default.ConsumerGroupGetCommandResult);
@@ -101,7 +102,8 @@ public sealed class ConsumerGroupGetCommand(ILogger<ConsumerGroupGetCommand> log
                     options.ResourceGroup!,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(consumerGroups ?? []), EventHubsJsonContext.Default.ConsumerGroupGetCommandResult);
             }

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupUpdateCommand.cs
@@ -86,7 +86,8 @@ public sealed class ConsumerGroupUpdateCommand(ILogger<ConsumerGroupUpdateComman
                 options.Subscription!,
                 options.UserMetadata,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(consumerGroup), EventHubsJsonContext.Default.ConsumerGroupUpdateCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubDeleteCommand.cs
@@ -80,7 +80,8 @@ public sealed class EventHubDeleteCommand(ILogger<EventHubDeleteCommand> logger,
                 options.ResourceGroup!,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(
                 new(deleted, options.EventHub!),

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubGetCommand.cs
@@ -85,7 +85,8 @@ public sealed class EventHubGetCommand(ILogger<EventHubGetCommand> logger, IEven
                     options.ResourceGroup!,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
 
                 var results = eventHub != null ? new List<Models.EventHub> { eventHub } : new List<Models.EventHub>();
                 context.Response.Results = ResponseResult.Create(new(results), EventHubsJsonContext.Default.EventHubGetCommandResult);
@@ -97,7 +98,8 @@ public sealed class EventHubGetCommand(ILogger<EventHubGetCommand> logger, IEven
                     options.ResourceGroup!,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(eventHubs ?? []), EventHubsJsonContext.Default.EventHubGetCommandResult);
             }

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubUpdateCommand.cs
@@ -91,7 +91,8 @@ public sealed class EventHubUpdateCommand(ILogger<EventHubUpdateCommand> logger,
                 options.PartitionCount,
                 options.MessageRetentionInHours,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(
                 new(eventHub),

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceDeleteCommand.cs
@@ -81,7 +81,8 @@ public sealed class NamespaceDeleteCommand(ILogger<NamespaceDeleteCommand> logge
                 options.ResourceGroup!,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(
                 new(success, $"Namespace '{options.Namespace}' deleted successfully"),

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceGetCommand.cs
@@ -98,7 +98,8 @@ public sealed class NamespaceGetCommand(ILogger<NamespaceGetCommand> logger)
                     options.ResourceGroup!,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
 
                 context.Response.Results = namespaceDetails != null
                     ? ResponseResult.Create(new(namespaceDetails), EventHubsJsonContext.Default.NamespaceGetCommandResult)
@@ -110,7 +111,8 @@ public sealed class NamespaceGetCommand(ILogger<NamespaceGetCommand> logger)
                     options.ResourceGroup,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(namespaces ?? []), EventHubsJsonContext.Default.NamespacesGetCommandResult);
             }

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceUpdateCommand.cs
@@ -160,7 +160,8 @@ public sealed class NamespaceUpdateCommand(ILogger<NamespaceUpdateCommand> logge
                 options.ZoneRedundant,
                 tags,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(
                 new NamespaceUpdateCommandResult(updatedNamespace),

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/IEventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/IEventHubsService.cs
@@ -12,14 +12,16 @@ public interface IEventHubsService
         string? resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<Namespace> GetNamespaceAsync(
         string namespaceName,
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<Namespace> CreateOrUpdateNamespaceAsync(
         string namespaceName,
@@ -35,21 +37,24 @@ public interface IEventHubsService
         bool? zoneRedundant = null,
         Dictionary<string, string>? tags = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<bool> DeleteNamespaceAsync(
         string namespaceName,
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<EventHub>> GetEventHubsAsync(
         string namespaceName,
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<EventHub?> GetEventHubAsync(
         string eventHubName,
@@ -57,7 +62,8 @@ public interface IEventHubsService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<EventHub> CreateOrUpdateEventHubAsync(
         string eventHubName,
@@ -67,7 +73,8 @@ public interface IEventHubsService
         int? partitionCount = null,
         long? messageRetentionInHours = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<bool> DeleteEventHubAsync(
         string eventHubName,
@@ -75,7 +82,8 @@ public interface IEventHubsService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<ConsumerGroup> CreateOrUpdateConsumerGroupAsync(
         string consumerGroupName,
@@ -85,7 +93,8 @@ public interface IEventHubsService
         string subscription,
         string? userMetadata = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<bool> DeleteConsumerGroupAsync(
         string consumerGroupName,
@@ -94,7 +103,8 @@ public interface IEventHubsService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<ConsumerGroup>> GetConsumerGroupsAsync(
         string eventHubName,
@@ -102,7 +112,8 @@ public interface IEventHubsService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<ConsumerGroup?> GetConsumerGroupAsync(
         string consumerGroupName,
@@ -111,5 +122,6 @@ public interface IEventHubsService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/ConsumerGroup/ConsumerGroupDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/ConsumerGroup/ConsumerGroupDeleteCommandTests.cs
@@ -54,7 +54,8 @@ public class ConsumerGroupDeleteCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(true);
         }
 
@@ -87,7 +88,8 @@ public class ConsumerGroupDeleteCommandTests
             "test-rg",
             "test-subscription",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         // Act
@@ -104,7 +106,8 @@ public class ConsumerGroupDeleteCommandTests
             "test-rg",
             "test-subscription",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -120,7 +123,8 @@ public class ConsumerGroupDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Consumer group 'test-consumer-group' could not be found"));
 
         // Act
@@ -144,7 +148,8 @@ public class ConsumerGroupDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("The current user does not have access to subscription 'unauthorized-sub'"));
 
         // Act
@@ -174,7 +179,8 @@ public class ConsumerGroupDeleteCommandTests
             resourceGroup,
             subscriptionId,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         // Act
@@ -190,6 +196,7 @@ public class ConsumerGroupDeleteCommandTests
             resourceGroup,
             subscriptionId,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/ConsumerGroup/ConsumerGroupGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/ConsumerGroup/ConsumerGroupGetCommandTests.cs
@@ -61,7 +61,8 @@ public class ConsumerGroupGetCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(consumerGroups);
 
             _eventHubsService.GetConsumerGroupAsync(
@@ -71,7 +72,8 @@ public class ConsumerGroupGetCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(consumerGroups.First());
         }
 
@@ -109,7 +111,8 @@ public class ConsumerGroupGetCommandTests
             "test-rg",
             "test-subscription",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedConsumerGroups);
 
         // Act
@@ -125,7 +128,8 @@ public class ConsumerGroupGetCommandTests
             "test-rg",
             "test-subscription",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -152,7 +156,8 @@ public class ConsumerGroupGetCommandTests
             "test-rg",
             "test-subscription",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedConsumerGroup);
 
         // Act
@@ -169,7 +174,8 @@ public class ConsumerGroupGetCommandTests
             "test-rg",
             "test-subscription",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -185,7 +191,8 @@ public class ConsumerGroupGetCommandTests
             "test-rg",
             "test-subscription",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns((Models.ConsumerGroup?)null);
 
         // Act
@@ -208,7 +215,8 @@ public class ConsumerGroupGetCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Event Hub 'test-eventhub' could not be found"));
 
         // Act
@@ -232,7 +240,8 @@ public class ConsumerGroupGetCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("The current user does not have access to subscription 'unauthorized-sub'"));
 
         // Act

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/ConsumerGroup/ConsumerGroupUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/ConsumerGroup/ConsumerGroupUpdateCommandTests.cs
@@ -68,7 +68,8 @@ public class ConsumerGroupUpdateCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(consumerGroup);
         }
 
@@ -113,7 +114,8 @@ public class ConsumerGroupUpdateCommandTests
             "test-subscription",
             "custom-metadata",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedConsumerGroup);
 
         // Act
@@ -131,7 +133,8 @@ public class ConsumerGroupUpdateCommandTests
             "test-subscription",
             "custom-metadata",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -159,7 +162,8 @@ public class ConsumerGroupUpdateCommandTests
             "test-subscription",
             null,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedConsumerGroup);
 
         // Act
@@ -177,7 +181,8 @@ public class ConsumerGroupUpdateCommandTests
             "test-subscription",
             null,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -194,7 +199,8 @@ public class ConsumerGroupUpdateCommandTests
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Event Hub 'test-eventhub' could not be found"));
 
         // Act
@@ -219,7 +225,8 @@ public class ConsumerGroupUpdateCommandTests
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("The current user does not have access to subscription 'unauthorized-sub'"));
 
         // Act

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/EventHub/EventHubDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/EventHub/EventHubDeleteCommandTests.cs
@@ -51,7 +51,8 @@ public class EventHubDeleteCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(true);
         }
 
@@ -84,7 +85,8 @@ public class EventHubDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Namespace 'test-namespace' not found in resource group 'test-rg'"));
 
         // Act
@@ -108,7 +110,8 @@ public class EventHubDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Authentication failed"));
 
         // Act
@@ -132,7 +135,8 @@ public class EventHubDeleteCommandTests
             Arg.Is("test-rg"),
             Arg.Is("test-subscription"),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         // Act
@@ -156,7 +160,8 @@ public class EventHubDeleteCommandTests
             Arg.Is("test-rg"),
             Arg.Is("test-subscription"),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(false);
 
         // Act

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/EventHub/EventHubUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/EventHub/EventHubUpdateCommandTests.cs
@@ -68,7 +68,8 @@ public class EventHubUpdateCommandTests
                 Arg.Any<int?>(),
                 Arg.Any<long?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(eventHub);
         }
 
@@ -103,7 +104,8 @@ public class EventHubUpdateCommandTests
             Arg.Any<int?>(),
             Arg.Any<long?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Namespace 'test-namespace' not found in resource group 'test-rg'"));
 
         // Act
@@ -129,7 +131,8 @@ public class EventHubUpdateCommandTests
             Arg.Any<int?>(),
             Arg.Any<long?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Authentication failed"));
 
         // Act
@@ -167,7 +170,8 @@ public class EventHubUpdateCommandTests
             Arg.Is(8),
             Arg.Is(336L),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(eventHub);
 
         // Act

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceDeleteCommandTests.cs
@@ -70,7 +70,8 @@ public class NamespaceDeleteCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(true);
         }
 
@@ -109,7 +110,8 @@ public class NamespaceDeleteCommandTests
             "test-rg",
             "test-sub",
             null,
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         // Act
@@ -123,7 +125,8 @@ public class NamespaceDeleteCommandTests
             "test-rg",
             "test-sub",
             null,
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -142,7 +145,8 @@ public class NamespaceDeleteCommandTests
             "test-rg",
             "test-sub",
             "test-tenant-123",
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         // Act
@@ -156,7 +160,8 @@ public class NamespaceDeleteCommandTests
             "test-rg",
             "test-sub",
             "test-tenant-123",
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -174,7 +179,8 @@ public class NamespaceDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new KeyNotFoundException("Namespace not found"));
 
         // Act
@@ -200,7 +206,8 @@ public class NamespaceDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
         // Act
@@ -227,7 +234,8 @@ public class NamespaceDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(conflictException);
 
         // Act
@@ -254,7 +262,8 @@ public class NamespaceDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Identity.AuthenticationFailedException("Authentication failed"));
 
         // Act
@@ -282,7 +291,8 @@ public class NamespaceDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
         // Act
@@ -308,7 +318,8 @@ public class NamespaceDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
         // Act
@@ -334,7 +345,8 @@ public class NamespaceDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         // Act
@@ -393,7 +405,8 @@ public class NamespaceDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         // Act
@@ -406,7 +419,8 @@ public class NamespaceDeleteCommandTests
             resourceGroup,
             subscription,
             tenant,
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -424,7 +438,8 @@ public class NamespaceDeleteCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         // Act
@@ -437,6 +452,7 @@ public class NamespaceDeleteCommandTests
             "test-rg",
             "test-sub",
             null, // tenant should be null
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceGetCommandTests.cs
@@ -72,7 +72,13 @@ public class NamespaceGetCommandTests
                     true,
                     new Dictionary<string, string> { { "env", "prod" } });
 
-                _eventHubsService.GetNamespaceAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+                _eventHubsService.GetNamespaceAsync(
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    Arg.Any<string?>(),
+                    Arg.Any<RetryPolicyOptions?>(),
+                    Arg.Any<CancellationToken>())
                     .Returns(namespaceDetails);
             }
             else
@@ -101,7 +107,8 @@ public class NamespaceGetCommandTests
                     Arg.Any<string>(),
                     Arg.Any<string>(),
                     Arg.Any<string?>(),
-                    Arg.Any<RetryPolicyOptions?>())
+                    Arg.Any<RetryPolicyOptions?>(),
+                    Arg.Any<CancellationToken>())
                     .Returns(namespaces);
             }
         }
@@ -132,7 +139,8 @@ public class NamespaceGetCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Resource Group 'rg-eventhubs-test' could not be found"));
 
         // Act
@@ -152,7 +160,8 @@ public class NamespaceGetCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("The current user does not have access to subscription 'unauthorized-sub'"));
 
         // Act

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceUpdateCommandTests.cs
@@ -88,7 +88,8 @@ public class NamespaceUpdateCommandTests
                 Arg.Any<bool?>(),
                 Arg.Any<Dictionary<string, string>?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(updatedNamespace);
         }
 
@@ -140,7 +141,8 @@ public class NamespaceUpdateCommandTests
             null, // zoneRedundant
             null, // tags
             null, // tenant
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(updatedNamespace);
 
         // Act
@@ -163,7 +165,8 @@ public class NamespaceUpdateCommandTests
             null,
             null,
             null,
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -193,7 +196,8 @@ public class NamespaceUpdateCommandTests
             Arg.Any<bool?>(),
             Arg.Any<Dictionary<string, string>?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(updatedNamespace);
 
         // Act
@@ -241,7 +245,8 @@ public class NamespaceUpdateCommandTests
                 tags.ContainsKey("team") &&
                 tags["team"] == "platform"),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(updatedNamespace);
 
         // Act
@@ -304,7 +309,8 @@ public class NamespaceUpdateCommandTests
             true,
             Arg.Any<Dictionary<string, string>?>(),
             null,
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(updatedNamespace);
 
         // Act
@@ -327,7 +333,8 @@ public class NamespaceUpdateCommandTests
             true,
             Arg.Any<Dictionary<string, string>?>(),
             null,
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -355,7 +362,8 @@ public class NamespaceUpdateCommandTests
             Arg.Any<bool?>(),
             Arg.Any<Dictionary<string, string>?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Update failed"));
 
         // Act
@@ -391,7 +399,8 @@ public class NamespaceUpdateCommandTests
             Arg.Any<bool?>(),
             Arg.Any<Dictionary<string, string>?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new KeyNotFoundException("Namespace not found"));
 
         // Act
@@ -429,7 +438,8 @@ public class NamespaceUpdateCommandTests
             Arg.Any<bool?>(),
             Arg.Any<Dictionary<string, string>?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(updatedNamespace);
 
         // Act
@@ -451,7 +461,8 @@ public class NamespaceUpdateCommandTests
             null,
             null,
             "test-tenant-123",
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.Extension/src/Commands/AzqrCommand.cs
+++ b/tools/Azure.Mcp.Tools.Extension/src/Commands/AzqrCommand.cs
@@ -103,7 +103,7 @@ public sealed class AzqrCommand(ILogger<AzqrCommand> logger, int processTimeoutS
             command += " --json";
 
             var processService = context.GetService<IExternalProcessService>();
-            var result = await processService.ExecuteAsync(azqrPath, command, _processTimeoutSeconds);
+            var result = await processService.ExecuteAsync(azqrPath, command, _processTimeoutSeconds, cancellationToken: cancellationToken);
 
             if (result.ExitCode != 0)
             {

--- a/tools/Azure.Mcp.Tools.Extension/src/Commands/CliInstallCommand.cs
+++ b/tools/Azure.Mcp.Tools.Extension/src/Commands/CliInstallCommand.cs
@@ -82,7 +82,7 @@ This tool can provide installation instructions for the specified CLI tool among
             // Only log the cli type when we know for sure it doesn't have private data.
             context.Activity?.AddTag("cliType", cliType);
 
-            using HttpResponseMessage responseMessage = await cliInstallService.GetCliInstallInstructions(cliType);
+            using HttpResponseMessage responseMessage = await cliInstallService.GetCliInstallInstructions(cliType, cancellationToken);
             responseMessage.EnsureSuccessStatusCode();
 
             var responseBody = await responseMessage.Content.ReadAsStringAsync(cancellationToken);

--- a/tools/Azure.Mcp.Tools.Extension/src/Services/CliInstallService.cs
+++ b/tools/Azure.Mcp.Tools.Extension/src/Services/CliInstallService.cs
@@ -10,7 +10,7 @@ internal class CliInstallService(IHttpClientService httpClientService) : ICliIns
 {
     private readonly IHttpClientService _httpClientService = httpClientService;
 
-    public async Task<HttpResponseMessage> GetCliInstallInstructions(string cliType)
+    public async Task<HttpResponseMessage> GetCliInstallInstructions(string cliType, CancellationToken cancellationToken)
     {
         string osStr;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -53,7 +53,7 @@ internal class CliInstallService(IHttpClientService httpClientService) : ICliIns
             Method = HttpMethod.Get,
             RequestUri = new Uri(instructionsUrl)
         };
-        HttpResponseMessage responseMessage = await _httpClientService.DefaultClient.SendAsync(requestMessage);
+        HttpResponseMessage responseMessage = await _httpClientService.DefaultClient.SendAsync(requestMessage, cancellationToken);
         return responseMessage;
     }
 }

--- a/tools/Azure.Mcp.Tools.Extension/src/Services/ICliInstallService.cs
+++ b/tools/Azure.Mcp.Tools.Extension/src/Services/ICliInstallService.cs
@@ -5,5 +5,5 @@ namespace Azure.Mcp.Tools.Extension.Services;
 
 public interface ICliInstallService
 {
-    public Task<HttpResponseMessage> GetCliInstallInstructions(string cliType);
+    public Task<HttpResponseMessage> GetCliInstallInstructions(string cliType, CancellationToken cancellationToken);
 }

--- a/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.UnitTests/AzqrCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.UnitTests/AzqrCommandTests.cs
@@ -74,7 +74,8 @@ public sealed class AzqrCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<int>(),
-            Arg.Any<IEnumerable<string>>())
+            Arg.Any<IEnumerable<string>>(),
+            Arg.Any<CancellationToken>())
             .Returns(new ProcessResult(0, expectedOutput, string.Empty, $"scan --subscription-id {mockSubscriptionId}"));
 
         try
@@ -90,7 +91,8 @@ public sealed class AzqrCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<int>(),
-                Arg.Any<IEnumerable<string>>());
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<CancellationToken>());
         }
         finally
         {

--- a/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.UnitTests/CliInstallCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.UnitTests/CliInstallCommandTests.cs
@@ -61,7 +61,7 @@ public sealed class CliInstallCommandTests
         // Arrange
         if (shouldSucceed)
         {
-            _cliInstallService.GetCliInstallInstructions(Arg.Any<string>())
+            _cliInstallService.GetCliInstallInstructions(Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent("Instructions")
@@ -87,7 +87,7 @@ public sealed class CliInstallCommandTests
     public async Task ExecuteAsync_DeserializationValidation()
     {
         // Arrange
-        _cliInstallService.GetCliInstallInstructions(Arg.Any<string>())
+        _cliInstallService.GetCliInstallInstructions(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent("Instructions")
@@ -114,7 +114,7 @@ public sealed class CliInstallCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _cliInstallService.GetCliInstallInstructions(Arg.Any<string>()).ThrowsAsync(new Exception("Test error"));
+        _cliInstallService.GetCliInstallInstructions(Arg.Any<string>(), Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test error"));
 
         var parseResult = _commandDefinition.Parse("--cli-type az");
 

--- a/tools/Azure.Mcp.Tools.Foundry/src/Services/FoundryService.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/src/Services/FoundryService.cs
@@ -422,7 +422,7 @@ public class FoundryService(
         }
 
         // Create Azure OpenAI client with flexible authentication
-        AzureOpenAIClient client = await CreateOpenAIClientWithAuth(endpoint, resourceName, cognitiveServicesAccount.Value, authMethod, tenant);
+        AzureOpenAIClient client = await CreateOpenAIClientWithAuth(endpoint, resourceName, cognitiveServicesAccount.Value, authMethod, tenant, cancellationToken);
 
         var chatClient = client.GetChatClient(deploymentName);
 
@@ -500,7 +500,7 @@ public class FoundryService(
         }
 
         // Create Azure OpenAI client with flexible authentication
-        AzureOpenAIClient client = await CreateOpenAIClientWithAuth(endpoint, resourceName, cognitiveServicesAccount.Value, authMethod, tenant);
+        AzureOpenAIClient client = await CreateOpenAIClientWithAuth(endpoint, resourceName, cognitiveServicesAccount.Value, authMethod, tenant, cancellationToken);
 
         var embeddingClient = client.GetEmbeddingClient(deploymentName);
 
@@ -651,7 +651,7 @@ public class FoundryService(
         }
 
         // Create Azure OpenAI client with flexible authentication
-        AzureOpenAIClient client = await CreateOpenAIClientWithAuth(endpoint, resourceName, cognitiveServicesAccount.Value, authMethod, tenant);
+        AzureOpenAIClient client = await CreateOpenAIClientWithAuth(endpoint, resourceName, cognitiveServicesAccount.Value, authMethod, tenant, cancellationToken);
 
         var chatClient = client.GetChatClient(deploymentName);
 
@@ -766,7 +766,8 @@ public class FoundryService(
         string resourceName,
         CognitiveServicesAccountResource cognitiveServicesAccount,
         AuthMethod authMethod,
-        string? tenant = null)
+        string? tenant = null,
+        CancellationToken cancellationToken = default)
     {
         AzureOpenAIClient client;
 
@@ -774,7 +775,7 @@ public class FoundryService(
         {
             case AuthMethod.Key:
                 // Get the access key
-                var keys = await cognitiveServicesAccount.GetKeysAsync();
+                var keys = await cognitiveServicesAccount.GetKeysAsync(cancellationToken);
                 var key = keys.Value.Key1;
 
                 if (string.IsNullOrEmpty(key))
@@ -787,7 +788,7 @@ public class FoundryService(
 
             case AuthMethod.Credential:
             default:
-                var credential = await GetCredential(tenant);
+                var credential = await GetCredential(cancellationToken);
                 client = new AzureOpenAIClient(new Uri(endpoint), credential);
                 break;
         }

--- a/tools/Azure.Mcp.Tools.FunctionApp/src/Commands/FunctionApp/FunctionAppGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/src/Commands/FunctionApp/FunctionAppGetCommand.cs
@@ -80,7 +80,8 @@ public sealed class FunctionAppGetCommand(ILogger<FunctionAppGetCommand> logger)
                 options.FunctionAppName!,
                 options.ResourceGroup!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(functionApps ?? []), FunctionAppJsonContext.Default.FunctionAppGetCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.FunctionApp/src/Services/IFunctionAppService.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/src/Services/IFunctionAppService.cs
@@ -12,5 +12,6 @@ public interface IFunctionAppService
         string? functionAppName,
         string? resourceGroup,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.FunctionApp/tests/Azure.Mcp.Tools.FunctionApp.UnitTests/FunctionApp/FunctionAppGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/tests/Azure.Mcp.Tools.FunctionApp.UnitTests/FunctionApp/FunctionAppGetCommandTests.cs
@@ -54,7 +54,8 @@ public sealed class FunctionAppGetCommandTests
                 Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
                 Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(testFunctionApps);
         }
 
@@ -91,7 +92,8 @@ public sealed class FunctionAppGetCommandTests
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedFunctionApps);
 
         var context = new CommandContext(_serviceProvider);
@@ -110,7 +112,8 @@ public sealed class FunctionAppGetCommandTests
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
 
         var json = JsonSerializer.Serialize(response.Results);
 
@@ -135,7 +138,8 @@ public sealed class FunctionAppGetCommandTests
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         var context = new CommandContext(_serviceProvider);
@@ -159,7 +163,13 @@ public sealed class FunctionAppGetCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _service.GetFunctionApp(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+        _service.GetFunctionApp(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<List<FunctionAppInfo>?>(new Exception("Test error")));
 
         var context = new CommandContext(_serviceProvider);
@@ -191,7 +201,13 @@ public sealed class FunctionAppGetCommandTests
     {
         if (shouldSucceed)
         {
-            _service.GetFunctionApp(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+            _service.GetFunctionApp(
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns([new FunctionAppInfo("app1", "rg1", "eastus", "plan1", "Running", "app1.azurewebsites.net", null)]);
         }
 
@@ -207,7 +223,13 @@ public sealed class FunctionAppGetCommandTests
     public async Task ExecuteAsync_ReturnsFunctionApp()
     {
         var expected = new FunctionAppInfo("app1", "rg1", "eastus", "plan1", "Running", "app1.azurewebsites.net", null);
-        _service.GetFunctionApp(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+        _service.GetFunctionApp(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns([expected]);
 
         var context = new CommandContext(_serviceProvider);
@@ -228,7 +250,13 @@ public sealed class FunctionAppGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsEmptyWhenNotFound()
     {
-        _service.GetFunctionApp(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+        _service.GetFunctionApp(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns((List<FunctionAppInfo>?)null);
 
         var context = new CommandContext(_serviceProvider);

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTest/TestCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTest/TestCreateCommand.cs
@@ -90,7 +90,8 @@ public sealed class TestCreateCommand(ILogger<TestCreateCommand> logger)
                 options.RampUpTime,
                 options.Endpoint,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             // Set results if any were returned
             context.Response.Results = results != null ?

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTest/TestGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTest/TestGetCommand.cs
@@ -70,7 +70,8 @@ public sealed class TestGetCommand(ILogger<TestGetCommand> logger)
                 options.TestId!,
                 options.ResourceGroup,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             // Set results if any were returned
             context.Response.Results = results != null ?

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestResource/TestResourceCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestResource/TestResourceCreateCommand.cs
@@ -53,7 +53,8 @@ public sealed class TestResourceCreateCommand(ILogger<TestResourceCreateCommand>
                 options.ResourceGroup!,
                 options.TestResourceName!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
             // Set results if any were returned
             context.Response.Results = results != null ?
                 ResponseResult.Create(new(results), LoadTestJsonContext.Default.TestResourceCreateCommandResult) :

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestResource/TestResourceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestResource/TestResourceListCommand.cs
@@ -52,7 +52,8 @@ public sealed class TestResourceListCommand(ILogger<TestResourceListCommand> log
                 options.ResourceGroup,
                 options.TestResourceName,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
             // Set results if any were returned
             context.Response.Results = ResponseResult.Create(new(results ?? []), LoadTestJsonContext.Default.TestResourceListCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestRun/TestRunCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestRun/TestRunCreateCommand.cs
@@ -80,7 +80,8 @@ public sealed class TestRunCreateCommand(ILogger<TestRunCreateCommand> logger)
                 options.DisplayName,
                 options.Description,
                 false, // DebugMode false will default to a normal test run - in future we may add a DebugMode option
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
             // Set results if any were returned
             context.Response.Results = results != null ?
                 ResponseResult.Create(new(results), LoadTestJsonContext.Default.TestRunCreateCommandResult) :

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestRun/TestRunGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestRun/TestRunGetCommand.cs
@@ -69,7 +69,8 @@ public sealed class TestRunGetCommand(ILogger<TestRunGetCommand> logger)
                 options.TestRunId!,
                 options.ResourceGroup,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
             // Set results if any were returned
             context.Response.Results = results != null ?
                 ResponseResult.Create(new(results), LoadTestJsonContext.Default.TestRunGetCommandResult) :

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestRun/TestRunListCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestRun/TestRunListCommand.cs
@@ -68,7 +68,8 @@ public sealed class TestRunListCommand(ILogger<TestRunListCommand> logger)
                 options.TestId!,
                 options.ResourceGroup,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
             // Set results if any were returned
             context.Response.Results = ResponseResult.Create(new(results ?? []), LoadTestJsonContext.Default.TestRunListCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestRun/TestRunUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestRun/TestRunUpdateCommand.cs
@@ -81,7 +81,8 @@ public sealed class TestRunUpdateCommand(ILogger<TestRunUpdateCommand> logger)
                 options.DisplayName,
                 options.Description,
                 false, // DebugMode false will default to a normal test run - in future we may add a DebugMode option
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
             // Set results if any were returned
             context.Response.Results = results != null ?
                 ResponseResult.Create(new(results), LoadTestJsonContext.Default.TestRunUpdateCommandResult) :

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Services/ILoadTestingService.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Services/ILoadTestingService.cs
@@ -9,13 +9,75 @@ namespace Azure.Mcp.Tools.LoadTesting.Services;
 
 public interface ILoadTestingService
 {
-    Task<TestResource> CreateOrUpdateLoadTestingResourceAsync(string subscription, string resourceGroup, string? testResourceName = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
-    Task<List<TestResource>> GetLoadTestResourcesAsync(string subscription, string? resourceGroup = null, string? testResourceName = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
-    Task<TestRun> GetLoadTestRunAsync(string subscription, string testResourceName, string testRunId, string? resourceGroup = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
-    Task<TestRun> CreateOrUpdateLoadTestRunAsync(string subscription, string testResourceName, string testId, string? testRunId = null, string? oldTestRunId = null, string? resourceGroup = null, string? tenant = null, string? displayName = null, string? description = null, bool? debugMode = false, RetryPolicyOptions? retryPolicy = null);
-    Task<List<TestRun>> GetLoadTestRunsFromTestIdAsync(string subscription, string testResourceName, string testId, string? resourceGroup = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
-    Task<Test> GetTestAsync(string subscription, string testResourceName, string testId, string? resourceGroup = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
-    Task<Test> CreateTestAsync(string subscription, string testResourceName, string testId, string? resourceGroup = null,
-        string? displayName = null, string? description = null,
-        int? duration = 20, int? virtualUsers = 50, int? rampUpTime = 1, string? endpointUrl = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
+    Task<TestResource> CreateOrUpdateLoadTestingResourceAsync(
+        string subscription,
+        string resourceGroup,
+        string? testResourceName = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<List<TestResource>> GetLoadTestResourcesAsync(
+        string subscription,
+        string? resourceGroup = null,
+        string? testResourceName = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<TestRun> GetLoadTestRunAsync(
+        string subscription,
+        string testResourceName,
+        string testRunId,
+        string? resourceGroup = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<TestRun> CreateOrUpdateLoadTestRunAsync(
+        string subscription,
+        string testResourceName,
+        string testId,
+        string? testRunId = null,
+        string? oldTestRunId = null,
+        string? resourceGroup = null,
+        string? tenant = null,
+        string? displayName = null,
+        string? description = null,
+        bool? debugMode = false,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<List<TestRun>> GetLoadTestRunsFromTestIdAsync(
+        string subscription,
+        string testResourceName,
+        string testId,
+        string? resourceGroup = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<Test> GetTestAsync(
+        string subscription,
+        string testResourceName,
+        string testId,
+        string? resourceGroup = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<Test> CreateTestAsync(
+        string subscription,
+        string testResourceName,
+        string testId,
+        string? resourceGroup = null,
+        string? displayName = null,
+        string? description = null,
+        int? duration = 20,
+        int? virtualUsers = 50,
+        int? rampUpTime = 1,
+        string? endpointUrl = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestCreateCommandTests.cs
@@ -51,7 +51,8 @@ public class TestCreateCommandTests
             Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId1"), Arg.Is("resourceGroup123"),
             Arg.Is("TestDisplayName"), Arg.Is("TestDescription"),
             Arg.Is((int?)20), Arg.Is((int?)50), Arg.Is((int?)1), Arg.Is("https://example.com/api/test"),
-            Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var command = new TestCreateCommand(_logger);
@@ -95,7 +96,8 @@ public class TestCreateCommandTests
             Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId1"), Arg.Is("resourceGroup123"),
             Arg.Is("TestDisplayName"), Arg.Is("TestDescription"),
             Arg.Is((int?)20), Arg.Is((int?)50), Arg.Is((int?)1), Arg.Is((string?)null),
-            Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var command = new TestCreateCommand(_logger);
@@ -116,7 +118,8 @@ public class TestCreateCommandTests
             Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId1"), Arg.Is("resourceGroup123"),
             Arg.Is("TestDisplayName"), Arg.Is("TestDescription"),
             Arg.Is((int?)20), Arg.Is((int?)50), Arg.Is((int?)1), Arg.Is("https://example.com/api/test"),
-            Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<Test>(new Exception("Test error")));
 
         var command = new TestCreateCommand(_logger);

--- a/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestGetCommandTests.cs
@@ -49,7 +49,13 @@ public class TestGetCommandTests
     {
         var expected = new Test { TestId = "testId1", DisplayName = "TestDisplayName", Description = "TestDescription" };
         _service.GetTestAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId1"), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("testId1"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var command = new TestGetCommand(_logger);
@@ -80,7 +86,13 @@ public class TestGetCommandTests
     {
         var expected = new Test();
         _service.GetTestAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId1"), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("testId1"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var command = new TestGetCommand(_logger);
@@ -99,7 +111,13 @@ public class TestGetCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         _service.GetTestAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId1"), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("testId1"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<Test>(new Exception("Test error")));
 
         var command = new TestGetCommand(_logger);

--- a/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestResourceCreateTests.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestResourceCreateTests.cs
@@ -48,7 +48,13 @@ public class TestResourceCreateCommandTests
     public async Task ExecuteAsync_CreateLoadTests()
     {
         var expectedLoadTests = new TestResource { Id = "Id1", Name = "loadTest1" };
-        _service.CreateOrUpdateLoadTestingResourceAsync(Arg.Is("sub123"), Arg.Is("resourceGroup123"), Arg.Is("testResourceName"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+        _service.CreateOrUpdateLoadTestingResourceAsync(
+            Arg.Is("sub123"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedLoadTests);
 
         var command = new TestResourceCreateCommand(_logger);
@@ -76,7 +82,13 @@ public class TestResourceCreateCommandTests
     public async Task ExecuteAsync_CreateLoadTests_FromDefaultResource()
     {
         var expectedLoadTests = new TestResource { Id = "Id1", Name = "loadTest1" };
-        _service.CreateOrUpdateLoadTestingResourceAsync(Arg.Is("sub123"), Arg.Is("resourceGroup123"), Arg.Is((string?)null), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+        _service.CreateOrUpdateLoadTestingResourceAsync(
+            Arg.Is("sub123"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is((string?)null),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedLoadTests);
 
         var command = new TestResourceCreateCommand(_logger);
@@ -101,7 +113,13 @@ public class TestResourceCreateCommandTests
     [Fact]
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
-        _service.CreateOrUpdateLoadTestingResourceAsync(Arg.Is("sub123"), Arg.Is("resourceGroup123"), Arg.Is("loadTestName"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+        _service.CreateOrUpdateLoadTestingResourceAsync(
+            Arg.Is("sub123"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("loadTestName"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<TestResource>(new Exception("Test error")));
 
         var context = new CommandContext(_serviceProvider);

--- a/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestResourcesListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestResourcesListCommandTests.cs
@@ -48,7 +48,13 @@ public class TestResourceListCommandTests
     public async Task ExecuteAsync_ReturnsLoadTests_FromResourceGroup()
     {
         var expectedLoadTests = new List<TestResource> { new() { Id = "Id1", Name = "loadTest1" }, new() { Id = "Id2", Name = "loadTest2" } };
-        _service.GetLoadTestResourcesAsync(Arg.Is("sub123"), Arg.Is("resourceGroup123"), Arg.Is((string?)null), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+        _service.GetLoadTestResourcesAsync(
+            Arg.Is("sub123"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is((string?)null),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedLoadTests);
 
         var command = new TestResourceListCommand(_logger);
@@ -77,7 +83,13 @@ public class TestResourceListCommandTests
     public async Task ExecuteAsync_ReturnsLoadTests_FromTestResource()
     {
         var expectedLoadTests = new List<TestResource> { new() { Id = "Id1", Name = "loadTest1" } };
-        _service.GetLoadTestResourcesAsync(Arg.Is("sub123"), Arg.Is("resourceGroup123"), Arg.Is("testResourceName"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+        _service.GetLoadTestResourcesAsync(
+            Arg.Is("sub123"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedLoadTests);
 
         var command = new TestResourceListCommand(_logger);
@@ -104,7 +116,13 @@ public class TestResourceListCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsLoadTests_WhenLoadTestsNotExist()
     {
-        _service.GetLoadTestResourcesAsync(Arg.Is("sub123"), Arg.Is("resourceGroup123"), Arg.Is("loadTestName"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+        _service.GetLoadTestResourcesAsync(
+            Arg.Is("sub123"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("loadTestName"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
              .Returns([]);
 
         var command = new TestResourceListCommand(_logger);
@@ -127,7 +145,13 @@ public class TestResourceListCommandTests
     [Fact]
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
-        _service.GetLoadTestResourcesAsync(Arg.Is("sub123"), Arg.Is("resourceGroup123"), Arg.Is("loadTestName"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+        _service.GetLoadTestResourcesAsync(
+            Arg.Is("sub123"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("loadTestName"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<List<TestResource>>(new Exception("Test error")));
 
         var context = new CommandContext(_serviceProvider);

--- a/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestRunCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestRunCreateCommandTests.cs
@@ -49,7 +49,18 @@ public class TestRunCreateCommandTests
     {
         var expected = new TestRun { TestId = "testId1", TestRunId = "testRunId1", DisplayName = "displayName" };
         _service.CreateOrUpdateLoadTestRunAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId1"), Arg.Is("run1"), Arg.Is((string?)null), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Is("displayName"), Arg.Is((string?)null), Arg.Is(false), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("testId1"),
+            Arg.Is("run1"),
+            Arg.Is((string?)null),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Is("displayName"),
+            Arg.Is((string?)null),
+            Arg.Is(false),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var command = new TestRunCreateCommand(_logger);
@@ -74,7 +85,18 @@ public class TestRunCreateCommandTests
     {
         var expected = new TestRun { TestId = "testId1", TestRunId = "testRunId1" };
         _service.CreateOrUpdateLoadTestRunAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId1"), Arg.Is("run1"), Arg.Is("oldId1"), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Is((string?)null), Arg.Is((string?)null), Arg.Is(false), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("testId1"),
+            Arg.Is("run1"),
+            Arg.Is("oldId1"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Is((string?)null),
+            Arg.Is((string?)null),
+            Arg.Is(false),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var command = new TestRunCreateCommand(_logger);
@@ -99,7 +121,18 @@ public class TestRunCreateCommandTests
     {
         var expected = new TestRun();
         _service.CreateOrUpdateLoadTestRunAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId1"), Arg.Is("run1"), Arg.Is((string?)null), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Is((string?)null), Arg.Is((string?)null), Arg.Is(false), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("testId1"),
+            Arg.Is("run1"),
+            Arg.Is((string?)null),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Is((string?)null),
+            Arg.Is((string?)null),
+            Arg.Is(false),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var command = new TestRunCreateCommand(_logger);
@@ -113,7 +146,18 @@ public class TestRunCreateCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         _service.CreateOrUpdateLoadTestRunAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId1"), Arg.Is("run1"), Arg.Is((string?)null), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Is((string?)null), Arg.Is((string?)null), Arg.Is(false), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("testId1"),
+            Arg.Is("run1"),
+            Arg.Is((string?)null),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Is((string?)null),
+            Arg.Is((string?)null),
+            Arg.Is(false),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<TestRun>(new Exception("Test error")));
 
         var command = new TestRunCreateCommand(_logger);

--- a/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestRunGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestRunGetCommandTests.cs
@@ -49,7 +49,13 @@ public class TestRunGetCommandTests
     {
         var expected = new TestRun { TestId = "testId1", TestRunId = "testRunId1" };
         _service.GetLoadTestRunAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("run1"), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("run1"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var command = new TestRunGetCommand(_logger);
@@ -80,7 +86,13 @@ public class TestRunGetCommandTests
 
         var expected = new TestRun();
         _service.GetLoadTestRunAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("run1"), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("run1"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var command = new TestRunGetCommand(_logger);
@@ -97,7 +109,13 @@ public class TestRunGetCommandTests
     {
 
         _service.GetLoadTestRunAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("run1"), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("run1"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<TestRun>(new Exception("Test error")));
 
         var command = new TestRunGetCommand(_logger);

--- a/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestRunListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestRunListCommandTests.cs
@@ -53,7 +53,13 @@ public class TestRunListCommandTests
             new() { TestId = "testId2", TestRunId = "testRunId2" }
         };
         _service.GetLoadTestRunsFromTestIdAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId"), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("testId"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var command = new TestRunListCommand(_logger);
@@ -85,7 +91,13 @@ public class TestRunListCommandTests
     {
         var expected = new List<TestRun>();
         _service.GetLoadTestRunsFromTestIdAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId"), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("testId"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var command = new TestRunListCommand(_logger);
@@ -104,7 +116,13 @@ public class TestRunListCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         _service.GetLoadTestRunsFromTestIdAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId"), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("testId"),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<List<TestRun>>(new Exception("Test error")));
 
         var command = new TestRunListCommand(_logger);

--- a/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestRunUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.UnitTests/TestRunUpdateCommandTests.cs
@@ -47,7 +47,18 @@ public class TestRunUpdateCommandTests
     {
         var expected = new TestRun { TestId = "testId1", TestRunId = "testRunId1", DisplayName = "displayName" };
         _service.CreateOrUpdateLoadTestRunAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId1"), Arg.Is("run1"), Arg.Is((string?)null), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Is("displayName"), Arg.Is((string?)null), Arg.Is(false), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("testId1"),
+            Arg.Is("run1"),
+            Arg.Is((string?)null),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Is("displayName"),
+            Arg.Is((string?)null),
+            Arg.Is(false),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var command = new TestRunUpdateCommand(_logger);
@@ -71,7 +82,18 @@ public class TestRunUpdateCommandTests
     {
         var expected = new TestRun();
         _service.CreateOrUpdateLoadTestRunAsync(
-            Arg.Is("sub123"), Arg.Is("testResourceName"), Arg.Is("testId1"), Arg.Is("run1"), Arg.Is((string?)null), Arg.Is("resourceGroup123"), Arg.Is("tenant123"), Arg.Is((string?)null), Arg.Is((string?)null), Arg.Is(false), Arg.Any<RetryPolicyOptions>())
+            Arg.Is("sub123"),
+            Arg.Is("testResourceName"),
+            Arg.Is("testId1"),
+            Arg.Is("run1"),
+            Arg.Is((string?)null),
+            Arg.Is("resourceGroup123"),
+            Arg.Is("tenant123"),
+            Arg.Is((string?)null),
+            Arg.Is((string?)null),
+            Arg.Is(false),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var command = new TestRunUpdateCommand(_logger);

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemCreateCommand.cs
@@ -133,7 +133,8 @@ public sealed class FileSystemCreateCommand(ILogger<FileSystemCreateCommand> log
                 options.SourceVaultId,
                 options.UserAssignedIdentityId,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(fs), ManagedLustreJsonContext.Default.FileSystemCreateResult);
         }

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemListCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemListCommand.cs
@@ -66,7 +66,8 @@ public sealed class FileSystemListCommand(ILogger<FileSystemListCommand> logger)
                 options.Subscription!,
                 options.ResourceGroup,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(fileSystems ?? []), ManagedLustreJsonContext.Default.FileSystemListResult);
         }

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemUpdateCommand.cs
@@ -94,7 +94,8 @@ public sealed class FileSystemUpdateCommand(ILogger<FileSystemUpdateCommand> log
                 options.SquashUid,
                 options.SquashGid,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new FileSystemUpdateResult(fs), ManagedLustreJsonContext.Default.FileSystemUpdateResult);
         }

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/Sku/SkuGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/Sku/SkuGetCommand.cs
@@ -59,7 +59,7 @@ public sealed class SkuGetCommand(ILogger<SkuGetCommand> logger)
 
             var options = BindOptions(parseResult);
             var service = context.GetService<IManagedLustreService>();
-            var skus = await service.SkuGetInfoAsync(options.Subscription!, options.Tenant, options.Location, options.RetryPolicy);
+            var skus = await service.SkuGetInfoAsync(options.Subscription!, options.Tenant, options.Location, options.RetryPolicy, cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(skus ?? []), ManagedLustreJsonContext.Default.SkuGetResult);
         }

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/SubnetSize/SubnetSizeAskCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/SubnetSize/SubnetSizeAskCommand.cs
@@ -81,8 +81,8 @@ public sealed class SubnetSizeAskCommand(ILogger<SubnetSizeAskCommand> logger)
                 options.Subscription!,
                 options.Sku!, options.Size,
                 options.Tenant,
-                options.RetryPolicy
-                );
+                options.RetryPolicy,
+                cancellationToken);
             context.Response.Results = ResponseResult.Create(new(result), ManagedLustreJsonContext.Default.FileSystemSubnetSizeResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/SubnetSize/SubnetSizeValidateCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/SubnetSize/SubnetSizeValidateCommand.cs
@@ -87,7 +87,8 @@ public sealed class SubnetSizeValidateCommand(ILogger<SubnetSizeValidateCommand>
                                 options.SubnetId!,
                                 options.Location!,
                                 options.Tenant,
-                                options.RetryPolicy);
+                                options.RetryPolicy,
+                                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new FileSystemCheckSubnetResult(subnetIsValid), ManagedLustreJsonContext.Default.FileSystemCheckSubnetResult);
         }

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/IManagedLustreService.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/IManagedLustreService.cs
@@ -12,12 +12,14 @@ public interface IManagedLustreService
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<int> GetRequiredAmlFSSubnetsSize(string subscription,
         string sku, int size,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<bool> CheckAmlFSSubnetAsync(
         string subscription,
@@ -26,13 +28,15 @@ public interface IManagedLustreService
         string subnetId,
         string location,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<ManagedLustreSkuInfo>> SkuGetInfoAsync(
         string subscription,
         string? tenant = null,
         string? location = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<LustreFileSystem> CreateFileSystemAsync(
         string subscription,
@@ -61,7 +65,8 @@ public interface IManagedLustreService
         string? sourceVaultId = null,
         string? userAssignedIdentityId = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<LustreFileSystem> UpdateFileSystemAsync(
         string subscription,
@@ -76,6 +81,7 @@ public interface IManagedLustreService
         long? squashUid = null,
         long? squashGid = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }
 

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/FileSystemCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/FileSystemCreateCommandTests.cs
@@ -76,12 +76,31 @@ public class FileSystemCreateCommandTests
         {
             var expected = CreateLustre();
             _svc.CreateFileSystemAsync(
-                Arg.Is(Sub), Arg.Is(Rg), Arg.Is(Name), Arg.Is(Location), Arg.Is(Sku), Arg.Is(Size), Arg.Is(SubnetId), Arg.Is(Zone),
-                Arg.Is("Monday"), Arg.Is("00:00"),
-                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<long?>(), Arg.Any<long?>(),
-                Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>()).Returns(expected);
+                Arg.Is(Sub),
+                Arg.Is(Rg),
+                Arg.Is(Name),
+                Arg.Is(Location),
+                Arg.Is(Sku),
+                Arg.Is(Size),
+                Arg.Is(SubnetId),
+                Arg.Is(Zone),
+                Arg.Is("Monday"),
+                Arg.Is("00:00"),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<long?>(),
+                Arg.Any<long?>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+                .Returns(expected);
         }
 
         var parseResult = _commandDefinition.Parse(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
@@ -132,12 +151,32 @@ public class FileSystemCreateCommandTests
     public async Task ExecuteAsync_RootSquashNotNone_WithParams_CallsService()
     {
         var expected = CreateLustre();
-        _svc.CreateFileSystemAsync(Sub, Rg, Name, Location, Sku, Size, SubnetId, Zone,
-            "Monday", "00:00",
-            null, null, null,
-            "All", "nid1,nid2", 1000, 1000,
-            false, null, null, null,
-            null, Arg.Any<RetryPolicyOptions?>()).Returns(expected);
+        _svc.CreateFileSystemAsync(
+            Sub,
+            Rg,
+            Name,
+            Location,
+            Sku,
+            Size,
+            SubnetId,
+            Zone,
+            "Monday",
+            "00:00",
+            null,
+            null,
+            null,
+            "All",
+            "nid1,nid2",
+            1000,
+            1000,
+            false,
+            null,
+            null,
+            null,
+            null,
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expected);
 
         var args = _commandDefinition.Parse([
             "--subscription", Sub,
@@ -159,12 +198,31 @@ public class FileSystemCreateCommandTests
         var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _svc.Received(1).CreateFileSystemAsync(Sub, Rg, Name, Location, Sku, Size, SubnetId, Zone,
-            "Monday", "00:00",
-            null, null, null,
-            "All", "nid1,nid2", 1000, 1000,
-            false, null, null, null,
-            null, Arg.Any<RetryPolicyOptions?>());
+        await _svc.Received(1).CreateFileSystemAsync(
+            Sub,
+            Rg,
+            Name,
+            Location,
+            Sku,
+            Size,
+            SubnetId,
+            Zone,
+            "Monday",
+            "00:00",
+            null,
+            null,
+            null,
+            "All",
+            "nid1,nid2",
+            1000,
+            1000,
+            false,
+            null,
+            null,
+            null,
+            null,
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -220,13 +278,32 @@ public class FileSystemCreateCommandTests
     public async Task ExecuteAsync_EncryptionEnabledWithKeyAndVault_CallsService()
     {
         var expected = CreateLustre();
-        _svc.CreateFileSystemAsync(Sub, Rg, Name, Location, Sku, Size, SubnetId, Zone,
-            "Monday", "00:00",
-            null, null, null,
-            null, null, null, null,
-            true, "https://kv.vault.azure.net/keys/k/123", "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv",
+        _svc.CreateFileSystemAsync(
+            Sub,
+            Rg,
+            Name,
+            Location,
+            Sku,
+            Size,
+            SubnetId,
+            Zone,
+            "Monday",
+            "00:00",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            true,
+            "https://kv.vault.azure.net/keys/k/123",
+            "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv",
             "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
-            null, Arg.Any<RetryPolicyOptions?>()).Returns(expected);
+            null,
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expected);
 
         var args = _commandDefinition.Parse([
             "--subscription", Sub,
@@ -247,24 +324,62 @@ public class FileSystemCreateCommandTests
 
         var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _svc.Received(1).CreateFileSystemAsync(Sub, Rg, Name, Location, Sku, Size, SubnetId, Zone,
-            "Monday", "00:00",
-            null, null, null,
-            null, null, null, null,
-            true, "https://kv.vault.azure.net/keys/k/123", "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv",
+        await _svc.Received(1).CreateFileSystemAsync(
+            Sub,
+            Rg,
+            Name,
+            Location,
+            Sku,
+            Size,
+            SubnetId,
+            Zone,
+            "Monday",
+            "00:00",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            true,
+            "https://kv.vault.azure.net/keys/k/123",
+            "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv",
             "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
-            null, Arg.Any<RetryPolicyOptions?>());
+            null,
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ExecuteAsync_ServiceThrowsGeneralException_Returns500()
     {
-        _svc.CreateFileSystemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<long?>(), Arg.Any<long?>(),
-            Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>()).ThrowsAsync(new Exception("error"));
+        _svc.CreateFileSystemAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<long?>(),
+            Arg.Any<long?>(),
+            Arg.Any<bool>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("error"));
 
         var args = _commandDefinition.Parse([
             "--subscription", Sub,
@@ -287,12 +402,32 @@ public class FileSystemCreateCommandTests
     [Fact]
     public async Task ExecuteAsync_HandlesRequestFailedException_Conflict()
     {
-        _svc.CreateFileSystemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<long?>(), Arg.Any<long?>(),
-            Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>()).ThrowsAsync(new Azure.RequestFailedException(409, "conflict"));
+        _svc.CreateFileSystemAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<long?>(),
+            Arg.Any<long?>(),
+            Arg.Any<bool>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(409, "conflict"));
 
         var args = _commandDefinition.Parse([
             "--subscription", Sub,
@@ -315,12 +450,31 @@ public class FileSystemCreateCommandTests
     [Fact]
     public async Task ExecuteAsync_HsmOneContainerMissing_ReturnsErrorFromService()
     {
-        _svc.CreateFileSystemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<long?>(), Arg.Any<long?>(),
-            Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>()).ThrowsAsync(new Exception("Both hsm-container and hsm-log-container must be provided"));
+        _svc.CreateFileSystemAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<long?>(),
+            Arg.Any<long?>(),
+            Arg.Any<bool>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Both hsm-container and hsm-log-container must be provided"));
 
         var args = _commandDefinition.Parse([
             "--subscription", Sub,

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/FileSystemListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/FileSystemListCommandTests.cs
@@ -106,7 +106,8 @@ public class FileSystemListCommandTests
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var args = _commandDefinition.Parse([
@@ -168,7 +169,8 @@ public class FileSystemListCommandTests
                 Arg.Is(_knownSubscriptionId),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(expected);
 
         }
@@ -206,7 +208,8 @@ public class FileSystemListCommandTests
             Arg.Is(_knownSubscriptionId),
             Arg.Is<string?>(x => x == null),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         var args = _commandDefinition.Parse([
@@ -232,7 +235,11 @@ public class FileSystemListCommandTests
     {
         // Arrange - 404 Not Found
         _amlfsService.ListFileSystemsAsync(
-            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "not found"));
 
         var args = _commandDefinition.Parse(["--subscription", _knownSubscriptionId]);
@@ -248,7 +255,11 @@ public class FileSystemListCommandTests
     {
         // Arrange - 403 Forbidden
         _amlfsService.ListFileSystemsAsync(
-            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.Forbidden, "forbidden"));
 
         var args = _commandDefinition.Parse(["--subscription", _knownSubscriptionId]);

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/FileSystemUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/FileSystemUpdateCommandTests.cs
@@ -70,9 +70,18 @@ public class FileSystemUpdateCommandTests
         if (shouldSucceed)
         {
             _svc.UpdateFileSystemAsync(
-                Arg.Is(Sub), Arg.Is(Rg), Arg.Is(Name),
-                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<long?>(), Arg.Any<long?>(),
-                Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+                Arg.Is(Sub),
+                Arg.Is(Rg),
+                Arg.Is(Name),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<long?>(),
+                Arg.Any<long?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(CreateLustre());
         }
 
@@ -102,7 +111,19 @@ public class FileSystemUpdateCommandTests
     public async Task ExecuteAsync_MaintenanceUpdate_CallsServiceAndReturnsResult()
     {
         var expected = CreateLustre();
-        _svc.UpdateFileSystemAsync(Sub, Rg, Name, "Monday", "01:00", null, null, null, null, null, Arg.Any<RetryPolicyOptions?>())
+        _svc.UpdateFileSystemAsync(
+            Sub,
+            Rg,
+            Name,
+            "Monday",
+            "01:00",
+            null,
+            null,
+            null,
+            null,
+            null,
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var args = _commandDefinition.Parse([
@@ -115,7 +136,19 @@ public class FileSystemUpdateCommandTests
 
         var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _svc.Received(1).UpdateFileSystemAsync(Sub, Rg, Name, "Monday", "01:00", null, null, null, null, null, Arg.Any<RetryPolicyOptions?>());
+        await _svc.Received(1).UpdateFileSystemAsync(
+            Sub,
+            Rg,
+            Name,
+            "Monday",
+            "01:00",
+            null,
+            null,
+            null,
+            null,
+            null,
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
 
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize(json, ManagedLustreJsonContext.Default.FileSystemUpdateResult);
@@ -127,7 +160,19 @@ public class FileSystemUpdateCommandTests
     public async Task ExecuteAsync_RootSquashUpdate_CallsService()
     {
         var expected = CreateLustre();
-        _svc.UpdateFileSystemAsync(Sub, Rg, Name, null, null, "All", "nid1,nid2", 1000, 1000, null, Arg.Any<RetryPolicyOptions?>())
+        _svc.UpdateFileSystemAsync(
+            Sub,
+            Rg,
+            Name,
+            null,
+            null,
+            "All",
+            "nid1,nid2",
+            1000,
+            1000,
+            null,
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var args = _commandDefinition.Parse([
@@ -142,16 +187,38 @@ public class FileSystemUpdateCommandTests
 
         var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _svc.Received(1).UpdateFileSystemAsync(Sub, Rg, Name, null, null, "All", "nid1,nid2", 1000, 1000, null, Arg.Any<RetryPolicyOptions?>());
+        await _svc.Received(1).UpdateFileSystemAsync(
+            Sub,
+            Rg,
+            Name,
+            null,
+            null,
+            "All",
+            "nid1,nid2",
+            1000,
+            1000,
+            null,
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ExecuteAsync_ServiceThrowsRequestFailed_ReturnsStatus()
     {
-        _svc.UpdateFileSystemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<long?>(), Arg.Any<long?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
-            .ThrowsAsync(new Azure.RequestFailedException(404, "not found"));
+        _svc.UpdateFileSystemAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<long?>(),
+            Arg.Any<long?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(404, "not found"));
 
         var args = _commandDefinition.Parse([
             "--subscription", Sub,
@@ -179,9 +246,18 @@ public class FileSystemUpdateCommandTests
         if (shouldSucceed)
         {
             _svc.UpdateFileSystemAsync(
-                Arg.Is(Sub), Arg.Is(Rg), Arg.Is(Name),
-                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<long?>(), Arg.Any<long?>(),
-                Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+                Arg.Is(Sub),
+                Arg.Is(Rg),
+                Arg.Is(Name),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<long?>(),
+                Arg.Any<long?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(CreateLustre());
         }
 
@@ -203,7 +279,19 @@ public class FileSystemUpdateCommandTests
     public async Task ExecuteAsync_RootSquashMode_WithUidGid_SucceedsAndCallsService()
     {
         var expected = CreateLustre();
-        _svc.UpdateFileSystemAsync(Sub, Rg, Name, null, null, "All", "nid1,nid2", 2000, 3000, null, Arg.Any<RetryPolicyOptions?>())
+        _svc.UpdateFileSystemAsync(
+            Sub,
+            Rg,
+            Name,
+            null,
+            null,
+            "All",
+            "nid1,nid2",
+            2000,
+            3000,
+            null,
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var args = _commandDefinition.Parse([
@@ -218,7 +306,19 @@ public class FileSystemUpdateCommandTests
 
         var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _svc.Received(1).UpdateFileSystemAsync(Sub, Rg, Name, null, null, "All", "nid1,nid2", 2000, 3000, null, Arg.Any<RetryPolicyOptions?>());
+        await _svc.Received(1).UpdateFileSystemAsync(
+            Sub,
+            Rg,
+            Name,
+            null,
+            null,
+            "All",
+            "nid1,nid2",
+            2000,
+            3000,
+            null,
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/Sku/SkuGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/Sku/SkuGetCommandTests.cs
@@ -72,7 +72,8 @@ public class SkuGetCommandTests
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var args = _commandDefinition.Parse([
@@ -104,7 +105,12 @@ public class SkuGetCommandTests
     {
         if (shouldSucceed)
         {
-            _amlfsService.SkuGetInfoAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+            _amlfsService.SkuGetInfoAsync(
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns([new("n", "eastus", false, [])]);
         }
 

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/SubnetSize/SubnetSizeAskCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/SubnetSize/SubnetSizeAskCommandTests.cs
@@ -58,7 +58,8 @@ public class FileSystemSubnetSizeCommandTests
             Arg.Is("AMLFS-Durable-Premium-40"),
             Arg.Is(480),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(21);
 
         var args = _commandDefinition.Parse([
@@ -86,7 +87,13 @@ public class FileSystemSubnetSizeCommandTests
     public async Task ExecuteAsync_ValidSkus_DoNotThrow(string sku)
     {
         // Arrange
-        _amlfsService.GetRequiredAmlFSSubnetsSize(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>()).Returns(10);
+        _amlfsService.GetRequiredAmlFSSubnetsSize(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>()).Returns(10);
         var args = _commandDefinition.Parse(["--sku", sku, "--size", "48", "--subscription", _knownSubscriptionId]);
 
         // Act
@@ -105,7 +112,14 @@ public class FileSystemSubnetSizeCommandTests
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
     {
         // Arrange
-        _amlfsService.GetRequiredAmlFSSubnetsSize(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>()).Returns(10);
+        _amlfsService.GetRequiredAmlFSSubnetsSize(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(10);
         var parsedArgs = _commandDefinition.Parse(args);
 
         // Act
@@ -138,7 +152,13 @@ public class FileSystemSubnetSizeCommandTests
     public async Task ExecuteAsync_ServiceThrows_IsHandled()
     {
         // Arrange
-        _amlfsService.GetRequiredAmlFSSubnetsSize(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+        _amlfsService.GetRequiredAmlFSSubnetsSize(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("error"));
 
         var args = _commandDefinition.Parse(["--sku", "AMLFS-Durable-Premium-40", "--size", "100", "--subscription", _knownSubscriptionId]);

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/SubnetSize/SubnetSizeValidateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.UnitTests/FileSystem/SubnetSize/SubnetSizeValidateCommandTests.cs
@@ -53,7 +53,14 @@ public class FileSystemCheckSubnetCommandTests
     {
         // Arrange
         _amlfsService.CheckAmlFSSubnetAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(true));
 
         // Arrange
@@ -103,7 +110,14 @@ public class FileSystemCheckSubnetCommandTests
     {
         // Arrange
         _amlfsService.CheckAmlFSSubnetAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("error"));
 
         var args = _commandDefinition.Parse([

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsCreateCommand.cs
@@ -160,7 +160,8 @@ public sealed class WebTestsCreateCommand(ILogger<WebTestsCreateCommand> logger)
                 sslLifetimeCheckInDays: options.SslLifetimeCheckInDays,
                 timeoutInSeconds: options.TimeoutInSeconds,
                 tenant: options.Tenant,
-                retryPolicy: options.RetryPolicy);
+                retryPolicy: options.RetryPolicy,
+                cancellationToken: cancellationToken);
 
             context.Response.Results = ResponseResult.Create(
                 new(webTest),

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsGetCommand.cs
@@ -71,7 +71,8 @@ public sealed class WebTestsGetCommand(ILogger<WebTestsGetCommand> logger) : Bas
                 options.ResourceGroup!,
                 options.ResourceName!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             if (webTest != null)
             {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsListCommand.cs
@@ -63,8 +63,8 @@ public sealed class WebTestsListCommand(ILogger<WebTestsListCommand> logger) : B
         {
             var monitorWebTestService = context.GetService<IMonitorWebTestService>();
             var webTests = options.ResourceGroup == null
-                ? await monitorWebTestService.ListWebTests(options.Subscription!, options.Tenant, options.RetryPolicy)
-                : await monitorWebTestService.ListWebTests(options.Subscription!, options.ResourceGroup, options.Tenant, options.RetryPolicy);
+                ? await monitorWebTestService.ListWebTests(options.Subscription!, options.Tenant, options.RetryPolicy, cancellationToken)
+                : await monitorWebTestService.ListWebTests(options.Subscription!, options.ResourceGroup, options.Tenant, options.RetryPolicy, cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(webTests ?? []), MonitorJsonContext.Default.WebTestsListCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsUpdateCommand.cs
@@ -159,7 +159,8 @@ public sealed class WebTestsUpdateCommand(ILogger<WebTestsUpdateCommand> logger)
                 sslLifetimeCheckInDays: options.SslLifetimeCheckInDays,
                 timeoutInSeconds: options.TimeoutInSeconds,
                 tenant: options.Tenant,
-                retryPolicy: options.RetryPolicy);
+                retryPolicy: options.RetryPolicy,
+                cancellationToken: cancellationToken);
 
             context.Response.Results = ResponseResult.Create(
                 new(webTest),

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/IMonitorWebTestService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/IMonitorWebTestService.cs
@@ -11,20 +11,23 @@ public interface IMonitorWebTestService
     Task<List<WebTestSummaryInfo>> ListWebTests(
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<WebTestSummaryInfo>> ListWebTests(
         string subscription,
         string resourceGroup,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<WebTestDetailedInfo> GetWebTest(
         string subscription,
         string resourceGroup,
         string name,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<WebTestDetailedInfo> CreateWebTest(
         string subscription,
@@ -50,7 +53,8 @@ public interface IMonitorWebTestService
         int? sslLifetimeCheckInDays = null,
         int? timeoutInSeconds = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<WebTestDetailedInfo> UpdateWebTest(
         string subscription,
@@ -76,5 +80,6 @@ public interface IMonitorWebTestService
         int? sslLifetimeCheckInDays = null,
         int? timeoutInSeconds = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Metrics/MetricsQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Metrics/MetricsQueryCommandTests.cs
@@ -12,6 +12,7 @@ using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.Metrics;
@@ -717,7 +718,7 @@ public class MetricsQueryCommandTests
     {
         // Arrange
         var expectedException = new Exception("Service unavailable");
-        _service.When(x => x.QueryMetricsAsync(
+        _service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -731,8 +732,8 @@ public class MetricsQueryCommandTests
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<CancellationToken>()))
-            .Do(x => throw expectedException);
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(expectedException);
 
         var context = new CommandContext(_serviceProvider);
         var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names CPU --metric-namespace microsoft.compute/virtualmachines");
@@ -751,7 +752,7 @@ public class MetricsQueryCommandTests
     {
         // Arrange
         var expectedException = new Exception("Service error");
-        _service.When(x => x.QueryMetricsAsync(
+        _service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -765,8 +766,8 @@ public class MetricsQueryCommandTests
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<CancellationToken>()))
-            .Do(x => throw expectedException);
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(expectedException);
 
         var context = new CommandContext(_serviceProvider);
         var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names CPU --metric-namespace microsoft.compute/virtualmachines");

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsCreateCommandTests.cs
@@ -12,6 +12,7 @@ using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.WebTests;
@@ -165,13 +166,31 @@ public class WebTestsCreateCommandTests
             };
 
             _service.CreateWebTest(
-                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-                Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-                Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-                Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string[]>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<int?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<IReadOnlyDictionary<string, string>?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<int?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(expectedResult);
         }
 
@@ -225,13 +244,31 @@ public class WebTestsCreateCommandTests
                 Location = "eastus"
             };
             _service.CreateWebTest(
-                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-                Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-                Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-                Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string[]>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<int?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<IReadOnlyDictionary<string, string>?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<int?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(expectedResult);
         }
 
@@ -286,13 +323,31 @@ public class WebTestsCreateCommandTests
                 Location = "eastus"
             };
             _service.CreateWebTest(
-                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-                Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-                Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-                Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string[]>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<int?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<IReadOnlyDictionary<string, string>?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<int?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(expectedResult);
         }
 
@@ -333,13 +388,31 @@ public class WebTestsCreateCommandTests
         };
 
         _service.CreateWebTest(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-            Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-            Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-            Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string[]>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<int?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
         var parseResult = _commandDefinition.Parse(args);
@@ -389,13 +462,31 @@ public class WebTestsCreateCommandTests
         };
 
         _service.CreateWebTest(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-            Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-            Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-            Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string[]>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<int?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
         var parseResult = _commandDefinition.Parse(args);
@@ -435,7 +526,8 @@ public class WebTestsCreateCommandTests
             30,
             60,
             null,
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     #endregion
@@ -471,15 +563,15 @@ public class WebTestsCreateCommandTests
     {
         // Arrange
         var expectedException = new Exception("Service unavailable");
-        _service.When(x => x.CreateWebTest(
+        _service.CreateWebTest(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
             Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
             Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
             Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>()))
-            .Do(x => throw expectedException);
+            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(expectedException);
 
         var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1", "--appinsights-component", "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1", "--location", "eastus", "--webtest-locations", "US East", "--request-url", "https://example.com" };
         var parseResult = _commandDefinition.Parse(args);
@@ -498,15 +590,15 @@ public class WebTestsCreateCommandTests
     {
         // Arrange
         var expectedException = new Exception("Service error");
-        _service.When(x => x.CreateWebTest(
+        _service.CreateWebTest(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<int?>(), Arg.Any<bool?>(),
             Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
             Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
             Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>()))
-            .Do(x => throw expectedException);
+            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(expectedException);
 
         var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1", "--appinsights-component", "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1", "--location", "eastus", "--webtest-locations", "US East", "--request-url", "https://example.com" };
         var parseResult = _commandDefinition.Parse(args);

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsListCommandTests.cs
@@ -12,6 +12,7 @@ using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.WebTests;
@@ -120,7 +121,7 @@ public class WebTestsListCommandTests
             }
         };
 
-        _service.ListWebTests("sub1", null, Arg.Any<RetryPolicyOptions?>())
+        _service.ListWebTests("sub1", null, Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedResults);
 
         var parseResult = _commandDefinition.Parse(args);
@@ -129,7 +130,7 @@ public class WebTestsListCommandTests
         await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
 
         // Assert
-        await _service.Received(1).ListWebTests("sub1", null, Arg.Any<RetryPolicyOptions?>());
+        await _service.Received(1).ListWebTests("sub1", null, Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -149,7 +150,7 @@ public class WebTestsListCommandTests
             }
         };
 
-        _service.ListWebTests("sub1", "rg1", null, Arg.Any<RetryPolicyOptions?>())
+        _service.ListWebTests("sub1", "rg1", null, Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedResults);
 
         var parseResult = _commandDefinition.Parse(args);
@@ -158,7 +159,7 @@ public class WebTestsListCommandTests
         await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
 
         // Assert
-        await _service.Received(1).ListWebTests("sub1", "rg1", null, Arg.Any<RetryPolicyOptions?>());
+        await _service.Received(1).ListWebTests("sub1", "rg1", null, Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 
     #endregion
@@ -191,9 +192,9 @@ public class WebTestsListCommandTests
             }
         };
 
-        _service.ListWebTests(Arg.Any<string>(), Arg.Is<string>(rg => rg != null), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+        _service.ListWebTests(Arg.Any<string>(), Arg.Is<string>(rg => rg != null), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedResults);
-        _service.ListWebTests(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+        _service.ListWebTests(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedResults);
 
         var argArray = string.IsNullOrEmpty(args) ? Array.Empty<string>() : args.Split(' ', StringSplitOptions.RemoveEmptyEntries);
@@ -221,7 +222,7 @@ public class WebTestsListCommandTests
     public async Task ExecuteAsync_EmptyResults_ReturnsSuccessWithNullResults()
     {
         // Arrange
-        _service.ListWebTests(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+        _service.ListWebTests(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(new List<WebTestSummaryInfo>());
 
         var parseResult = _commandDefinition.Parse(["--subscription", "sub1"]);
@@ -242,7 +243,7 @@ public class WebTestsListCommandTests
     public async Task ExecuteAsync_CallsServiceWithCorrectParameters()
     {
         // Arrange
-        _service.ListWebTests(Arg.Any<string>(), Arg.Is<string>(rg => rg != null), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+        _service.ListWebTests(Arg.Any<string>(), Arg.Is<string>(rg => rg != null), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(new List<WebTestSummaryInfo>());
 
         var parseResult = _commandDefinition.Parse(["--subscription", "sub1", "--resource-group", "rg1"]);
@@ -251,7 +252,7 @@ public class WebTestsListCommandTests
         await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
 
         // Assert
-        await _service.Received(1).ListWebTests("sub1", "rg1", null, Arg.Any<RetryPolicyOptions?>());
+        await _service.Received(1).ListWebTests("sub1", "rg1", null, Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 
     #endregion
@@ -285,11 +286,12 @@ public class WebTestsListCommandTests
     {
         // Arrange
         var expectedException = new Exception("Service unavailable");
-        _service.When(x => x.ListWebTests(
+        _service.ListWebTests(
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>()))
-            .Do(x => throw expectedException);
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(expectedException);
 
         var parseResult = _commandDefinition.Parse(["--subscription", "sub1"]);
 
@@ -307,11 +309,12 @@ public class WebTestsListCommandTests
     {
         // Arrange
         var expectedException = new Exception("Service error");
-        _service.When(x => x.ListWebTests(
+        _service.ListWebTests(
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>()))
-            .Do(x => throw expectedException);
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(expectedException);
 
         var parseResult = _commandDefinition.Parse(["--subscription", "sub1"]);
 

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsUpdateCommandTests.cs
@@ -13,6 +13,7 @@ using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.WebTests;
@@ -165,13 +166,31 @@ public class WebTestsUpdateCommandTests
             };
 
             _service.UpdateWebTest(
-                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<string[]?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-                Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-                Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-                Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string[]?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<IReadOnlyDictionary<string, string>?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<int?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(expectedResult);
         }
 
@@ -214,13 +233,31 @@ public class WebTestsUpdateCommandTests
                 Location = "eastus"
             };
             _service.UpdateWebTest(
-                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<string[]?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-                Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-                Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-                Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string[]?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<IReadOnlyDictionary<string, string>?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<int?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(expectedResult);
         }
 
@@ -264,13 +301,31 @@ public class WebTestsUpdateCommandTests
                 Location = "eastus"
             };
             _service.UpdateWebTest(
-                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<string[]?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-                Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-                Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-                Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string[]?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<IReadOnlyDictionary<string, string>?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<bool?>(),
+                Arg.Any<int?>(),
+                Arg.Any<int?>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(expectedResult);
         }
 
@@ -311,13 +366,31 @@ public class WebTestsUpdateCommandTests
         };
 
         _service.UpdateWebTest(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string[]?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-            Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-            Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-            Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
         var parseResult = _commandDefinition.Parse(args);
@@ -381,13 +454,31 @@ public class WebTestsUpdateCommandTests
         };
 
         _service.UpdateWebTest(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string[]?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-            Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-            Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-            Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
         var parseResult = _commandDefinition.Parse(args);
@@ -427,7 +518,8 @@ public class WebTestsUpdateCommandTests
             30,
             90,
             null,
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -450,13 +542,31 @@ public class WebTestsUpdateCommandTests
         };
 
         _service.UpdateWebTest(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string[]?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-            Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-            Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-            Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
         var parseResult = _commandDefinition.Parse(args);
@@ -493,7 +603,8 @@ public class WebTestsUpdateCommandTests
             null,                      // sslLifetimeCheckInDays - not provided, should be null
             null,                      // timeoutInSeconds - not provided, should be null
             null,                      // tenant
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -519,13 +630,31 @@ public class WebTestsUpdateCommandTests
         };
 
         _service.UpdateWebTest(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string[]?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-            Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-            Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-            Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
         var parseResult = _commandDefinition.Parse(args);
@@ -561,7 +690,8 @@ public class WebTestsUpdateCommandTests
             null,                      // sslLifetimeCheckInDays - not provided, should be null
             30,                        // timeoutInSeconds - explicitly provided as 30
             null,                      // tenant
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     #endregion
@@ -596,15 +726,33 @@ public class WebTestsUpdateCommandTests
     {
         // Arrange
         var expectedException = new Exception("Service unavailable");
-        _service.When(x => x.UpdateWebTest(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string[]?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-            Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-            Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-            Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>()))
-            .Do(x => throw expectedException);
+        _service.UpdateWebTest(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(expectedException);
 
         var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1" };
         var parseResult = _commandDefinition.Parse(args);
@@ -623,15 +771,33 @@ public class WebTestsUpdateCommandTests
     {
         // Arrange
         var expectedException = new Exception("Service error");
-        _service.When(x => x.UpdateWebTest(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string[]?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<bool?>(),
-            Arg.Any<int?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<string?>(),
-            Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<string?>(), Arg.Any<bool?>(),
-            Arg.Any<bool?>(), Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>()))
-            .Do(x => throw expectedException);
+        _service.UpdateWebTest(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<int?>(),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(expectedException);
 
         var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1" };
         var parseResult = _commandDefinition.Parse(args);

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Database/DatabaseListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Database/DatabaseListCommand.cs
@@ -59,7 +59,14 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
         try
         {
             IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
-            List<string> databases = await pgService.ListDatabasesAsync(options.Subscription!, options.ResourceGroup!, options.AuthType!, options.User!, options.Password, options.Server!);
+            List<string> databases = await pgService.ListDatabasesAsync(
+                options.Subscription!,
+                options.ResourceGroup!,
+                options.AuthType!,
+                options.User!,
+                options.Password,
+                options.Server!,
+                cancellationToken);
             context.Response.Results = ResponseResult.Create(new(databases ?? []), PostgresJsonContext.Default.DatabaseListCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Database/DatabaseQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Database/DatabaseQueryCommand.cs
@@ -60,7 +60,16 @@ public sealed class DatabaseQueryCommand(ILogger<DatabaseQueryCommand> logger) :
             IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
             // Validate the query early to avoid sending unsafe SQL to the server.
             SqlQueryValidator.EnsureReadOnlySelect(options.Query);
-            List<string> queryResult = await pgService.ExecuteQueryAsync(options.Subscription!, options.ResourceGroup!, options.AuthType!, options.User!, options.Password, options.Server!, options.Database!, options.Query!);
+            List<string> queryResult = await pgService.ExecuteQueryAsync(
+                options.Subscription!,
+                options.ResourceGroup!,
+                options.AuthType!,
+                options.User!,
+                options.Password,
+                options.Server!,
+                options.Database!,
+                options.Query!,
+                cancellationToken);
             context.Response.Results = ResponseResult.Create(new(queryResult ?? []), PostgresJsonContext.Default.DatabaseQueryCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerConfigGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerConfigGetCommand.cs
@@ -44,7 +44,7 @@ public sealed class ServerConfigGetCommand(ILogger<ServerConfigGetCommand> logge
         {
 
             IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
-            var config = await pgService.GetServerConfigAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!);
+            var config = await pgService.GetServerConfigAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!, cancellationToken);
             context.Response.Results = config?.Length > 0 ?
                 ResponseResult.Create(new(config), PostgresJsonContext.Default.ServerConfigGetCommandResult) :
                 null;

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerListCommand.cs
@@ -43,7 +43,7 @@ public sealed class ServerListCommand(ILogger<ServerListCommand> logger) : BaseP
         try
         {
             IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
-            List<string> servers = await pgService.ListServersAsync(options.Subscription!, options.ResourceGroup!, options.User!);
+            List<string> servers = await pgService.ListServersAsync(options.Subscription!, options.ResourceGroup!, options.User!, cancellationToken);
             context.Response.Results = ResponseResult.Create(new(servers ?? []), PostgresJsonContext.Default.ServerListCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamGetCommand.cs
@@ -58,7 +58,7 @@ public sealed class ServerParamGetCommand(ILogger<ServerParamGetCommand> logger)
         try
         {
             IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
-            var parameterValue = await pgService.GetServerParameterAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!, options.Param!);
+            var parameterValue = await pgService.GetServerParameterAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!, options.Param!, cancellationToken);
             context.Response.Results = parameterValue?.Length > 0 ?
                 ResponseResult.Create(new(parameterValue), PostgresJsonContext.Default.ServerParamGetCommandResult) :
                 null;

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamSetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamSetCommand.cs
@@ -60,7 +60,7 @@ public sealed class ServerParamSetCommand(ILogger<ServerParamSetCommand> logger)
         try
         {
             IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
-            var result = await pgService.SetServerParameterAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!, options.Param!, options.Value!);
+            var result = await pgService.SetServerParameterAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!, options.Param!, options.Value!, cancellationToken);
             context.Response.Results = !string.IsNullOrEmpty(result) ?
                 ResponseResult.Create(new(result, options.Param!, options.Value!), PostgresJsonContext.Default.ServerParamSetCommandResult) :
                 null;

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Table/TableListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Table/TableListCommand.cs
@@ -40,7 +40,15 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseDat
         try
         {
             IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
-            List<string> tables = await pgService.ListTablesAsync(options.Subscription!, options.ResourceGroup!, options.AuthType!, options.User!, options.Password, options.Server!, options.Database!);
+            List<string> tables = await pgService.ListTablesAsync(
+                options.Subscription!,
+                options.ResourceGroup!,
+                options.AuthType!,
+                options.User!,
+                options.Password,
+                options.Server!,
+                options.Database!,
+                cancellationToken);
             context.Response.Results = ResponseResult.Create(new(tables ?? []), PostgresJsonContext.Default.TableListCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Table/TableSchemaGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Table/TableSchemaGetCommand.cs
@@ -56,7 +56,16 @@ public sealed class TableSchemaGetCommand(ILogger<TableSchemaGetCommand> logger)
 
 
             IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
-            List<string> schema = await pgService.GetTableSchemaAsync(options.Subscription!, options.ResourceGroup!, options.AuthType!, options.User!, options.Password, options.Server!, options.Database!, options.Table!);
+            List<string> schema = await pgService.GetTableSchemaAsync(
+                options.Subscription!,
+                options.ResourceGroup!,
+                options.AuthType!,
+                options.User!,
+                options.Password,
+                options.Server!,
+                options.Database!,
+                options.Table!,
+                cancellationToken);
             context.Response.Results = ResponseResult.Create(new(schema ?? []), PostgresJsonContext.Default.TableSchemaGetCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Postgres/src/Providers/DbProvider.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Providers/DbProvider.cs
@@ -5,9 +5,9 @@ namespace Azure.Mcp.Tools.Postgres.Providers
 {
     internal class DbProvider : IDbProvider
     {
-        public async Task<IPostgresResource> GetPostgresResource(string connectionString, string authType)
+        public async Task<IPostgresResource> GetPostgresResource(string connectionString, string authType, CancellationToken cancellationToken)
         {
-            return await PostgresResource.CreateAsync(connectionString, authType);
+            return await PostgresResource.CreateAsync(connectionString, authType, cancellationToken);
         }
 
         public NpgsqlCommand GetCommand(string query, IPostgresResource postgresResource)
@@ -15,9 +15,9 @@ namespace Azure.Mcp.Tools.Postgres.Providers
             return new NpgsqlCommand(query, postgresResource.Connection);
         }
 
-        public async Task<DbDataReader> ExecuteReaderAsync(NpgsqlCommand command)
+        public async Task<DbDataReader> ExecuteReaderAsync(NpgsqlCommand command, CancellationToken cancellationToken)
         {
-            return await command.ExecuteReaderAsync();
+            return await command.ExecuteReaderAsync(cancellationToken);
         }
     }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/src/Providers/IDbProvider.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Providers/IDbProvider.cs
@@ -6,8 +6,8 @@ namespace Azure.Mcp.Tools.Postgres.Providers
 {
     public interface IDbProvider
     {
-        Task<IPostgresResource> GetPostgresResource(string connectionString, string authType);
+        Task<IPostgresResource> GetPostgresResource(string connectionString, string authType, CancellationToken cancellationToken);
         NpgsqlCommand GetCommand(string query, IPostgresResource postgresResource);
-        Task<DbDataReader> ExecuteReaderAsync(NpgsqlCommand command);
+        Task<DbDataReader> ExecuteReaderAsync(NpgsqlCommand command, CancellationToken cancellationToken);
     }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/src/Providers/PostgresResource.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Providers/PostgresResource.cs
@@ -10,7 +10,7 @@ namespace Azure.Mcp.Tools.Postgres.Providers
         public NpgsqlConnection Connection { get; }
         private readonly NpgsqlDataSource _dataSource;
 
-        public static async Task<PostgresResource> CreateAsync(string connectionString, string authType)
+        public static async Task<PostgresResource> CreateAsync(string connectionString, string authType, CancellationToken cancellationToken)
         {
             // Configure SSL settings for secure connection
             var connectionBuilder = new NpgsqlConnectionStringBuilder(connectionString)
@@ -25,7 +25,7 @@ namespace Azure.Mcp.Tools.Postgres.Providers
             NpgsqlConnection connection;
             try
             {
-                connection = await dataSource.OpenConnectionAsync();
+                connection = await dataSource.OpenConnectionAsync(cancellationToken);
             }
             catch (PostgresException e) when (e.Message.Contains("28P01"))
             {

--- a/tools/Azure.Mcp.Tools.Postgres/src/Services/IPostgresService.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Services/IPostgresService.cs
@@ -5,14 +5,74 @@ namespace Azure.Mcp.Tools.Postgres.Services;
 
 public interface IPostgresService
 {
-    Task<List<string>> ListDatabasesAsync(string subscriptionId, string resourceGroup, string authType, string user, string? password, string server);
-    Task<List<string>> ExecuteQueryAsync(string subscriptionId, string resourceGroup, string authType, string user, string? password, string server, string database, string query);
-    Task<List<string>> ListTablesAsync(string subscriptionId, string resourceGroup, string authType, string user, string? password, string server, string database);
-    Task<List<string>> GetTableSchemaAsync(string subscriptionId, string resourceGroup, string authType, string user, string? password, string server, string database, string table);
+    Task<List<string>> ListDatabasesAsync(
+        string subscriptionId,
+        string resourceGroup,
+        string authType,
+        string user,
+        string? password,
+        string server,
+        CancellationToken cancellationToken);
 
-    Task<List<string>> ListServersAsync(string subscriptionId, string resourceGroup, string user);
-    Task<string> GetServerConfigAsync(string subscriptionId, string resourceGroup, string user, string server);
-    Task<string> GetServerParameterAsync(string subscriptionId, string resourceGroup, string user, string server, string param);
-    Task<string> SetServerParameterAsync(string subscription, string resourceGroup, string user, string server, string param, string value);
+    Task<List<string>> ExecuteQueryAsync(
+        string subscriptionId,
+        string resourceGroup,
+        string authType,
+        string user,
+        string? password,
+        string server,
+        string database,
+        string query,
+        CancellationToken cancellationToken);
 
+    Task<List<string>> ListTablesAsync(
+        string subscriptionId,
+        string resourceGroup,
+        string authType,
+        string user,
+        string? password,
+        string server,
+        string database,
+        CancellationToken cancellationToken);
+
+    Task<List<string>> GetTableSchemaAsync(
+        string subscriptionId,
+        string resourceGroup,
+        string authType,
+        string user,
+        string? password,
+        string server,
+        string database,
+        string table,
+        CancellationToken cancellationToken);
+
+    Task<List<string>> ListServersAsync(
+        string subscriptionId,
+        string resourceGroup,
+        string user,
+        CancellationToken cancellationToken);
+
+    Task<string> GetServerConfigAsync(
+        string subscriptionId,
+        string resourceGroup,
+        string user,
+        string server,
+        CancellationToken cancellationToken);
+
+    Task<string> GetServerParameterAsync(
+        string subscriptionId,
+        string resourceGroup,
+        string user,
+        string server,
+        string param,
+        CancellationToken cancellationToken);
+
+    Task<string> SetServerParameterAsync(
+        string subscription,
+        string resourceGroup,
+        string user,
+        string server,
+        string param,
+        string value,
+        CancellationToken cancellationToken);
 }

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Database/DatabaseListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Database/DatabaseListCommandTests.cs
@@ -38,7 +38,7 @@ public class DatabaseListCommandTests
     public async Task ExecuteAsync_ReturnsDatabases_WhenDatabasesExist()
     {
         var expectedDatabases = new List<string> { "db1", "db2" };
-        _postgresService.ListDatabasesAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1").Returns(expectedDatabases);
+        _postgresService.ListDatabasesAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", Arg.Any<CancellationToken>()).Returns(expectedDatabases);
 
         var command = new DatabaseListCommand(_logger);
         var args = command.GetCommand().Parse($"--subscription sub123 --resource-group rg1 --{PostgresOptionDefinitions.AuthTypeText} {AuthTypes.MicrosoftEntra} --user user1 --server server1");
@@ -60,7 +60,7 @@ public class DatabaseListCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsMessage_WhenNoDatabasesExist()
     {
-        _postgresService.ListDatabasesAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1").Returns([]);
+        _postgresService.ListDatabasesAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", Arg.Any<CancellationToken>()).Returns([]);
 
         var command = new DatabaseListCommand(_logger);
         var args = command.GetCommand().Parse($"--subscription sub123 --resource-group rg1 --{PostgresOptionDefinitions.AuthTypeText} {AuthTypes.MicrosoftEntra} --user user1 --server server1");
@@ -82,7 +82,7 @@ public class DatabaseListCommandTests
     [Fact]
     public async Task ExecuteAsync_HandlesException()
     {
-        _postgresService.ListDatabasesAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1").ThrowsAsync(new Exception("Test exception"));
+        _postgresService.ListDatabasesAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test exception"));
 
         var command = new DatabaseListCommand(_logger);
         var args = command.GetCommand().Parse($"--subscription sub123 --resource-group rg1 --{PostgresOptionDefinitions.AuthTypeText} {AuthTypes.MicrosoftEntra} --user user1 --server server1");

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Database/DatabaseQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Database/DatabaseQueryCommandTests.cs
@@ -42,7 +42,7 @@ public class DatabaseQueryCommandTests
     {
         var expectedResults = new List<string> { "result1", "result2" };
 
-        _postgresService.ExecuteQueryAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "SELECT * FROM test;")
+        _postgresService.ExecuteQueryAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "SELECT * FROM test;", Arg.Any<CancellationToken>())
             .Returns(expectedResults);
 
         var command = new DatabaseQueryCommand(_logger);
@@ -63,7 +63,7 @@ public class DatabaseQueryCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenQueryFails()
     {
-        _postgresService.ExecuteQueryAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "SELECT * FROM test;")
+        _postgresService.ExecuteQueryAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "SELECT * FROM test;", Arg.Any<CancellationToken>())
             .Returns([]);
 
         var command = new DatabaseQueryCommand(_logger);
@@ -136,7 +136,7 @@ public class DatabaseQueryCommandTests
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status); // CommandValidationException => 400
         // Service should never be called for invalid queries.
-        await _postgresService.DidNotReceive().ExecuteQueryAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+        await _postgresService.DidNotReceive().ExecuteQueryAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -159,6 +159,6 @@ public class DatabaseQueryCommandTests
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
-        await _postgresService.DidNotReceive().ExecuteQueryAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+        await _postgresService.DidNotReceive().ExecuteQueryAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Server/ServerConfigGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Server/ServerConfigGetCommandTests.cs
@@ -36,7 +36,7 @@ public class ServerConfigGetCommandTests
     public async Task ExecuteAsync_ReturnsConfig_WhenConfigExists()
     {
         var expectedConfig = "config123";
-        _postgresService.GetServerConfigAsync("sub123", "rg1", "user1", "server123").Returns(expectedConfig);
+        _postgresService.GetServerConfigAsync("sub123", "rg1", "user1", "server123", Arg.Any<CancellationToken>()).Returns(expectedConfig);
 
         var command = new ServerConfigGetCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server123"]);
@@ -57,7 +57,7 @@ public class ServerConfigGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsNull_WhenConfigDoesNotExist()
     {
-        _postgresService.GetServerConfigAsync("sub123", "rg1", "user1", "server123").Returns("");
+        _postgresService.GetServerConfigAsync("sub123", "rg1", "user1", "server123", Arg.Any<CancellationToken>()).Returns("");
 
         var command = new ServerConfigGetCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server123"]);

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Server/ServerListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Server/ServerListCommandTests.cs
@@ -37,7 +37,7 @@ public class ServerListCommandTests
     public async Task ExecuteAsync_ReturnsServers_WhenServersExist()
     {
         var expectedServers = new List<string> { "server1", "server2" };
-        _postgresService.ListServersAsync("sub123", "rg1", "user1").Returns(expectedServers);
+        _postgresService.ListServersAsync("sub123", "rg1", "user1", Arg.Any<CancellationToken>()).Returns(expectedServers);
         var command = new ServerListCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1"]);
         var context = new CommandContext(_serviceProvider);
@@ -57,7 +57,7 @@ public class ServerListCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoServers()
     {
-        _postgresService.ListServersAsync("sub123", "rg1", "user1").Returns([]);
+        _postgresService.ListServersAsync("sub123", "rg1", "user1", Arg.Any<CancellationToken>()).Returns([]);
 
         var command = new ServerListCommand(_logger);
 
@@ -78,7 +78,7 @@ public class ServerListCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
-        _postgresService.ListServersAsync("sub123", "rg1", "user1")
+        _postgresService.ListServersAsync("sub123", "rg1", "user1", Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         var command = new ServerListCommand(_logger);

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Server/ServerParamGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Server/ServerParamGetCommandTests.cs
@@ -36,7 +36,7 @@ public class ServerParamGetCommandTests
     public async Task ExecuteAsync_ReturnsParamValue_WhenParamExists()
     {
         var expectedValue = "value123";
-        _postgresService.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123").Returns(expectedValue);
+        _postgresService.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", Arg.Any<CancellationToken>()).Returns(expectedValue);
 
         var command = new ServerParamGetCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server123", "--param", "param123"]);
@@ -58,7 +58,7 @@ public class ServerParamGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsNull_WhenParamDoesNotExist()
     {
-        _postgresService.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123").Returns("");
+        _postgresService.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", Arg.Any<CancellationToken>()).Returns("");
         var command = new ServerParamGetCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server123", "--param", "param123"]);
         var context = new CommandContext(_serviceProvider);

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Server/ServerParamSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Server/ServerParamSetCommandTests.cs
@@ -36,7 +36,7 @@ public class ServerParamSetCommandTests
     public async Task ExecuteAsync_ReturnsSuccessMessage_WhenParamIsSet()
     {
         var expectedMessage = "Parameter 'param123' updated successfully to 'value123'.";
-        _postgresService.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", "value123").Returns(expectedMessage);
+        _postgresService.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", "value123", Arg.Any<CancellationToken>()).Returns(expectedMessage);
 
         var command = new ServerParamSetCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server123", "--param", "param123", "--value", "value123"]);
@@ -60,7 +60,7 @@ public class ServerParamSetCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsNull_WhenParamDoesNotExist()
     {
-        _postgresService.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", "value123").Returns("");
+        _postgresService.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", "value123", Arg.Any<CancellationToken>()).Returns("");
         var command = new ServerParamSetCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server123", "--param", "param123", "--value", "value123"]);
         var context = new CommandContext(_serviceProvider);
@@ -103,7 +103,7 @@ public class ServerParamSetCommandTests
     public async Task ExecuteAsync_CallsServiceWithCorrectParameters()
     {
         var expectedMessage = "Parameter updated successfully.";
-        _postgresService.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200").Returns(expectedMessage);
+        _postgresService.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200", Arg.Any<CancellationToken>()).Returns(expectedMessage);
 
         var command = new ServerParamSetCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server123", "--param", "max_connections", "--value", "200"]);
@@ -111,6 +111,6 @@ public class ServerParamSetCommandTests
 
         await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
 
-        await _postgresService.Received(1).SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200");
+        await _postgresService.Received(1).SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200", Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Services/PostgresServiceParameterizedQueryTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Services/PostgresServiceParameterizedQueryTests.cs
@@ -36,11 +36,11 @@ public class PostgresServiceParameterizedQueryTests
             .Returns(new AccessToken("fake-token", DateTime.UtcNow.AddHours(1)));
 
         _dbProvider = Substitute.For<IDbProvider>();
-        _dbProvider.GetPostgresResource(Arg.Any<string>(), Arg.Any<string>())
+        _dbProvider.GetPostgresResource(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Substitute.For<IPostgresResource>());
         _dbProvider.GetCommand(Arg.Any<string>(), Arg.Any<IPostgresResource>())
             .Returns(Substitute.For<NpgsqlCommand>());
-        _dbProvider.ExecuteReaderAsync(Arg.Any<NpgsqlCommand>())
+        _dbProvider.ExecuteReaderAsync(Arg.Any<NpgsqlCommand>(), Arg.Any<CancellationToken>())
             .Returns(Substitute.For<DbDataReader>());
 
         _postgresService = new PostgresService(_resourceGroupService, tenantService, _entraTokenAuth, _dbProvider);
@@ -69,7 +69,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert - Method should accept these parameters without throwing
         // The actual parameterization is tested through integration tests
-        var task = _postgresService.GetTableSchemaAsync(subscriptionId, resourceGroup, authType, user, password, server, database, tableName);
+        var task = _postgresService.GetTableSchemaAsync(subscriptionId, resourceGroup, authType, user, password, server, database, tableName, TestContext.Current.CancellationToken);
 
         // The method will fail at the connection stage, but that's expected in unit tests
         // What we're testing is that the method signature accepts these parameters correctly
@@ -98,7 +98,7 @@ public class PostgresServiceParameterizedQueryTests
         // Act & Assert
         // The method should not throw due to SQL injection attempts
         // With proper parameterization, malicious input is treated as a literal table name
-        var task = _postgresService.GetTableSchemaAsync(subscriptionId, resourceGroup, authType, user, password, server, database, maliciousTableName);
+        var task = _postgresService.GetTableSchemaAsync(subscriptionId, resourceGroup, authType, user, password, server, database, maliciousTableName, TestContext.Current.CancellationToken);
 
         // The method will fail at the connection stage, but importantly,
         // it won't fail due to SQL parsing errors caused by injection attempts
@@ -120,7 +120,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // Should handle special characters safely through parameterization
-        var task = _postgresService.GetTableSchemaAsync(subscriptionId, resourceGroup, authType, user, password, server, database, tableName);
+        var task = _postgresService.GetTableSchemaAsync(subscriptionId, resourceGroup, authType, user, password, server, database, tableName, TestContext.Current.CancellationToken);
         Assert.NotNull(task);
     }
 
@@ -140,7 +140,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // Should handle empty/whitespace table names without security issues
-        var task = _postgresService.GetTableSchemaAsync(subscriptionId, resourceGroup, authType, user, password, server, database, tableName);
+        var task = _postgresService.GetTableSchemaAsync(subscriptionId, resourceGroup, authType, user, password, server, database, tableName, TestContext.Current.CancellationToken);
         Assert.NotNull(task);
     }
 
@@ -158,7 +158,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // Should handle null table name without security issues
-        var task = _postgresService.GetTableSchemaAsync(subscriptionId, resourceGroup, authType, user, password, server, database, null!);
+        var task = _postgresService.GetTableSchemaAsync(subscriptionId, resourceGroup, authType, user, password, server, database, null!, TestContext.Current.CancellationToken);
         Assert.NotNull(task);
     }
 
@@ -178,7 +178,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // The method should fail validation before attempting to connect to database
-        var task = _postgresService.ExecuteQueryAsync(subscriptionId, resourceGroup, authType, user, password, server, database, maliciousQuery);
+        var task = _postgresService.ExecuteQueryAsync(subscriptionId, resourceGroup, authType, user, password, server, database, maliciousQuery, TestContext.Current.CancellationToken);
 
         // We expect this to eventually throw due to validation, not due to database connection
         // The validation should catch dangerous queries before any database interaction
@@ -202,7 +202,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // Valid queries should pass validation and proceed to connection attempt
-        var task = _postgresService.ExecuteQueryAsync(subscriptionId, resourceGroup, authType, user, password, server, database, validQuery);
+        var task = _postgresService.ExecuteQueryAsync(subscriptionId, resourceGroup, authType, user, password, server, database, validQuery, TestContext.Current.CancellationToken);
         Assert.NotNull(task);
     }
 
@@ -232,7 +232,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // The method should accept complex queries with vector operations and Azure OpenAI functions
-        var task = _postgresService.ExecuteQueryAsync(subscriptionId, resourceGroup, authType, user, password, server, database, vectorQuery);
+        var task = _postgresService.ExecuteQueryAsync(subscriptionId, resourceGroup, authType, user, password, server, database, vectorQuery, TestContext.Current.CancellationToken);
 
         // Verify the task is created successfully (will fail at connection stage in unit test)
         Assert.NotNull(task);
@@ -258,7 +258,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // Should accept queries with various vector similarity operators
-        var task = _postgresService.ExecuteQueryAsync(subscriptionId, resourceGroup, authType, user, password, server, database, vectorQuery);
+        var task = _postgresService.ExecuteQueryAsync(subscriptionId, resourceGroup, authType, user, password, server, database, vectorQuery, TestContext.Current.CancellationToken);
         Assert.NotNull(task);
     }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Table/TableListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Table/TableListCommandTests.cs
@@ -37,7 +37,7 @@ public class TableListCommandTests
     public async Task ExecuteAsync_ReturnsTables_WhenTablesExist()
     {
         var expectedTables = new List<string> { "table1", "table2" };
-        _postgresService.ListTablesAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123").Returns(expectedTables);
+        _postgresService.ListTablesAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", Arg.Any<CancellationToken>()).Returns(expectedTables);
 
         var command = new TableListCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", $"--{PostgresOptionDefinitions.AuthTypeText}", AuthTypes.MicrosoftEntra, "--user", "user1", "--server", "server1", "--database", "db123"]);
@@ -58,7 +58,7 @@ public class TableListCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsEmptyList_WhenNoTablesExist()
     {
-        _postgresService.ListTablesAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123").Returns([]);
+        _postgresService.ListTablesAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", Arg.Any<CancellationToken>()).Returns([]);
 
         var command = new TableListCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", $"--{PostgresOptionDefinitions.AuthTypeText}", AuthTypes.MicrosoftEntra, "--user", "user1", "--server", "server1", "--database", "db123"]);

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Table/TableSchemaGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Table/TableSchemaGetCommandTests.cs
@@ -37,7 +37,7 @@ public class TableSchemaGetCommandTests
     public async Task ExecuteAsync_ReturnsSchema_WhenSchemaExists()
     {
         var expectedSchema = new List<string>(["CREATE TABLE test (id INT);"]);
-        _postgresService.GetTableSchemaAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "table123").Returns(expectedSchema);
+        _postgresService.GetTableSchemaAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "table123", Arg.Any<CancellationToken>()).Returns(expectedSchema);
 
         var command = new TableSchemaGetCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", $"--{PostgresOptionDefinitions.AuthTypeText}", AuthTypes.MicrosoftEntra, "--user", "user1", "--server", "server1", "--database", "db123", "--table", "table123"]);
@@ -56,7 +56,7 @@ public class TableSchemaGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenSchemaDoesNotExist()
     {
-        _postgresService.GetTableSchemaAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "table123").Returns([]);
+        _postgresService.GetTableSchemaAsync("sub123", "rg1", AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "table123", Arg.Any<CancellationToken>()).Returns([]);
 
         var command = new TableSchemaGetCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", $"--{PostgresOptionDefinitions.AuthTypeText}", AuthTypes.MicrosoftEntra, "--user", "user1", "--server", "server1", "--database", "db123", "--table", "table123"]);

--- a/tools/Azure.Mcp.Tools.Quota/src/Commands/Region/AvailabilityListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Commands/Region/AvailabilityListCommand.cs
@@ -84,7 +84,8 @@ public sealed class AvailabilityListCommand(ILogger<AvailabilityListCommand> log
                 options.Subscription!,
                 options.CognitiveServiceModelName,
                 options.CognitiveServiceModelVersion,
-                options.CognitiveServiceDeploymentSkuName);
+                options.CognitiveServiceDeploymentSkuName,
+                cancellationToken);
 
             _logger.LogInformation("Region check result: {ToolResult}", toolResult);
 

--- a/tools/Azure.Mcp.Tools.Quota/src/Commands/Usage/CheckCommand.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Commands/Usage/CheckCommand.cs
@@ -75,7 +75,8 @@ public class CheckCommand(ILogger<CheckCommand> logger) : SubscriptionCommand<Ch
             Dictionary<string, List<UsageInfo>> toolResult = await quotaService.GetAzureQuotaAsync(
                 resourceTypes,
                 options.Subscription!,
-                options.Region);
+                options.Region,
+                cancellationToken);
 
             _logger.LogInformation("Quota check result: {ToolResult}", toolResult);
 

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/IQuotaService.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/IQuotaService.cs
@@ -10,12 +10,14 @@ public interface IQuotaService
     Task<Dictionary<string, List<UsageInfo>>> GetAzureQuotaAsync(
         List<string> resourceTypes,
         string subscriptionId,
-        string location);
+        string location,
+        CancellationToken cancellationToken);
 
     Task<List<string>> GetAvailableRegionsForResourceTypesAsync(
         string[] resourceTypes,
         string subscriptionId,
         string? cognitiveServiceModelName = null,
         string? cognitiveServiceModelVersion = null,
-        string? cognitiveServiceDeploymentSkuName = null);
+        string? cognitiveServiceDeploymentSkuName = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/CognitiveServicesUsageChecker.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/CognitiveServicesUsageChecker.cs
@@ -10,12 +10,12 @@ namespace Azure.Mcp.Tools.Quota.Services.Util.Usage;
 
 public class CognitiveServicesUsageChecker(TokenCredential credential, string subscriptionId, ILogger<CognitiveServicesUsageChecker> logger) : AzureUsageChecker(credential, subscriptionId, logger)
 {
-    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location)
+    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location, CancellationToken cancellationToken)
     {
         try
         {
             var subscription = ResourceClient.GetSubscriptionResource(new ResourceIdentifier($"/subscriptions/{SubscriptionId}"));
-            var usages = subscription.GetUsagesAsync(location);
+            var usages = subscription.GetUsagesAsync(location, cancellationToken: cancellationToken);
             var result = new List<UsageInfo>();
 
             await foreach (ServiceAccountUsage item in usages)

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/ComputeUsageChecker.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/ComputeUsageChecker.cs
@@ -10,12 +10,12 @@ namespace Azure.Mcp.Tools.Quota.Services.Util.Usage;
 
 public class ComputeUsageChecker(TokenCredential credential, string subscriptionId, ILogger<ComputeUsageChecker> logger) : AzureUsageChecker(credential, subscriptionId, logger)
 {
-    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location)
+    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location, CancellationToken cancellationToken)
     {
         try
         {
             var subscription = ResourceClient.GetSubscriptionResource(new ResourceIdentifier($"/subscriptions/{SubscriptionId}"));
-            var usages = subscription.GetUsagesAsync(location);
+            var usages = subscription.GetUsagesAsync(location, cancellationToken);
             var result = new List<UsageInfo>();
 
             await foreach (ComputeUsage item in usages)

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/ContainerAppUsageChecker.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/ContainerAppUsageChecker.cs
@@ -9,12 +9,12 @@ namespace Azure.Mcp.Tools.Quota.Services.Util.Usage;
 
 public class ContainerAppUsageChecker(TokenCredential credential, string subscriptionId, ILogger<ContainerAppUsageChecker> logger) : AzureUsageChecker(credential, subscriptionId, logger)
 {
-    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location)
+    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location, CancellationToken cancellationToken)
     {
         try
         {
             var subscription = ResourceClient.GetSubscriptionResource(new ResourceIdentifier($"/subscriptions/{SubscriptionId}"));
-            var usages = subscription.GetUsagesAsync(location);
+            var usages = subscription.GetUsagesAsync(location, cancellationToken);
             var result = new List<UsageInfo>();
 
             await foreach (var item in usages)

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/ContainerInstanceUsageChecker.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/ContainerInstanceUsageChecker.cs
@@ -10,12 +10,12 @@ namespace Azure.Mcp.Tools.Quota.Services.Util.Usage;
 
 public class ContainerInstanceUsageChecker(TokenCredential credential, string subscriptionId, ILogger<ContainerInstanceUsageChecker> logger) : AzureUsageChecker(credential, subscriptionId, logger)
 {
-    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location)
+    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location, CancellationToken cancellationToken)
     {
         try
         {
             var subscription = ResourceClient.GetSubscriptionResource(new ResourceIdentifier($"/subscriptions/{SubscriptionId}"));
-            var usages = subscription.GetUsagesWithLocationAsync(location);
+            var usages = subscription.GetUsagesWithLocationAsync(location, cancellationToken);
 
             var result = new List<UsageInfo>();
             await foreach (ContainerInstanceUsage item in usages)

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/HDInsightUsageChecker.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/HDInsightUsageChecker.cs
@@ -10,12 +10,12 @@ namespace Azure.Mcp.Tools.Quota.Services.Util.Usage;
 
 public class HDInsightUsageChecker(TokenCredential credential, string subscriptionId, ILogger<HDInsightUsageChecker> logger) : AzureUsageChecker(credential, subscriptionId, logger)
 {
-    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location)
+    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location, CancellationToken cancellationToken)
     {
         try
         {
             var subscription = ResourceClient.GetSubscriptionResource(new ResourceIdentifier($"/subscriptions/{SubscriptionId}"));
-            var usages = subscription.GetHDInsightUsagesAsync(location);
+            var usages = subscription.GetHDInsightUsagesAsync(location, cancellationToken);
             var result = new List<UsageInfo>();
 
             await foreach (HDInsightUsage item in usages)

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/MachineLearningUsageChecker.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/MachineLearningUsageChecker.cs
@@ -9,12 +9,12 @@ namespace Azure.Mcp.Tools.Quota.Services.Util.Usage;
 
 public class MachineLearningUsageChecker(TokenCredential credential, string subscriptionId, ILogger<MachineLearningUsageChecker> logger) : AzureUsageChecker(credential, subscriptionId, logger)
 {
-    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location)
+    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location, CancellationToken cancellationToken)
     {
         try
         {
             var subscription = ResourceClient.GetSubscriptionResource(new ResourceIdentifier($"/subscriptions/{SubscriptionId}"));
-            var usages = subscription.GetMachineLearningUsagesAsync(location);
+            var usages = subscription.GetMachineLearningUsagesAsync(location, cancellationToken);
             var result = new List<UsageInfo>();
 
             await foreach (var item in usages)

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/NetworkUsageChecker.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/NetworkUsageChecker.cs
@@ -9,12 +9,12 @@ namespace Azure.Mcp.Tools.Quota.Services.Util.Usage;
 
 public class NetworkUsageChecker(TokenCredential credential, string subscriptionId, ILogger<NetworkUsageChecker> logger) : AzureUsageChecker(credential, subscriptionId, logger)
 {
-    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location)
+    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location, CancellationToken cancellationToken)
     {
         try
         {
             var subscription = ResourceClient.GetSubscriptionResource(new ResourceIdentifier($"/subscriptions/{SubscriptionId}"));
-            var usages = subscription.GetUsagesAsync(location);
+            var usages = subscription.GetUsagesAsync(location, cancellationToken);
             var result = new List<UsageInfo>();
 
             await foreach (var item in usages)

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/PostgreSQLUsageChecker.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/PostgreSQLUsageChecker.cs
@@ -12,12 +12,12 @@ public class PostgreSQLUsageChecker(TokenCredential credential, string subscript
 {
     private readonly IHttpClientService _httpClientService = httpClientService;
 
-    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location)
+    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location, CancellationToken cancellationToken)
     {
         try
         {
             var requestUrl = $"{managementEndpoint}/subscriptions/{SubscriptionId}/providers/Microsoft.DBforPostgreSQL/locations/{location}/resourceType/flexibleServers/usages?api-version=2023-06-01-preview";
-            using var rawResponse = await GetQuotaByUrlAsync(requestUrl);
+            using var rawResponse = await GetQuotaByUrlAsync(requestUrl, cancellationToken);
 
             if (rawResponse?.RootElement.TryGetProperty("value", out var valueElement) != true)
             {

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/SearchUsageChecker.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/SearchUsageChecker.cs
@@ -10,12 +10,12 @@ namespace Azure.Mcp.Tools.Quota.Services.Util.Usage;
 
 public class SearchUsageChecker(TokenCredential credential, string subscriptionId, ILogger<SearchUsageChecker> logger) : AzureUsageChecker(credential, subscriptionId, logger)
 {
-    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location)
+    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location, CancellationToken cancellationToken)
     {
         try
         {
             var subscription = ResourceClient.GetSubscriptionResource(new ResourceIdentifier($"/subscriptions/{SubscriptionId}"));
-            var usages = subscription.GetUsagesBySubscriptionAsync(location);
+            var usages = subscription.GetUsagesBySubscriptionAsync(location, cancellationToken: cancellationToken);
             var result = new List<UsageInfo>();
 
             await foreach (QuotaUsageResult item in usages)

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/StorageUsageChecker.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/Util/Usage/StorageUsageChecker.cs
@@ -9,12 +9,12 @@ namespace Azure.Mcp.Tools.Quota.Services.Util.Usage;
 
 public class StorageUsageChecker(TokenCredential credential, string subscriptionId, ILogger<StorageUsageChecker> logger) : AzureUsageChecker(credential, subscriptionId, logger)
 {
-    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location)
+    public override async Task<List<UsageInfo>> GetUsageForLocationAsync(string location, CancellationToken cancellationToken)
     {
         try
         {
             var subscription = ResourceClient.GetSubscriptionResource(new ResourceIdentifier($"/subscriptions/{SubscriptionId}"));
-            var usages = subscription.GetUsagesByLocationAsync(location);
+            var usages = subscription.GetUsagesByLocationAsync(location, cancellationToken);
             var result = new List<UsageInfo>();
 
             await foreach (var item in usages)

--- a/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.UnitTests/Commands/Region/AvailabilityListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.UnitTests/Commands/Region/AvailabilityListCommandTests.cs
@@ -62,7 +62,8 @@ public sealed class AvailabilityListCommandTests
                 subscriptionId,
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<string?>())
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
             .Returns(expectedRegions);
 
         var args = _commandDefinition.Parse([
@@ -89,7 +90,8 @@ public sealed class AvailabilityListCommandTests
             subscriptionId,
             null,
             null,
-            null);
+            null,
+            Arg.Any<CancellationToken>());
 
         // Verify the response structure
         var json = JsonSerializer.Serialize(result.Results);
@@ -130,7 +132,8 @@ public sealed class AvailabilityListCommandTests
                 subscriptionId,
                 cognitiveServiceModelName,
                 Arg.Any<string?>(),
-                cognitiveServiceDeploymentSkuName)
+                cognitiveServiceDeploymentSkuName,
+                Arg.Any<CancellationToken>())
             .Returns(expectedRegions);
 
         var args = _commandDefinition.Parse([
@@ -158,7 +161,8 @@ public sealed class AvailabilityListCommandTests
             subscriptionId,
             cognitiveServiceModelName,
             null,
-            cognitiveServiceDeploymentSkuName);
+            cognitiveServiceDeploymentSkuName,
+            Arg.Any<CancellationToken>());
 
         // Verify the response structure
         var json = JsonSerializer.Serialize(result.Results);
@@ -202,7 +206,8 @@ public sealed class AvailabilityListCommandTests
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -218,7 +223,8 @@ public sealed class AvailabilityListCommandTests
                 subscriptionId,
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<string?>())
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
             .ThrowsAsync(expectedException);
 
         var args = _commandDefinition.Parse([
@@ -255,7 +261,8 @@ public sealed class AvailabilityListCommandTests
                 subscriptionId,
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<string?>())
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
             .Returns(expectedRegions);
 
         var args = _commandDefinition.Parse([
@@ -282,7 +289,8 @@ public sealed class AvailabilityListCommandTests
             subscriptionId,
             null,
             null,
-            null);
+            null,
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -297,7 +305,8 @@ public sealed class AvailabilityListCommandTests
                 subscriptionId,
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<string?>())
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
             .Returns([]);
 
         var args = _commandDefinition.Parse([
@@ -339,7 +348,8 @@ public sealed class AvailabilityListCommandTests
                 subscriptionId,
                 cognitiveServiceModelName,
                 cognitiveServiceModelVersion,
-                cognitiveServiceDeploymentSkuName)
+                cognitiveServiceDeploymentSkuName,
+                Arg.Any<CancellationToken>())
             .Returns(expectedRegions);
 
         var args = _commandDefinition.Parse([
@@ -367,7 +377,8 @@ public sealed class AvailabilityListCommandTests
             subscriptionId,
             cognitiveServiceModelName,
             cognitiveServiceModelVersion,
-            cognitiveServiceDeploymentSkuName);
+            cognitiveServiceDeploymentSkuName,
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -398,7 +409,8 @@ public sealed class AvailabilityListCommandTests
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -419,7 +431,8 @@ public sealed class AvailabilityListCommandTests
                 subscriptionId,
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<string?>())
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
             .Returns(expectedRegions);
 
         var args = _commandDefinition.Parse([
@@ -446,7 +459,8 @@ public sealed class AvailabilityListCommandTests
             subscriptionId,
             null,
             null,
-            null);
+            null,
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -477,7 +491,8 @@ public sealed class AvailabilityListCommandTests
                 subscriptionId,
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<string?>())
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
             .Returns(expectedRegions);
 
         var args = _commandDefinition.Parse([
@@ -501,7 +516,8 @@ public sealed class AvailabilityListCommandTests
             subscriptionId,
             null,
             null,
-            null);
+            null,
+            Arg.Any<CancellationToken>());
 
         // Verify the response structure
         var json = JsonSerializer.Serialize(result.Results);

--- a/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.UnitTests/Commands/Usage/CheckCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.UnitTests/Commands/Usage/CheckCommandTests.cs
@@ -73,7 +73,8 @@ public sealed class CheckCommandTests
                     list.Contains("Microsoft.App") &&
                     list.Contains("Microsoft.Storage/storageAccounts")),
                 subscriptionId,
-                region)
+                region,
+                Arg.Any<CancellationToken>())
             .Returns(expectedQuotaInfo);
 
         var args = _commandDefinition.Parse([
@@ -99,7 +100,8 @@ public sealed class CheckCommandTests
                 list.Contains("Microsoft.App") &&
                 list.Contains("Microsoft.Storage/storageAccounts")),
             subscriptionId,
-            region);
+            region,
+            Arg.Any<CancellationToken>());
 
         // Verify the response structure
         var json = JsonSerializer.Serialize(result.Results);
@@ -135,7 +137,8 @@ public sealed class CheckCommandTests
         _quotaService.GetAzureQuotaAsync(
                 Arg.Any<List<string>>(),
                 subscriptionId,
-                region)
+                region,
+                Arg.Any<CancellationToken>())
             .Returns([]);
 
         var args = _commandDefinition.Parse([
@@ -166,7 +169,8 @@ public sealed class CheckCommandTests
         _quotaService.GetAzureQuotaAsync(
                 Arg.Any<List<string>>(),
                 subscriptionId,
-                region)
+                region,
+                Arg.Any<CancellationToken>())
             .ThrowsAsync(expectedException);
 
         var args = _commandDefinition.Parse([
@@ -208,7 +212,8 @@ public sealed class CheckCommandTests
                     list.Contains("Microsoft.Storage/storageAccounts") &&
                     list.Contains("Microsoft.Compute/virtualMachines")),
                 subscriptionId,
-                region)
+                region,
+                Arg.Any<CancellationToken>())
             .Returns(expectedQuotaInfo);
 
         var args = _commandDefinition.Parse([
@@ -234,7 +239,8 @@ public sealed class CheckCommandTests
                 list.Contains("Microsoft.Storage/storageAccounts") &&
                 list.Contains("Microsoft.Compute/virtualMachines")),
             subscriptionId,
-            region);
+            region,
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -248,7 +254,8 @@ public sealed class CheckCommandTests
         _quotaService.GetAzureQuotaAsync(
                 Arg.Any<List<string>>(),
                 subscriptionId,
-                region)
+                region,
+                Arg.Any<CancellationToken>())
             .Returns([]);
 
         var args = _commandDefinition.Parse([
@@ -320,7 +327,8 @@ public sealed class CheckCommandTests
                     list.Contains("microsoft.storage/storageaccounts") &&
                     list.Contains("Microsoft.Compute/VirtualMachines")),
                 subscriptionId,
-                region)
+                region,
+                Arg.Any<CancellationToken>())
             .Returns(expectedQuotaInfo);
 
         var args = _commandDefinition.Parse([
@@ -347,7 +355,8 @@ public sealed class CheckCommandTests
                 list.Contains("microsoft.storage/storageaccounts") &&
                 list.Contains("Microsoft.Compute/VirtualMachines")),
             subscriptionId,
-            region);
+            region,
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -374,7 +383,8 @@ public sealed class CheckCommandTests
                     list.Count == 1 &&
                     list.Contains("Microsoft.UnsupportedProvider/resourceType")),
                 subscriptionId,
-                region)
+                region,
+                Arg.Any<CancellationToken>())
             .Returns(expectedQuotaInfo);
 
         var args = _commandDefinition.Parse([
@@ -399,7 +409,8 @@ public sealed class CheckCommandTests
                 list.Count == 1 &&
                 list.Contains("Microsoft.UnsupportedProvider/resourceType")),
             subscriptionId,
-            region);
+            region,
+            Arg.Any<CancellationToken>());
 
         // Verify the response structure
         var json = JsonSerializer.Serialize(result.Results);
@@ -443,7 +454,8 @@ public sealed class CheckCommandTests
         _quotaService.GetAzureQuotaAsync(
                 Arg.Is<List<string>>(list => list.Count == 50),
                 subscriptionId,
-                region)
+                region,
+                Arg.Any<CancellationToken>())
             .Returns(expectedQuotaInfo);
 
         var args = _commandDefinition.Parse([
@@ -466,7 +478,8 @@ public sealed class CheckCommandTests
         await _quotaService.Received(1).GetAzureQuotaAsync(
             Arg.Is<List<string>>(list => list.Count == 50),
             subscriptionId,
-            region);
+            region,
+            Arg.Any<CancellationToken>());
 
         // Verify the response contains all expected resource types
         var json = JsonSerializer.Serialize(result.Results);
@@ -501,7 +514,8 @@ public sealed class CheckCommandTests
                     list.Count == 1 &&
                     list.Contains("Microsoft.Storage/storageAccounts")),
                 subscriptionId,
-                region)
+                region,
+                Arg.Any<CancellationToken>())
             .Returns(expectedQuotaInfo);
 
         var args = _commandDefinition.Parse([
@@ -526,7 +540,8 @@ public sealed class CheckCommandTests
                 list.Count == 1 &&
                 list.Contains("Microsoft.Storage/storageAccounts")),
             subscriptionId,
-            region);
+            region,
+            Arg.Any<CancellationToken>());
 
         // Verify the response structure contains descriptive error in Description
         var json = JsonSerializer.Serialize(result.Results);

--- a/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceCreateCommand.cs
@@ -88,7 +88,8 @@ public sealed class ResourceCreateCommand(ILogger<ResourceCreateCommand> logger)
                 options.AccessKeyAuthenticationEnabled,
                 options.Modules,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(
                 new ResourceCreateCommandResult(resource),

--- a/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceListCommand.cs
@@ -54,7 +54,8 @@ public sealed class ResourceListCommand(ILogger<ResourceListCommand> logger) : S
             var resources = await redisService.ListResourcesAsync(
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(resources ?? []), RedisJsonContext.Default.ResourceListCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Redis/src/Services/IRedisService.cs
+++ b/tools/Azure.Mcp.Tools.Redis/src/Services/IRedisService.cs
@@ -14,12 +14,14 @@ public interface IRedisService
     /// <param name="subscription">The subscription ID or name</param>
     /// <param name="tenant">Optional tenant ID for cross-tenant operations</param>
     /// <param name="retryPolicy">Optional retry policy configuration</param>
+    /// <param name="cancellationToken">A cancellation token</param>
     /// <returns>List of Redis resource details</returns>
     /// <exception cref="Exception">When the service request fails</exception>
     Task<IEnumerable<Resource>> ListResourcesAsync(
     string subscription,
     string? tenant = null,
-    RetryPolicyOptions? retryPolicy = null);
+    RetryPolicyOptions? retryPolicy = null,
+    CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Creates a new Redis resource in the specified subscription and resource group.
@@ -34,6 +36,7 @@ public interface IRedisService
     /// <param name="modules">The modules to enable (e.g. "RedisJSON", "RedisBloom")</param>
     /// <param name="tenant">Optional tenant ID for cross-tenant operations</param>
     /// <param name="retryPolicy">Optional retry policy configuration</param>
+    /// <param name="cancellationToken">A cancellation token</param>
     /// <returns>Details of the Redis resource being created.</returns>
     /// <exception cref="Exception">When the service request fails</exception>
     Task<Resource> CreateResourceAsync(
@@ -45,5 +48,6 @@ public interface IRedisService
         bool? accessKeyAuthenticationEnabled,
         string[]? modules = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Redis/tests/Azure.Mcp.Tools.Redis.UnitTests/ResourceCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Redis/tests/Azure.Mcp.Tools.Redis.UnitTests/ResourceCreateCommandTests.cs
@@ -57,7 +57,8 @@ public class ResourceCreateCommandTests
             Arg.Any<bool?>(),
             Arg.Any<string[]?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
         .Returns(expectedResource);
 
         var command = new ResourceCreateCommand(_logger);
@@ -145,7 +146,8 @@ public class ResourceCreateCommandTests
             Arg.Any<bool?>(),
             Arg.Any<string[]?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
         .ThrowsAsync(new Exception("Resource group 'test-rg' not found"));
 
         var command = new ResourceCreateCommand(_logger);
@@ -173,7 +175,8 @@ public class ResourceCreateCommandTests
             Arg.Any<bool?>(),
             Arg.Any<string[]?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -203,7 +206,8 @@ public class ResourceCreateCommandTests
                 modules.Contains("RedisBloom") &&
                 modules.Contains("RedisJSON")),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
         .Returns(expectedResource);
 
         var command = new ResourceCreateCommand(_logger);
@@ -244,7 +248,8 @@ public class ResourceCreateCommandTests
                 modules.Contains("RedisBloom") &&
                 modules.Contains("RedisJSON")),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -270,7 +275,8 @@ public class ResourceCreateCommandTests
             true,
             Arg.Any<string[]?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
         .Returns(expectedResource);
 
         var command = new ResourceCreateCommand(_logger);
@@ -307,7 +313,8 @@ public class ResourceCreateCommandTests
             true,
             Arg.Any<string[]?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -336,7 +343,8 @@ public class ResourceCreateCommandTests
                 modules.Length == 1 &&
                 modules.Contains("RedisJSON")),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
         .Returns(expectedResource);
 
         var command = new ResourceCreateCommand(_logger);
@@ -377,6 +385,7 @@ public class ResourceCreateCommandTests
                 modules.Length == 1 &&
                 modules.Contains("RedisJSON")),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Redis/tests/Azure.Mcp.Tools.Redis.UnitTests/ResourceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Redis/tests/Azure.Mcp.Tools.Redis.UnitTests/ResourceListCommandTests.cs
@@ -40,7 +40,7 @@ public class ResourceListCommandTests
     public async Task ExecuteAsync_ReturnsCaches_WhenCachesExist()
     {
         var expectedCaches = new CacheModel[] { new() { Name = "cache1" }, new() { Name = "cache2" } };
-        _redisService.ListResourcesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _redisService.ListResourcesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedCaches);
 
         var command = new ResourceListCommand(_logger);
@@ -65,7 +65,7 @@ public class ResourceListCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoCaches()
     {
-        _redisService.ListResourcesAsync("sub123").Returns([]);
+        _redisService.ListResourcesAsync("sub123", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>()).Returns([]);
 
         var command = new ResourceListCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123"]);
@@ -86,7 +86,7 @@ public class ResourceListCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
-        _redisService.ListResourcesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _redisService.ListResourcesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         var command = new ResourceListCommand(_logger);
@@ -133,7 +133,7 @@ public class ResourceListCommandTests
         };
 
         var expectedCaches = new CacheModel[] { new() { Name = "cache1" }, new() { Name = "cache2", AccessPolicyAssignments = expectedAssignments } };
-        _redisService.ListResourcesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _redisService.ListResourcesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedCaches);
 
         var command = new ResourceListCommand(_logger);
@@ -166,7 +166,7 @@ public class ResourceListCommandTests
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoAccessPolicyAssignments()
     {
         var expectedCaches = new CacheModel[] { new() { Name = "cache1" } };
-        _redisService.ListResourcesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _redisService.ListResourcesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedCaches);
 
         var command = new ResourceListCommand(_logger);
@@ -218,7 +218,7 @@ public class ResourceListCommandTests
 
         var expectedCaches = new CacheModel[] { new() { Name = "cache1", Databases = expectedDatabases } };
 
-        _redisService.ListResourcesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _redisService.ListResourcesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedCaches);
         var command = new ResourceListCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123"]);
@@ -250,7 +250,7 @@ public class ResourceListCommandTests
     {
         var expectedCaches = new CacheModel[] { new() { Name = "cache1" } };
 
-        _redisService.ListResourcesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _redisService.ListResourcesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedCaches);
         var command = new ResourceListCommand(_logger);
         var args = command.GetCommand().Parse(["--subscription", "sub123"]);

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/ServiceHealthEvents/ServiceHealthEventsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/ServiceHealthEvents/ServiceHealthEventsListCommandTests.cs
@@ -10,6 +10,7 @@ using Azure.Mcp.Tools.ResourceHealth.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.ResourceHealth.UnitTests.ServiceHealthEvents;
@@ -132,7 +133,7 @@ public class ServiceHealthEventsListCommandTests
     {
         // Arrange
         var expectedError = "Service error";
-        _resourceHealthService.When(x => x.ListServiceHealthEventsAsync(
+        _resourceHealthService.ListServiceHealthEventsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -142,8 +143,8 @@ public class ServiceHealthEventsListCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<CancellationToken>()))
-            .Do(x => throw new InvalidOperationException(expectedError));
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException(expectedError));
 
         var parsedArgs = _commandDefinition.Parse(["--subscription", "nonexistent-sub"]);
 

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexGetCommand.cs
@@ -71,7 +71,8 @@ public sealed class IndexGetCommand(ILogger<IndexGetCommand> logger) : GlobalCom
             var indexes = await searchService.GetIndexDetails(
                 options.Service!,
                 options.Index,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(indexes ?? []), SearchJsonContext.Default.IndexGetCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexQueryCommand.cs
@@ -70,7 +70,8 @@ public sealed class IndexQueryCommand(ILogger<IndexQueryCommand> logger) : Globa
                 options.Service!,
                 options.Index!,
                 options.Query!,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(results, SearchJsonContext.Default.ListJsonElement);
         }

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseGetCommand.cs
@@ -70,7 +70,7 @@ public sealed class KnowledgeBaseGetCommand(ILogger<KnowledgeBaseGetCommand> log
         try
         {
             var searchService = context.GetService<ISearchService>();
-            var bases = await searchService.ListKnowledgeBases(options.Service!, options.KnowledgeBase, options.RetryPolicy);
+            var bases = await searchService.ListKnowledgeBases(options.Service!, options.KnowledgeBase, options.RetryPolicy, cancellationToken);
             context.Response.Results = ResponseResult.Create(new(bases ?? []), SearchJsonContext.Default.KnowledgeBaseGetCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseRetrieveCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseRetrieveCommand.cs
@@ -104,7 +104,7 @@ public sealed class KnowledgeBaseRetrieveCommand(ILogger<KnowledgeBaseRetrieveCo
         try
         {
             var searchService = context.GetService<ISearchService>();
-            var result = await searchService.RetrieveFromKnowledgeBase(options.Service!, options.KnowledgeBase!, options.Query, parsedMessages, options.RetryPolicy);
+            var result = await searchService.RetrieveFromKnowledgeBase(options.Service!, options.KnowledgeBase!, options.Query, parsedMessages, options.RetryPolicy, cancellationToken);
             context.Response.Results = ResponseResult.Create(new(result), SearchJsonContext.Default.KnowledgeBaseRetrieveCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeSourceGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeSourceGetCommand.cs
@@ -72,7 +72,7 @@ public sealed class KnowledgeSourceGetCommand(ILogger<KnowledgeSourceGetCommand>
         try
         {
             var searchService = context.GetService<ISearchService>();
-            var sources = await searchService.ListKnowledgeSources(options.Service!, options.KnowledgeSource, options.RetryPolicy);
+            var sources = await searchService.ListKnowledgeSources(options.Service!, options.KnowledgeSource, options.RetryPolicy, cancellationToken);
             context.Response.Results = ResponseResult.Create(new(sources ?? []), SearchJsonContext.Default.KnowledgeSourceGetCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Service/ServiceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Service/ServiceListCommand.cs
@@ -52,7 +52,8 @@ public sealed class ServiceListCommand(ILogger<ServiceListCommand> logger) : Sub
             var services = await searchService.ListServices(
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(services ?? []), SearchJsonContext.Default.ServiceListCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Search/src/Services/ISearchService.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Services/ISearchService.cs
@@ -11,33 +11,39 @@ public interface ISearchService
     Task<List<string>> ListServices(
         string subscription,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<IndexInfo>> GetIndexDetails(
         string serviceName,
         string? indexName,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<KnowledgeSourceInfo>> ListKnowledgeSources(
         string serviceName,
         string? knowledgeSourceName = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<KnowledgeBaseInfo>> ListKnowledgeBases(
         string serviceName,
         string? knowledgeBaseName = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<JsonElement>> QueryIndex(
         string serviceName,
         string indexName,
         string searchText,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<string> RetrieveFromKnowledgeBase(
         string serviceName,
         string baseName,
         string? query,
         IEnumerable<(string role, string message)>? messages,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text;
+using System.Threading;
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Core.Services.Azure.Subscription;
@@ -35,7 +36,8 @@ public sealed class SearchService(
     public async Task<List<string>> ListServices(
         string subscription,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null)
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
 
@@ -43,17 +45,17 @@ public sealed class SearchService(
             ? $"{SearchServicesCacheKey}_{subscription}"
             : $"{SearchServicesCacheKey}_{subscription}_{tenantId}";
 
-        var cachedServices = await _cacheService.GetAsync<List<string>>(CacheGroup, cacheKey, s_cacheDurationServices);
+        var cachedServices = await _cacheService.GetAsync<List<string>>(CacheGroup, cacheKey, s_cacheDurationServices, cancellationToken);
         if (cachedServices != null)
         {
             return cachedServices;
         }
 
-        var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenantId, retryPolicy);
+        var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenantId, retryPolicy, cancellationToken);
         var services = new List<string>();
         try
         {
-            await foreach (var service in subscriptionResource.GetSearchServicesAsync())
+            await foreach (var service in subscriptionResource.GetSearchServicesAsync(cancellationToken: cancellationToken))
             {
                 if (service?.Data?.Name != null)
                 {
@@ -61,7 +63,7 @@ public sealed class SearchService(
                 }
             }
 
-            await _cacheService.SetAsync(CacheGroup, cacheKey, services, s_cacheDurationServices);
+            await _cacheService.SetAsync(CacheGroup, cacheKey, services, s_cacheDurationServices, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -74,7 +76,8 @@ public sealed class SearchService(
     public async Task<List<IndexInfo>> GetIndexDetails(
         string serviceName,
         string? indexName,
-        RetryPolicyOptions? retryPolicy = null)
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(serviceName), serviceName));
 
@@ -84,8 +87,8 @@ public sealed class SearchService(
         {
             try
             {
-                var searchClient = await GetSearchIndexClient(serviceName, retryPolicy);
-                await foreach (var index in searchClient.GetIndexesAsync())
+                var searchClient = await GetSearchIndexClient(serviceName, retryPolicy, cancellationToken);
+                await foreach (var index in searchClient.GetIndexesAsync(cancellationToken: cancellationToken))
                 {
                     indexes.Add(MapToIndexInfo(index));
                 }
@@ -100,8 +103,8 @@ public sealed class SearchService(
         {
             try
             {
-                var searchClient = await GetSearchIndexClient(serviceName, retryPolicy);
-                var index = await searchClient.GetIndexAsync(indexName);
+                var searchClient = await GetSearchIndexClient(serviceName, retryPolicy, cancellationToken);
+                var index = await searchClient.GetIndexAsync(indexName, cancellationToken: cancellationToken);
 
                 indexes.Add(MapToIndexInfo(index.Value));
             }
@@ -118,7 +121,8 @@ public sealed class SearchService(
         string serviceName,
         string indexName,
         string searchText,
-        RetryPolicyOptions? retryPolicy = null)
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
             (nameof(serviceName), serviceName),
@@ -127,8 +131,8 @@ public sealed class SearchService(
 
         try
         {
-            var searchClient = await GetSearchIndexClient(serviceName, retryPolicy);
-            var indexDefinition = await searchClient.GetIndexAsync(indexName);
+            var searchClient = await GetSearchIndexClient(serviceName, retryPolicy, cancellationToken);
+            var indexDefinition = await searchClient.GetIndexAsync(indexName, cancellationToken: cancellationToken);
             var client = searchClient.GetSearchClient(indexName);
 
             var options = new SearchOptions
@@ -141,7 +145,7 @@ public sealed class SearchService(
             var vectorizableFields = FindVectorizableFields(indexDefinition.Value, vectorFields);
             ConfigureSearchOptions(searchText, options, indexDefinition.Value, vectorFields);
 
-            var searchResponse = await client.SearchAsync(searchText, SearchJsonContext.Default.JsonElement, options);
+            var searchResponse = await client.SearchAsync(searchText, SearchJsonContext.Default.JsonElement, options, cancellationToken: cancellationToken);
 
             return await ProcessSearchResults(searchResponse);
         }
@@ -154,25 +158,26 @@ public sealed class SearchService(
     public async Task<List<KnowledgeSourceInfo>> ListKnowledgeSources(
         string serviceName,
         string? knowledgeSourceName = null,
-        RetryPolicyOptions? retryPolicy = null)
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(serviceName), serviceName));
 
         try
         {
             var sources = new List<KnowledgeSourceInfo>();
-            var searchClient = await GetSearchIndexClient(serviceName, retryPolicy);
+            var searchClient = await GetSearchIndexClient(serviceName, retryPolicy, cancellationToken);
 
             if (string.IsNullOrEmpty(knowledgeSourceName))
             {
-                await foreach (var source in searchClient.GetKnowledgeSourcesAsync())
+                await foreach (var source in searchClient.GetKnowledgeSourcesAsync(cancellationToken: cancellationToken))
                 {
                     sources.Add(new KnowledgeSourceInfo(source.Name, source.GetType().Name, source.Description));
                 }
             }
             else
             {
-                var result = await searchClient.GetKnowledgeSourceAsync(knowledgeSourceName);
+                var result = await searchClient.GetKnowledgeSourceAsync(knowledgeSourceName, cancellationToken: cancellationToken);
                 if (result?.Value != null)
                 {
                     sources.Add(new KnowledgeSourceInfo(result.Value.Name, result.Value.GetType().Name, result.Value.Description));
@@ -190,25 +195,26 @@ public sealed class SearchService(
     public async Task<List<KnowledgeBaseInfo>> ListKnowledgeBases(
         string serviceName,
         string? knowledgeBaseName = null,
-        RetryPolicyOptions? retryPolicy = null)
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(serviceName), serviceName));
 
         try
         {
             var bases = new List<KnowledgeBaseInfo>();
-            var searchClient = await GetSearchIndexClient(serviceName, retryPolicy);
+            var searchClient = await GetSearchIndexClient(serviceName, retryPolicy, cancellationToken);
 
             if (string.IsNullOrEmpty(knowledgeBaseName))
             {
-                await foreach (var knowledgeBase in searchClient.GetKnowledgeAgentsAsync())
+                await foreach (var knowledgeBase in searchClient.GetKnowledgeAgentsAsync(cancellationToken: cancellationToken))
                 {
                     bases.Add(new KnowledgeBaseInfo(knowledgeBase.Name, knowledgeBase.Description, [.. knowledgeBase.KnowledgeSources.Select(ks => ks.Name)]));
                 }
             }
             else
             {
-                var result = await searchClient.GetKnowledgeAgentAsync(knowledgeBaseName);
+                var result = await searchClient.GetKnowledgeAgentAsync(knowledgeBaseName, cancellationToken: cancellationToken);
                 if (result?.Value != null)
                 {
                     if (result.Value.Name.Equals(knowledgeBaseName, StringComparison.OrdinalIgnoreCase))
@@ -225,30 +231,32 @@ public sealed class SearchService(
             throw new Exception($"Error retrieving Search knowledge bases: {ex.Message}", ex);
         }
     }
+
     public async Task<string> RetrieveFromKnowledgeBase(
         string serviceName,
         string baseName,
         string? query,
         IEnumerable<(string role, string message)>? messages,
-        RetryPolicyOptions? retryPolicy = null)
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(serviceName), serviceName), (nameof(baseName), baseName));
 
         try
         {
-            var searchClient = await GetSearchIndexClient(serviceName, retryPolicy);
+            var searchClient = await GetSearchIndexClient(serviceName, retryPolicy, cancellationToken);
 
             var clientOptions = AddDefaultPolicies(new SearchClientOptions());
             ConfigureRetryPolicy(clientOptions, retryPolicy);
 
-            var knowledgeBaseClient = new KnowledgeAgentRetrievalClient(searchClient.Endpoint, baseName, await GetCredential(), clientOptions);
+            var knowledgeBaseClient = new KnowledgeAgentRetrievalClient(searchClient.Endpoint, baseName, await GetCredential(cancellationToken: cancellationToken), clientOptions);
 
             var request = new KnowledgeAgentRetrievalRequest(
                 messages != null ?
                     messages.Select(m => new KnowledgeAgentMessage([new KnowledgeAgentMessageTextContent(m.message)]) { Role = m.role }) :
                     [new KnowledgeAgentMessage([new KnowledgeAgentMessageTextContent(query)]) { Role = "user" }]);
 
-            var results = await knowledgeBaseClient.RetrieveAsync(request);
+            var results = await knowledgeBaseClient.RetrieveAsync(request, cancellationToken: cancellationToken);
 
             var response = results.GetRawResponse().Content ?? throw new InvalidOperationException("Response had no content");
             return await ProcessRetrieveResponse(response.ToStream());
@@ -314,20 +322,20 @@ public sealed class SearchService(
         return vectorizableFields;
     }
 
-    private async Task<SearchIndexClient> GetSearchIndexClient(string serviceName, RetryPolicyOptions? retryPolicy)
+    private async Task<SearchIndexClient> GetSearchIndexClient(string serviceName, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken = default)
     {
         var key = $"{SearchServicesCacheKey}_{serviceName}";
-        var searchClient = await _cacheService.GetAsync<SearchIndexClient>(CacheGroup, key, s_cacheDurationClients);
+        var searchClient = await _cacheService.GetAsync<SearchIndexClient>(CacheGroup, key, s_cacheDurationClients, cancellationToken);
         if (searchClient == null)
         {
-            var credential = await GetCredential();
+            var credential = await GetCredential(cancellationToken);
 
             var clientOptions = AddDefaultPolicies(new SearchClientOptions());
             ConfigureRetryPolicy(clientOptions, retryPolicy);
 
             var endpoint = new Uri($"https://{serviceName}.search.windows.net");
             searchClient = new SearchIndexClient(endpoint, credential, clientOptions);
-            await _cacheService.SetAsync(CacheGroup, key, searchClient, s_cacheDurationClients);
+            await _cacheService.SetAsync(CacheGroup, key, searchClient, s_cacheDurationClients, cancellationToken);
         }
         return searchClient;
     }

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Index/IndexGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Index/IndexGetCommandTests.cs
@@ -42,7 +42,8 @@ public class IndexGetCommandTests
         _searchService.GetIndexDetails(
             Arg.Is("service123"),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedIndexes);
 
         var command = new IndexGetCommand(_logger);
@@ -68,7 +69,8 @@ public class IndexGetCommandTests
         _searchService.GetIndexDetails(
             Arg.Any<string>(),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         var command = new IndexGetCommand(_logger);
@@ -97,7 +99,8 @@ public class IndexGetCommandTests
         _searchService.GetIndexDetails(
             Arg.Is(serviceName),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         var command = new IndexGetCommand(_logger);
@@ -121,7 +124,11 @@ public class IndexGetCommandTests
         var expectedDefinition = CreateMockIndexDefinition();
 
         // When using ThrowsAsync or Returns with NSubstitute, we need to match the exact parameter signature
-        _searchService.GetIndexDetails(Arg.Is(serviceName), Arg.Is(indexName), Arg.Any<RetryPolicyOptions?>())
+        _searchService.GetIndexDetails(
+            Arg.Is(serviceName),
+            Arg.Is(indexName),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns([expectedDefinition]);
 
         var command = new IndexGetCommand(_logger);
@@ -154,7 +161,11 @@ public class IndexGetCommandTests
         var serviceName = "service123";
         var indexName = "index1";
 
-        _searchService.GetIndexDetails(Arg.Is(serviceName), Arg.Is(indexName), Arg.Any<RetryPolicyOptions?>())
+        _searchService.GetIndexDetails(
+            Arg.Is(serviceName),
+            Arg.Is(indexName),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         var command = new IndexGetCommand(_logger);
@@ -185,7 +196,8 @@ public class IndexGetCommandTests
         _searchService.GetIndexDetails(
             Arg.Is(serviceName),
             Arg.Is(indexName),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         var command = new IndexGetCommand(_logger);

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Index/IndexQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Index/IndexQueryCommandTests.cs
@@ -56,7 +56,12 @@ public class IndexQueryCommandTests
             ).RootElement
         ];
 
-        _searchService.QueryIndex(Arg.Is(serviceName), Arg.Is(indexName), Arg.Is(queryText), Arg.Any<RetryPolicyOptions?>())
+        _searchService.QueryIndex(
+            Arg.Is(serviceName),
+            Arg.Is(indexName),
+            Arg.Is(queryText),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedResults);
 
         var command = new IndexQueryCommand(_logger);
@@ -86,7 +91,12 @@ public class IndexQueryCommandTests
         var indexName = "index1";
         var queryText = "test query";
 
-        _searchService.QueryIndex(Arg.Is(serviceName), Arg.Is(indexName), Arg.Is(queryText), Arg.Any<RetryPolicyOptions?>())
+        _searchService.QueryIndex(
+            Arg.Is(serviceName),
+            Arg.Is(indexName),
+            Arg.Is(queryText),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         var command = new IndexQueryCommand(_logger);

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Knowledge/KnowledgeBaseGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Knowledge/KnowledgeBaseGetCommandTests.cs
@@ -43,7 +43,11 @@ public class KnowledgeBaseGetCommandTests
             new("base2", "Second base", ["source2", "source3"])
         };
 
-        _searchService.ListKnowledgeBases(Arg.Is("service123"), Arg.Is((string?)null), Arg.Any<RetryPolicyOptions>())
+        _searchService.ListKnowledgeBases(
+            Arg.Is("service123"),
+            Arg.Is((string?)null),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedBases);
 
         var command = new KnowledgeBaseGetCommand(_logger);
@@ -73,7 +77,11 @@ public class KnowledgeBaseGetCommandTests
     {
         var expectedBase = new KnowledgeBaseInfo("base1", "First base", ["source1"]);
 
-        _searchService.ListKnowledgeBases(Arg.Is("service123"), Arg.Is("base1"), Arg.Any<RetryPolicyOptions>())
+        _searchService.ListKnowledgeBases(
+            Arg.Is("service123"),
+            Arg.Is("base1"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([expectedBase]);
 
         var command = new KnowledgeBaseGetCommand(_logger);
@@ -96,7 +104,12 @@ public class KnowledgeBaseGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoBases()
     {
-        _searchService.ListKnowledgeBases(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions>()).Returns([]);
+        _searchService.ListKnowledgeBases(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns([]);
 
         var command = new KnowledgeBaseGetCommand(_logger);
 
@@ -118,7 +131,11 @@ public class KnowledgeBaseGetCommandTests
         var expectedError = "Test error";
         var serviceName = "service123";
 
-        _searchService.ListKnowledgeBases(Arg.Is(serviceName), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions>())
+        _searchService.ListKnowledgeBases(
+            Arg.Is(serviceName),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         var command = new KnowledgeBaseGetCommand(_logger);

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Knowledge/KnowledgeBaseRetrieveCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Knowledge/KnowledgeBaseRetrieveCommandTests.cs
@@ -40,7 +40,8 @@ public class KnowledgeBaseRetrieveCommandTests
             Arg.Is("base1"),
             Arg.Is("life"),
             Arg.Is<List<(string role, string message)>?>(m => m == null),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(json);
 
         var command = new KnowledgeBaseRetrieveCommand(_logger);
@@ -62,7 +63,8 @@ public class KnowledgeBaseRetrieveCommandTests
             Arg.Is("base1"),
             Arg.Is<string?>(q => q == null),
             Arg.Is<List<(string role, string message)>?>(m => m != null && m.Count == 1 && m[0].role == "user"),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(json);
 
         var command = new KnowledgeBaseRetrieveCommand(_logger);
@@ -118,7 +120,8 @@ public class KnowledgeBaseRetrieveCommandTests
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<List<(string role, string message)>?>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test failure"));
 
         var command = new KnowledgeBaseRetrieveCommand(_logger);

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Knowledge/KnowledgeSourceGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Knowledge/KnowledgeSourceGetCommandTests.cs
@@ -43,7 +43,11 @@ public class KnowledgeSourceGetCommandTests
             new("source2", "IndexSource", "Second source")
         };
 
-        _searchService.ListKnowledgeSources(Arg.Is("service123"), Arg.Is((string?)null), Arg.Any<RetryPolicyOptions>())
+        _searchService.ListKnowledgeSources(
+            Arg.Is("service123"),
+            Arg.Is((string?)null),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedSources);
 
         var command = new KnowledgeSourceGetCommand(_logger);
@@ -67,7 +71,11 @@ public class KnowledgeSourceGetCommandTests
     {
         var expectedSource = new KnowledgeSourceInfo("source1", "BlobSource", "First source");
 
-        _searchService.ListKnowledgeSources(Arg.Is("service123"), Arg.Is("source1"), Arg.Any<RetryPolicyOptions>())
+        _searchService.ListKnowledgeSources(
+            Arg.Is("service123"),
+            Arg.Is("source1"),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([expectedSource]);
 
         var command = new KnowledgeSourceGetCommand(_logger);
@@ -90,7 +98,11 @@ public class KnowledgeSourceGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoSources()
     {
-        _searchService.ListKnowledgeSources(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions>()).Returns([]);
+        _searchService.ListKnowledgeSources(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>()).Returns([]);
 
         var command = new KnowledgeSourceGetCommand(_logger);
 
@@ -112,7 +124,11 @@ public class KnowledgeSourceGetCommandTests
         var expectedError = "Test error";
         var serviceName = "service123";
 
-        _searchService.ListKnowledgeSources(Arg.Is(serviceName), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions>())
+        _searchService.ListKnowledgeSources(
+            Arg.Is(serviceName),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         var command = new KnowledgeSourceGetCommand(_logger);

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Service/ServiceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Service/ServiceListCommandTests.cs
@@ -38,7 +38,11 @@ public class ServiceListCommandTests
     {
         // Arrange
         var expectedServices = new List<string> { "service1", "service2" };
-        _searchService.ListServices(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _searchService.ListServices(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedServices);
 
         var command = new ServiceListCommand(_logger);
@@ -64,7 +68,11 @@ public class ServiceListCommandTests
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoServices()
     {
         // Arrange
-        _searchService.ListServices(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _searchService.ListServices(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         var command = new ServiceListCommand(_logger);
@@ -93,7 +101,11 @@ public class ServiceListCommandTests
         var expectedError = "Test error";
         var subscriptionId = "sub123";
 
-        _searchService.ListServices(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _searchService.ListServices(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         var command = new ServiceListCommand(_logger);

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Queue/QueueDetailsCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Queue/QueueDetailsCommand.cs
@@ -76,7 +76,8 @@ public sealed class QueueDetailsCommand(ILogger<QueueDetailsCommand> logger) : S
                 options.Namespace!,
                 options.Name!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(details), ServiceBusJsonContext.Default.QueueDetailsCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Queue/QueuePeekCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Queue/QueuePeekCommand.cs
@@ -81,7 +81,8 @@ public sealed class QueuePeekCommand(ILogger<QueuePeekCommand> logger) : Subscri
                 options.Name!,
                 options.MaxMessages ?? 1,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(messages ?? []), ServiceBusJsonContext.Default.QueuePeekCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/SubscriptionDetailsCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/SubscriptionDetailsCommand.cs
@@ -79,7 +79,8 @@ public sealed class SubscriptionDetailsCommand(ILogger<SubscriptionDetailsComman
                 options.TopicName!,
                 options.SubscriptionName!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(details), ServiceBusJsonContext.Default.SubscriptionDetailsCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/SubscriptionPeekCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/SubscriptionPeekCommand.cs
@@ -86,7 +86,8 @@ public sealed class SubscriptionPeekCommand(ILogger<SubscriptionPeekCommand> log
                 options.SubscriptionName!,
                 options.MaxMessages ?? 1,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(messages ?? []), ServiceBusJsonContext.Default.SubscriptionPeekCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/TopicDetailsCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/TopicDetailsCommand.cs
@@ -73,7 +73,8 @@ public sealed class TopicDetailsCommand(ILogger<TopicDetailsCommand> logger) : S
                 options.Namespace!,
                 options.TopicName!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(details), ServiceBusJsonContext.Default.TopicDetailsCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Services/IServiceBusService.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Services/IServiceBusService.cs
@@ -24,7 +24,8 @@ public interface IServiceBusService
         string topicName,
         string subscriptionName,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the details of a Service Bus queue.
@@ -40,7 +41,8 @@ public interface IServiceBusService
         string namespaceName,
         string queueName,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the details of a Service Bus topic.
@@ -55,7 +57,8 @@ public interface IServiceBusService
         string namespaceName,
         string topicName,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Peeks messages from a Service Bus queue without removing them.
@@ -73,7 +76,8 @@ public interface IServiceBusService
         string queueName,
         int maxMessages,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Peeks messages from a Service Bus subscription without removing them.
@@ -93,5 +97,6 @@ public interface IServiceBusService
         string subscriptionName,
         int maxMessages,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Services/ServiceBusService.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Services/ServiceBusService.cs
@@ -16,12 +16,13 @@ public class ServiceBusService(ITenantService tenantService) : BaseAzureService(
         string namespaceName,
         string queueName,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null)
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var credential = await GetCredential(tenantId);
+        var credential = await GetCredential(cancellationToken);
         var client = new ServiceBusAdministrationClient(namespaceName, credential);
-        var runtimeProperties = (await client.GetQueueRuntimePropertiesAsync(queueName)).Value;
-        var properties = (await client.GetQueueAsync(queueName)).Value;
+        var runtimeProperties = (await client.GetQueueRuntimePropertiesAsync(queueName, cancellationToken)).Value;
+        var properties = (await client.GetQueueAsync(queueName, cancellationToken)).Value;
 
         return new QueueDetails
         {
@@ -53,12 +54,13 @@ public class ServiceBusService(ITenantService tenantService) : BaseAzureService(
         string topicName,
         string subscriptionName,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null)
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var credential = await GetCredential(tenantId);
+        var credential = await GetCredential(cancellationToken);
         var client = new ServiceBusAdministrationClient(namespaceName, credential);
-        var runtimeProperties = (await client.GetSubscriptionRuntimePropertiesAsync(topicName, subscriptionName)).Value;
-        var properties = (await client.GetSubscriptionAsync(topicName, subscriptionName)).Value;
+        var runtimeProperties = (await client.GetSubscriptionRuntimePropertiesAsync(topicName, subscriptionName, cancellationToken)).Value;
+        var properties = (await client.GetSubscriptionAsync(topicName, subscriptionName, cancellationToken)).Value;
 
         return new SubscriptionDetails
         {
@@ -83,12 +85,13 @@ public class ServiceBusService(ITenantService tenantService) : BaseAzureService(
         string namespaceName,
         string topicName,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null)
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var credential = await GetCredential(tenantId);
+        var credential = await GetCredential(cancellationToken);
         var client = new ServiceBusAdministrationClient(namespaceName, credential);
-        var runtimeProperties = (await client.GetTopicRuntimePropertiesAsync(topicName)).Value;
-        var properties = (await client.GetTopicAsync(topicName)).Value;
+        var runtimeProperties = (await client.GetTopicRuntimePropertiesAsync(topicName, cancellationToken)).Value;
+        var properties = (await client.GetTopicAsync(topicName, cancellationToken)).Value;
 
         return new TopicDetails
         {
@@ -110,14 +113,15 @@ public class ServiceBusService(ITenantService tenantService) : BaseAzureService(
         string queueName,
         int maxMessages,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null)
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var credential = await GetCredential(tenantId);
+        var credential = await GetCredential(cancellationToken);
 
         await using (var client = new ServiceBusClient(namespaceName, credential))
         await using (var receiver = client.CreateReceiver(queueName))
         {
-            var messages = await receiver.PeekMessagesAsync(maxMessages);
+            var messages = await receiver.PeekMessagesAsync(maxMessages, cancellationToken: cancellationToken);
 
             return [.. messages];
         }
@@ -129,14 +133,15 @@ public class ServiceBusService(ITenantService tenantService) : BaseAzureService(
         string subscriptionName,
         int maxMessages,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null)
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var credential = await GetCredential(tenantId);
+        var credential = await GetCredential(cancellationToken);
 
         await using (var client = new ServiceBusClient(namespaceName, credential))
         await using (var receiver = client.CreateReceiver(topicName, subscriptionName))
         {
-            var messages = await receiver.PeekMessagesAsync(maxMessages);
+            var messages = await receiver.PeekMessagesAsync(maxMessages, cancellationToken: cancellationToken);
 
             return [.. messages];
         }

--- a/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.UnitTests/Queue/QueueDetailsCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.UnitTests/Queue/QueueDetailsCommandTests.cs
@@ -67,7 +67,8 @@ public class QueueDetailsCommandTests
             Arg.Is(NamespaceName),
             Arg.Is(QueueName),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>()
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>()
         ).Returns(expectedDetails);
 
         var args = _commandDefinition.Parse(["--subscription", SubscriptionId, "--namespace", NamespaceName, "--queue", QueueName]);
@@ -98,7 +99,8 @@ public class QueueDetailsCommandTests
             Arg.Is(NamespaceName),
             Arg.Is(QueueName),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>()
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>()
         ).ThrowsAsync(serviceBusException);
 
         var args = _commandDefinition.Parse(["--subscription", SubscriptionId, "--namespace", NamespaceName, "--queue", QueueName]);
@@ -122,7 +124,8 @@ public class QueueDetailsCommandTests
             Arg.Is(NamespaceName),
             Arg.Is(QueueName),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>()
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>()
         ).ThrowsAsync(new Exception(expectedError));
 
         var args = _commandDefinition.Parse(["--subscription", SubscriptionId, "--namespace", NamespaceName, "--queue", QueueName]);
@@ -158,7 +161,8 @@ public class QueueDetailsCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>())
+                Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
                 .Returns(expectedDetails);
         }
 

--- a/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.UnitTests/Topic/SubscriptionDetailsCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.UnitTests/Topic/SubscriptionDetailsCommandTests.cs
@@ -69,7 +69,8 @@ public class SubscriptionDetailsCommandTests
             Arg.Is(TopicName),
             Arg.Is(SubscriptionName),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>()
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>()
         ).Returns(expectedDetails);
 
         var args = _commandDefinition.Parse([
@@ -106,7 +107,8 @@ public class SubscriptionDetailsCommandTests
             Arg.Is(TopicName),
             Arg.Is(SubscriptionName),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>()
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>()
         ).ThrowsAsync(serviceBusException);
 
         var args = _commandDefinition.Parse([
@@ -136,7 +138,8 @@ public class SubscriptionDetailsCommandTests
             Arg.Is(TopicName),
             Arg.Is(SubscriptionName),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>()
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>()
         ).ThrowsAsync(new Exception(expectedError));
 
         var args = _commandDefinition.Parse([
@@ -179,7 +182,8 @@ public class SubscriptionDetailsCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>())
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
                 .Returns(expectedDetails);
         }
 

--- a/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.UnitTests/Topic/TopicDetailsCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.UnitTests/Topic/TopicDetailsCommandTests.cs
@@ -67,7 +67,8 @@ public class TopicDetailsCommandTests
             Arg.Is(NamespaceName),
             Arg.Is(TopicName),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>()
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>()
         ).Returns(expectedDetails);
 
         var args = _commandDefinition.Parse(["--subscription", SubscriptionId, "--namespace", NamespaceName, "--topic", TopicName]);
@@ -98,7 +99,8 @@ public class TopicDetailsCommandTests
             Arg.Is(NamespaceName),
             Arg.Is(TopicName),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>()
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>()
         ).ThrowsAsync(serviceBusException);
 
         var args = _commandDefinition.Parse(["--subscription", SubscriptionId, "--namespace", NamespaceName, "--topic", TopicName]);
@@ -121,7 +123,8 @@ public class TopicDetailsCommandTests
             Arg.Is(NamespaceName),
             Arg.Is(TopicName),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>()
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>()
         ).ThrowsAsync(new Exception(expectedError));
 
         var args = _commandDefinition.Parse(["--subscription", SubscriptionId, "--namespace", NamespaceName, "--topic", TopicName]);
@@ -157,7 +160,8 @@ public class TopicDetailsCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>())
+                Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
                 .Returns(expectedDetails);
         }
 

--- a/tools/Azure.Mcp.Tools.SignalR/src/Commands/Runtime/RuntimeGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.SignalR/src/Commands/Runtime/RuntimeGetCommand.cs
@@ -73,7 +73,8 @@ public sealed class RuntimeGetCommand(ILogger<RuntimeGetCommand> logger)
                 options.SignalR,
                 options.Tenant,
                 options.AuthMethod,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             _logger.LogInformation("Found {Count} SignalR service(s) in subscription {SubscriptionId}",
                 runtimes.Count(), options.Subscription);

--- a/tools/Azure.Mcp.Tools.SignalR/src/Services/ISignalRService.cs
+++ b/tools/Azure.Mcp.Tools.SignalR/src/Services/ISignalRService.cs
@@ -17,5 +17,6 @@ public interface ISignalRService
         string? signalRName,
         string? tenant = null,
         AuthMethod? authMethod = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.SignalR/tests/Azure.Mcp.Tools.SignalR.UnitTests/Runtime/RuntimeGetCommandTest.cs
+++ b/tools/Azure.Mcp.Tools.SignalR/tests/Azure.Mcp.Tools.SignalR.UnitTests/Runtime/RuntimeGetCommandTest.cs
@@ -101,7 +101,13 @@ public class RuntimeGetCommandTests
                 }
             };
             _signalRService.GetRuntimeAsync(
-                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<AuthMethod?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(runtimes);
         }
 
@@ -128,7 +134,13 @@ public class RuntimeGetCommandTests
     {
         // Arrange
         _signalRService.GetRuntimeAsync(
-            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<AuthMethod?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         var parseResult = _commandDefinition.Parse(["--subscription", "sub1"]);
@@ -150,7 +162,13 @@ public class RuntimeGetCommandTests
     {
         // Arrange
         _signalRService.GetRuntimeAsync(
-            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<AuthMethod?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         var parseResult = _commandDefinition.Parse(["--subscription", "sub1"]);
@@ -170,7 +188,13 @@ public class RuntimeGetCommandTests
         // Arrange
         var notFoundException = new RequestFailedException(404, "Not Found");
         _signalRService.GetRuntimeAsync(
-            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<AuthMethod?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
         var parseResult = _commandDefinition.Parse(["--subscription", "sub1"]);
@@ -188,7 +212,13 @@ public class RuntimeGetCommandTests
         // Arrange
         var forbiddenException = new RequestFailedException(403, "Forbidden");
         _signalRService.GetRuntimeAsync(
-            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>())
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<AuthMethod?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(forbiddenException);
 
         var parseResult = _commandDefinition.Parse(["--subscription", "sub1"]);

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountCreateCommand.cs
@@ -90,7 +90,8 @@ public sealed class AccountCreateCommand(ILogger<AccountCreateCommand> logger) :
                 options.AccessTier,
                 options.EnableHierarchicalNamespace,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             // Set results
             context.Response.Results = ResponseResult.Create(new(account), StorageJsonContext.Default.AccountCreateCommandResult);

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobGetCommand.cs
@@ -70,7 +70,8 @@ public sealed class BlobGetCommand(ILogger<BlobGetCommand> logger) : BaseContain
                 options.Blob,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy
+                options.RetryPolicy,
+                cancellationToken
             );
 
             context.Response.Results = ResponseResult.Create(new(details ?? []), StorageJsonContext.Default.BlobGetCommandResult);

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobUploadCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobUploadCommand.cs
@@ -70,7 +70,8 @@ public sealed class BlobUploadCommand(ILogger<BlobUploadCommand> logger) : BaseB
                 options.LocalFilePath!,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(result, StorageJsonContext.Default.BlobUploadResult);
 

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerCreateCommand.cs
@@ -52,7 +52,8 @@ public sealed class ContainerCreateCommand(ILogger<ContainerCreateCommand> logge
                 options.Container!,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy);
+                options.RetryPolicy,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(containerInfo), StorageJsonContext.Default.ContainerCreateCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerGetCommand.cs
@@ -68,7 +68,8 @@ public sealed class ContainerGetCommand(ILogger<ContainerGetCommand> logger) : B
                 options.Container,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy
+                options.RetryPolicy,
+                cancellationToken
             );
 
             context.Response.Results = ResponseResult.Create(new(containers ?? []), StorageJsonContext.Default.ContainerGetCommandResult);

--- a/tools/Azure.Mcp.Tools.Storage/src/Services/IStorageService.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Services/IStorageService.cs
@@ -24,7 +24,8 @@ public interface IStorageService
         string? accessTier = null,
         bool? enableHierarchicalNamespace = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<BlobInfo>> GetBlobDetails(
         string account,
@@ -32,21 +33,24 @@ public interface IStorageService
         string? blob,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<List<ContainerInfo>> GetContainerDetails(
         string account,
         string? container,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<ContainerInfo> CreateContainer(
         string account,
         string container,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<BlobUploadResult> UploadBlob(
         string account,
@@ -55,5 +59,6 @@ public interface IStorageService
         string localFilePath,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null);
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.UnitTests/Account/AccountCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.UnitTests/Account/AccountCreateCommandTests.cs
@@ -90,7 +90,8 @@ public class AccountCreateCommandTests
                 Arg.Any<string>(),
                 Arg.Any<bool?>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>())
+                Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
                 .Returns(expectedAccount);
         }
 
@@ -133,7 +134,8 @@ public class AccountCreateCommandTests
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(conflictException);
 
         var parseResult = _commandDefinition.Parse(["--account", "existingaccount", "--resource-group", "testrg", "--location", "eastus", "--subscription", "sub123"]);
@@ -161,7 +163,8 @@ public class AccountCreateCommandTests
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
         var parseResult = _commandDefinition.Parse(["--account", "testaccount", "--resource-group", "nonexistentrg", "--location", "eastus", "--subscription", "sub123"]);
@@ -189,7 +192,8 @@ public class AccountCreateCommandTests
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(authException);
 
         var parseResult = _commandDefinition.Parse(["--account", "testaccount", "--resource-group", "testrg", "--location", "eastus", "--subscription", "sub123"]);
@@ -215,7 +219,8 @@ public class AccountCreateCommandTests
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<StorageAccountResult>(new Exception("Test error")));
 
         var parseResult = _commandDefinition.Parse(["--account", "testaccount", "--resource-group", "testrg", "--location", "eastus", "--subscription", "sub123"]);
@@ -261,7 +266,8 @@ public class AccountCreateCommandTests
             "Cool",
             true,
             null,
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedAccount);
 
         var parseResult = _commandDefinition.Parse([
@@ -288,6 +294,7 @@ public class AccountCreateCommandTests
             "Cool",
             true,
             null,
-            Arg.Any<RetryPolicyOptions>());
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/Hostpool/HostpoolListCommand.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/Hostpool/HostpoolListCommand.cs
@@ -58,14 +58,16 @@ public sealed class HostpoolListCommand(ILogger<HostpoolListCommand> logger) : B
                     options.Subscription!,
                     options.ResourceGroup,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
             }
             else
             {
                 hostpools = await virtualDesktopService.ListHostpoolsAsync(
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
             }
 
             context.Response.Results = ResponseResult.Create(new([.. hostpools ?? []]), VirtualDesktopJsonContext.Default.HostPoolListCommandResult);

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/SessionHost/SessionHostListCommand.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/SessionHost/SessionHostListCommand.cs
@@ -59,7 +59,8 @@ public sealed class SessionHostListCommand(ILogger<SessionHostListCommand> logge
                     options.Subscription!,
                     options.HostPoolResourceId,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
             }
             else if (!string.IsNullOrEmpty(options.ResourceGroup))
             {
@@ -68,7 +69,8 @@ public sealed class SessionHostListCommand(ILogger<SessionHostListCommand> logge
                     options.ResourceGroup,
                     options.HostPoolName!,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
             }
             else
             {
@@ -76,7 +78,8 @@ public sealed class SessionHostListCommand(ILogger<SessionHostListCommand> logge
                     options.Subscription!,
                     options.HostPoolName!,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
             }
 
             context.Response.Results = ResponseResult.Create(new([.. sessionHosts ?? []]), VirtualDesktopJsonContext.Default.SessionHostListCommandResult);

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/SessionHost/SessionHostUserSessionListCommand.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/SessionHost/SessionHostUserSessionListCommand.cs
@@ -58,7 +58,8 @@ public sealed class SessionHostUserSessionListCommand(ILogger<SessionHostUserSes
                     options.HostPoolResourceId,
                     options.SessionHostName!,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
             }
             else if (!string.IsNullOrEmpty(options.ResourceGroup))
             {
@@ -68,7 +69,8 @@ public sealed class SessionHostUserSessionListCommand(ILogger<SessionHostUserSes
                     options.HostPoolName!,
                     options.SessionHostName!,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
             }
             else
             {
@@ -77,7 +79,8 @@ public sealed class SessionHostUserSessionListCommand(ILogger<SessionHostUserSes
                     options.HostPoolName!,
                     options.SessionHostName!,
                     options.Tenant,
-                    options.RetryPolicy);
+                    options.RetryPolicy,
+                    cancellationToken);
             }
 
             context.Response.Results = ResponseResult.Create(new([.. userSessions ?? []]), VirtualDesktopJsonContext.Default.SessionHostUserSessionListCommandResult);

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Services/IVirtualDesktopService.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Services/IVirtualDesktopService.cs
@@ -9,12 +9,63 @@ using Azure.Mcp.Core.Options;
 
 public interface IVirtualDesktopService
 {
-    Task<IReadOnlyList<HostPool>> ListHostpoolsAsync(string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
-    Task<IReadOnlyList<HostPool>> ListHostpoolsByResourceGroupAsync(string subscription, string resourceGroup, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
-    Task<IReadOnlyList<SessionHost>> ListSessionHostsAsync(string subscription, string hostPoolName, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
-    Task<IReadOnlyList<SessionHost>> ListSessionHostsByResourceIdAsync(string subscription, string hostPoolResourceId, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
-    Task<IReadOnlyList<SessionHost>> ListSessionHostsByResourceGroupAsync(string subscription, string resourceGroup, string hostPoolName, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
-    Task<IReadOnlyList<UserSession>> ListUserSessionsAsync(string subscription, string hostPoolName, string sessionHostName, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
-    Task<IReadOnlyList<UserSession>> ListUserSessionsByResourceIdAsync(string subscription, string hostPoolResourceId, string sessionHostName, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
-    Task<IReadOnlyList<UserSession>> ListUserSessionsByResourceGroupAsync(string subscription, string resourceGroup, string hostPoolName, string sessionHostName, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
+    Task<IReadOnlyList<HostPool>> ListHostpoolsAsync(
+        string subscription,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<HostPool>> ListHostpoolsByResourceGroupAsync(
+        string subscription,
+        string resourceGroup,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SessionHost>> ListSessionHostsAsync(
+        string subscription,
+        string hostPoolName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SessionHost>> ListSessionHostsByResourceIdAsync(
+        string subscription,
+        string hostPoolResourceId,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SessionHost>> ListSessionHostsByResourceGroupAsync(
+        string subscription,
+        string resourceGroup,
+        string hostPoolName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<UserSession>> ListUserSessionsAsync(
+        string subscription,
+        string hostPoolName,
+        string sessionHostName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<UserSession>> ListUserSessionsByResourceIdAsync(
+        string subscription,
+        string hostPoolResourceId,
+        string sessionHostName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<UserSession>> ListUserSessionsByResourceGroupAsync(
+        string subscription,
+        string resourceGroup,
+        string hostPoolName,
+        string sessionHostName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Services/VirtualDesktopService.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Services/VirtualDesktopService.cs
@@ -12,42 +12,56 @@ public class VirtualDesktopService(ISubscriptionService subscriptionService) : I
 {
     private readonly ISubscriptionService _subscriptionService = subscriptionService;
 
-    public async Task<IReadOnlyList<HostPool>> ListHostpoolsAsync(string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
+    public async Task<IReadOnlyList<HostPool>> ListHostpoolsAsync(
+        string subscription,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
+        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
         var hostpools = new List<HostPool>();
-        await foreach (HostPoolResource resource in sub.GetHostPoolsAsync())
+        await foreach (HostPoolResource resource in sub.GetHostPoolsAsync(cancellationToken))
         {
             hostpools.Add(new HostPool(resource));
         }
         return hostpools;
     }
 
-    public async Task<IReadOnlyList<HostPool>> ListHostpoolsByResourceGroupAsync(string subscription, string resourceGroup, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
+    public async Task<IReadOnlyList<HostPool>> ListHostpoolsByResourceGroupAsync(
+        string subscription,
+        string resourceGroup,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
+        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
         var hostpools = new List<HostPool>();
 
-        var resourceGroupResource = await sub.GetResourceGroupAsync(resourceGroup);
-        await foreach (HostPoolResource resource in resourceGroupResource.Value.GetHostPools().GetAllAsync())
+        var resourceGroupResource = await sub.GetResourceGroupAsync(resourceGroup, cancellationToken);
+        await foreach (HostPoolResource resource in resourceGroupResource.Value.GetHostPools().GetAllAsync(cancellationToken))
         {
             hostpools.Add(new HostPool(resource));
         }
         return hostpools;
     }
 
-    public async Task<IReadOnlyList<SessionHost>> ListSessionHostsAsync(string subscription, string hostPoolName, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
+    public async Task<IReadOnlyList<SessionHost>> ListSessionHostsAsync(
+        string subscription,
+        string hostPoolName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
+        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
         var sessionHosts = new List<SessionHost>();
 
-        await foreach (HostPoolResource resource in sub.GetHostPoolsAsync())
+        await foreach (HostPoolResource resource in sub.GetHostPoolsAsync(cancellationToken))
         {
             if (resource.Data.Name == hostPoolName)
             {
                 var armClient = sub.GetCachedClient(client => client);
                 var hostPool = armClient.GetHostPoolResource(resource.Id);
-                await foreach (SessionHostResource sessionHost in hostPool.GetSessionHosts().GetAllAsync())
+                await foreach (SessionHostResource sessionHost in hostPool.GetSessionHosts().GetAllAsync(cancellationToken))
                 {
                     sessionHosts.Add(new SessionHost(sessionHost));
                 }
@@ -58,22 +72,28 @@ public class VirtualDesktopService(ISubscriptionService subscriptionService) : I
         return sessionHosts;
     }
 
-    public async Task<IReadOnlyList<UserSession>> ListUserSessionsAsync(string subscription, string hostPoolName, string sessionHostName, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
+    public async Task<IReadOnlyList<UserSession>> ListUserSessionsAsync(
+        string subscription,
+        string hostPoolName,
+        string sessionHostName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
+        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
         var userSessions = new List<UserSession>();
 
-        await foreach (HostPoolResource resource in sub.GetHostPoolsAsync())
+        await foreach (HostPoolResource resource in sub.GetHostPoolsAsync(cancellationToken))
         {
             if (resource.Data.Name == hostPoolName)
             {
                 var armClient = sub.GetCachedClient(client => client);
                 var hostPool = armClient.GetHostPoolResource(resource.Id);
-                await foreach (SessionHostResource sessionHost in hostPool.GetSessionHosts().GetAllAsync())
+                await foreach (SessionHostResource sessionHost in hostPool.GetSessionHosts().GetAllAsync(cancellationToken))
                 {
                     if (sessionHost.Data.Name == sessionHostName || sessionHost.Data.Name == $"{hostPoolName}/{sessionHostName}")
                     {
-                        await foreach (UserSessionResource userSession in sessionHost.GetUserSessions().GetAllAsync())
+                        await foreach (UserSessionResource userSession in sessionHost.GetUserSessions().GetAllAsync(cancellationToken))
                         {
                             userSessions.Add(new UserSession(userSession));
                         }
@@ -87,14 +107,19 @@ public class VirtualDesktopService(ISubscriptionService subscriptionService) : I
         return userSessions;
     }
 
-    public async Task<IReadOnlyList<SessionHost>> ListSessionHostsByResourceIdAsync(string subscription, string hostPoolResourceId, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
+    public async Task<IReadOnlyList<SessionHost>> ListSessionHostsByResourceIdAsync(
+        string subscription,
+        string hostPoolResourceId,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
+        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
         var sessionHosts = new List<SessionHost>();
 
         var armClient = sub.GetCachedClient(client => client);
         var hostPool = armClient.GetHostPoolResource(Azure.Core.ResourceIdentifier.Parse(hostPoolResourceId));
-        await foreach (SessionHostResource sessionHost in hostPool.GetSessionHosts().GetAllAsync())
+        await foreach (SessionHostResource sessionHost in hostPool.GetSessionHosts().GetAllAsync(cancellationToken))
         {
             sessionHosts.Add(new SessionHost(sessionHost));
         }
@@ -102,18 +127,24 @@ public class VirtualDesktopService(ISubscriptionService subscriptionService) : I
         return sessionHosts;
     }
 
-    public async Task<IReadOnlyList<UserSession>> ListUserSessionsByResourceIdAsync(string subscription, string hostPoolResourceId, string sessionHostName, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
+    public async Task<IReadOnlyList<UserSession>> ListUserSessionsByResourceIdAsync(
+        string subscription,
+        string hostPoolResourceId,
+        string sessionHostName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
+        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
         var userSessions = new List<UserSession>();
 
         var armClient = sub.GetCachedClient(client => client);
         var hostPool = armClient.GetHostPoolResource(Azure.Core.ResourceIdentifier.Parse(hostPoolResourceId));
-        await foreach (SessionHostResource sessionHost in hostPool.GetSessionHosts().GetAllAsync())
+        await foreach (SessionHostResource sessionHost in hostPool.GetSessionHosts().GetAllAsync(cancellationToken))
         {
             if (sessionHost.Data.Name == sessionHostName || sessionHost.Data.Name.EndsWith($"/{sessionHostName}"))
             {
-                await foreach (UserSessionResource userSession in sessionHost.GetUserSessions().GetAllAsync())
+                await foreach (UserSessionResource userSession in sessionHost.GetUserSessions().GetAllAsync(cancellationToken))
                 {
                     userSessions.Add(new UserSession(userSession));
                 }
@@ -124,15 +155,21 @@ public class VirtualDesktopService(ISubscriptionService subscriptionService) : I
         return userSessions;
     }
 
-    public async Task<IReadOnlyList<SessionHost>> ListSessionHostsByResourceGroupAsync(string subscription, string resourceGroup, string hostPoolName, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
+    public async Task<IReadOnlyList<SessionHost>> ListSessionHostsByResourceGroupAsync(
+        string subscription,
+        string resourceGroup,
+        string hostPoolName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
+        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
         var sessionHosts = new List<SessionHost>();
 
-        var resourceGroupResource = await sub.GetResourceGroupAsync(resourceGroup);
-        var hostPool = await resourceGroupResource.Value.GetHostPoolAsync(hostPoolName);
+        var resourceGroupResource = await sub.GetResourceGroupAsync(resourceGroup, cancellationToken);
+        var hostPool = await resourceGroupResource.Value.GetHostPoolAsync(hostPoolName, cancellationToken);
 
-        await foreach (SessionHostResource sessionHost in hostPool.Value.GetSessionHosts().GetAllAsync())
+        await foreach (SessionHostResource sessionHost in hostPool.Value.GetSessionHosts().GetAllAsync(cancellationToken))
         {
             sessionHosts.Add(new SessionHost(sessionHost));
         }
@@ -140,19 +177,26 @@ public class VirtualDesktopService(ISubscriptionService subscriptionService) : I
         return sessionHosts;
     }
 
-    public async Task<IReadOnlyList<UserSession>> ListUserSessionsByResourceGroupAsync(string subscription, string resourceGroup, string hostPoolName, string sessionHostName, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
+    public async Task<IReadOnlyList<UserSession>> ListUserSessionsByResourceGroupAsync(
+        string subscription,
+        string resourceGroup,
+        string hostPoolName,
+        string sessionHostName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
+        var sub = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
         var userSessions = new List<UserSession>();
 
-        var resourceGroupResource = await sub.GetResourceGroupAsync(resourceGroup);
-        var hostPool = await resourceGroupResource.Value.GetHostPoolAsync(hostPoolName);
+        var resourceGroupResource = await sub.GetResourceGroupAsync(resourceGroup, cancellationToken);
+        var hostPool = await resourceGroupResource.Value.GetHostPoolAsync(hostPoolName, cancellationToken);
 
-        await foreach (SessionHostResource sessionHost in hostPool.Value.GetSessionHosts().GetAllAsync())
+        await foreach (SessionHostResource sessionHost in hostPool.Value.GetSessionHosts().GetAllAsync(cancellationToken))
         {
             if (sessionHost.Data.Name == sessionHostName || sessionHost.Data.Name.EndsWith($"/{sessionHostName}"))
             {
-                await foreach (UserSessionResource userSession in sessionHost.GetUserSessions().GetAllAsync())
+                await foreach (UserSessionResource userSession in sessionHost.GetUserSessions().GetAllAsync(cancellationToken))
                 {
                     userSessions.Add(new UserSession(userSession));
                 }

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.UnitTests/Hostpool/HostpoolListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.UnitTests/Hostpool/HostpoolListCommandTests.cs
@@ -67,9 +67,9 @@ public class HostpoolListCommandTests
                 new() { Name = "hostpool1" },
                 new() { Name = "hostpool2" }
             }.AsReadOnly();
-            _virtualDesktopService.ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            _virtualDesktopService.ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
                 .Returns(hostpools);
-            _virtualDesktopService.ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            _virtualDesktopService.ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
                 .Returns(hostpools);
         }
 
@@ -95,9 +95,9 @@ public class HostpoolListCommandTests
     public async Task ExecuteAsync_ReturnsEmptyResult_WhenNoHostpools()
     {
         // Arrange
-        _virtualDesktopService.ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _virtualDesktopService.ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns([]);
-        _virtualDesktopService.ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _virtualDesktopService.ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         var parseResult = _commandDefinition.Parse("--subscription test-sub");
@@ -114,7 +114,7 @@ public class HostpoolListCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _virtualDesktopService.ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _virtualDesktopService.ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<IReadOnlyList<HostPool>>(new Exception("Test error")));
 
         var parseResult = _commandDefinition.Parse("--subscription test-sub");
@@ -137,7 +137,7 @@ public class HostpoolListCommandTests
             new() { Name = "hostpool1" },
             new() { Name = "hostpool2" }
         }.AsReadOnly();
-        _virtualDesktopService.ListHostpoolsAsync("test-sub", null, Arg.Any<RetryPolicyOptions>())
+        _virtualDesktopService.ListHostpoolsAsync("test-sub", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedHostpools);
 
         var parseResult = _commandDefinition.Parse("--subscription test-sub");
@@ -149,7 +149,7 @@ public class HostpoolListCommandTests
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        await _virtualDesktopService.Received(1).ListHostpoolsAsync("test-sub", null, Arg.Any<RetryPolicyOptions>());
+        await _virtualDesktopService.Received(1).ListHostpoolsAsync("test-sub", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -161,7 +161,7 @@ public class HostpoolListCommandTests
             new() { Name = "hostpool1" },
             new() { Name = "hostpool2" }
         }.AsReadOnly();
-        _virtualDesktopService.ListHostpoolsByResourceGroupAsync("test-sub", "test-rg", null, Arg.Any<RetryPolicyOptions>())
+        _virtualDesktopService.ListHostpoolsByResourceGroupAsync("test-sub", "test-rg", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedHostpools);
 
         var parseResult = _commandDefinition.Parse("--subscription test-sub --resource-group test-rg");
@@ -173,8 +173,8 @@ public class HostpoolListCommandTests
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        await _virtualDesktopService.Received(1).ListHostpoolsByResourceGroupAsync("test-sub", "test-rg", null, Arg.Any<RetryPolicyOptions>());
-        await _virtualDesktopService.DidNotReceive().ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>());
+        await _virtualDesktopService.Received(1).ListHostpoolsByResourceGroupAsync("test-sub", "test-rg", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
+        await _virtualDesktopService.DidNotReceive().ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -186,7 +186,7 @@ public class HostpoolListCommandTests
             new() { Name = "hostpool1" },
             new() { Name = "hostpool2" }
         }.AsReadOnly();
-        _virtualDesktopService.ListHostpoolsAsync("test-sub", null, Arg.Any<RetryPolicyOptions>())
+        _virtualDesktopService.ListHostpoolsAsync("test-sub", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedHostpools);
 
         var parseResult = _commandDefinition.Parse("--subscription test-sub");
@@ -198,15 +198,15 @@ public class HostpoolListCommandTests
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        await _virtualDesktopService.Received(1).ListHostpoolsAsync("test-sub", null, Arg.Any<RetryPolicyOptions>());
-        await _virtualDesktopService.DidNotReceive().ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>());
+        await _virtualDesktopService.Received(1).ListHostpoolsAsync("test-sub", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
+        await _virtualDesktopService.DidNotReceive().ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsEmptyResult_WhenNoHostpoolsInResourceGroup()
     {
         // Arrange
-        _virtualDesktopService.ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _virtualDesktopService.ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         var parseResult = _commandDefinition.Parse("--subscription test-sub --resource-group test-rg");

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.UnitTests/SessionHost/SessionHostListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.UnitTests/SessionHost/SessionHostListCommandTests.cs
@@ -75,14 +75,16 @@ public class SessionHostListCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>())
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult<IReadOnlyList<SessionHostModel>>(mockSessionHosts));
 
             _virtualDesktopService.ListSessionHostsByResourceIdAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>())
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult<IReadOnlyList<SessionHostModel>>(mockSessionHosts));
 
             _virtualDesktopService.ListSessionHostsByResourceGroupAsync(
@@ -90,7 +92,8 @@ public class SessionHostListCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>())
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult<IReadOnlyList<SessionHostModel>>(mockSessionHosts));
         }
 
@@ -128,7 +131,8 @@ public class SessionHostListCommandTests
             "sub123",
             "pool1",
             null,
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedSessionHosts);
 
         var context = new CommandContext(_serviceProvider);
@@ -146,7 +150,8 @@ public class SessionHostListCommandTests
             "sub123",
             "pool1",
             null,
-            Arg.Any<RetryPolicyOptions>());
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -164,7 +169,8 @@ public class SessionHostListCommandTests
             "sub123",
             resourceId,
             null,
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedSessionHosts);
 
         var context = new CommandContext(_serviceProvider);
@@ -182,13 +188,15 @@ public class SessionHostListCommandTests
             "sub123",
             resourceId,
             null,
-            Arg.Any<RetryPolicyOptions>());
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
 
         await _virtualDesktopService.DidNotReceive().ListSessionHostsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>());
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -219,7 +227,8 @@ public class SessionHostListCommandTests
             "rg1",
             "pool1",
             null,
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedSessionHosts);
 
         var context = new CommandContext(_serviceProvider);
@@ -244,7 +253,8 @@ public class SessionHostListCommandTests
             "rg1",
             "pool1",
             null,
-            Arg.Any<RetryPolicyOptions>());
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -255,14 +265,16 @@ public class SessionHostListCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         _virtualDesktopService.ListSessionHostsByResourceIdAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         var context = new CommandContext(_serviceProvider);
@@ -285,14 +297,16 @@ public class SessionHostListCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<IReadOnlyList<SessionHostModel>>(new Exception("Test error")));
 
         _virtualDesktopService.ListSessionHostsByResourceIdAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<IReadOnlyList<SessionHostModel>>(new Exception("Test error")));
 
         var context = new CommandContext(_serviceProvider);

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.UnitTests/SessionHost/SessionHostUserSessionListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.UnitTests/SessionHost/SessionHostUserSessionListCommandTests.cs
@@ -86,7 +86,8 @@ public class SessionHostUserSessionListCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(userSessions.AsReadOnly());
 
             _virtualDesktopService.ListUserSessionsByResourceIdAsync(
@@ -94,7 +95,8 @@ public class SessionHostUserSessionListCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(userSessions.AsReadOnly());
 
             _virtualDesktopService.ListUserSessionsByResourceGroupAsync(
@@ -103,7 +105,8 @@ public class SessionHostUserSessionListCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>())
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns(userSessions.AsReadOnly());
         }
 
@@ -158,7 +161,8 @@ public class SessionHostUserSessionListCommandTests
             "test-hostpool",
             "test-sessionhost",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
         var parseResult = _commandDefinition.Parse("--subscription test-sub --hostpool test-hostpool --sessionhost test-sessionhost");
@@ -176,7 +180,8 @@ public class SessionHostUserSessionListCommandTests
             "test-hostpool",
             "test-sessionhost",
             null,
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -202,7 +207,8 @@ public class SessionHostUserSessionListCommandTests
             resourceId,
             "test-sessionhost",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
         var parseResult = _commandDefinition.Parse($"--subscription test-sub --hostpool-resource-id {resourceId} --sessionhost test-sessionhost");
@@ -220,14 +226,16 @@ public class SessionHostUserSessionListCommandTests
             resourceId,
             "test-sessionhost",
             null,
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
 
         await _virtualDesktopService.DidNotReceive().ListUserSessionsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -253,7 +261,8 @@ public class SessionHostUserSessionListCommandTests
             "test-hostpool",
             "test-sessionhost",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
         var parseResult = _commandDefinition.Parse("--subscription test-sub --hostpool test-hostpool --sessionhost test-sessionhost --resource-group test-rg");
@@ -272,21 +281,24 @@ public class SessionHostUserSessionListCommandTests
             "test-hostpool",
             "test-sessionhost",
             null,
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
 
         await _virtualDesktopService.DidNotReceive().ListUserSessionsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
 
         await _virtualDesktopService.DidNotReceive().ListUserSessionsByResourceIdAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -300,7 +312,8 @@ public class SessionHostUserSessionListCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
         _virtualDesktopService.ListUserSessionsByResourceIdAsync(
@@ -308,7 +321,8 @@ public class SessionHostUserSessionListCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
         var parseResult = _commandDefinition.Parse("--subscription test-sub --hostpool test-hostpool --sessionhost test-sessionhost");
@@ -331,7 +345,8 @@ public class SessionHostUserSessionListCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         _virtualDesktopService.ListUserSessionsByResourceIdAsync(
@@ -339,7 +354,8 @@ public class SessionHostUserSessionListCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         var parseResult = _commandDefinition.Parse("--subscription test-sub --hostpool test-hostpool --sessionhost test-sessionhost");
@@ -363,7 +379,8 @@ public class SessionHostUserSessionListCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(exception);
 
         _virtualDesktopService.ListUserSessionsByResourceIdAsync(
@@ -371,7 +388,8 @@ public class SessionHostUserSessionListCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(exception);
 
         var parseResult = _commandDefinition.Parse("--subscription test-sub --hostpool test-hostpool --sessionhost test-sessionhost");
@@ -395,7 +413,8 @@ public class SessionHostUserSessionListCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(exception);
 
         _virtualDesktopService.ListUserSessionsByResourceIdAsync(
@@ -403,7 +422,8 @@ public class SessionHostUserSessionListCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(exception);
 
         var parseResult = _commandDefinition.Parse("--subscription test-sub --hostpool test-hostpool --sessionhost test-sessionhost");
@@ -439,7 +459,8 @@ public class SessionHostUserSessionListCommandTests
             "test-hostpool",
             "test-sessionhost",
             "test-tenant",
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
         _virtualDesktopService.ListUserSessionsByResourceIdAsync(
@@ -447,7 +468,8 @@ public class SessionHostUserSessionListCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
         var parseResult = _commandDefinition.Parse("--subscription test-sub --hostpool test-hostpool --sessionhost test-sessionhost --tenant test-tenant");
@@ -465,6 +487,7 @@ public class SessionHostUserSessionListCommandTests
             "test-hostpool",
             "test-sessionhost",
             "test-tenant",
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/CreateWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/CreateWorkbooksCommand.cs
@@ -83,7 +83,8 @@ public sealed class CreateWorkbooksCommand(ILogger<CreateWorkbooksCommand> logge
                  */
                 options.SourceId ?? "azure monitor",
                 options.RetryPolicy,
-                options.Tenant) ?? throw new InvalidOperationException("Failed to create workbook");
+                options.Tenant,
+                cancellationToken) ?? throw new InvalidOperationException("Failed to create workbook");
 
             context.Response.Results = ResponseResult.Create(new(createdWorkbook), WorkbooksJsonContext.Default.CreateWorkbooksCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/DeleteWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/DeleteWorkbooksCommand.cs
@@ -64,7 +64,7 @@ public sealed class DeleteWorkbooksCommand(ILogger<DeleteWorkbooksCommand> logge
         try
         {
             var workbooksService = context.GetService<IWorkbooksService>();
-            var deleted = await workbooksService.DeleteWorkbook(options.WorkbookId!, options.RetryPolicy, options.Tenant);
+            var deleted = await workbooksService.DeleteWorkbook(options.WorkbookId!, options.RetryPolicy, options.Tenant, cancellationToken);
 
             if (deleted)
             {

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ListWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ListWorkbooksCommand.cs
@@ -77,7 +77,8 @@ public sealed class ListWorkbooksCommand(ILogger<ListWorkbooksCommand> logger) :
                 options.ResourceGroup!,
                 filters,
                 options.RetryPolicy,
-                options.Tenant);
+                options.Tenant,
+                cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(workbooks ?? []), WorkbooksJsonContext.Default.ListWorkbooksCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ShowWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ShowWorkbooksCommand.cs
@@ -62,7 +62,7 @@ public sealed class ShowWorkbooksCommand(ILogger<ShowWorkbooksCommand> logger) :
         try
         {
             var workbooksService = context.GetService<IWorkbooksService>();
-            var workbook = await workbooksService.GetWorkbook(options.WorkbookId!, options.RetryPolicy, options.Tenant) ?? throw new InvalidOperationException("Failed to retrieve workbook");
+            var workbook = await workbooksService.GetWorkbook(options.WorkbookId!, options.RetryPolicy, options.Tenant, cancellationToken) ?? throw new InvalidOperationException("Failed to retrieve workbook");
 
             context.Response.Results = ResponseResult.Create(new(workbook), WorkbooksJsonContext.Default.ShowWorkbooksCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/UpdateWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/UpdateWorkbooksCommand.cs
@@ -70,7 +70,8 @@ public sealed class UpdateWorkbooksCommand(ILogger<UpdateWorkbooksCommand> logge
                 options.DisplayName,
                 options.SerializedContent,
                 options.RetryPolicy,
-                options.Tenant) ?? throw new InvalidOperationException("Failed to update workbook");
+                options.Tenant,
+                cancellationToken) ?? throw new InvalidOperationException("Failed to update workbook");
 
             context.Response.Results = ResponseResult.Create(new(updatedWorkbook), WorkbooksJsonContext.Default.UpdateWorkbooksCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Services/IWorkbooksService.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Services/IWorkbooksService.cs
@@ -8,9 +8,41 @@ namespace Azure.Mcp.Tools.Workbooks.Services;
 
 public interface IWorkbooksService
 {
-    Task<List<WorkbookInfo>> ListWorkbooks(string subscription, string resourceGroupName, WorkbookFilters? filters = null, RetryPolicyOptions? retryPolicy = null, string? tenant = null);
-    Task<WorkbookInfo?> CreateWorkbook(string subscription, string resourceGroupName, string displayName, string serializedData, string sourceId, RetryPolicyOptions? retryPolicy = null, string? tenant = null);
-    Task<WorkbookInfo?> GetWorkbook(string workbookId, RetryPolicyOptions? retryPolicy = null, string? tenant = null);
-    Task<WorkbookInfo?> UpdateWorkbook(string workbookId, string? displayName = null, string? serializedContent = null, RetryPolicyOptions? retryPolicy = null, string? tenant = null);
-    Task<bool> DeleteWorkbook(string workbookId, RetryPolicyOptions? retryPolicy = null, string? tenant = null);
+    Task<List<WorkbookInfo>> ListWorkbooks(
+        string subscription,
+        string resourceGroupName,
+        WorkbookFilters? filters = null,
+        RetryPolicyOptions? retryPolicy = null,
+        string? tenant = null,
+        CancellationToken cancellationToken = default);
+
+    Task<WorkbookInfo?> CreateWorkbook(
+        string subscription,
+        string resourceGroupName,
+        string displayName,
+        string serializedData,
+        string sourceId,
+        RetryPolicyOptions? retryPolicy = null,
+        string? tenant = null,
+        CancellationToken cancellationToken = default);
+
+    Task<WorkbookInfo?> GetWorkbook(
+        string workbookId,
+        RetryPolicyOptions? retryPolicy = null,
+        string? tenant = null,
+        CancellationToken cancellationToken = default);
+
+    Task<WorkbookInfo?> UpdateWorkbook(
+        string workbookId,
+        string? displayName = null,
+        string? serializedContent = null,
+        RetryPolicyOptions? retryPolicy = null,
+        string? tenant = null,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> DeleteWorkbook(
+        string workbookId,
+        RetryPolicyOptions? retryPolicy = null,
+        string? tenant = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/CreateWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/CreateWorkbooksCommandTests.cs
@@ -94,7 +94,8 @@ public class CreateWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            cancellationToken: Arg.Any<CancellationToken>())
             .Returns(workbook);
 
         var context = new CommandContext(_serviceProvider);
@@ -117,7 +118,8 @@ public class CreateWorkbooksCommandTests
             "Test Workbook",
             """{"items":[{"type":"text","content":"Test content"}]}""",
             "azure monitor",
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -145,7 +147,8 @@ public class CreateWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            cancellationToken: Arg.Any<CancellationToken>())
             .Returns(workbook);
 
         var context = new CommandContext(_serviceProvider);
@@ -165,7 +168,8 @@ public class CreateWorkbooksCommandTests
             "Test Workbook",
             """{"items":[{"type":"text","content":"Test content"}]}""",
             "custom-source",
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -178,7 +182,8 @@ public class CreateWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            cancellationToken: Arg.Any<CancellationToken>())
             .Returns((WorkbookInfo?)null);
 
         var context = new CommandContext(_serviceProvider);
@@ -205,7 +210,8 @@ public class CreateWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            cancellationToken: Arg.Any<CancellationToken>())
             .Returns(Task.FromException<WorkbookInfo?>(new InvalidOperationException("Service error")));
 
         var context = new CommandContext(_serviceProvider);
@@ -247,7 +253,8 @@ public class CreateWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            cancellationToken: Arg.Any<CancellationToken>())
             .Returns(workbook);
 
         var context = new CommandContext(_serviceProvider);
@@ -266,7 +273,8 @@ public class CreateWorkbooksCommandTests
             "My Test Workbook",
             """{"version": "Notebook/1.0","items": [{"type": "1","content": "Hello World"}]}""",
             "azure monitor",
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -280,7 +288,8 @@ public class CreateWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            cancellationToken: Arg.Any<CancellationToken>())
             .Returns(workbook);
 
         var context = new CommandContext(_serviceProvider);
@@ -299,7 +308,8 @@ public class CreateWorkbooksCommandTests
             "Test Workbook",
             """{"items":[]}""",
             "azure monitor",
-            Arg.Any<RetryPolicyOptions?>());
+            Arg.Any<RetryPolicyOptions?>(),
+            cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -314,7 +324,8 @@ public class CreateWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(workbook);
 
         var context = new CommandContext(_serviceProvider);
@@ -336,7 +347,8 @@ public class CreateWorkbooksCommandTests
             """{"items":[]}""",
             "azure monitor",
             Arg.Any<RetryPolicyOptions?>(),
-            "test-tenant");
+            "test-tenant",
+            Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -436,7 +448,8 @@ public class CreateWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            cancellationToken: Arg.Any<CancellationToken>())
             .Returns(workbook);
 
         var context = new CommandContext(_serviceProvider);
@@ -465,7 +478,8 @@ public class CreateWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            cancellationToken: Arg.Any<CancellationToken>())
             .Returns(workbook);
 
         var context = new CommandContext(_serviceProvider);
@@ -492,7 +506,8 @@ public class CreateWorkbooksCommandTests
                 opts != null &&
                 opts.MaxRetries == 5 &&
                 opts.DelaySeconds == 2.5 &&
-                opts.MaxDelaySeconds == 30));
+                opts.MaxDelaySeconds == 30),
+            cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -505,7 +520,8 @@ public class CreateWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>())
+            Arg.Any<RetryPolicyOptions?>(),
+            cancellationToken: Arg.Any<CancellationToken>())
             .Returns(Task.FromException<WorkbookInfo?>(new ArgumentException("Invalid workbook data")));
 
         var context = new CommandContext(_serviceProvider);

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/DeleteWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/DeleteWorkbooksCommandTests.cs
@@ -64,7 +64,8 @@ public class DeleteWorkbooksCommandTests
         _service.DeleteWorkbook(
             Arg.Is(workbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         var args = _command.GetCommand().Parse([
@@ -98,7 +99,8 @@ public class DeleteWorkbooksCommandTests
         _service.DeleteWorkbook(
             Arg.Is(workbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(false);
 
         var args = _command.GetCommand().Parse([
@@ -125,7 +127,8 @@ public class DeleteWorkbooksCommandTests
         _service.DeleteWorkbook(
             Arg.Is(workbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new Exception("Service error")));
 
         var args = _command.GetCommand().Parse([
@@ -152,7 +155,8 @@ public class DeleteWorkbooksCommandTests
         _service.DeleteWorkbook(
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         var args = _command.GetCommand().Parse([
@@ -169,7 +173,8 @@ public class DeleteWorkbooksCommandTests
         await _service.Received(1).DeleteWorkbook(
             Arg.Is(workbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Is("test-tenant"));
+            Arg.Is("test-tenant"),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -181,7 +186,8 @@ public class DeleteWorkbooksCommandTests
         _service.DeleteWorkbook(
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         var args = _command.GetCommand().Parse([
@@ -197,7 +203,8 @@ public class DeleteWorkbooksCommandTests
         await _service.Received(1).DeleteWorkbook(
             Arg.Is(workbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Is((string?)null));
+            Arg.Is((string?)null),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -209,7 +216,8 @@ public class DeleteWorkbooksCommandTests
         _service.DeleteWorkbook(
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         var args = _command.GetCommand().Parse([
@@ -226,7 +234,8 @@ public class DeleteWorkbooksCommandTests
         await _service.Received(1).DeleteWorkbook(
             Arg.Is(workbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -274,7 +283,8 @@ public class DeleteWorkbooksCommandTests
         _service.DeleteWorkbook(
             Arg.Is(validWorkbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         var args = _command.GetCommand().Parse([
@@ -307,7 +317,8 @@ public class DeleteWorkbooksCommandTests
         _service.DeleteWorkbook(
             Arg.Is(displayName),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         var args = _command.GetCommand().Parse([
@@ -340,7 +351,8 @@ public class DeleteWorkbooksCommandTests
         _service.DeleteWorkbook(
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(true);
 
         var args = _command.GetCommand().Parse([
@@ -360,6 +372,7 @@ public class DeleteWorkbooksCommandTests
             Arg.Is<RetryPolicyOptions>(options =>
                 options.MaxRetries == 5 &&
                 options.DelaySeconds == 2),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/ListWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/ListWorkbooksCommandTests.cs
@@ -109,7 +109,8 @@ public class ListWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<WorkbookFilters?>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbooks);
 
         var args = _command.GetCommand().Parse([
@@ -155,7 +156,8 @@ public class ListWorkbooksCommandTests
             Arg.Is("rg123"),
             Arg.Any<WorkbookFilters?>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
         var args = _command.GetCommand().Parse([
@@ -190,7 +192,8 @@ public class ListWorkbooksCommandTests
             Arg.Is("rg123"),
             Arg.Any<WorkbookFilters?>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<List<WorkbookInfo>>(null!));
 
         var args = _command.GetCommand().Parse([
@@ -225,7 +228,8 @@ public class ListWorkbooksCommandTests
             Arg.Is("rg123"),
             Arg.Any<WorkbookFilters?>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<List<WorkbookInfo>>(new Exception("Service error")));
 
         var args = _command.GetCommand().Parse([
@@ -255,7 +259,8 @@ public class ListWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<WorkbookFilters?>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbooks);
 
         var args = _command.GetCommand().Parse([
@@ -275,7 +280,8 @@ public class ListWorkbooksCommandTests
             Arg.Is("test-resource-group"),
             Arg.Any<WorkbookFilters?>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -288,7 +294,8 @@ public class ListWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<WorkbookFilters?>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbooks);
 
         var args = _command.GetCommand().Parse([
@@ -307,7 +314,8 @@ public class ListWorkbooksCommandTests
             Arg.Is("test-resource-group"),
             Arg.Any<WorkbookFilters?>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -320,7 +328,8 @@ public class ListWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<WorkbookFilters?>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbooks);
 
         var args = _command.GetCommand().Parse([
@@ -340,7 +349,8 @@ public class ListWorkbooksCommandTests
             Arg.Is("test-resource-group"),
             Arg.Any<WorkbookFilters?>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -403,7 +413,8 @@ public class ListWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Any<WorkbookFilters?>(),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbooks);
 
         var args = _command.GetCommand().Parse([
@@ -460,7 +471,8 @@ public class ListWorkbooksCommandTests
             Arg.Is("rg123"),
             Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == "shared"),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbooks);
 
         var args = _command.GetCommand().Parse([
@@ -483,7 +495,8 @@ public class ListWorkbooksCommandTests
             "rg123",
             Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == "shared"),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -513,7 +526,8 @@ public class ListWorkbooksCommandTests
             Arg.Is("rg123"),
             Arg.Is<WorkbookFilters?>(f => f != null && f.Category == "sentinel"),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbooks);
 
         var args = _command.GetCommand().Parse([
@@ -536,7 +550,8 @@ public class ListWorkbooksCommandTests
             "rg123",
             Arg.Is<WorkbookFilters?>(f => f != null && f.Category == "sentinel"),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -567,7 +582,8 @@ public class ListWorkbooksCommandTests
             Arg.Is("rg123"),
             Arg.Is<WorkbookFilters?>(f => f != null && f.SourceId == sourceId),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbooks);
 
         var args = _command.GetCommand().Parse([
@@ -590,7 +606,8 @@ public class ListWorkbooksCommandTests
             "rg123",
             Arg.Is<WorkbookFilters?>(f => f != null && f.SourceId == sourceId),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -621,7 +638,8 @@ public class ListWorkbooksCommandTests
             Arg.Is("rg123"),
             Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == "shared" && f.Category == "sentinel" && f.SourceId == sourceId),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbooks);
 
         var args = _command.GetCommand().Parse([
@@ -646,7 +664,8 @@ public class ListWorkbooksCommandTests
             "rg123",
             Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == "shared" && f.Category == "sentinel" && f.SourceId == sourceId),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -677,7 +696,8 @@ public class ListWorkbooksCommandTests
             Arg.Is("rg123"),
             Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == "shared" && f.Category == "sentinel" && f.SourceId == sourceId),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbooks);
 
         var args = _command.GetCommand().Parse([
@@ -702,7 +722,8 @@ public class ListWorkbooksCommandTests
             "rg123",
             Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == "shared" && f.Category == "sentinel" && f.SourceId == sourceId),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -732,7 +753,8 @@ public class ListWorkbooksCommandTests
             Arg.Is("rg123"),
             Arg.Is<WorkbookFilters?>(f => f != null && !f.HasFilters),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbooks);
 
         var args = _command.GetCommand().Parse([
@@ -754,7 +776,8 @@ public class ListWorkbooksCommandTests
             "rg123",
             Arg.Is<WorkbookFilters?>(f => f != null && !f.HasFilters),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -769,7 +792,8 @@ public class ListWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == kind),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbooks);
 
         var args = _command.GetCommand().Parse([
@@ -791,7 +815,8 @@ public class ListWorkbooksCommandTests
             "rg123",
             Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == kind),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -808,7 +833,8 @@ public class ListWorkbooksCommandTests
             Arg.Any<string>(),
             Arg.Is<WorkbookFilters?>(f => f != null && f.Category == category),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbooks);
 
         var args = _command.GetCommand().Parse([
@@ -830,6 +856,7 @@ public class ListWorkbooksCommandTests
             "rg123",
             Arg.Is<WorkbookFilters?>(f => f != null && f.Category == category),
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/ShowWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/ShowWorkbooksCommandTests.cs
@@ -92,7 +92,8 @@ public class ShowWorkbooksCommandTests
         _service.GetWorkbook(
             Arg.Is(workbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbook);
 
         var args = _command.GetCommand().Parse([
@@ -129,7 +130,8 @@ public class ShowWorkbooksCommandTests
         _service.GetWorkbook(
             Arg.Is(workbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<WorkbookInfo?>(null));
 
         var args = _command.GetCommand().Parse([
@@ -156,7 +158,8 @@ public class ShowWorkbooksCommandTests
         _service.GetWorkbook(
             Arg.Is(workbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<WorkbookInfo?>(new Exception("Service error")));
 
         var args = _command.GetCommand().Parse([
@@ -197,7 +200,8 @@ public class ShowWorkbooksCommandTests
         _service.GetWorkbook(
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbook);
 
         var args = _command.GetCommand().Parse([
@@ -214,7 +218,8 @@ public class ShowWorkbooksCommandTests
         await _service.Received(1).GetWorkbook(
             Arg.Is(workbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Is("test-tenant"));
+            Arg.Is("test-tenant"),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -240,7 +245,8 @@ public class ShowWorkbooksCommandTests
         _service.GetWorkbook(
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbook);
 
         var args = _command.GetCommand().Parse([
@@ -256,7 +262,8 @@ public class ShowWorkbooksCommandTests
         await _service.Received(1).GetWorkbook(
             Arg.Is(workbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Is((string?)null));
+            Arg.Is((string?)null),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -282,7 +289,8 @@ public class ShowWorkbooksCommandTests
         _service.GetWorkbook(
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbook);
 
         var args = _command.GetCommand().Parse([
@@ -299,7 +307,8 @@ public class ShowWorkbooksCommandTests
         await _service.Received(1).GetWorkbook(
             Arg.Is(workbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -400,7 +409,8 @@ public class ShowWorkbooksCommandTests
         _service.GetWorkbook(
             Arg.Is(workbookId),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedWorkbook);
 
         var args = _command.GetCommand().Parse([

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/UpdateWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/UpdateWorkbooksCommandTests.cs
@@ -93,7 +93,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Is(workbookId),
             Arg.Is("Updated Test Workbook"),
             Arg.Is("{\"version\":\"Notebook/1.0\",\"updated\":true}"),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            cancellationToken: Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
 
         var args = _command.GetCommand().Parse([
@@ -145,7 +146,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Is(workbookId),
             Arg.Is("New Display Name Only"),
             Arg.Is((string?)null),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            cancellationToken: Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
 
         var args = _command.GetCommand().Parse([
@@ -195,7 +197,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Is(workbookId),
             Arg.Is((string?)null),
             Arg.Is(newSerializedContent),
-            Arg.Any<RetryPolicyOptions>())
+            Arg.Any<RetryPolicyOptions>(),
+            cancellationToken: Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
 
         var args = _command.GetCommand().Parse([
@@ -249,7 +252,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
 
         var args = _command.GetCommand().Parse([
@@ -269,7 +273,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Is(displayName),
             Arg.Is(serializedContent),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Is((string?)null));
+            Arg.Is((string?)null),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -283,7 +288,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<WorkbookInfo?>(null));
 
         var args = _command.GetCommand().Parse([
@@ -312,7 +318,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<WorkbookInfo?>(new Exception("Service error")));
 
         var args = _command.GetCommand().Parse([
@@ -403,7 +410,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Is("Updated Complex Workbook"),
             Arg.Is(complexSerializedData),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
 
         var args = _command.GetCommand().Parse([
@@ -460,7 +468,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
 
         var args = _command.GetCommand().Parse([
@@ -480,7 +489,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Is("Test Workbook"),
             Arg.Is((string?)null),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Is(tenantId));
+            Arg.Is(tenantId),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -509,7 +519,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
 
         var args = _command.GetCommand().Parse([
@@ -529,7 +540,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Is("Test Workbook"),
             Arg.Is((string?)null),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -558,7 +570,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
 
         var args = _command.GetCommand().Parse([
@@ -579,7 +592,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Is("Test Workbook"),
             Arg.Is((string?)null),
             Arg.Is<RetryPolicyOptions>(x => x.MaxRetries == 5 && x.DelaySeconds == 2.5),
-            Arg.Any<string?>());
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -594,7 +608,8 @@ public class UpdateWorkbooksCommandTests
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<string?>())
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
             .Returns(Task.FromException<WorkbookInfo?>(exception));
 
         var args = _command.GetCommand().Parse([

--- a/tools/Fabric.Mcp.Tools.PublicApi/src/Commands/BestPractices/GetExamplesCommand.cs
+++ b/tools/Fabric.Mcp.Tools.PublicApi/src/Commands/BestPractices/GetExamplesCommand.cs
@@ -65,7 +65,7 @@ public sealed class GetExamplesCommand(ILogger<GetExamplesCommand> logger) : Glo
         try
         {
             var fabricService = context.GetService<IFabricPublicApiService>();
-            var availableExamples = await fabricService.GetWorkloadExamplesAsync(options.WorkloadType!);
+            var availableExamples = await fabricService.GetWorkloadExamplesAsync(options.WorkloadType!, cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(availableExamples), FabricJsonContext.Default.ExampleFileResult);
         }

--- a/tools/Fabric.Mcp.Tools.PublicApi/src/Commands/PublicApis/GetPlatformApisCommand.cs
+++ b/tools/Fabric.Mcp.Tools.PublicApi/src/Commands/PublicApis/GetPlatformApisCommand.cs
@@ -49,7 +49,7 @@ public sealed class GetPlatformApisCommand(ILogger<GetPlatformApisCommand> logge
         try
         {
             var fabricService = context.GetService<IFabricPublicApiService>();
-            var apis = await fabricService.GetWorkloadPublicApis("platform");
+            var apis = await fabricService.GetWorkloadPublicApis("platform", cancellationToken);
 
             context.Response.Results = ResponseResult.Create(apis, FabricJsonContext.Default.FabricWorkloadPublicApi);
         }

--- a/tools/Fabric.Mcp.Tools.PublicApi/src/Commands/PublicApis/GetWorkloadApisCommand.cs
+++ b/tools/Fabric.Mcp.Tools.PublicApi/src/Commands/PublicApis/GetWorkloadApisCommand.cs
@@ -72,7 +72,7 @@ public sealed class GetWorkloadApisCommand(ILogger<GetWorkloadApisCommand> logge
             }
 
             var fabricService = context.GetService<IFabricPublicApiService>();
-            var apis = await fabricService.GetWorkloadPublicApis(options.WorkloadType);
+            var apis = await fabricService.GetWorkloadPublicApis(options.WorkloadType, cancellationToken);
 
             context.Response.Results = ResponseResult.Create(apis, FabricJsonContext.Default.FabricWorkloadPublicApi);
         }

--- a/tools/Fabric.Mcp.Tools.PublicApi/src/Commands/PublicApis/ListWorkloadsCommand.cs
+++ b/tools/Fabric.Mcp.Tools.PublicApi/src/Commands/PublicApis/ListWorkloadsCommand.cs
@@ -47,7 +47,7 @@ public sealed class ListWorkloadsCommand(ILogger<ListWorkloadsCommand> logger) :
             }
 
             var fabricService = context.GetService<IFabricPublicApiService>();
-            var workloads = await fabricService.ListWorkloadsAsync();
+            var workloads = await fabricService.ListWorkloadsAsync(cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(workloads), FabricJsonContext.Default.ItemListCommandResult);
         }

--- a/tools/Fabric.Mcp.Tools.PublicApi/src/Services/EmbeddedResourceProviderService.cs
+++ b/tools/Fabric.Mcp.Tools.PublicApi/src/Services/EmbeddedResourceProviderService.cs
@@ -14,14 +14,14 @@ namespace Fabric.Mcp.Tools.PublicApi.Services
             return EmbeddedResourceHelper.ReadEmbeddedResource(assembly, resourceFileName);
         }
 
-        public Task<string> GetResource(string resourceName)
+        public Task<string> GetResource(string resourceName, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Loading embedded resource: {ResourceName}", resourceName);
 
             return Task.FromResult(GetEmbeddedResource(resourceName));
         }
 
-        public Task<string[]> ListResourcesInPath(string path, ResourceType? filterResources = null)
+        public Task<string[]> ListResourcesInPath(string path, ResourceType? filterResources = null, CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Listing resources in path: {Path}", path);
 

--- a/tools/Fabric.Mcp.Tools.PublicApi/src/Services/IFabricPublicApiService.cs
+++ b/tools/Fabric.Mcp.Tools.PublicApi/src/Services/IFabricPublicApiService.cs
@@ -7,11 +7,11 @@ namespace Fabric.Mcp.Tools.PublicApi.Services;
 
 public interface IFabricPublicApiService
 {
-    Task<IEnumerable<string>> ListWorkloadsAsync();
+    Task<IEnumerable<string>> ListWorkloadsAsync(CancellationToken cancellationToken);
 
-    Task<FabricWorkloadPublicApi> GetWorkloadPublicApis(string workloadType);
+    Task<FabricWorkloadPublicApi> GetWorkloadPublicApis(string workloadType, CancellationToken cancellationToken);
 
-    Task<IDictionary<string, string>> GetWorkloadExamplesAsync(string workloadType);
+    Task<IDictionary<string, string>> GetWorkloadExamplesAsync(string workloadType, CancellationToken cancellationToken);
 
     string GetWorkloadItemDefinition(string workloadType);
 

--- a/tools/Fabric.Mcp.Tools.PublicApi/src/Services/IResourceProviderService.cs
+++ b/tools/Fabric.Mcp.Tools.PublicApi/src/Services/IResourceProviderService.cs
@@ -8,8 +8,8 @@
 
     public interface IResourceProviderService
     {
-        Task<string> GetResource(string resourceName);
+        Task<string> GetResource(string resourceName, CancellationToken cancellationToken);
 
-        Task<string[]> ListResourcesInPath(string path, ResourceType? filterResources = null);
+        Task<string[]> ListResourcesInPath(string path, ResourceType? filterResources = null, CancellationToken cancellationToken = default);
     }
 }

--- a/tools/Fabric.Mcp.Tools.PublicApi/src/Services/NetworkResourceProviderService.cs
+++ b/tools/Fabric.Mcp.Tools.PublicApi/src/Services/NetworkResourceProviderService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using System.Threading;
 using Azure.Mcp.Core.Services.Http;
 using Microsoft.Extensions.Logging;
 
@@ -12,33 +13,33 @@ namespace Fabric.Mcp.Tools.PublicApi.Services
         private const string BaseGithubUrl = "https://api.github.com/repos/microsoft/";
 
 
-        public async Task<string> GetResource(string resourceName)
+        public async Task<string> GetResource(string resourceName, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Fetching network resource: {ResourceName}", resourceName);
 
-            var resourceJson = await GetResourceFromGithub(BaseGithubUrl + resourceName);
+            var resourceJson = await GetResourceFromGithub(BaseGithubUrl + resourceName, cancellationToken);
 
             if (resourceJson.TryGetProperty("download_url", out var downloadUrl) && !string.IsNullOrEmpty(downloadUrl.GetString()))
             {
                 using var requestMessage = new HttpRequestMessage(HttpMethod.Get, downloadUrl.GetString());
                 requestMessage.Headers.Add("User-Agent", "request");
 
-                using (var httpResponse = await _httpClientService.DefaultClient.SendAsync(requestMessage))
+                using (var httpResponse = await _httpClientService.DefaultClient.SendAsync(requestMessage, cancellationToken))
                 {
                     httpResponse.EnsureSuccessStatusCode();
 
-                    return await httpResponse.Content.ReadAsStringAsync();
+                    return await httpResponse.Content.ReadAsStringAsync(cancellationToken);
                 }
             }
 
             throw new FileNotFoundException($"Resource {resourceName} was not found.");
         }
 
-        public async Task<string[]> ListResourcesInPath(string path, ResourceType? filterResources = null)
+        public async Task<string[]> ListResourcesInPath(string path, ResourceType? filterResources = null, CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Listing resources in path: {Path}", path);
 
-            var contentArray = await GetGithubContentArrayAsync(BaseGithubUrl + path);
+            var contentArray = await GetGithubContentArrayAsync(BaseGithubUrl + path, cancellationToken);
 
             return contentArray
                 .Where(content => filterResources switch
@@ -52,34 +53,34 @@ namespace Fabric.Mcp.Tools.PublicApi.Services
                 .ToArray();
         }
 
-        private async Task<JsonElement> GetResourceFromGithub(string resourceName)
+        private async Task<JsonElement> GetResourceFromGithub(string resourceName, CancellationToken cancellationToken)
         {
             using var requestMessage = new HttpRequestMessage(HttpMethod.Get, resourceName);
             requestMessage.Headers.Add("User-Agent", "request");
 
-            using (var httpResponse = await _httpClientService.DefaultClient.SendAsync(requestMessage))
+            using (var httpResponse = await _httpClientService.DefaultClient.SendAsync(requestMessage, cancellationToken))
             {
                 httpResponse.EnsureSuccessStatusCode();
 
-                await using var content = await httpResponse.Content.ReadAsStreamAsync();
-                using (var jsonDoc = await JsonDocument.ParseAsync(content))
+                await using var content = await httpResponse.Content.ReadAsStreamAsync(cancellationToken);
+                using (var jsonDoc = await JsonDocument.ParseAsync(content, cancellationToken: cancellationToken))
                 {
                     return jsonDoc.RootElement.Clone();
                 }
             }
         }
 
-        private async Task<JsonElement[]> GetGithubContentArrayAsync(string? requestUrl)
+        private async Task<JsonElement[]> GetGithubContentArrayAsync(string? requestUrl, CancellationToken cancellationToken)
         {
             using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUrl);
             requestMessage.Headers.Add("User-Agent", "request");
 
-            using (var httpResponse = await _httpClientService.DefaultClient.SendAsync(requestMessage))
+            using (var httpResponse = await _httpClientService.DefaultClient.SendAsync(requestMessage, cancellationToken))
             {
                 httpResponse.EnsureSuccessStatusCode();
 
-                await using var content = await httpResponse.Content.ReadAsStreamAsync();
-                using (var jsonDoc = await JsonDocument.ParseAsync(content))
+                await using var content = await httpResponse.Content.ReadAsStreamAsync(cancellationToken);
+                using (var jsonDoc = await JsonDocument.ParseAsync(content, cancellationToken: cancellationToken))
                 {
                     return jsonDoc.RootElement.EnumerateArray()
                         .Select(element => element.Clone())

--- a/tools/Fabric.Mcp.Tools.PublicApi/tests/Fabric.Mcp.Tools.PublicApi.UnitTests/Commands/BestPracticesCommandsTests.cs
+++ b/tools/Fabric.Mcp.Tools.PublicApi/tests/Fabric.Mcp.Tools.PublicApi.UnitTests/Commands/BestPracticesCommandsTests.cs
@@ -201,7 +201,7 @@ public class BestPracticesCommandsTests
             { "example2.json", "content2" }
         };
 
-        fabricService.GetWorkloadExamplesAsync("notebook").Returns(expectedExamples);
+        fabricService.GetWorkloadExamplesAsync("notebook", Arg.Any<CancellationToken>()).Returns(expectedExamples);
 
         var services = new ServiceCollection();
         services.AddSingleton(fabricService);
@@ -216,7 +216,7 @@ public class BestPracticesCommandsTests
         // Assert
         Assert.Equal(HttpStatusCode.OK, result.Status);
         Assert.NotNull(result.Results);
-        await fabricService.Received(1).GetWorkloadExamplesAsync("notebook");
+        await fabricService.Received(1).GetWorkloadExamplesAsync("notebook", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -240,7 +240,7 @@ public class BestPracticesCommandsTests
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, result.Status);
         Assert.Equal("Missing Required options: --workload-type", result.Message);
-        await fabricService.DidNotReceive().GetWorkloadExamplesAsync(Arg.Any<string>());
+        await fabricService.DidNotReceive().GetWorkloadExamplesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -251,7 +251,7 @@ public class BestPracticesCommandsTests
         var command = new GetExamplesCommand(logger);
         var fabricService = Substitute.For<IFabricPublicApiService>();
 
-        fabricService.GetWorkloadExamplesAsync("notebook").ThrowsAsync(new InvalidOperationException("Service error"));
+        fabricService.GetWorkloadExamplesAsync("notebook", Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException("Service error"));
 
         var services = new ServiceCollection();
         services.AddSingleton(fabricService);

--- a/tools/Fabric.Mcp.Tools.PublicApi/tests/Fabric.Mcp.Tools.PublicApi.UnitTests/Commands/PublicApisCommandsTests.cs
+++ b/tools/Fabric.Mcp.Tools.PublicApi/tests/Fabric.Mcp.Tools.PublicApi.UnitTests/Commands/PublicApisCommandsTests.cs
@@ -57,7 +57,7 @@ public class PublicApisCommandsTests
         var fabricService = Substitute.For<IFabricPublicApiService>();
         var expectedWorkloads = new[] { "notebook", "report", "platform" };
 
-        fabricService.ListWorkloadsAsync().Returns(expectedWorkloads);
+        fabricService.ListWorkloadsAsync(Arg.Any<CancellationToken>()).Returns(expectedWorkloads);
 
         var services = new ServiceCollection();
         services.AddSingleton(fabricService);
@@ -72,7 +72,7 @@ public class PublicApisCommandsTests
         // Assert
         Assert.Equal(HttpStatusCode.OK, result.Status);
         Assert.NotNull(result.Results);
-        await fabricService.Received(1).ListWorkloadsAsync();
+        await fabricService.Received(1).ListWorkloadsAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class PublicApisCommandsTests
         var command = new ListWorkloadsCommand(logger);
         var fabricService = Substitute.For<IFabricPublicApiService>();
 
-        fabricService.ListWorkloadsAsync().ThrowsAsync(new InvalidOperationException("Service error"));
+        fabricService.ListWorkloadsAsync(Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException("Service error"));
 
         var services = new ServiceCollection();
         services.AddSingleton(fabricService);
@@ -141,7 +141,7 @@ public class PublicApisCommandsTests
         var fabricService = Substitute.For<IFabricPublicApiService>();
         var expectedApi = new FabricWorkloadPublicApi("api-spec", new Dictionary<string, string> { { "model1", "definition1" } });
 
-        fabricService.GetWorkloadPublicApis("platform").Returns(expectedApi);
+        fabricService.GetWorkloadPublicApis("platform", Arg.Any<CancellationToken>()).Returns(expectedApi);
 
         var services = new ServiceCollection();
         services.AddSingleton(fabricService);
@@ -156,7 +156,7 @@ public class PublicApisCommandsTests
         // Assert
         Assert.Equal(HttpStatusCode.OK, result.Status);
         Assert.NotNull(result.Results);
-        await fabricService.Received(1).GetWorkloadPublicApis("platform");
+        await fabricService.Received(1).GetWorkloadPublicApis("platform", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -167,7 +167,7 @@ public class PublicApisCommandsTests
         var command = new GetPlatformApisCommand(logger);
         var fabricService = Substitute.For<IFabricPublicApiService>();
 
-        fabricService.GetWorkloadPublicApis("platform").ThrowsAsync(new InvalidOperationException("Service error"));
+        fabricService.GetWorkloadPublicApis("platform", Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException("Service error"));
 
         var services = new ServiceCollection();
         services.AddSingleton(fabricService);
@@ -226,7 +226,7 @@ public class PublicApisCommandsTests
         var fabricService = Substitute.For<IFabricPublicApiService>();
         var expectedApi = new FabricWorkloadPublicApi("api-spec", new Dictionary<string, string> { { "model1", "definition1" } });
 
-        fabricService.GetWorkloadPublicApis("notebook").Returns(expectedApi);
+        fabricService.GetWorkloadPublicApis("notebook", Arg.Any<CancellationToken>()).Returns(expectedApi);
 
         var services = new ServiceCollection();
         services.AddSingleton(fabricService);
@@ -241,7 +241,7 @@ public class PublicApisCommandsTests
         // Assert
         Assert.Equal(HttpStatusCode.OK, result.Status);
         Assert.NotNull(result.Results);
-        await fabricService.Received(1).GetWorkloadPublicApis("notebook");
+        await fabricService.Received(1).GetWorkloadPublicApis("notebook", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -265,7 +265,7 @@ public class PublicApisCommandsTests
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, result.Status);
         Assert.Equal("Missing Required options: --workload-type", result.Message);
-        await fabricService.DidNotReceive().GetWorkloadPublicApis(Arg.Any<string>());
+        await fabricService.DidNotReceive().GetWorkloadPublicApis(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -290,7 +290,7 @@ public class PublicApisCommandsTests
         Assert.Equal(HttpStatusCode.NotFound, result.Status);
         Assert.Contains("No workload of type 'common' exists", result.Message);
         Assert.Contains("Did you mean 'platform'?", result.Message);
-        await fabricService.DidNotReceive().GetWorkloadPublicApis(Arg.Any<string>());
+        await fabricService.DidNotReceive().GetWorkloadPublicApis(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -302,7 +302,7 @@ public class PublicApisCommandsTests
         var fabricService = Substitute.For<IFabricPublicApiService>();
 
         var httpException = new HttpRequestException("Not found", null, HttpStatusCode.NotFound);
-        fabricService.GetWorkloadPublicApis("invalid-workload").ThrowsAsync(httpException);
+        fabricService.GetWorkloadPublicApis("invalid-workload", Arg.Any<CancellationToken>()).ThrowsAsync(httpException);
 
         var services = new ServiceCollection();
         services.AddSingleton(fabricService);
@@ -329,7 +329,7 @@ public class PublicApisCommandsTests
         var fabricService = Substitute.For<IFabricPublicApiService>();
 
         var httpException = new HttpRequestException("Service unavailable", null, HttpStatusCode.ServiceUnavailable);
-        fabricService.GetWorkloadPublicApis("notebook").ThrowsAsync(httpException);
+        fabricService.GetWorkloadPublicApis("notebook", Arg.Any<CancellationToken>()).ThrowsAsync(httpException);
 
         var services = new ServiceCollection();
         services.AddSingleton(fabricService);
@@ -354,7 +354,7 @@ public class PublicApisCommandsTests
         var command = new GetWorkloadApisCommand(logger);
         var fabricService = Substitute.For<IFabricPublicApiService>();
 
-        fabricService.GetWorkloadPublicApis("notebook").ThrowsAsync(new InvalidOperationException("Service error"));
+        fabricService.GetWorkloadPublicApis("notebook", Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException("Service error"));
 
         var services = new ServiceCollection();
         services.AddSingleton(fabricService);

--- a/tools/Fabric.Mcp.Tools.PublicApi/tests/Fabric.Mcp.Tools.PublicApi.UnitTests/Services/EmbeddedResourceProviderServiceTests.cs
+++ b/tools/Fabric.Mcp.Tools.PublicApi/tests/Fabric.Mcp.Tools.PublicApi.UnitTests/Services/EmbeddedResourceProviderServiceTests.cs
@@ -32,7 +32,7 @@ public class EmbeddedResourceProviderServiceTests
         var resourceName = "pagination.md";
 
         // Act
-        var result = await _service.GetResource(resourceName);
+        var result = await _service.GetResource(resourceName, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -50,7 +50,7 @@ public class EmbeddedResourceProviderServiceTests
         var fullResourceName = resourceNames.First();
 
         // Act
-        var result = await _service.GetResource(fullResourceName);
+        var result = await _service.GetResource(fullResourceName, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -61,7 +61,7 @@ public class EmbeddedResourceProviderServiceTests
     public async Task ListResourcesInPath_WithEmptyPath_ReturnsAllResources()
     {
         // Act
-        var allResources = await _service.ListResourcesInPath(string.Empty, null);
+        var allResources = await _service.ListResourcesInPath(string.Empty, null, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(allResources);
@@ -78,9 +78,9 @@ public class EmbeddedResourceProviderServiceTests
     public async Task ListResourcesInPath_FiltersByFileType(string path)
     {
         // Act
-        var allInPath = await _service.ListResourcesInPath(path, null);
-        var filesInPath = await _service.ListResourcesInPath(path, ResourceType.File);
-        var dirsInPath = await _service.ListResourcesInPath(path, ResourceType.Directory);
+        var allInPath = await _service.ListResourcesInPath(path, null, TestContext.Current.CancellationToken);
+        var filesInPath = await _service.ListResourcesInPath(path, ResourceType.File, TestContext.Current.CancellationToken);
+        var dirsInPath = await _service.ListResourcesInPath(path, ResourceType.Directory, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotEmpty(allInPath);
@@ -100,7 +100,7 @@ public class EmbeddedResourceProviderServiceTests
     public async Task ListResourcesInPath_WithNonexistentPath_ReturnsEmptyArray(string path, ResourceType resourceType)
     {
         // Act
-        var result = await _service.ListResourcesInPath(path, resourceType);
+        var result = await _service.ListResourcesInPath(path, resourceType, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(result);
@@ -111,7 +111,7 @@ public class EmbeddedResourceProviderServiceTests
     public async Task ListResourcesInPath_WithRootLevelFiles_ReturnsCorrectly()
     {
         // Act - Get root level files (files directly in Resources folder)
-        var rootFiles = await _service.ListResourcesInPath(string.Empty, ResourceType.File);
+        var rootFiles = await _service.ListResourcesInPath(string.Empty, ResourceType.File, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.NotNull(rootFiles);
@@ -135,7 +135,7 @@ public class EmbeddedResourceProviderServiceTests
         var resourceName = "non-existent-resource.md";
 
         // Act & Assert
-        await Assert.ThrowsAsync<ArgumentException>(async () => await _service.GetResource(resourceName));
+        await Assert.ThrowsAsync<ArgumentException>(async () => await _service.GetResource(resourceName, TestContext.Current.CancellationToken));
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`
Continuation of #1056 and #1133 to add `CancellationToken` to many method signatures. This _should_ cover all interface types in the repo at the current time, but there likely others still needing updating.

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
