### PR TITLE
Make it easier to call Build-Code.ps1

### DIFF
--- a/eng/pipelines/templates/jobs/build.yml
+++ b/eng/pipelines/templates/jobs/build.yml
@@ -63,15 +63,12 @@ jobs:
       pwsh: true
       filePath: $(Build.SourcesDirectory)/eng/scripts/Build-Code.ps1
       arguments: >
-        -ServerName '${{ parameters.ServerName }}'
         -BuildInfoPath '$(Pipeline.Workspace)/build_info/build_info.json'
         -OutputPath '$(Build.ArtifactStagingDirectory)'
-        -OperatingSystem '${{ parameters.OSName }}'
-        -Architecture '$(Architecture)'
-        -Native:$$(Native)
+        -ServerName '${{ parameters.ServerName }}'
+        -PlatformName '$(PlatformName)'
         -ReleaseBuild:$${{ ne(parameters.PublishTarget, 'none') }}
         -SelfContained
-        -Trimmed:$$(Trimmed)
         -SingleFile
 
   - task: Powershell@2

--- a/eng/scripts/New-BuildInfo.ps1
+++ b/eng/scripts/New-BuildInfo.ps1
@@ -13,7 +13,7 @@ param(
 )
 
 . "$PSScriptRoot/../common/scripts/common.ps1"
-. "$PSScriptRoot/helpers/PathHelpers.ps1"
+. "$PSScriptRoot/helpers/BuildHelpers.ps1"
 $RepoRoot = $RepoRoot.Path.Replace('\', '/')
 $isPipelineRun = $CI -or $env:TF_BUILD -eq 'true'
 $isPullRequestBuild = $env:BUILD_REASON -eq 'PullRequest'
@@ -64,11 +64,7 @@ $coreDirectories = Get-ChildItem "$RepoRoot/core" -Directory
 
 $architectures = @('x64', 'arm64')
 
-$operatingSystems = @(
-    @{ name = 'linux'; nodeName = 'linux'; dotnetName = 'linux'; extension = '' }
-    @{ name = 'macos'; nodeName = 'darwin'; dotnetName = 'osx'; extension = '' }
-    @{ name = 'windows'; nodeName = 'win32'; dotnetName = 'win'; extension = '.exe' }
-)
+$operatingSystems = Get-OperatingSystems
 
 # Public releases always use the version from the repo without a dynamic prerelease suffix, except for test pipelines
 # which always use a dynamic prerelease suffix to allow for multiple releases from the same commit
@@ -562,6 +558,7 @@ function Get-BuildMatrices {
             $runRecordedTests = $runUnitTests -and ($pathsToTest | Where-Object { $_.hasRecordedTests } | Measure-Object | Select-Object -ExpandProperty Count) -gt 0
 
             $buildMatrix[$legName] = [ordered]@{
+                PlatformName = $platform.name
                 Pool = $pool
                 OSVmImage = $vmImage
                 Architecture = $arch

--- a/eng/scripts/helpers/BuildHelpers.ps1
+++ b/eng/scripts/helpers/BuildHelpers.ps1
@@ -1,3 +1,11 @@
+function Get-OperatingSystems {
+    return @(
+        @{ name = 'linux'; nodeName = 'linux'; dotnetName = 'linux'; extension = '' }
+        @{ name = 'macos'; nodeName = 'darwin'; dotnetName = 'osx'; extension = '' }
+        @{ name = 'windows'; nodeName = 'win32'; dotnetName = 'win'; extension = '.exe' }
+    )
+}
+
 function Get-RepoRelativePath {
     [CmdletBinding()]
     param(


### PR DESCRIPTION
## What does this PR do?
Allow callers to specify  PlatformName or a combination of Trimmed, Native, etc when running Build-Code.ps1

Currently, calling Build-Code.ps1 requires that the passed in parameters match an existing server/platform in build_info.json.
This change removes that requirement

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
