### PR TITLE
Update Azure FileShares e2e test prompts

### DIFF
--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -277,45 +277,45 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | eventhubs_namespace_update | Create an new namespace <namespace_name> in my resource group <resource_group_name> |
 | eventhubs_namespace_update | Update my namespace <namespace_name> in my resource group <resource_group_name>|
 
-## Azure File Shares
+## Azure FileShares
 
 | Tool Name | Test Prompt |
 |:----------|:----------|
-| fileshares_fileshare_create | Create a new file share <file_share_name> in storage account <account_name> in resource group <resource_group_name> |
-| fileshares_fileshare_create | Create file share <file_share_name> in account <account_name> with quota 100 GB |
-| fileshares_fileshare_create | Create a file share named <file_share_name> in storage account <account_name> with access tier Hot |
-| fileshares_fileshare_create | Set up a new file share <file_share_name> in storage account <account_name> |
-| fileshares_fileshare_delete | Delete the file share <file_share_name> from storage account <account_name> in resource group <resource_group_name> |
-| fileshares_fileshare_delete | Remove file share <file_share_name> from account <account_name> |
-| fileshares_fileshare_get | List all file shares in storage account <account_name> |
-| fileshares_fileshare_get | Show me the file shares in storage account <account_name> in resource group <resource_group_name> |
-| fileshares_fileshare_get | Get details of file share <file_share_name> in storage account <account_name> |
-| fileshares_fileshare_get | Show me the file share <file_share_name> in account <account_name> |
-| fileshares_fileshare_get | What file shares exist in storage account <account_name>? |
-| fileshares_fileshare_limits_get | Get the file share limits for subscription <subscription> |
-| fileshares_fileshare_limits_get | What are the file share limits in my subscription? |
-| fileshares_fileshare_limits_get | Show me the file share service limits |
+| fileshares_fileshare_create | Create a new file share <file_share_name> in resource group <resource_group_name> |
+| fileshares_fileshare_create | Create file share <file_share_name> in resource group <resource_group_name> with 100 GB storage |
+| fileshares_fileshare_create | Create a file share named <file_share_name> in location <location> with resource group <resource_group_name> |
+| fileshares_fileshare_create | Set up a new file share <file_share_name> in resource group <resource_group_name> |
+| fileshares_fileshare_delete | Delete the file share <file_share_name> from resource group <resource_group_name> |
+| fileshares_fileshare_delete | Remove file share <file_share_name> in resource group <resource_group_name> |
+| fileshares_fileshare_get | List all file shares in my subscription |
+| fileshares_fileshare_get | Show me the file shares in resource group <resource_group_name> |
+| fileshares_fileshare_get | Get details of file share <file_share_name> in resource group <resource_group_name> |
+| fileshares_fileshare_get | Show me the file share <file_share_name> in resource group <resource_group_name> |
+| fileshares_fileshare_get | What file shares exist in resource group <resource_group_name>? |
+| fileshares_fileshare_limits_get | Get the file share limits for subscription <subscription> in location <location> |
+| fileshares_fileshare_limits_get | What are the file share limits in my subscription for location <location>? |
+| fileshares_fileshare_limits_get | Show me the file share service limits in location <location> |
 | fileshares_fileshare_nameavailability_check | Check if file share name <file_share_name> is available in subscription <subscription> |
 | fileshares_fileshare_nameavailability_check | Is the file share name <file_share_name> available? |
 | fileshares_fileshare_nameavailability_check | Verify availability of file share name <file_share_name> |
-| fileshares_fileshare_provisioningrecommendation_get | Get provisioning recommendations for file share <file_share_name> in storage account <account_name> |
+| fileshares_fileshare_provisioningrecommendation_get | Get provisioning recommendations for file share <file_share_name> in resource group <resource_group_name> |
 | fileshares_fileshare_provisioningrecommendation_get | Show me provisioning recommendations for file share <file_share_name> |
 | fileshares_fileshare_provisioningrecommendation_get | What are the recommended provisioning settings for file share <file_share_name>? |
-| fileshares_fileshare_snapshot_create | Create a snapshot of file share <file_share_name> in storage account <account_name> |
-| fileshares_fileshare_snapshot_create | Create a snapshot for file share <file_share_name> in account <account_name> |
+| fileshares_fileshare_snapshot_create | Create a snapshot of file share <file_share_name> in resource group <resource_group_name> |
+| fileshares_fileshare_snapshot_create | Create a snapshot for file share <file_share_name> in resource group <resource_group_name> |
 | fileshares_fileshare_snapshot_create | Take a snapshot of file share <file_share_name> |
-| fileshares_fileshare_snapshot_delete | Delete the snapshot <snapshot_id> from file share <file_share_name> in storage account <account_name> |
+| fileshares_fileshare_snapshot_delete | Delete the snapshot <snapshot_id> from file share <file_share_name> in resource group <resource_group_name> |
 | fileshares_fileshare_snapshot_delete | Remove snapshot <snapshot_id> from file share <file_share_name> |
-| fileshares_fileshare_snapshot_get | List all snapshots for file share <file_share_name> in storage account <account_name> |
-| fileshares_fileshare_snapshot_get | Show me the snapshots of file share <file_share_name> in account <account_name> |
+| fileshares_fileshare_snapshot_get | List all snapshots for file share <file_share_name> in resource group <resource_group_name> |
+| fileshares_fileshare_snapshot_get | Show me the snapshots of file share <file_share_name> in resource group <resource_group_name> |
 | fileshares_fileshare_snapshot_get | Get snapshot <snapshot_id> for file share <file_share_name> |
-| fileshares_fileshare_snapshot_update | Update the snapshot <snapshot_id> of file share <file_share_name> in storage account <account_name> |
+| fileshares_fileshare_snapshot_update | Update the snapshot <snapshot_id> of file share <file_share_name> in resource group <resource_group_name> |
 | fileshares_fileshare_snapshot_update | Update metadata for snapshot <snapshot_id> of file share <file_share_name> |
-| fileshares_fileshare_update | Update file share <file_share_name> in storage account <account_name> |
-| fileshares_fileshare_update | Update the quota for file share <file_share_name> to 200 GB |
-| fileshares_fileshare_update | Change the access tier of file share <file_share_name> to Cool |
-| fileshares_fileshare_update | Modify file share <file_share_name> in account <account_name> with new settings |
-| fileshares_fileshare_usage_get | Get usage data for file share <file_share_name> in storage account <account_name> |
+| fileshares_fileshare_update | Update file share <file_share_name> in resource group <resource_group_name> |
+| fileshares_fileshare_update | Update the provisioned storage for file share <file_share_name> to 200 GB |
+| fileshares_fileshare_update | Change the media tier of file share <file_share_name> to Standard |
+| fileshares_fileshare_update | Modify file share <file_share_name> in resource group <resource_group_name> with new settings |
+| fileshares_fileshare_usage_get | Get usage data for file share <file_share_name> in resource group <resource_group_name> |
 | fileshares_fileshare_usage_get | Show me the usage statistics for file share <file_share_name> |
 | fileshares_fileshare_usage_get | What is the current usage of file share <file_share_name>? |
 


### PR DESCRIPTION
Revised Azure FileShares test prompts to use resource group and location parameters instead of storage account, and updated prompt wording for consistency and clarity.

## What does this PR do?
`[Provide a clear, concise description of the changes]`

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
