### PR TITLE
Add Visual Studio tool name tests

### DIFF
--- a/servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.UnitTests/Infrastructure/VisualStudioToolNameTests.cs
+++ b/servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.UnitTests/Infrastructure/VisualStudioToolNameTests.cs
@@ -18,8 +18,11 @@ public class VisualStudioToolNameTests
     private const string AzureBestPracticesToolName = "get_azure_bestpractices_get";
     private const string ExtensionCliGenerateToolName = "extension_cli_generate";
 
-    [Fact]
-    public async Task AllMode_BestPracticesToolName_MustNotChange()
+    /// <summary>
+    /// Starts the Azure MCP server in 'all' mode, performs MCP initialization handshake,
+    /// and retrieves the list of tool names.
+    /// </summary>
+    private static async Task<List<string>> GetAllModeToolNamesAsync(CancellationToken cancellationToken)
     {
         // Arrange
         var exeName = OperatingSystem.IsWindows() ? "azmcp.exe" : "azmcp";
@@ -47,9 +50,10 @@ public class VisualStudioToolNameTests
             // Wait for server to initialize by checking if it's ready to receive requests
             // The server is ready when it starts listening on stdin
             using var initializationTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-                TestContext.Current.CancellationToken, 
-                initializationTimeout.Token);
+            using var linkedCts =
+                CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken,
+                    initializationTimeout.Token);
 
             // Attempt to read any startup output/errors to ensure process is running
             // If the process exits immediately, this will help catch that
@@ -111,132 +115,29 @@ public class VisualStudioToolNameTests
             Assert.NotNull(result);
             Assert.NotNull(result.Tools);
 
-            var toolNames = result.Tools.Select(t => t.Name).ToList();
-
-            // Assert - Verify the Azure Best Practices tool name exists and hasn't changed
-            // Visual Studio has a hard-coded dependency on this exact tool name in FirstPartyToolsProvider.cs
-            // Changing this name will break Visual Studio's integration with Azure MCP Server
-            // Reference: https://devdiv.visualstudio.com/DevDiv/_git/VisualStudio.Conversations/pullrequest/705038
-            Assert.Contains(AzureBestPracticesToolName, toolNames);
+            return result.Tools.Select(t => t.Name).ToList();
         }
         finally
         {
             if (!process.HasExited)
             {
                 process.Kill(entireProcessTree: true);
-                await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+                await process.WaitForExitAsync(cancellationToken);
             }
         }
     }
 
     [Fact]
-    public async Task AllMode_ExtensionCliGenerateToolName_MustNotChange()
+    public async Task AllMode_VisualStudioToolNames_MustNotChange()
     {
-        // Arrange
-        var exeName = OperatingSystem.IsWindows() ? "azmcp.exe" : "azmcp";
-        var azmcpPath = Path.Combine(AppContext.BaseDirectory, exeName);
+        // Act - Get tool names from server
+        var toolNames = await GetAllModeToolNamesAsync(TestContext.Current.CancellationToken);
 
-        Assert.True(File.Exists(azmcpPath), $"Executable not found at {azmcpPath}. Please build the Azure.Mcp.Server project first.");
-
-        // Act - Start the server process in "all" mode which exposes individual tools
-        var processStartInfo = new ProcessStartInfo
-        {
-            FileName = azmcpPath,
-            Arguments = "server start --mode all",
-            UseShellExecute = false,
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true
-        };
-
-        using var process = Process.Start(processStartInfo);
-        Assert.NotNull(process);
-
-        try
-        {
-            // Wait for server to initialize by checking if it's ready to receive requests
-            // The server is ready when it starts listening on stdin
-            using var initializationTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-                TestContext.Current.CancellationToken, 
-                initializationTimeout.Token);
-
-            // Attempt to read any startup output/errors to ensure process is running
-            // If the process exits immediately, this will help catch that
-            await Task.Delay(500, linkedCts.Token); // Brief delay to allow process to fail fast if misconfigured
-            Assert.False(process.HasExited, "Server process exited immediately after start");
-
-            // Send initialize request first (required by MCP protocol)
-            var initRequest = new JsonRpcRequest
-            {
-                Method = "initialize",
-                Params = JsonSerializer.SerializeToNode(new
-                {
-                    protocolVersion = "2024-11-05",
-                    capabilities = new { },
-                    clientInfo = new { name = "test-client", version = "1.0" }
-                }),
-                Id = new RequestId(3)
-            };
-
-            var initRequestJson = JsonSerializer.Serialize(initRequest);
-            await process.StandardInput.WriteLineAsync(initRequestJson.AsMemory(), linkedCts.Token);
-            await process.StandardInput.FlushAsync(linkedCts.Token);
-
-            // Read initialize response
-            var initResponseLine = await process.StandardOutput.ReadLineAsync(linkedCts.Token);
-            Assert.NotNull(initResponseLine);
-
-            // Send initialized notification
-            var initializedNotification = new JsonRpcNotification
-            {
-                Method = "notifications/initialized"
-            };
-
-            var notificationJson = JsonSerializer.Serialize(initializedNotification);
-            await process.StandardInput.WriteLineAsync(notificationJson.AsMemory(), linkedCts.Token);
-            await process.StandardInput.FlushAsync(linkedCts.Token);
-
-            // Send tools/list request
-            var request = new JsonRpcRequest
-            {
-                Method = "tools/list",
-                Params = JsonSerializer.SerializeToNode(new ListToolsRequestParams()),
-                Id = new RequestId(4)
-            };
-
-            var requestJson = JsonSerializer.Serialize(request);
-            await process.StandardInput.WriteLineAsync(requestJson.AsMemory(), linkedCts.Token);
-            await process.StandardInput.FlushAsync(linkedCts.Token);
-
-            // Read response with timeout
-            var responseLine = await process.StandardOutput.ReadLineAsync(linkedCts.Token);
-            Assert.NotNull(responseLine);
-
-            var response = JsonSerializer.Deserialize<JsonRpcResponse>(responseLine);
-            Assert.NotNull(response);
-            Assert.NotNull(response.Result);
-
-            var result = JsonSerializer.Deserialize<ListToolsResult>(JsonSerializer.Serialize(response.Result));
-            Assert.NotNull(result);
-            Assert.NotNull(result.Tools);
-
-            var toolNames = result.Tools.Select(t => t.Name).ToList();
-
-            // Assert - Verify the Extension CLI Generate tool name exists and hasn't changed
-            // Visual Studio has a hard-coded dependency on this exact tool name in FirstPartyToolsProvider.cs
-            // Changing this name will break Visual Studio's integration with Azure MCP Server 
-            // Reference: https://devdiv.visualstudio.com/DevDiv/_git/VisualStudio.Conversations/pullrequest/705038
-            Assert.Contains(ExtensionCliGenerateToolName, toolNames);
-        }
-        finally
-        {
-            if (!process.HasExited)
-            {
-                process.Kill(entireProcessTree: true);
-                await process.WaitForExitAsync(TestContext.Current.CancellationToken);
-            }
-        }
+        // Assert - Verify both Visual Studio tool names exist and haven't changed
+        // Visual Studio has hard-coded dependencies on these exact tool names in FirstPartyToolsProvider.cs
+        // Changing these names will break Visual Studio's integration with Azure MCP Server
+        // Reference: https://devdiv.visualstudio.com/DevDiv/_git/VisualStudio.Conversations/pullrequest/705038
+        Assert.Contains(AzureBestPracticesToolName, toolNames);
+        Assert.Contains(ExtensionCliGenerateToolName, toolNames);
     }
 }


### PR DESCRIPTION
Adds test to ensure Visual Studio tool name dependencies remain stable

Visual Studio has hard-coded dependencies on these exact tool names in FirstPartyToolsProvider.cs:
- get_azure_bestpractices_get
- extension_cli_generate