### PR TITLE
Publish symbols during release

### DIFF
--- a/eng/pipelines/templates/jobs/publish-symbols.yml
+++ b/eng/pipelines/templates/jobs/publish-symbols.yml
@@ -1,0 +1,51 @@
+parameters:
+  - name: DependsOn
+    type: object
+    default: []
+
+jobs:
+- job: PublishSymbols
+  dependsOn: ${{ parameters.DependsOn }}
+  displayName: "Publish symbols"
+  condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
+  timeoutInMinutes: 120
+
+  steps:
+  - checkout: azure-sdk-build-tools
+
+  - download: current
+    displayName: Download binaries_signed
+    artifact: binaries_signed
+    
+  - task: AzurePowershell@5
+    displayName: 'Reserve symbols api request name'
+    inputs:
+      pwsh: true
+      azureSubscription: 'Azure SDK Symbols Publishing'
+      azurePowerShellVersion: 'LatestVersion'
+      ScriptType: 'FilePath'
+      ScriptPath: $(Build.SourcesDirectory)/scripts/symbols/New-SymbolsApiRequestName.ps1
+      ScriptArguments: >
+        -ProjectName 'azure-sdk'
+        -VariableName 'SymbolsRequestName'
+
+  - task: PublishSymbols@2
+    displayName: 'Publish symbols to Azure DevOps'
+    inputs:
+      SymbolsFolder: $(Pipeline.Workspace)/binaries_signed
+      SearchPattern: '**/*.pdb'
+      SymbolServerType: 'TeamServices'
+      SymbolsArtifactName: '$(SymbolsRequestName)'
+
+  - task: AzurePowershell@5
+    displayName: 'Request SymWeb and MSDL api publishing'
+    inputs:
+      pwsh: true
+      azureSubscription: 'Azure SDK Symbols Publishing'
+      azurePowerShellVersion: 'LatestVersion'
+      ScriptType: 'FilePath'
+      ScriptPath: $(Build.SourcesDirectory)/scripts/symbols/Invoke-SymbolsApiRequest.ps1
+      ScriptArguments: >
+        -ProjectName 'azure-sdk'
+        -RequestName '$(SymbolsRequestName)'
+        -Wait

--- a/eng/pipelines/templates/jobs/release.yml
+++ b/eng/pipelines/templates/jobs/release.yml
@@ -47,6 +47,8 @@ jobs:
     env:
       GH_TOKEN: $(azuresdk-github-pat)
 
+- template: /eng/pipelines/templates/jobs/publish-symbols.yml
+
 - template: /eng/pipelines/templates/jobs/npm/release-npm.yml
   parameters:
     ServerName: ${{ parameters.ServerName }}


### PR DESCRIPTION
## What does this PR do?
Publishes symbols during release

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
