### PR TITLE
Fabric MCP - Remove Fabric from VSIX categories, update version to 0.…

### DIFF
--- a/servers/Fabric.Mcp.Server/src/Fabric.Mcp.Server.csproj
+++ b/servers/Fabric.Mcp.Server/src/Fabric.Mcp.Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>0.0.0-beta.1</Version>
+    <Version>0.0.0-beta.2</Version>
     <CliName>fabmcp</CliName>
     <AssemblyTitle>Fabric MCP Server</AssemblyTitle>
     <Description>Microsoft Fabric MCP Server - Model Context Protocol implementation for Fabric</Description>

--- a/servers/Fabric.Mcp.Server/vscode/package.json
+++ b/servers/Fabric.Mcp.Server/vscode/package.json
@@ -13,7 +13,6 @@
     },
     "categories": [
         "AI",
-        "Fabric",
         "Chat"
     ],
     "keywords": [


### PR DESCRIPTION
Fabric MCP 
- Remove 'Fabric' from VSIX categories since it's not supported
- Update version to 0.0.0-beta.2