### PR TITLE
Disable external process commands in remote (http)

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Options/ServiceStartOptions.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Options/ServiceStartOptions.cs
@@ -91,9 +91,8 @@ public class ServiceStartOptions
     public string? Cloud { get; set; } = null;
 
     /// <summary>
-    /// Gets a value indicating whether the server is running in HTTP mode with On-Behalf-Of authentication.
+    /// Gets a value indicating whether the server is running in HTTP (remote) mode.
     /// </summary>
     [JsonIgnore]
-    public bool IsHttpOnBehalfOfMode => Transport == TransportTypes.Http
-        && OutgoingAuthStrategy == OutgoingAuthStrategy.UseOnBehalfOf;
+    public bool IsHttpMode => Transport == TransportTypes.Http;
 }

--- a/servers/Azure.Mcp.Server/changelog-entries/1768876346795.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1768876346795.yaml
@@ -1,3 +1,3 @@
 changes:
   - section: "Features Added"
-    description: "Disable external process commands (azqr) in HTTP + On-Behalf-Of mode for security"
+    description: "Disable external process commands (azqr) in HTTP remote mode for security"

--- a/tools/Azure.Mcp.Tools.Extension/src/ExtensionSetup.cs
+++ b/tools/Azure.Mcp.Tools.Extension/src/ExtensionSetup.cs
@@ -58,9 +58,9 @@ public sealed class ExtensionSetup : IAreaSetup
     /// <summary>
     /// Determines whether extension commands that use external process execution should be exposed.
     /// External process commands (like azqr) use <see cref="IExternalProcessService"/> to spawn
-    /// local processes. In HTTP + On-Behalf-Of mode, spawning child processes on a remote server is a security
-    /// risk: processes run under the server's host identity (not the OBO user's context), and malicious or
-    /// excessive requests could exhaust resources.
+    /// local processes. In HTTP (remote) mode, spawning child processes on a remote server is a security
+    /// risk: processes run under the server's host identity (not the caller's context), and malicious or
+    /// excessive requests could exhaust resources leading to denial-of-service.
     /// </summary>
     /// <param name="serviceProvider">The service provider to resolve ServiceStartOptions from.</param>
     /// <returns>True if external process commands should be exposed; false otherwise.</returns>
@@ -68,7 +68,7 @@ public sealed class ExtensionSetup : IAreaSetup
     {
         if (serviceProvider.GetService<ServiceStartOptions>() is ServiceStartOptions startOptions)
         {
-            return !startOptions.IsHttpOnBehalfOfMode;
+            return !startOptions.IsHttpMode;
         }
 
         // ServiceStartOptions is unavailable in the first DI container (CLI routing), where all commands

--- a/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.UnitTests/ExtensionSetupTests.cs
+++ b/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.UnitTests/ExtensionSetupTests.cs
@@ -27,9 +27,9 @@ public sealed class ExtensionSetupTests
     }
 
     [Fact]
-    public void RegisterCommands_HttpOboMode_ExcludesAzqrCommand()
+    public void RegisterCommands_RemoteHttpOboMode_ExcludesAzqrCommand()
     {
-        // Arrange
+        // Arrange: HTTP (remote) + OBO auth mode
         var options = new ServiceStartOptions
         {
             Transport = TransportTypes.Http,
@@ -42,15 +42,37 @@ public sealed class ExtensionSetupTests
         var commandGroup = setup.RegisterCommands(provider);
 
         // Assert
+        // In remote mode the azqr command that shells out to an external process is excluded.
         Assert.DoesNotContain("azqr", commandGroup.Commands.Keys);
         // cli subgroup and its commands should still be present
         Assert.Contains(commandGroup.SubGroup, g => g.Name == "cli");
     }
 
     [Fact]
-    public void RegisterCommands_StdioMode_IncludesAzqrCommand()
+    public void RegisterCommands_RemoteHttpHostIdentityMode_ExcludesAzqrCommand()
     {
-        // Arrange – stdio transport (default), no OBO
+        // Arrange: HTTP (remote) + HostIdentity auth mode
+        var options = new ServiceStartOptions
+        {
+            Transport = TransportTypes.Http,
+            OutgoingAuthStrategy = OutgoingAuthStrategy.UseHostingEnvironmentIdentity,
+        };
+        var provider = BuildServiceProvider(options);
+        var setup = new ExtensionSetup();
+
+        // Act
+        var commandGroup = setup.RegisterCommands(provider);
+
+        // Assert
+        // In remote mode the azqr command that shells out to an external process is excluded.
+        Assert.DoesNotContain("azqr", commandGroup.Commands.Keys);
+        Assert.Contains(commandGroup.SubGroup, g => g.Name == "cli");
+    }
+
+    [Fact]
+    public void RegisterCommands_LocalStdioMode_IncludesAzqrCommand()
+    {
+        // Arrange: stdio transport
         var options = new ServiceStartOptions
         {
             Transport = TransportTypes.StdIo,
@@ -62,6 +84,7 @@ public sealed class ExtensionSetupTests
         var commandGroup = setup.RegisterCommands(provider);
 
         // Assert
+        // In local mode the azqr command that shells out to an external process is allowed.
         Assert.Contains("azqr", commandGroup.Commands.Keys);
         Assert.Contains(commandGroup.SubGroup, g => g.Name == "cli");
     }


### PR DESCRIPTION
## What does this PR do?

External process commands (like azqr) use `IExternalProcessService` to spawn local processes. In remote (HTTP) mode, this is a security risk: processes run under the server's host identity (not the OBO user's context), and malicious requests could exhaust server resources.

- Add `IsHttpMode()` method to `ServiceStartOptions`
- Conditionally exclude `AzqrCommand` registration in `ExtensionSetup`

Fixes https://github.com/microsoft/mcp/issues/1521

Users running locally are expected to use stdio mode. Of course, HTTP can be run locally ((which is less secure with plain-text traffic) as well, but the primary use case for HTTP is remote deployment, which we want to ensure is secure by default. 

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
