### PR TITLE
Setting manual `playback` should override all TestSettings

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Tests/Client/CommandTestsBase.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Tests/Client/CommandTestsBase.cs
@@ -55,7 +55,7 @@ public abstract class CommandTestsBase(ITestOutputHelper output) : IAsyncLifetim
 
         // if the user has set to playback in LiveTestSettings, they're
         // intentionally checking playback mode, load the playback settings
-        // and ignore what we got from the .livetestsettings file
+        // and ignore what we got from the .testsettings.json file
         if (Settings.TestMode == TestMode.Playback)
         {
             Settings = PlaybackSettings;


### PR DESCRIPTION
We were failing `playback` because a present `.livetestsettings` values for `subscriptionId` and the like were still being pass through during playback mode....which obviously will fail with playback mismatch.