### PR TITLE
Fix IRegistryRoot DI registration in Fabric.Mcp.Server

### DIFF
--- a/servers/Fabric.Mcp.Server/Fabric.Mcp.Server.slnx
+++ b/servers/Fabric.Mcp.Server/Fabric.Mcp.Server.slnx
@@ -17,6 +17,9 @@
   <Folder Name="/servers/Fabric.Mcp.Server/src/">
     <Project Path="./src/Fabric.Mcp.Server.csproj" />
   </Folder>
+  <Folder Name="/servers/Fabric.Mcp.Server/tests/">
+    <Project Path="./tests/Fabric.Mcp.Server.UnitTests/Fabric.Mcp.Server.UnitTests.csproj" />
+  </Folder>
   <Folder Name="/tools/" />
   <Folder Name="/tools/Fabric.Mcp.Tools.OneLake/" />
   <Folder Name="/tools/Fabric.Mcp.Tools.OneLake/src/">

--- a/servers/Fabric.Mcp.Server/src/Program.cs
+++ b/servers/Fabric.Mcp.Server/src/Program.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Text.Json;
+using Azure.Mcp.Core.Areas.Server;
 using Azure.Mcp.Core.Areas.Server.Commands;
 using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Extensions;
@@ -161,6 +162,8 @@ internal class Program
             services.AddSingleton(area);
             area.ConfigureServices(services);
         }
+
+        services.AddRegistryRoot();
     }
 
     internal static async Task InitializeServicesAsync(IServiceProvider serviceProvider)

--- a/servers/Fabric.Mcp.Server/tests/Fabric.Mcp.Server.UnitTests/Fabric.Mcp.Server.UnitTests.csproj
+++ b/servers/Fabric.Mcp.Server/tests/Fabric.Mcp.Server.UnitTests/Fabric.Mcp.Server.UnitTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Fabric.Mcp.Server.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+</Project>

--- a/servers/Fabric.Mcp.Server/tests/Fabric.Mcp.Server.UnitTests/Infrastructure/ServerStartupTests.cs
+++ b/servers/Fabric.Mcp.Server/tests/Fabric.Mcp.Server.UnitTests/Infrastructure/ServerStartupTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Fabric.Mcp.Server.UnitTests.Infrastructure;
+
+public class ServerStartupTests
+{
+    [Fact]
+    public async Task Server_Should_Initialize_Without_DI_Errors()
+    {
+        // Arrange
+        var exeName = OperatingSystem.IsWindows() ? "fabmcp.exe" : "fabmcp";
+        var fabmcpPath = Path.Combine(AppContext.BaseDirectory, exeName);
+
+        Assert.True(File.Exists(fabmcpPath), $"Executable not found at {fabmcpPath}");
+
+        var processStartInfo = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = fabmcpPath,
+            Arguments = "server start",
+            UseShellExecute = false,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using var process = System.Diagnostics.Process.Start(processStartInfo);
+        Assert.NotNull(process);
+
+        // Collect stderr asynchronously
+        var stderrBuilder = new System.Text.StringBuilder();
+        process.ErrorDataReceived += (sender, e) =>
+        {
+            if (e.Data != null)
+            {
+                stderrBuilder.AppendLine(e.Data);
+            }
+        };
+        process.BeginErrorReadLine();
+
+        try
+        {
+            await Task.Delay(500, TestContext.Current.CancellationToken);
+
+            // Send MCP initialize request
+            var initRequest = """
+                {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}
+                """;
+            await process.StandardInput.WriteLineAsync(initRequest);
+            await process.StandardInput.FlushAsync(TestContext.Current.CancellationToken);
+
+            // Read response - should get valid JSON, not an exception
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var response = await process.StandardOutput.ReadLineAsync(cts.Token);
+
+            // Check stderr for DI exceptions
+            var errorOutput = stderrBuilder.ToString();
+            Assert.DoesNotContain("Unable to resolve service", errorOutput);
+            Assert.DoesNotContain("InvalidOperationException", errorOutput);
+
+            // Verify we got a valid response
+            Assert.NotNull(response);
+            Assert.Contains("\"result\"", response, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                process.Kill();
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add missing AddRegistryRoot() call to ConfigureServices in Program.cs
- Add using Azure.Mcp.Core.Areas.Server namespace
- Add Fabric.Mcp.Server.UnitTests project with ServerStartupTests
- Test validates server starts without DI errors and responds to MCP initialize