### PR TITLE
Move `/Models/Option/` from Azure.Mcp.Core to Microsoft.Mcp.Core

### DIFF
--- a/core/Azure.Mcp.Core/src/Areas/Tools/Commands/ToolsListCommand.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Tools/Commands/ToolsListCommand.cs
@@ -11,6 +11,7 @@ using Azure.Mcp.Core.Models.Command;
 using Azure.Mcp.Core.Models.Option;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Core.Areas.Tools.Commands;
 

--- a/core/Azure.Mcp.Core/src/Models/Command/CommandInfo.cs
+++ b/core/Azure.Mcp.Core/src/Models/Command/CommandInfo.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json.Serialization;
 using Azure.Mcp.Core.Commands;
-using Azure.Mcp.Core.Models.Option;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Core.Models.Command;
 

--- a/core/Microsoft.Mcp.Core/src/Models/Option/OptionDefinition.cs
+++ b/core/Microsoft.Mcp.Core/src/Models/Option/OptionDefinition.cs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.CommandLine;
 using System.Text.Json.Serialization;
 
-namespace Azure.Mcp.Core.Models.Option;
+namespace Microsoft.Mcp.Core.Models.Option;
 
 public class OptionDefinition<T>(string name, string description, string? value = "", T? defaultValue = default, bool required = false, bool hidden = false)
     where T : notnull

--- a/core/Microsoft.Mcp.Core/src/Models/Option/OptionExtensions.cs
+++ b/core/Microsoft.Mcp.Core/src/Models/Option/OptionExtensions.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Azure.Mcp.Core.Models.Option;
+using System.CommandLine;
+
+namespace Microsoft.Mcp.Core.Models.Option;
 
 /// <summary>
 /// Extension methods for working with option definitions and command registration.

--- a/core/Microsoft.Mcp.Core/src/Models/Option/OptionInfo.cs
+++ b/core/Microsoft.Mcp.Core/src/Models/Option/OptionInfo.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Azure.Mcp.Core.Models.Option;
+namespace Microsoft.Mcp.Core.Models.Option;
 
 public class OptionInfo(
     string name,

--- a/tools/Azure.Mcp.Tools.Acr/src/Commands/BaseAcrCommand.cs
+++ b/tools/Azure.Mcp.Tools.Acr/src/Commands/BaseAcrCommand.cs
@@ -6,6 +6,7 @@ using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Extensions;
 using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Acr.Options;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Acr.Commands;
 

--- a/tools/Azure.Mcp.Tools.Aks/src/Commands/Nodepool/NodepoolGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Aks/src/Commands/Nodepool/NodepoolGetCommand.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Tools.Aks.Options;
 using Azure.Mcp.Tools.Aks.Options.Nodepool;
 using Azure.Mcp.Tools.Aks.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Aks.Commands.Nodepool;
 

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueGetCommand.cs
@@ -3,12 +3,12 @@
 
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Extensions;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.AppConfig.Models;
 using Azure.Mcp.Tools.AppConfig.Options;
 using Azure.Mcp.Tools.AppConfig.Options.KeyValue;
 using Azure.Mcp.Tools.AppConfig.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AppConfig.Commands.KeyValue;
 

--- a/tools/Azure.Mcp.Tools.AppLens/src/Commands/Resource/ResourceDiagnoseCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Commands/Resource/ResourceDiagnoseCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.AppLens.Options;
 using Azure.Mcp.Tools.AppLens.Options.Resource;
 using Azure.Mcp.Tools.AppLens.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AppLens.Commands.Resource;
 

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/BaseAppServiceCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/BaseAppServiceCommand.cs
@@ -6,6 +6,7 @@ using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.AppService.Options;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AppService.Commands;
 

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/src/Commands/Recommendation/RecommendationListCommand.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/src/Commands/Recommendation/RecommendationListCommand.cs
@@ -11,6 +11,7 @@ using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.ApplicationInsights.Options;
 using Azure.Mcp.Tools.ApplicationInsights.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ApplicationInsights.Commands.Recommendation;
 

--- a/tools/Azure.Mcp.Tools.AzureIsv/src/Commands/Datadog/MonitoredResourcesListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureIsv/src/Commands/Datadog/MonitoredResourcesListCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.AzureIsv.Options;
 using Azure.Mcp.Tools.AzureIsv.Options.Datadog;
 using Azure.Mcp.Tools.AzureIsv.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AzureIsv.Commands.Datadog;
 

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/BaseConfidentialLedgerCommand.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/BaseConfidentialLedgerCommand.cs
@@ -5,8 +5,8 @@ using System.CommandLine;
 using System.Diagnostics.CodeAnalysis;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Extensions;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.ConfidentialLedger.Options;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ConfidentialLedger.Commands;
 

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/Entries/LedgerEntryAppendCommand.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/Entries/LedgerEntryAppendCommand.cs
@@ -5,10 +5,10 @@ using System.CommandLine;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Extensions;
 using Azure.Mcp.Core.Models.Command;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.ConfidentialLedger.Options;
 using Azure.Mcp.Tools.ConfidentialLedger.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ConfidentialLedger.Commands.Entries;
 

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/Entries/LedgerEntryGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/Entries/LedgerEntryGetCommand.cs
@@ -3,10 +3,10 @@ using System.Net;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Extensions;
 using Azure.Mcp.Core.Models.Command;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.ConfidentialLedger.Options;
 using Azure.Mcp.Tools.ConfidentialLedger.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ConfidentialLedger.Commands.Entries;
 

--- a/tools/Azure.Mcp.Tools.EventGrid/src/Commands/Subscription/SubscriptionListCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/src/Commands/Subscription/SubscriptionListCommand.cs
@@ -7,6 +7,7 @@ using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.EventGrid.Options;
 using Azure.Mcp.Tools.EventGrid.Options.Subscription;
 using Azure.Mcp.Tools.EventGrid.Services;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventGrid.Commands.Subscription;
 

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupDeleteCommand.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Tools.EventHubs.Options;
 using Azure.Mcp.Tools.EventHubs.Options.ConsumerGroup;
 using Azure.Mcp.Tools.EventHubs.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.ConsumerGroup;
 

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupGetCommand.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Tools.EventHubs.Options;
 using Azure.Mcp.Tools.EventHubs.Options.ConsumerGroup;
 using Azure.Mcp.Tools.EventHubs.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.ConsumerGroup;
 

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupUpdateCommand.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Tools.EventHubs.Options;
 using Azure.Mcp.Tools.EventHubs.Options.ConsumerGroup;
 using Azure.Mcp.Tools.EventHubs.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.ConsumerGroup;
 

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubDeleteCommand.cs
@@ -10,6 +10,7 @@ using Azure.Mcp.Tools.EventHubs.Options;
 using Azure.Mcp.Tools.EventHubs.Options.EventHub;
 using Azure.Mcp.Tools.EventHubs.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.EventHub;
 

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubGetCommand.cs
@@ -11,6 +11,7 @@ using Azure.Mcp.Tools.EventHubs.Options;
 using Azure.Mcp.Tools.EventHubs.Options.EventHub;
 using Azure.Mcp.Tools.EventHubs.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.EventHub;
 

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubUpdateCommand.cs
@@ -10,6 +10,7 @@ using Azure.Mcp.Tools.EventHubs.Options;
 using Azure.Mcp.Tools.EventHubs.Options.EventHub;
 using Azure.Mcp.Tools.EventHubs.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.EventHub;
 

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceDeleteCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.EventHubs.Options;
 using Azure.Mcp.Tools.EventHubs.Options.Namespace;
 using Azure.Mcp.Tools.EventHubs.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.Namespace;
 

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceUpdateCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.EventHubs.Options;
 using Azure.Mcp.Tools.EventHubs.Options.Namespace;
 using Azure.Mcp.Tools.EventHubs.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.Namespace;
 

--- a/tools/Azure.Mcp.Tools.Extension/src/Commands/AzqrCommand.cs
+++ b/tools/Azure.Mcp.Tools.Extension/src/Commands/AzqrCommand.cs
@@ -12,6 +12,7 @@ using Azure.Mcp.Core.Services.ProcessExecution;
 using Azure.Mcp.Core.Services.Time;
 using Azure.Mcp.Tools.Extension.Options;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Extension.Commands;
 

--- a/tools/Azure.Mcp.Tools.Foundry/src/Commands/ModelDeploymentCommand.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/src/Commands/ModelDeploymentCommand.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Tools.Foundry.Models;
 using Azure.Mcp.Tools.Foundry.Options;
 using Azure.Mcp.Tools.Foundry.Options.Models;
 using Azure.Mcp.Tools.Foundry.Services;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Foundry.Commands;
 

--- a/tools/Azure.Mcp.Tools.Foundry/src/Commands/ModelsListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/src/Commands/ModelsListCommand.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Core.Commands;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Foundry.Models;
 using Azure.Mcp.Tools.Foundry.Options;
 using Azure.Mcp.Tools.Foundry.Options.Models;
 using Azure.Mcp.Tools.Foundry.Services;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Foundry.Commands;
 

--- a/tools/Azure.Mcp.Tools.Foundry/src/Commands/OpenAiChatCompletionsCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/src/Commands/OpenAiChatCompletionsCreateCommand.cs
@@ -10,6 +10,7 @@ using Azure.Mcp.Tools.Foundry.Models;
 using Azure.Mcp.Tools.Foundry.Options;
 using Azure.Mcp.Tools.Foundry.Options.Models;
 using Azure.Mcp.Tools.Foundry.Services;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Foundry.Commands;
 

--- a/tools/Azure.Mcp.Tools.Foundry/src/Commands/OpenAiCompletionsCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/src/Commands/OpenAiCompletionsCreateCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.Foundry.Models;
 using Azure.Mcp.Tools.Foundry.Options;
 using Azure.Mcp.Tools.Foundry.Options.Models;
 using Azure.Mcp.Tools.Foundry.Services;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Foundry.Commands;
 

--- a/tools/Azure.Mcp.Tools.Foundry/src/Commands/OpenAiEmbeddingsCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/src/Commands/OpenAiEmbeddingsCreateCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.Foundry.Models;
 using Azure.Mcp.Tools.Foundry.Options;
 using Azure.Mcp.Tools.Foundry.Options.Models;
 using Azure.Mcp.Tools.Foundry.Services;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Foundry.Commands;
 

--- a/tools/Azure.Mcp.Tools.Foundry/src/Commands/OpenAiModelsListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/src/Commands/OpenAiModelsListCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.Foundry.Models;
 using Azure.Mcp.Tools.Foundry.Options;
 using Azure.Mcp.Tools.Foundry.Options.Models;
 using Azure.Mcp.Tools.Foundry.Services;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Foundry.Commands;
 

--- a/tools/Azure.Mcp.Tools.Foundry/src/Commands/ResourceGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Foundry/src/Commands/ResourceGetCommand.cs
@@ -11,6 +11,7 @@ using Azure.Mcp.Tools.Foundry.Options;
 using Azure.Mcp.Tools.Foundry.Options.Models;
 using Azure.Mcp.Tools.Foundry.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Foundry.Commands;
 

--- a/tools/Azure.Mcp.Tools.FunctionApp/src/Commands/FunctionApp/FunctionAppGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/src/Commands/FunctionApp/FunctionAppGetCommand.cs
@@ -10,6 +10,7 @@ using Azure.Mcp.Tools.FunctionApp.Options;
 using Azure.Mcp.Tools.FunctionApp.Options.FunctionApp;
 using Azure.Mcp.Tools.FunctionApp.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FunctionApp.Commands.FunctionApp;
 

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Admin/AdminSettingsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Admin/AdminSettingsGetCommand.cs
@@ -4,10 +4,10 @@
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Extensions;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.KeyVault.Options;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.KeyVault.Commands.Admin;
 

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterGetCommand.cs
@@ -5,11 +5,11 @@ using System.Net;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Extensions;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Kusto.Models;
 using Azure.Mcp.Tools.Kusto.Options;
 using Azure.Mcp.Tools.Kusto.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Kusto.Commands;
 

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/BaseLoadTestingCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/BaseLoadTestingCommand.cs
@@ -7,6 +7,7 @@ using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Extensions;
 using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.LoadTesting.Options;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.LoadTesting.Commands;
 

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemCreateCommand.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Tools.ManagedLustre.Options;
 using Azure.Mcp.Tools.ManagedLustre.Options.FileSystem;
 using Azure.Mcp.Tools.ManagedLustre.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem;
 

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemListCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemListCommand.cs
@@ -7,6 +7,7 @@ using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.ManagedLustre.Options.FileSystem;
 using Azure.Mcp.Tools.ManagedLustre.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem;
 

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemUpdateCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.ManagedLustre.Options;
 using Azure.Mcp.Tools.ManagedLustre.Options.FileSystem;
 using Azure.Mcp.Tools.ManagedLustre.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem;
 

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/Sku/SkuGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/Sku/SkuGetCommand.cs
@@ -3,11 +3,11 @@
 
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Extensions;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.ManagedLustre.Options;
 using Azure.Mcp.Tools.ManagedLustre.Options.FileSystem;
 using Azure.Mcp.Tools.ManagedLustre.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem;

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Options/ManagedLustreOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Options/ManagedLustreOptionDefinitions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Models.Option;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Options;
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/ActivityLog/ActivityLogListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/ActivityLog/ActivityLogListCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.Monitor.Models.ActivityLog;
 using Azure.Mcp.Tools.Monitor.Options.ActivityLog;
 using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.ActivityLog;
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/BaseMonitorCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/BaseMonitorCommand.cs
@@ -6,6 +6,7 @@ using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Core.Options;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands;
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Metrics/BaseMetricsCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Metrics/BaseMetricsCommand.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Tools.Monitor.Options;
 using Azure.Mcp.Tools.Monitor.Options.Metrics;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.Metrics;
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Metrics/MetricsDefinitionsCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Metrics/MetricsDefinitionsCommand.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Core.Commands;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Monitor.Models;
 using Azure.Mcp.Tools.Monitor.Options;
 using Azure.Mcp.Tools.Monitor.Options.Metrics;
 using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.Metrics;
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsCreateCommand.cs
@@ -10,6 +10,7 @@ using Azure.Mcp.Tools.Monitor.Options;
 using Azure.Mcp.Tools.Monitor.Options.WebTests;
 using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.WebTests;
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsGetCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.Monitor.Options;
 using Azure.Mcp.Tools.Monitor.Options.WebTests;
 using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.WebTests;
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsListCommand.cs
@@ -7,6 +7,7 @@ using Azure.Mcp.Tools.Monitor.Models.WebTests;
 using Azure.Mcp.Tools.Monitor.Options.WebTests;
 using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.WebTests;
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsUpdateCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.Monitor.Options;
 using Azure.Mcp.Tools.Monitor.Options.WebTests;
 using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.WebTests;
 

--- a/tools/Azure.Mcp.Tools.MySql/src/Commands/BaseMySqlCommand.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Commands/BaseMySqlCommand.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Core.Extensions;
 using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.MySql.Options;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.MySql.Commands;
 

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/BasePostgresCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/BasePostgresCommand.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Core.Extensions;
 using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Postgres.Options;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Postgres.Commands;
 

--- a/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceCreateCommand.cs
@@ -10,6 +10,7 @@ using Azure.Mcp.Tools.Redis.Models;
 using Azure.Mcp.Tools.Redis.Options;
 using Azure.Mcp.Tools.Redis.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Redis.Commands;
 

--- a/tools/Azure.Mcp.Tools.ResourceHealth/src/Commands/AvailabilityStatus/AvailabilityStatusListCommand.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/src/Commands/AvailabilityStatus/AvailabilityStatusListCommand.cs
@@ -7,6 +7,7 @@ using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.ResourceHealth.Options.AvailabilityStatus;
 using Azure.Mcp.Tools.ResourceHealth.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ResourceHealth.Commands.AvailabilityStatus;
 

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexGetCommand.cs
@@ -4,12 +4,12 @@
 using System.Text.Json.Serialization;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Extensions;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Search.Models;
 using Azure.Mcp.Tools.Search.Options;
 using Azure.Mcp.Tools.Search.Options.Index;
 using Azure.Mcp.Tools.Search.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Search.Commands.Index;
 

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseGetCommand.cs
@@ -4,11 +4,11 @@
 using System.Text.Json.Serialization;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Extensions;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Search.Options;
 using Azure.Mcp.Tools.Search.Options.Knowledge;
 using Azure.Mcp.Tools.Search.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Search.Commands.Knowledge;
 

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseRetrieveCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseRetrieveCommand.cs
@@ -4,11 +4,11 @@
 using System.Net;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Extensions;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Search.Options;
 using Azure.Mcp.Tools.Search.Options.Knowledge;
 using Azure.Mcp.Tools.Search.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Search.Commands.Knowledge;
 

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeSourceGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeSourceGetCommand.cs
@@ -4,11 +4,11 @@
 using System.Text.Json.Serialization;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Extensions;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Search.Options;
 using Azure.Mcp.Tools.Search.Options.Knowledge;
 using Azure.Mcp.Tools.Search.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Search.Commands.Knowledge;
 

--- a/tools/Azure.Mcp.Tools.SignalR/src/Commands/BaseSignalRCommand.cs
+++ b/tools/Azure.Mcp.Tools.SignalR/src/Commands/BaseSignalRCommand.cs
@@ -7,6 +7,7 @@ using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Extensions;
 using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.SignalR.Options;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.SignalR.Commands;
 

--- a/tools/Azure.Mcp.Tools.Speech/src/Commands/BaseSpeechCommand.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Commands/BaseSpeechCommand.cs
@@ -5,8 +5,8 @@ using System.Diagnostics.CodeAnalysis;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Extensions;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Speech.Options;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Speech.Commands;
 

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/BaseSqlCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/BaseSqlCommand.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Core.Extensions;
 using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Sql.Options;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Sql.Commands;
 

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerListCommand.cs
@@ -12,6 +12,7 @@ using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Options.Server;
 using Azure.Mcp.Tools.Sql.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Sql.Commands.Server;
 

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountCreateCommand.cs
@@ -12,6 +12,7 @@ using Azure.Mcp.Tools.Storage.Options;
 using Azure.Mcp.Tools.Storage.Options.Account;
 using Azure.Mcp.Tools.Storage.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Storage.Commands.Account;
 

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountGetCommand.cs
@@ -5,12 +5,12 @@ using System.Text.Json.Serialization;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Extensions;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Options;
 using Azure.Mcp.Tools.Storage.Options.Account;
 using Azure.Mcp.Tools.Storage.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Storage.Commands.Account;
 

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobGetCommand.cs
@@ -4,12 +4,12 @@
 using System.Text.Json.Serialization;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Extensions;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Storage.Commands.Blob.Container;
 using Azure.Mcp.Tools.Storage.Options;
 using Azure.Mcp.Tools.Storage.Options.Blob;
 using Azure.Mcp.Tools.Storage.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Storage.Commands.Blob;
 

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerGetCommand.cs
@@ -4,11 +4,11 @@
 using System.Text.Json.Serialization;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Extensions;
-using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.Storage.Options;
 using Azure.Mcp.Tools.Storage.Options.Blob.Container;
 using Azure.Mcp.Tools.Storage.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Storage.Commands.Blob.Container;
 

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/BaseVirtualDesktopCommand.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/BaseVirtualDesktopCommand.cs
@@ -7,6 +7,7 @@ using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Extensions;
 using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Core.Options;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.VirtualDesktop.Commands;
 

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/CreateWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/CreateWorkbooksCommand.cs
@@ -10,6 +10,7 @@ using Azure.Mcp.Tools.Workbooks.Options;
 using Azure.Mcp.Tools.Workbooks.Options.Workbook;
 using Azure.Mcp.Tools.Workbooks.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Workbooks.Commands.Workbooks;
 

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ListWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ListWorkbooksCommand.cs
@@ -10,6 +10,7 @@ using Azure.Mcp.Tools.Workbooks.Options;
 using Azure.Mcp.Tools.Workbooks.Options.Workbook;
 using Azure.Mcp.Tools.Workbooks.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Workbooks.Commands.Workbooks;
 


### PR DESCRIPTION
The migration of code from Azure.Mcp.Core into Microsoft.Mcp.Core will be fairly complicated and should be broken into multiple easily grokked PRs.

This PR moves a very small portion of Core while still asserting that namespace updates are consumed and properly tested.