### PR TITLE
ManagedLustre: Use dash instead of underscore

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1770999084484.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1770999084484.yaml
@@ -1,0 +1,4 @@
+pr: 1728
+changes:
+  - section: "Breaking Changes"
+    description: "Change ManagedLustre group names to use dash instead of underscore. auto-blobimport, auto-blobexport, auto-import have dashes now."

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/ManagedLustreSetup.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/ManagedLustreSetup.cs
@@ -74,7 +74,7 @@ public class ManagedLustreSetup : IAreaSetup
         var skuGet = serviceProvider.GetRequiredService<SkuGetCommand>();
         sku.AddCommand(skuGet.Name, skuGet);
 
-        var autoexportJob = new CommandGroup("blob_autoexport", "Autoexport job operations for Azure Managed Lustre - Commands for creating jobs to export data from the filesystem to blob storage.");
+        var autoexportJob = new CommandGroup("blob-autoexport", "Autoexport job operations for Azure Managed Lustre - Commands for creating jobs to export data from the filesystem to blob storage.");
         fileSystem.AddSubGroup(autoexportJob);
 
         var autoexportJobCreate = serviceProvider.GetRequiredService<AutoexportJobCreateCommand>();
@@ -89,7 +89,7 @@ public class ManagedLustreSetup : IAreaSetup
         var autoexportJobDelete = serviceProvider.GetRequiredService<AutoexportJobDeleteCommand>();
         autoexportJob.AddCommand(autoexportJobDelete.Name, autoexportJobDelete);
 
-        var autoimportJob = new CommandGroup("blob_autoimport", "Autoimport job operations for Azure Managed Lustre - Commands for creating jobs to import data from blob storage to the filesystem.");
+        var autoimportJob = new CommandGroup("blob-autoimport", "Autoimport job operations for Azure Managed Lustre - Commands for creating jobs to import data from blob storage to the filesystem.");
         fileSystem.AddSubGroup(autoimportJob);
 
         var autoimportJobCreate = serviceProvider.GetRequiredService<AutoimportJobCreateCommand>();
@@ -104,7 +104,7 @@ public class ManagedLustreSetup : IAreaSetup
         var autoimportJobDelete = serviceProvider.GetRequiredService<AutoimportJobDeleteCommand>();
         autoimportJob.AddCommand(autoimportJobDelete.Name, autoimportJobDelete);
 
-        var blobImport = new CommandGroup("blob_import", "One-time blob import operations for Azure Managed Lustre - Commands for creating jobs to perform one-time import of data from blob storage to the filesystem.");
+        var blobImport = new CommandGroup("blob-import", "One-time blob import operations for Azure Managed Lustre - Commands for creating jobs to perform one-time import of data from blob storage to the filesystem.");
         fileSystem.AddSubGroup(blobImport);
 
         var importJobCreate = serviceProvider.GetRequiredService<ImportJobCreateCommand>();


### PR DESCRIPTION
## What does this PR do?

- Changes use of underscore to dash to follow naming guidlines in new-command.md

Related #1592 

## GitHub issue number?

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
