### PR TITLE
Bump `mcp-publisher` to align with `server.json` schema `2025-12-11`

### DIFF
--- a/eng/scripts/Deploy-ServerJson.ps1
+++ b/eng/scripts/Deploy-ServerJson.ps1
@@ -105,6 +105,8 @@ if (!(Test-Path $goInstallScriptPath)) {
 $env:GOEXPERIMENT = "systemcrypto"
 
 # Clone and build the publisher tool
+# FYI for EngSys or server.json schema changes. This publisher should be updated any time we update the manifest schema
+# version $schema in any server.json file: https://github.com/modelcontextprotocol/registry/releases/
 git clone --branch "v1.4.0" https://github.com/modelcontextprotocol/registry
 
 Set-Location registry


### PR DESCRIPTION
Unbeknownst to me, this is a two part system.

1. You have `mcp-publisher.exe` that is installed in `Deploy-ServerJson.ps1`
2. You have a manifest file `server.json` which targets a schema via property `$schema`
3. Both must be updated. As the `mcp-publisher` needs to have the newer schema locally as well.

I failed to update mcp-publisher.exe version in my previous PR #1527 . And it's quite visible in the `publisher` tag: https://github.com/modelcontextprotocol/registry/releases/tag/v1.4.0

Going to check this against template release prior to merge.