### PR TITLE
Display Build Info

### DIFF
--- a/eng/pipelines/templates/jobs/initialize.yml
+++ b/eng/pipelines/templates/jobs/initialize.yml
@@ -42,7 +42,7 @@ jobs:
         -TestPipeline:$${{ parameters.IsTestPipeline }}
 
   - pwsh: |
-      Get-Content '$(Build.ArtifactStagingDirectory)/build_info.json' | Write-Host
+      Get-Content '$(Build.ArtifactStagingDirectory)/build_info.json' | Out-Host
     displayName: Display Build Info
 
   - ${{ if ne(parameters.PublishTarget, 'none') }}:


### PR DESCRIPTION
It's a little bit aggravating to have to download the artifact. It's a single file no reason not to show it.