### PR TITLE
Ensure Failed Deployments output

### DIFF
--- a/eng/scripts/Deploy-TestResources.ps1
+++ b/eng/scripts/Deploy-TestResources.ps1
@@ -138,7 +138,7 @@ if ($jobInputs.Count -eq 1 -or !$Parallel) {
             Deploy-TestResources @jobInput
         } catch {
             Write-Host "Deployment failed for '$($jobInput.Path)'" -ForegroundColor Red
-            Write-Error $_
+            LogError $_
             $failedPaths += $jobInput.Path
         }
     }


### PR DESCRIPTION
@hallipr @alzimmermsft ran into a situation where a failed post-deployment script error got swallowed by our invocation. 

Everywhere has `ErrorActionPreference = Stop` set, but i'd expect output to immediately pop. Nevertheless, I absolutely saw alan's experience where a failure of the post-deployment script due to missing az module never showed up on the console.

