### PR TITLE
Throw fewer exceptions from AppLens

### DIFF
--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -10,6 +10,8 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 ### Bugs Fixed
 
+- Fixed various exceptions being thrown by the AppLens tool. [[#1419](https://github.com/microsoft/mcp/pull/1419)]
+
 ### Other Changes
 
 ## 2.0.0-beta.10 (2026-01-09)

--- a/tools/Azure.Mcp.Tools.AppLens/src/Commands/Resource/ResourceDiagnoseCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Commands/Resource/ResourceDiagnoseCommand.cs
@@ -91,7 +91,7 @@ public sealed class ResourceDiagnoseCommand(ILogger<ResourceDiagnoseCommand> log
             {
                 Success<AppLensInsights> success => ResponseResult.Create(new(success.Data, Message: null), AppLensJsonContext.Default.ResourceDiagnoseCommandResult),
                 Failure<AppLensInsights> failure => ResponseResult.Create(new ResourceDiagnoseCommandResult(null, failure.Message), AppLensJsonContext.Default.ResourceDiagnoseCommandResult),
-                _ => throw new InvalidOperationException($"Unexpected result type from ${nameof(service.DiagnoseResourceAsync)}.")
+                _ => throw new InvalidOperationException($"Unexpected result type from {nameof(service.DiagnoseResourceAsync)}.")
             };
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.AppLens/src/Commands/Resource/ResourceDiagnoseCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Commands/Resource/ResourceDiagnoseCommand.cs
@@ -89,7 +89,7 @@ public sealed class ResourceDiagnoseCommand(ILogger<ResourceDiagnoseCommand> log
 
             context.Response.Results = result switch
             {
-                Success<AppLensInsights> success => ResponseResult.Create(new (success.Data, Message: null), AppLensJsonContext.Default.ResourceDiagnoseCommandResult),
+                Success<AppLensInsights> success => ResponseResult.Create(new(success.Data, Message: null), AppLensJsonContext.Default.ResourceDiagnoseCommandResult),
                 Failure<AppLensInsights> failure => ResponseResult.Create(new ResourceDiagnoseCommandResult(null, failure.Message), AppLensJsonContext.Default.ResourceDiagnoseCommandResult),
                 _ => throw new InvalidOperationException($"Unexpected result type from ${nameof(service.DiagnoseResourceAsync)}.")
             };

--- a/tools/Azure.Mcp.Tools.AppLens/src/Commands/Resource/ResourceDiagnoseCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Commands/Resource/ResourceDiagnoseCommand.cs
@@ -87,7 +87,12 @@ public sealed class ResourceDiagnoseCommand(ILogger<ResourceDiagnoseCommand> log
                 options.Tenant,
                 cancellationToken);
 
-            context.Response.Results = ResponseResult.Create(new(result), AppLensJsonContext.Default.ResourceDiagnoseCommandResult);
+            context.Response.Results = result switch
+            {
+                Success<AppLensInsights> success => ResponseResult.Create(new (success.Data, Message: null), AppLensJsonContext.Default.ResourceDiagnoseCommandResult),
+                Failure<AppLensInsights> failure => ResponseResult.Create(new ResourceDiagnoseCommandResult(null, failure.Message), AppLensJsonContext.Default.ResourceDiagnoseCommandResult),
+                _ => throw new InvalidOperationException($"Unexpected result type from ${nameof(service.DiagnoseResourceAsync)}.")
+            };
         }
         catch (Exception ex)
         {

--- a/tools/Azure.Mcp.Tools.AppLens/src/Models/AppLensJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Models/AppLensJsonContext.cs
@@ -8,7 +8,7 @@ namespace Azure.Mcp.Tools.AppLens.Models;
 [JsonSerializable(typeof(ChatMessage))]
 [JsonSerializable(typeof(ChatMessageRequestBody))]
 [JsonSerializable(typeof(ChatMessageResponseBody))]
-[JsonSerializable(typeof(DiagnosticResult))]
+[JsonSerializable(typeof(AppLensInsights))]
 [JsonSerializable(typeof(ResourceDiagnoseCommandResult))]
 [JsonSerializable(typeof(JsonElement[]))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]

--- a/tools/Azure.Mcp.Tools.AppLens/src/Models/AppLensModels.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Models/AppLensModels.cs
@@ -178,7 +178,7 @@ public class ChatMessageResponseBody
 /// <param name="Solutions">List of proposed solutions.</param>
 /// <param name="ResourceId">The resource ID that was diagnosed.</param>
 /// <param name="ResourceType">The type of resource that was diagnosed.</param>
-public record DiagnosticResult(
+public record AppLensInsights(
     List<string> Insights,
     List<string> Solutions,
     string ResourceId,
@@ -188,7 +188,7 @@ public record DiagnosticResult(
 /// Command result for resource diagnose operation.
 /// </summary>
 /// <param name="Result">The diagnostic result.</param>
-public record ResourceDiagnoseCommandResult(DiagnosticResult Result);
+public record ResourceDiagnoseCommandResult(AppLensInsights Result);
 
 /// <summary>
 /// Represents the result of an operation, which can be either a success containing a value or a failure containing an

--- a/tools/Azure.Mcp.Tools.AppLens/src/Models/AppLensModels.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Models/AppLensModels.cs
@@ -13,23 +13,6 @@ namespace Azure.Mcp.Tools.AppLens.Models;
 public record AppLensSession(string SessionId, string ResourceId, string Token, int ExpiresIn);
 
 /// <summary>
-/// Represents the result of trying to obtain an AppLens session.
-/// </summary>
-public abstract record GetAppLensSessionResult;
-
-/// <summary>
-/// Represents the successful creation of an AppLens session.
-/// </summary>
-/// <param name="Session">The new AppLens session.</param>
-public sealed record SuccessfulAppLensSessionResult(AppLensSession Session) : GetAppLensSessionResult;
-
-/// <summary>
-/// Represents a failure while trying to create an AppLens session.
-/// </summary>
-/// <param name="Message">A message about the failure suitable for display to the user.</param>
-public sealed record FailedAppLensSessionResult(string Message) : GetAppLensSessionResult;
-
-/// <summary>
 /// Result of Azure Resource Graph query for resource lookup.
 /// </summary>
 /// <param name="Id">Resource ID.</param>
@@ -46,24 +29,14 @@ public record AppLensArgQueryResult(
     string ResourceKind,
     string ResourceName);
 
-/// <summary>
-/// Abstract base for resource finding results.
-/// </summary>
-public abstract record FindResourceIdResult;
 
 /// <summary>
-/// Successful resource finding result.
+/// Contains the results of successfully finding a resource based on its name.
 /// </summary>
 /// <param name="ResourceId">The resource ID.</param>
 /// <param name="ResourceTypeAndKind">The resource type and kind.</param>
 /// <param name="Message">Optional message.</param>
-public sealed record FoundResourceResult(string ResourceId, string ResourceTypeAndKind, string? Message) : FindResourceIdResult;
-
-/// <summary>
-/// Failed resource finding result.
-/// </summary>
-/// <param name="Message">Error message.</param>
-public sealed record DidNotFindResourceResult(string Message) : FindResourceIdResult;
+public sealed record FoundResourceData(string ResourceId, string ResourceTypeAndKind, string? Message);
 
 /// <summary>
 /// Options controlling the behavior of the AppLens service.
@@ -216,3 +189,31 @@ public record DiagnosticResult(
 /// </summary>
 /// <param name="Result">The diagnostic result.</param>
 public record ResourceDiagnoseCommandResult(DiagnosticResult Result);
+
+/// <summary>
+/// Represents the result of an operation, which can be either a success containing a value or a failure containing an
+/// error message.
+/// </summary>
+/// <remarks>Use the static methods <see cref="Success{T}(T)"/> and <see cref="Failure{T}(string)"/> to create
+/// instances representing successful or failed outcomes. This type is commonly used to encapsulate the outcome of
+/// operations that may fail, providing a way to handle errors without exceptions.</remarks>
+/// <typeparam name="T">The type of the value returned in the case of a successful result.</typeparam>
+public abstract record Result<T>()
+{
+    public static Success<T> Success(T data) => new(data);
+    public static Failure<T> Failure(string message) => new(message);
+}
+
+/// <summary>
+/// Represents a successful result that contains a value of the specified type.
+/// </summary>
+/// <typeparam name="T">The type of the value returned in the successful result.</typeparam>
+/// <param name="Data">The value associated with the successful result.</param>
+public sealed record Success<T>(T Data) : Result<T>;
+
+/// <summary>
+/// Represents a failed result with a message explaining the problem.
+/// </summary>
+/// <typeparam name="T">The type of the value returned in a successful result.</typeparam>
+/// <param name="Message">A message containing more details on the failure.</param>
+public sealed record Failure<T>(string Message) : Result<T>;

--- a/tools/Azure.Mcp.Tools.AppLens/src/Models/AppLensModels.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Models/AppLensModels.cs
@@ -188,7 +188,7 @@ public record AppLensInsights(
 /// Command result for resource diagnose operation.
 /// </summary>
 /// <param name="Result">The diagnostic result.</param>
-public record ResourceDiagnoseCommandResult(AppLensInsights Result);
+public record ResourceDiagnoseCommandResult(AppLensInsights? Result, string? Message);
 
 /// <summary>
 /// Represents the result of an operation, which can be either a success containing a value or a failure containing an

--- a/tools/Azure.Mcp.Tools.AppLens/src/Services/AppLensService.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Services/AppLensService.cs
@@ -39,34 +39,35 @@ public class AppLensService(IHttpClientService httpClientService, ISubscriptionS
         // Step 1: Get the resource ID
         var findResult = await FindResourceIdAsync(resource, subscriptionResource.Data.SubscriptionId, resourceGroup, resourceType, cancellationToken);
 
-        if (findResult is DidNotFindResourceResult notFound)
+        if (findResult is Failure<FoundResourceData> notFoundResult)
         {
-            throw new InvalidOperationException(notFound.Message);
+            throw new InvalidOperationException(notFoundResult.Message);
         }
 
-        var foundResource = (FoundResourceResult)findResult;
+        var successfulResult = (Success<FoundResourceData>)findResult;
+        var resourceData = successfulResult.Data;
 
         // Step 2: Get AppLens session
-        var session = await GetAppLensSessionAsync(foundResource.ResourceId, tenantId, cancellationToken);
+        var getSessionResult = await GetAppLensSessionAsync(resourceData.ResourceId, tenantId, cancellationToken);
 
-        if (session is FailedAppLensSessionResult failed)
+        if (getSessionResult is Failure<AppLensSession> failed)
         {
             throw new InvalidOperationException(failed.Message);
         }
 
-        var successfulSession = (SuccessfulAppLensSessionResult)session;
+        var successResult = (Success<AppLensSession>)getSessionResult;
 
         // Step 3: Ask AppLens the diagnostic question
-        var insights = await CollectInsightsAsync(successfulSession.Session, question, cancellationToken);
+        var insights = await CollectInsightsAsync(successResult.Data, question, cancellationToken);
 
         return new DiagnosticResult(
             insights.Insights,
             insights.Solutions,
-            foundResource.ResourceId,
-            foundResource.ResourceTypeAndKind);
+            resourceData.ResourceId,
+            resourceData.ResourceTypeAndKind);
     }
 
-    private Task<FindResourceIdResult> FindResourceIdAsync(
+    private Task<Result<FoundResourceData>> FindResourceIdAsync(
         string resource,
         string? subscription,
         string? resourceGroup,
@@ -77,15 +78,15 @@ public class AppLensService(IHttpClientService httpClientService, ISubscriptionS
 
         if (string.IsNullOrEmpty(subscription) || string.IsNullOrEmpty(resourceGroup))
         {
-            return Task.FromResult<FindResourceIdResult>(new DidNotFindResourceResult($"Subscription ID and Resource Group are required to locate resource '{resource}'. Please provide both --subscription-name-or-id and --resource-group parameters."));
+            return Task.FromResult<Result<FoundResourceData>>(Result<FoundResourceData>.Failure($"Subscription ID and Resource Group are required to locate resource '{resource}'. Please provide both --subscription-name-or-id and --resource-group parameters."));
         }
 
         var resourceId = $"/subscriptions/{subscription}/resourceGroups/{resourceGroup}/providers/{resourceType}/{resource}";
 
-        return Task.FromResult<FindResourceIdResult>(new FoundResourceResult(resourceId, resourceType ?? "Unknown", null));
+        return Task.FromResult<Result<FoundResourceData>>(Result<FoundResourceData>.Success(new FoundResourceData(resourceId, resourceType ?? "Unknown", null)));
     }
 
-    private async Task<GetAppLensSessionResult> GetAppLensSessionAsync(string resourceId, string? tenantId = null, CancellationToken cancellationToken = default)
+    private async Task<Result<AppLensSession>> GetAppLensSessionAsync(string resourceId, string? tenantId = null, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -109,21 +110,21 @@ public class AppLensService(IHttpClientService httpClientService, ISubscriptionS
             {
                 if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
-                    return new FailedAppLensSessionResult("The specified resource could not be found or does not support diagnostics.");
+                    return Result<AppLensSession>.Failure("The specified resource could not be found or does not support diagnostics.");
                 }
-                return new FailedAppLensSessionResult($"Failed to create diagnostics session for resource {resourceId}, http response code: {response.StatusCode}");
+                return Result<AppLensSession>.Failure($"Failed to create diagnostics session for resource {resourceId}, http response code: {response.StatusCode}");
             }
 
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
             AppLensSession? appLensSession;
             appLensSession = ParseGetTokenResponse(content);
 
-            return new SuccessfulAppLensSessionResult(
+            return Result<AppLensSession>.Success(
                 appLensSession with { ResourceId = resourceId });
         }
         catch (Exception ex)
         {
-            return new FailedAppLensSessionResult($"Failed to create AppLens session: {ex.Message}");
+            return Result<AppLensSession>.Failure($"Failed to create AppLens session: {ex.Message}");
         }
     }
 

--- a/tools/Azure.Mcp.Tools.AppLens/src/Services/AppLensService.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Services/AppLensService.cs
@@ -26,7 +26,7 @@ public class AppLensService(IHttpClientService httpClientService, ISubscriptionS
     private const string ConversationalDiagnosticsSignalREndpoint = "https://diagnosticschat.azure.com/chatHub";
 
     /// <inheritdoc />
-    public async Task<DiagnosticResult> DiagnoseResourceAsync(
+    public async Task<AppLensInsights> DiagnoseResourceAsync(
         string question,
         string resource,
         string subscription,
@@ -60,7 +60,7 @@ public class AppLensService(IHttpClientService httpClientService, ISubscriptionS
         // Step 3: Ask AppLens the diagnostic question
         var insights = await CollectInsightsAsync(successResult.Data, question, cancellationToken);
 
-        return new DiagnosticResult(
+        return new AppLensInsights(
             insights.Insights,
             insights.Solutions,
             resourceData.ResourceId,
@@ -263,7 +263,7 @@ public class AppLensService(IHttpClientService httpClientService, ISubscriptionS
     /// <param name="session">The AppLens session.</param>
     /// <param name="question">The diagnostic question.</param>
     /// <returns>A task containing diagnostic insights and solutions.</returns>
-    private async Task<DiagnosticResult> CollectInsightsAsync(AppLensSession session, string question, CancellationToken cancellationToken)
+    private async Task<AppLensInsights> CollectInsightsAsync(AppLensSession session, string question, CancellationToken cancellationToken)
     {
         var insights = new List<string>();
         var solutions = new List<string>();
@@ -281,7 +281,7 @@ public class AppLensService(IHttpClientService httpClientService, ISubscriptionS
             }
         }
 
-        return new DiagnosticResult(insights, solutions, session.ResourceId, "Resource");
+        return new AppLensInsights(insights, solutions, session.ResourceId, "Resource");
     }
 
     private static AppLensSession ParseGetTokenResponse(string rawResponse)

--- a/tools/Azure.Mcp.Tools.AppLens/src/Services/IAppLensService.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Services/IAppLensService.cs
@@ -19,7 +19,7 @@ public interface IAppLensService
     /// <param name="resourceGroup">The resource group of the Azure resource to diagnose.</param>
     /// <param name="resourceType">The resource type of the Azure resource to diagnose.</param>
     /// <returns>A diagnostic result containing insights and solutions.</returns>
-    Task<DiagnosticResult> DiagnoseResourceAsync(
+    Task<AppLensInsights> DiagnoseResourceAsync(
         string question,
         string resource,
         string subscription,

--- a/tools/Azure.Mcp.Tools.AppLens/src/Services/IAppLensService.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Services/IAppLensService.cs
@@ -19,7 +19,7 @@ public interface IAppLensService
     /// <param name="resourceGroup">The resource group of the Azure resource to diagnose.</param>
     /// <param name="resourceType">The resource type of the Azure resource to diagnose.</param>
     /// <returns>A diagnostic result containing insights and solutions.</returns>
-    Task<AppLensInsights> DiagnoseResourceAsync(
+    Task<Result<AppLensInsights>> DiagnoseResourceAsync(
         string question,
         string resource,
         string subscription,

--- a/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.UnitTests/Resource/ResourceDiagnoseCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.UnitTests/Resource/ResourceDiagnoseCommandTests.cs
@@ -39,7 +39,7 @@ public class ResourceDiagnoseCommandTests
     public async Task ExecuteAsync_ReturnsDiagnosticResult_WhenValidParametersProvided()
     {
         // Arrange
-        var expectedResult = new DiagnosticResult(
+        var expectedResult = new AppLensInsights(
             new List<string> { "Insight 1", "Insight 2" },
             new List<string> { "Solution 1", "Solution 2" },
             "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp",
@@ -262,7 +262,7 @@ public class ResourceDiagnoseCommandTests
     public async Task ExecuteAsync_HandlesEmptyDiagnosticResult()
     {
         // Arrange
-        var expectedResult = new DiagnosticResult(
+        var expectedResult = new AppLensInsights(
             new List<string>(),
             new List<string>(),
             "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp",
@@ -342,7 +342,7 @@ public class ResourceDiagnoseCommandTests
     public async Task ExecuteAsync_LogsInformationOnSuccess()
     {
         // Arrange
-        var expectedResult = new DiagnosticResult(
+        var expectedResult = new AppLensInsights(
             new List<string> { "Insight 1" },
             new List<string> { "Solution 1" },
             "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp",

--- a/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.UnitTests/Resource/ResourceDiagnoseCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.UnitTests/Resource/ResourceDiagnoseCommandTests.cs
@@ -39,12 +39,12 @@ public class ResourceDiagnoseCommandTests
     public async Task ExecuteAsync_ReturnsDiagnosticResult_WhenValidParametersProvided()
     {
         // Arrange
-        var expectedResult = new AppLensInsights(
+        var expectedResult = new Success<AppLensInsights>(new AppLensInsights(
             new List<string> { "Insight 1", "Insight 2" },
             new List<string> { "Solution 1", "Solution 2" },
             "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp",
             "Microsoft.Web/sites"
-        );
+        ));
 
         _appLensService.DiagnoseResourceAsync(
             "Why is my app slow?",
@@ -262,12 +262,12 @@ public class ResourceDiagnoseCommandTests
     public async Task ExecuteAsync_HandlesEmptyDiagnosticResult()
     {
         // Arrange
-        var expectedResult = new AppLensInsights(
+        var expectedResult = new Success<AppLensInsights>(new AppLensInsights(
             new List<string>(),
             new List<string>(),
             "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp",
             "Microsoft.Web/sites"
-        );
+        ));
 
         _appLensService.DiagnoseResourceAsync(
             "Why is my app slow?",
@@ -342,12 +342,12 @@ public class ResourceDiagnoseCommandTests
     public async Task ExecuteAsync_LogsInformationOnSuccess()
     {
         // Arrange
-        var expectedResult = new AppLensInsights(
+        var expectedResult = new Success<AppLensInsights>(new AppLensInsights(
             new List<string> { "Insight 1" },
             new List<string> { "Solution 1" },
             "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp",
             "Microsoft.Web/sites"
-        );
+        ));
 
         _appLensService.DiagnoseResourceAsync(
             "Why is my app slow?",


### PR DESCRIPTION
## What does this PR do?

The AppLens tool has a very low success rate. Looking through the code there are several common, non-exceptional cases where we're throwing an exception that escapes the tool. The MCP server infrastructure captures these exceptions and treats them as failures.

For example, we will currently throw an exception if the resource can't be found. This is pretty normal--the user may have mistyped the name, or the resource exists but not in the specified subscription. Rather than throwing exceptions we should simply return a message telling the LM that the resource wasn't found and to check the spelling.

Most of the changes here are concerned with bubbling existing messages up to the LM in this manner. This is not a complete solution to the problem but does address some low-hanging fruit. Beyond this we'll need to invest in better telemetry for AppLens so that we can see where things tend to go sideways.

## GitHub issue number?
https://github.com/microsoft/mcp-pr/issues/172

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [x] For MCP tool changes:
    - [x] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [x] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [x] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [x] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [x] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [x] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [x] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [x] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
