### PR TITLE
Release to dev feeds before public feeds

### DIFF
--- a/eng/pipelines/templates/jobs/npm/release-npm.yml
+++ b/eng/pipelines/templates/jobs/npm/release-npm.yml
@@ -36,7 +36,18 @@ jobs:
             $path = '$(Pipeline.Workspace)/drop/${{ parameters.ServerName }}/wrapper'
             Write-Host "`n`nContents of $path`:"
             Get-ChildItem $path -Recurse
-
+          displayName: 'List package contents'
+        - template: /eng/pipelines/templates/steps/publish-to-dev-feed.yml
+          parameters:
+            PathToArtifacts: $(Pipeline.Workspace)/drop
+            Registry: https://pkgs.dev.azure.com/1es-mcp/1es-mcp/_packaging/1es-mcp-registry/npm/registry/
+            ServiceConnection: 'Azure SDK MCP Server Connection'
+            Tag: latest
+        - template: /eng/pipelines/templates/steps/publish-to-dev-feed.yml
+          parameters:
+            PathToArtifacts: $(Pipeline.Workspace)/drop
+            Registry: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/
+            Tag: latest
         - task: ESRPRelease@10
           displayName: Publish platform packages to npmjs.com
           inputs:
@@ -106,14 +117,3 @@ jobs:
               ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
               MainPublisher: 'ESRPRELPACMANTEST'
               ProductState: latest
-        - template: /eng/pipelines/templates/steps/publish-to-dev-feed.yml
-          parameters:
-            PathToArtifacts: $(Pipeline.Workspace)/drop
-            Registry: https://pkgs.dev.azure.com/1es-mcp/1es-mcp/_packaging/1es-mcp-registry/npm/registry/
-            ServiceConnection: 'Azure SDK MCP Server Connection'
-            Tag: latest
-        - template: /eng/pipelines/templates/steps/publish-to-dev-feed.yml
-          parameters:
-            PathToArtifacts: $(Pipeline.Workspace)/drop
-            Registry: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/
-            Tag: latest


### PR DESCRIPTION
## What does this PR do?
Releasing to public feeds before devops feeds creates a race condition between the package being pushed directly to the dev feed and the dev feed pulling the package from its upstreams.  If the dev feed does pull an upstream version first, the direct publish will fail.

To prevent the race condition, we should always publish to the dev feed first.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
