### PR TITLE
fix: Removing --costs parameter since it was removed in azqr v.3.0.0 (#1738)

### DIFF
--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -10,6 +10,8 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 ### Bugs Fixed
 
+- Fixed `azqr` call failing due to `costs` parameter removed in latest version. [[#1739](https://github.com/microsoft/mcp/pull/1739)]
+
 ### Other Changes
 
 ## 2.0.0-beta.19 (2026-02-12)

--- a/tools/Azure.Mcp.Tools.Extension/src/Commands/AzqrCommand.cs
+++ b/tools/Azure.Mcp.Tools.Extension/src/Commands/AzqrCommand.cs
@@ -96,11 +96,6 @@ public sealed class AzqrCommand(ILogger<AzqrCommand> logger, int processTimeoutS
             var jsonReportFilePath = $"{reportFileName}.json";
             command += $" --output-name \"{reportFileName}\"";
 
-            // Azure Quick Review CLI can easily get throttle errors when scanning subscriptions with many resources with costs enabled.
-            // Unfortunately, getting such an error will abort the entire job and waste all the partial results.
-            // To reduce the chance of throttling, we disable costs reporting by default.
-            command += " --costs=false";
-
             // Also generate a JSON report for users who don't have access to Excel.
             command += " --json";
 


### PR DESCRIPTION
## What does this PR do?
This pull request makes a small change to the `AzqrCommand` execution logic. The default disabling of costs reporting in the Azure Quick Review CLI command has been removed, since version 3.0.0 of the tools removed the flag and disabled costs by default.

* Removed the line that appended `--costs=false` to the CLI command.

## GitHub issue number?
#1738 

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [x] For MCP tool changes:
    - [x] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [x] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
