### PR TITLE
Feature/consolidated tools improvement

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/CommandFactoryHelpers.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/CommandFactoryHelpers.cs
@@ -11,19 +11,31 @@ using Azure.Mcp.Tools.Advisor;
 using Azure.Mcp.Tools.Aks;
 using Azure.Mcp.Tools.AppConfig;
 using Azure.Mcp.Tools.AppLens;
+using Azure.Mcp.Tools.ApplicationInsights;
 using Azure.Mcp.Tools.AppService;
 using Azure.Mcp.Tools.Authorization;
+using Azure.Mcp.Tools.AzureBackup;
 using Azure.Mcp.Tools.AzureBestPractices;
 using Azure.Mcp.Tools.AzureIsv;
+using Azure.Mcp.Tools.AzureMigrate;
+using Azure.Mcp.Tools.AzureTerraform;
 using Azure.Mcp.Tools.AzureTerraformBestPractices;
 using Azure.Mcp.Tools.BicepSchema;
 using Azure.Mcp.Tools.CloudArchitect;
+using Azure.Mcp.Tools.Communication;
+using Azure.Mcp.Tools.Compute;
+using Azure.Mcp.Tools.ConfidentialLedger;
+using Azure.Mcp.Tools.ContainerApps;
 using Azure.Mcp.Tools.Cosmos;
 using Azure.Mcp.Tools.Deploy;
+using Azure.Mcp.Tools.DeviceRegistry;
 using Azure.Mcp.Tools.EventGrid;
+using Azure.Mcp.Tools.EventHubs;
 using Azure.Mcp.Tools.Extension;
+using Azure.Mcp.Tools.FileShares;
 using Azure.Mcp.Tools.FoundryExtensions;
 using Azure.Mcp.Tools.FunctionApp;
+using Azure.Mcp.Tools.Functions;
 using Azure.Mcp.Tools.Grafana;
 using Azure.Mcp.Tools.KeyVault;
 using Azure.Mcp.Tools.Kusto;
@@ -32,15 +44,22 @@ using Azure.Mcp.Tools.ManagedLustre;
 using Azure.Mcp.Tools.Marketplace;
 using Azure.Mcp.Tools.Monitor;
 using Azure.Mcp.Tools.MySql;
+using Azure.Mcp.Tools.Policy;
 using Azure.Mcp.Tools.Postgres;
+using Azure.Mcp.Tools.Pricing;
 using Azure.Mcp.Tools.Quota;
 using Azure.Mcp.Tools.Redis;
 using Azure.Mcp.Tools.ResourceHealth;
 using Azure.Mcp.Tools.Search;
 using Azure.Mcp.Tools.ServiceBus;
+using Azure.Mcp.Tools.ServiceFabric;
+using Azure.Mcp.Tools.SignalR;
+using Azure.Mcp.Tools.Speech;
 using Azure.Mcp.Tools.Sql;
 using Azure.Mcp.Tools.Storage;
+using Azure.Mcp.Tools.StorageSync;
 using Azure.Mcp.Tools.VirtualDesktop;
+using Azure.Mcp.Tools.WellArchitectedFramework;
 using Azure.Mcp.Tools.Workbooks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -64,27 +83,39 @@ internal class CommandFactoryHelpers
             // Core areas
             new SubscriptionSetup(),
             new GroupSetup(),
-            
+
             // Tool areas
             new AcrSetup(),
             new AdvisorSetup(),
             new AksSetup(),
             new AppConfigSetup(),
-            new AppServiceSetup(),
             new AppLensSetup(),
+            new ApplicationInsightsSetup(),
+            new AppServiceSetup(),
             new AuthorizationSetup(),
+            new AzureBackupSetup(),
             new AzureBestPracticesSetup(),
             new AzureIsvSetup(),
             new ManagedLustreSetup(),
+            new AzureMigrateSetup(),
+            new AzureTerraformSetup(),
             new AzureTerraformBestPracticesSetup(),
             new BicepSchemaSetup(),
             new CloudArchitectSetup(),
+            new CommunicationSetup(),
+            new ComputeSetup(),
+            new ConfidentialLedgerSetup(),
+            new ContainerAppsSetup(),
             new CosmosSetup(),
             new DeploySetup(),
+            new DeviceRegistrySetup(),
             new EventGridSetup(),
+            new EventHubsSetup(),
             new ExtensionSetup(),
+            new FileSharesSetup(),
             new FoundryExtensionsSetup(),
             new FunctionAppSetup(),
+            new FunctionsSetup(),
             new GrafanaSetup(),
             new KeyVaultSetup(),
             new KustoSetup(),
@@ -92,15 +123,22 @@ internal class CommandFactoryHelpers
             new MarketplaceSetup(),
             new MonitorSetup(),
             new MySqlSetup(),
+            new PolicySetup(),
             new PostgresSetup(),
+            new PricingSetup(),
             new QuotaSetup(),
             new RedisSetup(),
             new ResourceHealthSetup(),
             new SearchSetup(),
             new ServiceBusSetup(),
+            new ServiceFabricSetup(),
+            new SignalRSetup(),
+            new SpeechSetup(),
             new SqlSetup(),
             new StorageSetup(),
+            new StorageSyncSetup(),
             new VirtualDesktopSetup(),
+            new WellArchitectedFrameworkSetup(),
             new WorkbooksSetup(),
         ];
 
@@ -130,27 +168,39 @@ internal class CommandFactoryHelpers
             // Core areas
             new SubscriptionSetup(),
             new GroupSetup(),
-            
+
             // Tool areas
             new AcrSetup(),
             new AdvisorSetup(),
             new AksSetup(),
             new AppConfigSetup(),
-            new AppServiceSetup(),
             new AppLensSetup(),
+            new ApplicationInsightsSetup(),
+            new AppServiceSetup(),
             new AuthorizationSetup(),
+            new AzureBackupSetup(),
             new AzureBestPracticesSetup(),
             new AzureIsvSetup(),
             new ManagedLustreSetup(),
+            new AzureMigrateSetup(),
+            new AzureTerraformSetup(),
             new AzureTerraformBestPracticesSetup(),
             new BicepSchemaSetup(),
             new CloudArchitectSetup(),
+            new CommunicationSetup(),
+            new ComputeSetup(),
+            new ConfidentialLedgerSetup(),
+            new ContainerAppsSetup(),
             new CosmosSetup(),
             new DeploySetup(),
+            new DeviceRegistrySetup(),
             new EventGridSetup(),
+            new EventHubsSetup(),
             new ExtensionSetup(),
+            new FileSharesSetup(),
             new FoundryExtensionsSetup(),
             new FunctionAppSetup(),
+            new FunctionsSetup(),
             new GrafanaSetup(),
             new KeyVaultSetup(),
             new KustoSetup(),
@@ -158,15 +208,22 @@ internal class CommandFactoryHelpers
             new MarketplaceSetup(),
             new MonitorSetup(),
             new MySqlSetup(),
+            new PolicySetup(),
             new PostgresSetup(),
+            new PricingSetup(),
             new QuotaSetup(),
             new RedisSetup(),
             new ResourceHealthSetup(),
             new SearchSetup(),
             new ServiceBusSetup(),
+            new ServiceFabricSetup(),
+            new SignalRSetup(),
+            new SpeechSetup(),
             new SqlSetup(),
             new StorageSetup(),
+            new StorageSyncSetup(),
             new VirtualDesktopSetup(),
+            new WellArchitectedFrameworkSetup(),
             new WorkbooksSetup(),
         ];
 

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/CommandFactoryHelpers.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/CommandFactoryHelpers.cs
@@ -62,6 +62,7 @@ using Azure.Mcp.Tools.VirtualDesktop;
 using Azure.Mcp.Tools.WellArchitectedFramework;
 using Azure.Mcp.Tools.Workbooks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Areas;
 using Microsoft.Mcp.Core.Commands;

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/CommandFactoryHelpers.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/CommandFactoryHelpers.cs
@@ -62,7 +62,6 @@ using Azure.Mcp.Tools.VirtualDesktop;
 using Azure.Mcp.Tools.WellArchitectedFramework;
 using Azure.Mcp.Tools.Workbooks;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Areas;
 using Microsoft.Mcp.Core.Commands;

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/CommandFactoryHelpers.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/CommandFactoryHelpers.cs
@@ -77,71 +77,72 @@ namespace Azure.Mcp.Core.Tests.Areas.Server;
 
 internal class CommandFactoryHelpers
 {
+    private static IAreaSetup[] CreateAreaSetups() =>
+    [
+        // Core areas
+        new SubscriptionSetup(),
+        new GroupSetup(),
+
+        // Tool areas
+        new AcrSetup(),
+        new AdvisorSetup(),
+        new AksSetup(),
+        new AppConfigSetup(),
+        new AppLensSetup(),
+        new ApplicationInsightsSetup(),
+        new AppServiceSetup(),
+        new AuthorizationSetup(),
+        new AzureBackupSetup(),
+        new AzureBestPracticesSetup(),
+        new AzureIsvSetup(),
+        new ManagedLustreSetup(),
+        new AzureMigrateSetup(),
+        new AzureTerraformSetup(),
+        new AzureTerraformBestPracticesSetup(),
+        new BicepSchemaSetup(),
+        new CloudArchitectSetup(),
+        new CommunicationSetup(),
+        new ComputeSetup(),
+        new ConfidentialLedgerSetup(),
+        new ContainerAppsSetup(),
+        new CosmosSetup(),
+        new DeploySetup(),
+        new DeviceRegistrySetup(),
+        new EventGridSetup(),
+        new EventHubsSetup(),
+        new ExtensionSetup(),
+        new FileSharesSetup(),
+        new FoundryExtensionsSetup(),
+        new FunctionAppSetup(),
+        new FunctionsSetup(),
+        new GrafanaSetup(),
+        new KeyVaultSetup(),
+        new KustoSetup(),
+        new LoadTestingSetup(),
+        new MarketplaceSetup(),
+        new MonitorSetup(),
+        new MySqlSetup(),
+        new PolicySetup(),
+        new PostgresSetup(),
+        new PricingSetup(),
+        new QuotaSetup(),
+        new RedisSetup(),
+        new ResourceHealthSetup(),
+        new SearchSetup(),
+        new ServiceBusSetup(),
+        new ServiceFabricSetup(),
+        new SignalRSetup(),
+        new SpeechSetup(),
+        new SqlSetup(),
+        new StorageSetup(),
+        new StorageSyncSetup(),
+        new VirtualDesktopSetup(),
+        new WellArchitectedFrameworkSetup(),
+        new WorkbooksSetup(),
+    ];
+
     public static ICommandFactory CreateCommandFactory(IServiceProvider? serviceProvider = default)
     {
-        IAreaSetup[] areaSetups = [
-            // Core areas
-            new SubscriptionSetup(),
-            new GroupSetup(),
-
-            // Tool areas
-            new AcrSetup(),
-            new AdvisorSetup(),
-            new AksSetup(),
-            new AppConfigSetup(),
-            new AppLensSetup(),
-            new ApplicationInsightsSetup(),
-            new AppServiceSetup(),
-            new AuthorizationSetup(),
-            new AzureBackupSetup(),
-            new AzureBestPracticesSetup(),
-            new AzureIsvSetup(),
-            new ManagedLustreSetup(),
-            new AzureMigrateSetup(),
-            new AzureTerraformSetup(),
-            new AzureTerraformBestPracticesSetup(),
-            new BicepSchemaSetup(),
-            new CloudArchitectSetup(),
-            new CommunicationSetup(),
-            new ComputeSetup(),
-            new ConfidentialLedgerSetup(),
-            new ContainerAppsSetup(),
-            new CosmosSetup(),
-            new DeploySetup(),
-            new DeviceRegistrySetup(),
-            new EventGridSetup(),
-            new EventHubsSetup(),
-            new ExtensionSetup(),
-            new FileSharesSetup(),
-            new FoundryExtensionsSetup(),
-            new FunctionAppSetup(),
-            new FunctionsSetup(),
-            new GrafanaSetup(),
-            new KeyVaultSetup(),
-            new KustoSetup(),
-            new LoadTestingSetup(),
-            new MarketplaceSetup(),
-            new MonitorSetup(),
-            new MySqlSetup(),
-            new PolicySetup(),
-            new PostgresSetup(),
-            new PricingSetup(),
-            new QuotaSetup(),
-            new RedisSetup(),
-            new ResourceHealthSetup(),
-            new SearchSetup(),
-            new ServiceBusSetup(),
-            new ServiceFabricSetup(),
-            new SignalRSetup(),
-            new SpeechSetup(),
-            new SqlSetup(),
-            new StorageSetup(),
-            new StorageSyncSetup(),
-            new VirtualDesktopSetup(),
-            new WellArchitectedFrameworkSetup(),
-            new WorkbooksSetup(),
-        ];
-
         var services = serviceProvider ?? CreateDefaultServiceProvider();
         var logger = services.GetRequiredService<ILogger<CommandFactory>>();
         var configurationOptions = Microsoft.Extensions.Options.Options.Create(new McpServerConfiguration
@@ -152,7 +153,7 @@ internal class CommandFactoryHelpers
             RootCommandGroupName = "azmcp"
         });
         var telemetryService = services.GetService<ITelemetryService>() ?? new NoopTelemetryService();
-        var commandFactory = new CommandFactory(services, areaSetups, telemetryService, configurationOptions, logger);
+        var commandFactory = new CommandFactory(services, CreateAreaSetups(), telemetryService, configurationOptions, logger);
 
         return commandFactory;
     }
@@ -164,69 +165,6 @@ internal class CommandFactoryHelpers
 
     public static IServiceCollection SetupCommonServices()
     {
-        IAreaSetup[] areaSetups = [
-            // Core areas
-            new SubscriptionSetup(),
-            new GroupSetup(),
-
-            // Tool areas
-            new AcrSetup(),
-            new AdvisorSetup(),
-            new AksSetup(),
-            new AppConfigSetup(),
-            new AppLensSetup(),
-            new ApplicationInsightsSetup(),
-            new AppServiceSetup(),
-            new AuthorizationSetup(),
-            new AzureBackupSetup(),
-            new AzureBestPracticesSetup(),
-            new AzureIsvSetup(),
-            new ManagedLustreSetup(),
-            new AzureMigrateSetup(),
-            new AzureTerraformSetup(),
-            new AzureTerraformBestPracticesSetup(),
-            new BicepSchemaSetup(),
-            new CloudArchitectSetup(),
-            new CommunicationSetup(),
-            new ComputeSetup(),
-            new ConfidentialLedgerSetup(),
-            new ContainerAppsSetup(),
-            new CosmosSetup(),
-            new DeploySetup(),
-            new DeviceRegistrySetup(),
-            new EventGridSetup(),
-            new EventHubsSetup(),
-            new ExtensionSetup(),
-            new FileSharesSetup(),
-            new FoundryExtensionsSetup(),
-            new FunctionAppSetup(),
-            new FunctionsSetup(),
-            new GrafanaSetup(),
-            new KeyVaultSetup(),
-            new KustoSetup(),
-            new LoadTestingSetup(),
-            new MarketplaceSetup(),
-            new MonitorSetup(),
-            new MySqlSetup(),
-            new PolicySetup(),
-            new PostgresSetup(),
-            new PricingSetup(),
-            new QuotaSetup(),
-            new RedisSetup(),
-            new ResourceHealthSetup(),
-            new SearchSetup(),
-            new ServiceBusSetup(),
-            new ServiceFabricSetup(),
-            new SignalRSetup(),
-            new SpeechSetup(),
-            new SqlSetup(),
-            new StorageSetup(),
-            new StorageSyncSetup(),
-            new VirtualDesktopSetup(),
-            new WellArchitectedFrameworkSetup(),
-            new WorkbooksSetup(),
-        ];
-
         var builder = new ServiceCollection()
             .AddLogging()
             .AddSingleton<ITelemetryService, NoopTelemetryService>()
@@ -240,7 +178,7 @@ internal class CommandFactoryHelpers
             .AddSingleton(Substitute.For<IAzureTokenCredentialProvider>())
             .AddSingleton(Substitute.For<IAzureCloudConfiguration>());
 
-        foreach (var area in areaSetups)
+        foreach (var area in CreateAreaSetups())
         {
             area.ConfigureServices(builder);
         }

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategyTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategyTests.cs
@@ -78,13 +78,34 @@ public class ConsolidatedToolDiscoveryStrategyTests
             ConsolidatedToolDiscoveryStrategy.IgnoredCommandGroups,
             StringComparer.OrdinalIgnoreCase);
 
-        var expectedCount = sourceFactory.AllCommands.Count(kvp =>
-        {
-            var area = sourceFactory.GetServiceArea(kvp.Key);
-            return area == null || !ignoredGroups.Contains(area);
-        });
+        var expectedCommands = sourceFactory.AllCommands
+            .Where(kvp =>
+            {
+                var area = sourceFactory.GetServiceArea(kvp.Key);
+                return area == null || !ignoredGroups.Contains(area);
+            })
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-        Assert.Equal(expectedCount, consolidatedFactory.AllCommands.Count);
+        var consolidatedCommands = consolidatedFactory.AllCommands
+            .GroupBy(static kvp => kvp.Value, ReferenceEqualityComparer.Instance)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.Select(kvp => kvp.Key).ToArray(),
+                ReferenceEqualityComparer.Instance);
+
+        Assert.Equal(
+            expectedCommands.Values.Distinct(ReferenceEqualityComparer.Instance).Count(),
+            consolidatedCommands.Count);
+
+        var missingCommands = expectedCommands
+            .Where(kvp => !consolidatedCommands.ContainsKey(kvp.Value))
+            .Select(kvp => kvp.Key)
+            .OrderBy(static name => name)
+            .ToList();
+
+        Assert.True(
+            missingCommands.Count == 0,
+            $"Missing consolidated mappings for commands: {string.Join(", ", missingCommands)}");
     }
 
     [Fact]

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategyTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategyTests.cs
@@ -107,18 +107,6 @@ public class ConsolidatedToolDiscoveryStrategyTests
     }
 
     [Fact]
-    public void CreateConsolidatedCommandFactory_WithAllAreas_HasSubstantialCommandCount()
-    {
-        var strategy = CreateStrategy();
-
-        var factory = strategy.CreateConsolidatedCommandFactory();
-
-        Assert.True(factory.AllCommands.Count > 200,
-            $"Expected more than 200 consolidated commands but found {factory.AllCommands.Count}. " +
-            "Ensure CommandFactoryHelpers registers all tool areas matching production Program.cs.");
-    }
-
-    [Fact]
     public void CreateConsolidatedCommandFactory_WithNamespaceFilter_FiltersCommands()
     {
         var options = new ServiceStartOptions { Namespace = ["storage"] };

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategyTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategyTests.cs
@@ -47,13 +47,10 @@ public class ConsolidatedToolDiscoveryStrategyTests
     [Fact]
     public async Task DiscoverServersAsync_ReturnsEmptyList()
     {
-        // Arrange
         var strategy = CreateStrategy();
 
-        // Act
         var result = await strategy.DiscoverServersAsync(TestContext.Current.CancellationToken);
 
-        // Assert
         Assert.NotNull(result);
         Assert.Empty(result);
     }
@@ -61,63 +58,144 @@ public class ConsolidatedToolDiscoveryStrategyTests
     [Fact]
     public void CreateConsolidatedCommandFactory_WithDefaultOptions_ReturnsCommandFactory()
     {
-        // Arrange
         var strategy = CreateStrategy();
 
-        // Act
         var factory = strategy.CreateConsolidatedCommandFactory();
 
-        // Assert
         Assert.NotNull(factory);
         Assert.True(factory.AllCommands.Count > 10);
     }
 
     [Fact]
+    public void CreateConsolidatedCommandFactory_MapsAllRegisteredCommands()
+    {
+        var sourceFactory = CommandFactoryHelpers.CreateCommandFactory();
+        var strategy = CreateStrategy(commandFactory: sourceFactory);
+
+        var consolidatedFactory = strategy.CreateConsolidatedCommandFactory();
+
+        var ignoredGroups = new HashSet<string>(
+            ConsolidatedToolDiscoveryStrategy.IgnoredCommandGroups,
+            StringComparer.OrdinalIgnoreCase);
+
+        var expectedCount = sourceFactory.AllCommands.Count(kvp =>
+        {
+            var area = sourceFactory.GetServiceArea(kvp.Key);
+            return area == null || !ignoredGroups.Contains(area);
+        });
+
+        Assert.Equal(expectedCount, consolidatedFactory.AllCommands.Count);
+    }
+
+    [Fact]
+    public void CreateConsolidatedCommandFactory_WithAllAreas_HasSubstantialCommandCount()
+    {
+        var strategy = CreateStrategy();
+
+        var factory = strategy.CreateConsolidatedCommandFactory();
+
+        Assert.True(factory.AllCommands.Count > 200,
+            $"Expected more than 200 consolidated commands but found {factory.AllCommands.Count}. " +
+            "Ensure CommandFactoryHelpers registers all tool areas matching production Program.cs.");
+    }
+
+    [Fact]
     public void CreateConsolidatedCommandFactory_WithNamespaceFilter_FiltersCommands()
     {
-        // Arrange
         var options = new ServiceStartOptions { Namespace = ["storage"] };
         var strategy = CreateStrategy(options: options);
 
-        // Act
         var factory = strategy.CreateConsolidatedCommandFactory();
 
-        // Assert
         Assert.NotNull(factory);
-        // Should only have storage-related consolidated commands
         Assert.InRange(factory.AllCommands.Count, 1, 9);
     }
 
     [Fact]
     public void CreateConsolidatedCommandFactory_WithReadOnlyFilter_FiltersCommands()
     {
-        // Arrange
         var options = new ServiceStartOptions { ReadOnly = true };
         var strategy = CreateStrategy(options: options);
 
-        // Act
         var factory = strategy.CreateConsolidatedCommandFactory();
 
-        // Assert
         Assert.NotNull(factory);
         var allCommands = factory.AllCommands;
         Assert.NotEmpty(allCommands);
-        // All commands should be read-only
         Assert.All(allCommands.Values, cmd => Assert.True(cmd.Metadata.ReadOnly));
+    }
+
+    [Fact]
+    public void CreateConsolidatedCommandFactory_WithNullReadOnlyOption_DefaultsToFalse()
+    {
+        var defaultStrategy = CreateStrategy(options: new ServiceStartOptions { ReadOnly = null });
+        var explicitFalseStrategy = CreateStrategy(options: new ServiceStartOptions { ReadOnly = false });
+
+        var defaultFactory = defaultStrategy.CreateConsolidatedCommandFactory();
+        var explicitFalseFactory = explicitFalseStrategy.CreateConsolidatedCommandFactory();
+
+        Assert.Equal(explicitFalseFactory.AllCommands.Count, defaultFactory.AllCommands.Count);
+        Assert.Equal(
+            explicitFalseFactory.AllCommands.Keys.OrderBy(static name => name),
+            defaultFactory.AllCommands.Keys.OrderBy(static name => name));
+        Assert.Contains(defaultFactory.AllCommands.Values, cmd => !cmd.Metadata.ReadOnly);
     }
 
     [Fact]
     public void CreateConsolidatedCommandFactory_HandlesEmptyNamespaceFilter()
     {
-        // Arrange
         var options = new ServiceStartOptions { Namespace = [] };
         var strategy = CreateStrategy(options: options);
 
-        // Act
         var factory = strategy.CreateConsolidatedCommandFactory();
 
-        // Assert
         Assert.NotNull(factory);
         Assert.NotEmpty(factory.AllCommands);
+    }
+
+    [Fact]
+    public void AreMetadataEqual_BothNull_ReturnsTrue()
+    {
+        Assert.True(ConsolidatedToolDiscoveryStrategy.AreMetadataEqual(null, null));
+    }
+
+    [Fact]
+    public void AreMetadataEqual_OneNull_ReturnsFalse()
+    {
+        var metadata = new ToolMetadata { Destructive = false, ReadOnly = true };
+        Assert.False(ConsolidatedToolDiscoveryStrategy.AreMetadataEqual(metadata, null));
+        Assert.False(ConsolidatedToolDiscoveryStrategy.AreMetadataEqual(null, metadata));
+    }
+
+    [Fact]
+    public void AreMetadataEqual_MatchingValues_ReturnsTrue()
+    {
+        var metadata1 = new ToolMetadata
+        {
+            Destructive = false,
+            Idempotent = true,
+            OpenWorld = false,
+            ReadOnly = true,
+            Secret = false,
+            LocalRequired = false
+        };
+        var metadata2 = new ToolMetadata
+        {
+            Destructive = false,
+            Idempotent = true,
+            OpenWorld = false,
+            ReadOnly = true,
+            Secret = false,
+            LocalRequired = false
+        };
+        Assert.True(ConsolidatedToolDiscoveryStrategy.AreMetadataEqual(metadata1, metadata2));
+    }
+
+    [Fact]
+    public void AreMetadataEqual_DifferentValues_ReturnsFalse()
+    {
+        var metadata1 = new ToolMetadata { Destructive = false, ReadOnly = true };
+        var metadata2 = new ToolMetadata { Destructive = true, ReadOnly = true };
+        Assert.False(ConsolidatedToolDiscoveryStrategy.AreMetadataEqual(metadata1, metadata2));
     }
 }

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategyTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategyTests.cs
@@ -86,19 +86,17 @@ public class ConsolidatedToolDiscoveryStrategyTests
             })
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-        var consolidatedCommands = consolidatedFactory.AllCommands
-            .GroupBy(static kvp => kvp.Value, ReferenceEqualityComparer.Instance)
-            .ToDictionary(
-                static group => group.Key,
-                static group => group.Select(kvp => kvp.Key).ToArray(),
-                ReferenceEqualityComparer.Instance);
+        var expectedCommandSet = expectedCommands.Values
+            .ToHashSet(ReferenceEqualityComparer.Instance);
+        var consolidatedCommandSet = consolidatedFactory.AllCommands.Values
+            .ToHashSet(ReferenceEqualityComparer.Instance);
 
         Assert.Equal(
-            expectedCommands.Values.Distinct(ReferenceEqualityComparer.Instance).Count(),
-            consolidatedCommands.Count);
+            expectedCommandSet.Count,
+            consolidatedCommandSet.Count);
 
         var missingCommands = expectedCommands
-            .Where(kvp => !consolidatedCommands.ContainsKey(kvp.Value))
+            .Where(kvp => !consolidatedCommandSet.Contains(kvp.Value))
             .Select(kvp => kvp.Key)
             .OrderBy(static name => name)
             .ToList();

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategy.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategy.cs
@@ -82,7 +82,7 @@ public sealed class ConsolidatedToolDiscoveryStrategy(
 
 #if DEBUG
             // In debug mode, validate that all tools in MappedToolList found a match when conditions are met
-            if (_options.Value.ReadOnly == false && (_options.Value.Namespace == null || _options.Value.Namespace.Length == 0))
+            if ((_options.Value.ReadOnly ?? false) == false && (_options.Value.Namespace == null || _options.Value.Namespace.Length == 0))
             {
                 if (consolidatedTool.MappedToolList != null)
                 {
@@ -175,7 +175,7 @@ public sealed class ConsolidatedToolDiscoveryStrategy(
                 var serviceArea = _commandFactory.GetServiceArea(kvp.Key);
                 return serviceArea == null || !IgnoredCommandGroups.Contains(serviceArea, StringComparer.OrdinalIgnoreCase);
             })
-            .Where(kvp => _options.Value.ReadOnly == false || kvp.Value.Metadata.ReadOnly == true)
+            .Where(kvp => (_options.Value.ReadOnly ?? false) == false || kvp.Value.Metadata.ReadOnly == true)
             .Where(kvp => !_options.Value.IsHttpMode || !kvp.Value.Metadata.LocalRequired)
             .Where(kvp =>
             {


### PR DESCRIPTION
## What does this PR do?
Fixes consolidated tool discovery default behavior and aligns unit test command registration with production.

- Treats `ServiceStartOptions.ReadOnly == null` as `false` during command filtering, so the default (unset) behavior does not unintentionally filter down to read-only commands.
- Updates the unit test [CommandFactoryHelpers](cci:2://file:///c:/Users/PC/OneDrive/%EB%B0%94%ED%83%95%20%ED%99%94%EB%A9%B4/MS/mcp/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/CommandFactoryHelpers.cs:71:0-240:1) registration so the same tool areas are registered as in production, preventing gaps in consolidated tool validation coverage.
- Adds unit tests covering consolidated tool mapping completeness, expected command counts with all areas, and metadata equality edge cases.

**Notes for reviewers**
- This is a narrow behavior fix: only the `ReadOnly` default handling changes (null → false).
- All unit tests pass locally: `dotnet test core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests -c Debug` (852 tests).

## Relevant links
- Contribution guidelines: https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md
- Consolidated tools definition: https://github.com/microsoft/mcp/blob/main/core/Microsoft.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json
- Consolidated tool discovery strategy: https://github.com/microsoft/mcp/blob/main/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategy.cs
- Commit cleanup guide: https://github.com/Azure/azure-powershell/blob/main/documentation/development-docs/cleaning-up-commits.md
- ToolDescriptionEvaluator quickstart (reference): https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md

## GitHub issue number?
#1759 

## Pre-merge Checklist
- [x] Required for All PRs
  - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
  - [x] PR title clearly describes the change
  - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/main/documentation/development-docs/cleaning-up-commits.md))
  - [x] Added comprehensive tests for new/modified functionality
  - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)  
        Not applicable — no product docs/dependency updates, and no tool surface changes beyond correcting the default option interpretation.

- [ ] For MCP tool changes:
  - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles  
        Not applicable — this PR changes consolidated discovery behavior and test infrastructure, not an individual tool implementation.
  - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation  
        Not applicable.
  - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)  
        Not applicable.
  - [ ] Updated command list in [/servers/Azure.Mcp.Server/docs/azmcp-commands.md](cci:7://file:///c:/Users/PC/OneDrive/%EB%B0%94%ED%83%95%20%ED%99%94%EB%A9%B4/MS/mcp/servers/Azure.Mcp.Server/docs/azmcp-commands.md:0:0-0:0) and/or `/docs/fabric-commands.md`  
        Not applicable.
  - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)  
        Not applicable.
  - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts  
        Not applicable.
  - [ ] For tools with new names, including new tools or renamed tools, update [[consolidated-tools.json](cci:7://file:///c:/Users/PC/OneDrive/%EB%B0%94%ED%83%95%20%ED%99%94%EB%A9%B4/MS/mcp/core/Microsoft.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json:0:0-0:0)](https://github.com/microsoft/mcp/blob/main/core/Microsoft.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)  
        Not applicable.
  - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description  
        Not applicable.

- [ ] Extra steps for **Azure MCP Server** tool changes:
  - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`  
        Not applicable.
  - [x] 👉 For Community (non-Microsoft team member) PRs:
    - [x] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*  
          Not run — unit-test scoped change. Local unit tests were run (852 tests).