### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/auto-milestone-bugbash.yml
+++ b/.github/workflows/auto-milestone-bugbash.yml
@@ -21,7 +21,7 @@ jobs:
       contains(github.event.issue.body, '<!-- TEMPLATE: bug-bash-v1 -->')
     steps:
       - name: Apply milestone if missing
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -71,7 +71,7 @@ jobs:
       # need to point to that fork
       # Start-Build
       # - name: Checkout tools repo for GitHub Event Processor sources
-      #   uses: actions/checkout@v3
+      #   uses: actions/checkout@v6
       #   with:
       #     repository: Azure/azure-sdk-tools
       #     path: azure-sdk-tools
@@ -96,7 +96,7 @@ jobs:
           LABEL_SERVICE_API_KEY: ${{ env.LABEL_SERVICE_API_KEY }}
 
       - name: Archive github event data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: event
@@ -131,7 +131,7 @@ jobs:
       # need to point to that fork
       # Start-Build
       # - name: Checkout tools repo for GitHub Event Processor sources
-      #   uses: actions/checkout@v3
+      #   uses: actions/checkout@v6
       #   with:
       #     repository: Azure/azure-sdk-tools
       #     path: azure-sdk-tools
@@ -155,7 +155,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Archive github event data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: event

--- a/.github/workflows/post-apiview.yml
+++ b/.github/workflows/post-apiview.yml
@@ -18,7 +18,7 @@ jobs:
       contains(github.event.check_run.name, 'Build Analyze') )
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: 'eng/common'
     

--- a/.github/workflows/scheduled-event-processor.yml
+++ b/.github/workflows/scheduled-event-processor.yml
@@ -52,7 +52,7 @@ jobs:
       # need to point to that fork
       # Start-Build
       # - name: Checkout tools repo for GitHub Event Processor sources
-      #   uses: actions/checkout@v3
+      #   uses: actions/checkout@v6
       #   with:
       #     repository: Azure/azure-sdk-tools
       #     path: azure-sdk-tools
@@ -123,7 +123,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Archive github event data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: event


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [``](https://github.com/actions/checkout/releases/tag/) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |  |
| `actions/github-script` | [``](https://github.com/actions/github-script/releases/tag/) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) |  |
| `actions/upload-artifact` | [``](https://github.com/actions/upload-artifact/releases/tag/) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) |  |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
