### PR TITLE
Add ToolName validation to AnalyzeCode.ps1

### DIFF
--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -64,9 +64,9 @@ try {
         Write-Host "$($result.Violations.Count) tool(s) with invalid characters found. Review the output below for details."
         
         foreach ($violation in $result.Violations) {
-            Write-Host "Tool Area: $($violation.ToolArea), Tool Name: $($violation.ToolName), File: $($violation.FileName)"
+            Write-Host "- Area: $($violation.ToolArea), Name: $($violation.ToolName) in $($violation.FileName) (line: $($violation.LineNumber))"
         }
-        
+
         $hasErrors = $true
     } else {
         Write-Host "✅ Tool name character validation passed."

--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -57,6 +57,21 @@ try {
         Write-Host "All tools are within the $($toolNameResult.MaxAllowed) character limit."
     }
 
+    $result = & "$PSScriptRoot/Test-ToolNameCharacters.ps1" -ToolsDirectory "$RepoRoot/tools"
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "❌ Tool name character validation failed"
+        Write-Host "$($result.Violations.Count) tool(s) with invalid characters found. Review the output below for details."
+        
+        foreach ($violation in $result.Violations) {
+            Write-Host "Tool Area: $($violation.ToolArea), Tool Name: $($violation.ToolName), File: $($violation.FileName)"
+        }
+        
+        $hasErrors = $true
+    } else {
+        Write-Host "✅ Tool name character validation passed."
+    }
+
     # Run tool id validation
     $toolIdResult = & "$PSScriptRoot/Test-ToolId.ps1"
 

--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -57,14 +57,18 @@ try {
         Write-Host "All tools are within the $($toolNameResult.MaxAllowed) character limit."
     }
 
-    $result = & "$PSScriptRoot/Test-ToolNameCharacters.ps1" -ToolsDirectory "$RepoRoot/tools"
+    $toolCharResult = & "$PSScriptRoot/Test-ToolNameCharacters.ps1" -ToolsDirectory "$RepoRoot/tools"
 
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "❌ Tool name character validation failed"
-        Write-Host "$($result.Violations.Count) tool(s) with invalid characters found. Review the output below for details."
-        
-        foreach ($violation in $result.Violations) {
-            Write-Host "- Area: $($violation.ToolArea), Name: $($violation.ToolName) in $($violation.FileName) (line: $($violation.LineNumber))"
+        if ($null -eq $toolCharResult -or $null -eq $toolCharResult.Violations) {
+            Write-Host "❌ Tool name character validation script failed to execute."
+        } else {
+            Write-Host "❌ Tool name character validation failed"
+            Write-Host "$($toolCharResult.Violations.Count) tool(s) with invalid characters found. Review the output below for details."
+
+            foreach ($violation in $toolCharResult.Violations) {
+                Write-Host "- Area: $($violation.ToolArea), Name: $($violation.ToolName) in $($violation.FileName) (line: $($violation.LineNumber))"
+            }
         }
 
         $hasErrors = $true

--- a/eng/scripts/Test-ToolNameCharacters.ps1
+++ b/eng/scripts/Test-ToolNameCharacters.ps1
@@ -100,7 +100,7 @@ function Test-ToolAreaTools {
     $name = $(Split-Path $ToolAreaDirectory -Leaf)
     $toolViolationsForArea = @()
 
-    $areaTools = Get-ChildItem -Path $ToolAreaDirectory -Recurse -Include *Command.cs, *Setup.cs
+    $areaTools = Get-ChildItem $ToolAreaDirectory -Recurse | Where-Object { $_.Name.EndsWith("Command.cs") -or $_.Name.EndsWith("Setup.cs") } 
 
     if ($areaTools.Count -eq 0) {
         Write-Warning "No files with *Command.cs or *Setup.cs found in area: $ToolAreaDirectory"

--- a/eng/scripts/Test-ToolNameCharacters.ps1
+++ b/eng/scripts/Test-ToolNameCharacters.ps1
@@ -94,16 +94,17 @@ class ToolNameViolation {
 function Test-ToolAreaTools {
     param(
         [Parameter(Mandatory)]
-        [string]$ToolAreaDirectory
+        [string]$TestDirectory
     )
 
-    $name = $(Split-Path $ToolAreaDirectory -Leaf)
+    $name = $(Split-Path $TestDirectory -Leaf)
     $toolViolationsForArea = @()
 
-    $areaTools = Get-ChildItem $ToolAreaDirectory -Recurse | Where-Object { $_.Name.EndsWith("Command.cs") -or $_.Name.EndsWith("Setup.cs") } 
+    LogDebug "Processing tool area: $($TestDirectory)"
+    $areaTools = Get-ChildItem $TestDirectory -Recurse -Include '*Command.cs', '*Setup.cs'
 
     if ($areaTools.Count -eq 0) {
-        Write-Warning "No files with *Command.cs or *Setup.cs found in area: $ToolAreaDirectory"
+        Write-Warning "No files with *Command.cs or *Setup.cs found in area: $TestDirectory"
     }
 
     foreach ($file in $areaTools) {
@@ -145,9 +146,9 @@ function Test-ToolAreaTools {
                 }
             }
         }
+    }
 
         return $toolViolationsForArea
-    }
 }
 
 $ErrorActionPreference = 'Stop'
@@ -156,11 +157,10 @@ $ErrorActionPreference = 'Stop'
 $toolAreaDirectories = Get-ChildItem -Path $ToolsDirectory -Directory
 $overallViolations = @()
 
-LogDebug "Starting tool name character validation for $ToolsDirectory"
+LogDebug "Starting tool name character validation..."
 
 foreach ($toolAreaDir in $toolAreaDirectories) {
-    LogDebug "Processing tool area: $($toolAreaDir.FullName)"
-    $toolAreaResult = Test-ToolAreaTools -ToolAreaDirectory $toolAreaDir.FullName
+    $toolAreaResult = Test-ToolAreaTools -TestDirectory $toolAreaDir.FullName
 
     if ($toolAreaResult.Count -gt 0) {
         $overallViolations += $toolAreaResult

--- a/eng/scripts/Test-ToolNameCharacters.ps1
+++ b/eng/scripts/Test-ToolNameCharacters.ps1
@@ -1,0 +1,139 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7
+
+<#
+.SYNOPSIS
+    Performs tool name character validations.  Each tool name must only contain alphanumeric characters, hyphens, and underscores.
+
+.DESCRIPTION
+    This script validates that tool names are valid across all tools.
+#>
+param(
+    [Parameter(Mandatory)]
+    [string]$ToolsDirectory
+)
+
+class ToolArea {
+    [string]$ToolArea
+    [ToolNameViolation[]]$Violations
+
+    ToolArea([string]$ToolArea) {
+        $this.ToolArea = $ToolArea
+        $this.Violations = @()
+    }
+
+    [void]AddViolation([ToolNameViolation]$violation) {
+        $this.Violations += $violation
+    }
+
+    [bool]HasViolations() {
+        return $this.Violations.Count -gt 0
+    }
+}
+
+class ToolNameViolation {
+    [string]$FileName
+    [string]$ToolName
+    
+    ToolNameViolation([string]$FileName, [string]$ToolName) {
+        $this.FileName = $FileName
+        $this.ToolName = $ToolName
+    }
+}
+
+function Test-ToolAreaTools {
+    param(
+        [Parameter(Mandatory)]
+        [string]$ToolAreaDirectory
+    )
+
+    $name = $(Split-Path $ToolAreaDirectory -Leaf)
+    $toolAreaResult = [ToolArea]::new($name)
+
+    $areaTools = Get-ChildItem -Path $ToolAreaDirectory -Recurse -Include *Command.cs, *Setup.cs
+
+    if ($areaTools.Count -eq 0) {
+        Write-Warning "No files with *Command.cs or *Setup.cs found in area: $ToolAreaDirectory"
+    }
+
+    foreach ($file in $areaTools) {
+        Write-Debug "Processing file: $($file.FullName)"
+        $content = Get-Content $file.FullName
+
+        if ($file.Name -like '*Command.cs') {
+            $matchingPattern = 'public override string Name => "(.*)";'
+        } elseif ($file.Name -like '*Setup.cs') {
+            $matchingPattern = 'public string Name => "(.*)";'
+        } else {
+            throw "Unexpected file name: $($file.Name)"
+        }
+        
+        foreach ($line in $content) {
+            if ($line -match $matchingPattern) {
+                $toolName = $matches[1]
+
+                # Validate tool name format:
+                # - Each group contains alphanumeric chars or dashes
+                # - Each group cannot start or end with a dash
+                # Pattern breakdown:
+                #   ^                           - Start of string
+                #   [a-zA-Z0-9]                 - First char must be alphanumeric
+                #   ([a-zA-Z0-9-]*[a-zA-Z0-9])? - Optional: middle chars (alphanumeric or dash) ending with alphanumeric
+                #   $                           - End of string
+                $isValid = $($ToolName -match '^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$')
+
+                if (-not $isValid) {
+                    $toolAreaResult.AddViolation([ToolNameViolation]::new($file.FullName, $toolName))
+                }
+            }
+        }
+    }
+
+    return $toolAreaResult
+}
+
+$ErrorActionPreference = 'Stop'
+
+$toolAreaDirectories = Get-ChildItem -Path $ToolsDirectory -Directory
+$overallViolations = @()
+
+Write-Debug "Starting tool name character validation for $ToolsDirectory"
+
+foreach ($toolAreaDir in $toolAreaDirectories) {
+    Write-Debug "Processing tool area: $($toolAreaDir.FullName)"
+    $toolAreaResult = Test-ToolAreaTools -ToolAreaDirectory $toolAreaDir.FullName
+
+    if ($toolAreaResult.HasViolations()) {
+        $overallViolations += $toolAreaResult
+    }
+}
+
+Write-Debug "=================================================="
+Write-Debug "SUMMARY"
+Write-Debug "Tools Directory: $ToolsDirectory"
+Write-Debug "Total violations found: $($overallViolations.Count)"
+
+foreach ($area in $overallViolations) {
+    Write-Debug "Area: $($area.ToolArea)"
+    foreach ($violation in $area.Violations) {
+        Write-Debug "  - ToolName: $($violation.ToolName)"
+        Write-Debug "  - File: $($violation.FileName)"
+    }
+    Write-Debug
+}
+
+Write-Debug "=================================================="
+
+$result = [PSCustomObject]@{
+    HasViolations = $overallViolations.Count -gt 0
+    Violations     = $overallViolations
+    ErrorMessage  = "Names can only contain alphanumeric characters or dashes (cannot start or end with a dash)"
+}
+
+$result
+
+if ($overallViolations.Count -gt 0) {
+    exit 1
+} else {
+    exit 0
+}

--- a/eng/scripts/Test-ToolNameCharacters.ps1
+++ b/eng/scripts/Test-ToolNameCharacters.ps1
@@ -75,24 +75,6 @@ param(
     [string]$ToolsDirectory
 )
 
-class ToolArea {
-    [string]$ToolArea
-    [ToolNameViolation[]]$Violations
-
-    ToolArea([string]$ToolArea) {
-        $this.ToolArea = $ToolArea
-        $this.Violations = @()
-    }
-
-    [void]AddViolation([ToolNameViolation]$violation) {
-        $this.Violations += $violation
-    }
-
-    [bool]HasViolations() {
-        return $this.Violations.Count -gt 0
-    }
-}
-
 class ToolNameViolation {
     [string]$ToolArea
     [string]$ToolName
@@ -121,7 +103,7 @@ function Test-ToolAreaTools {
     }
 
     foreach ($file in $areaTools) {
-        Write-Debug "Processing: $($file.FullName)"
+        LogDebug "Processing: $($file.FullName)"
         $content = Get-Content $file.FullName
 
         if ($file.Name -like '*Command.cs') {
@@ -157,14 +139,15 @@ function Test-ToolAreaTools {
 }
 
 $ErrorActionPreference = 'Stop'
+. "$PSScriptRoot/../common/scripts/common.ps1"
 
 $toolAreaDirectories = Get-ChildItem -Path $ToolsDirectory -Directory
 $overallViolations = @()
 
-Write-Debug "Starting tool name character validation for $ToolsDirectory"
+LogDebug "Starting tool name character validation for $ToolsDirectory"
 
 foreach ($toolAreaDir in $toolAreaDirectories) {
-    Write-Debug "Processing tool area: $($toolAreaDir.FullName)"
+    LogDebug "Processing tool area: $($toolAreaDir.FullName)"
     $toolAreaResult = Test-ToolAreaTools -ToolAreaDirectory $toolAreaDir.FullName
 
     if ($toolAreaResult.Count -gt 0) {
@@ -172,18 +155,18 @@ foreach ($toolAreaDir in $toolAreaDirectories) {
     }
 }
 
-Write-Debug "=================================================="
-Write-Debug "SUMMARY"
-Write-Debug "Tools Directory: $ToolsDirectory"
-Write-Debug "Total violations found: $($overallViolations.Count)"
+LogDebug "=================================================="
+LogDebug "SUMMARY"
+LogDebug "Tools Directory: $ToolsDirectory"
+LogDebug "Total violations found: $($overallViolations.Count)"
 
 foreach ($violation in $overallViolations) {
-    Write-Debug "Area: $($violation.ToolArea)"
-    Write-Debug "  - ToolName: $($violation.ToolName)"
-    Write-Debug "  - File: $($violation.FileName)"
+    LogDebug "Area: $($violation.ToolArea)"
+    LogDebug "  - ToolName: $($violation.ToolName)"
+    LogDebug "  - File: $($violation.FileName)"
 }
 
-Write-Debug "=================================================="
+LogDebug "=================================================="
 
 $result = [PSCustomObject]@{
     HasViolations = $overallViolations.Count -gt 0

--- a/eng/scripts/Test-ToolNameCharacters.ps1
+++ b/eng/scripts/Test-ToolNameCharacters.ps1
@@ -113,15 +113,13 @@ function Test-ToolAreaTools {
 
         $patterns = @()
         if ($file.Name -like '*Command.cs') {
-            $patterns += 'public override string Name => "(.*)";'
+            $patterns += 'public override string Name => "([^"]+)";'
         } elseif ($file.Name -like '*Setup.cs') {
-            $patterns += 'public string Name => "(.*)";'
+            $patterns += 'public string Name => "([^"]+)";'
             # Matches: new CommandGroup("group-name", ...) - only string literals, not variables
             # Matches: AddCommand("command-name", ...) - only string literals, not variables
             $patterns += 'new CommandGroup\("([^"]+)",'
             $patterns += 'AddCommand\("([^"]+)",'
-        } else {
-            throw "Unexpected file name: $($file.Name)"
         }
 
         for ($i = 0; $i -lt $content.Count; $i++) {
@@ -138,7 +136,7 @@ function Test-ToolAreaTools {
                     #   [a-zA-Z0-9]                 - First char must be alphanumeric
                     #   ([a-zA-Z0-9-]*[a-zA-Z0-9])? - Optional: middle chars (alphanumeric or dash) ending with alphanumeric
                     #   $                           - End of string
-                    $isValid = $($ToolName -match '^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$')
+                    $isValid = $toolName -match '^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$'
 
                     if (-not $isValid) {
                         $toolViolationsForArea += [ToolNameViolation]::new($name, $file.FullName, $toolName, $i + 1)

--- a/eng/scripts/Test-ToolNameCharacters.ps1
+++ b/eng/scripts/Test-ToolNameCharacters.ps1
@@ -109,8 +109,10 @@ function Test-ToolAreaTools {
 
     foreach ($file in $areaTools) {
         LogDebug "Processing: $($file.FullName)"
-        $content = Get-Content $file.FullName
+        $rawContent = Get-Content $file.FullName -Raw
 
+        # Use patterns that tolerate whitespace (including newlines) between the
+        # opening paren and the quoted name so multi-line declarations are caught.
         $patterns = @()
         if ($file.Name -like '*Command.cs') {
             $patterns += 'public override string Name => "([^"]+)";'
@@ -118,30 +120,31 @@ function Test-ToolAreaTools {
         elseif ($file.Name -like '*Setup.cs') {
             $patterns += 'public string Name => "([^"]+)";'
             # Matches: new CommandGroup("group-name", ...) - only string literals, not variables
+            # Also matches multi-line: new CommandGroup(\n    "group-name", ...)
+            $patterns += 'new CommandGroup\(\s*"([^"]+)",'
             # Matches: AddCommand("command-name", ...) - only string literals, not variables
-            $patterns += 'new CommandGroup\("([^"]+)",'
-            $patterns += 'AddCommand\("([^"]+)",'
+            $patterns += 'AddCommand\(\s*"([^"]+)",'
         }
 
-        for ($i = 0; $i -lt $content.Count; $i++) {
-            $line = $content[$i]
-            foreach ($matchingPattern in $patterns) {
-                if ($line -match $matchingPattern) {
-                    $toolName = $matches[1]
+        foreach ($matchingPattern in $patterns) {
+            $regexMatches = [regex]::Matches($rawContent, $matchingPattern)
+            foreach ($m in $regexMatches) {
+                $toolName = $m.Groups[1].Value
 
-                    # Validate tool name format:
-                    # - Each group contains alphanumeric chars or dashes
-                    # - Each group cannot start or end with a dash
-                    # Pattern breakdown:
-                    #   ^                           - Start of string
-                    #   [a-zA-Z0-9]                 - First char must be alphanumeric
-                    #   ([a-zA-Z0-9-]*[a-zA-Z0-9])? - Optional: middle chars (alphanumeric or dash) ending with alphanumeric
-                    #   $                           - End of string
-                    $isValid = $toolName -match '^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$'
+                # Validate tool name format:
+                # - Each group contains alphanumeric chars or dashes
+                # - Each group cannot start or end with a dash
+                # Pattern breakdown:
+                #   ^                           - Start of string
+                #   [a-zA-Z0-9]                 - First char must be alphanumeric
+                #   ([a-zA-Z0-9-]*[a-zA-Z0-9])? - Optional: middle chars (alphanumeric or dash) ending with alphanumeric
+                #   $                           - End of string
+                $isValid = $toolName -match '^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$'
 
-                    if (-not $isValid) {
-                        $toolViolationsForArea += [ToolNameViolation]::new($name, $file.FullName, $toolName, $i + 1)
-                    }
+                if (-not $isValid) {
+                    # Calculate line number from match position in raw content
+                    $lineNumber = ($rawContent.Substring(0, $m.Groups[1].Index) -split "`n").Count
+                    $toolViolationsForArea += [ToolNameViolation]::new($name, $file.FullName, $toolName, $lineNumber)
                 }
             }
         }

--- a/eng/scripts/Test-ToolNameCharacters.ps1
+++ b/eng/scripts/Test-ToolNameCharacters.ps1
@@ -114,7 +114,8 @@ function Test-ToolAreaTools {
         $patterns = @()
         if ($file.Name -like '*Command.cs') {
             $patterns += 'public override string Name => "([^"]+)";'
-        } elseif ($file.Name -like '*Setup.cs') {
+        }
+        elseif ($file.Name -like '*Setup.cs') {
             $patterns += 'public string Name => "([^"]+)";'
             # Matches: new CommandGroup("group-name", ...) - only string literals, not variables
             # Matches: AddCommand("command-name", ...) - only string literals, not variables
@@ -146,7 +147,7 @@ function Test-ToolAreaTools {
         }
     }
 
-        return $toolViolationsForArea
+    return $toolViolationsForArea
 }
 
 $ErrorActionPreference = 'Stop'
@@ -179,7 +180,7 @@ LogDebug "=================================================="
 
 $result = [PSCustomObject]@{
     HasViolations = $overallViolations.Count -gt 0
-    Violations     = $overallViolations
+    Violations    = $overallViolations
     ErrorMessage  = "Names can only contain alphanumeric characters or dashes (cannot start or end with a dash)"
 }
 
@@ -187,6 +188,7 @@ $result
 
 if ($overallViolations.Count -gt 0) {
     exit 1
-} else {
+}
+else {
     exit 0
 }


### PR DESCRIPTION
## What does this PR do?

Adds tool name validation to AnalyzeCode.ps1 to ensure only tools with valid naming is added.  Using invalid characters like "_" results in invalid tool name parsing.

See: [Command Design Principles](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/new-command.md#command-design-principles).

Catches invalid names in `*Command.cs` and `*Setyup,cs` like:
- `public string Name => "bar_foo;`
- [`new CommandGroup("blob_autoexport")`](https://github.com/microsoft/mcp/blob/77729a886b7f62de6a45c2977e118ce12ace6689/tools/Azure.Mcp.Tools.ManagedLustre/src/ManagedLustreSetup.cs#L77)

## GitHub issue number?

Related: #1566 

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
