### PR TITLE
Enable HTTP support across all trimmed azmcp distributions and update Docker to use trimmed azmcp

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,10 +21,13 @@
     <DefineConstants>$(DefineConstants);BUILD_NATIVE</DefineConstants>
   </PropertyGroup>
 
-    <!-- HTTP transport is unsupported for native and trimmed variants. ENABLE_HTTP is not set for these build variants.
-       See https://github.com/AzureAD/microsoft-identity-web/issues/3576 -->
-
-  <PropertyGroup Condition="'$(PublishTrimmed)' != 'true' and '$(BuildNative)' != 'true'">
+    <!-- We're using a prerelease version of IdWeb with trimmer support, which enables HTTP support for
+      trimmed azmcp builds across all distributions. The ENABLE_HTTP flag provides a rollback mechanism:
+      if we need to revert to an IdWeb version without trimmer support, we can disable HTTP accordingly.
+      Eventually, ENABLE_HTTP directives will be removed from the code as IdWeb's trimmer support moves
+      closer to GA.
+      See https://github.com/microsoft/mcp/issues/1764 -->
+  <PropertyGroup>
     <DefineConstants>$(DefineConstants);ENABLE_HTTP</DefineConstants>
   </PropertyGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -72,9 +72,9 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="9.5.0" />
-    <PackageVersion Include="Microsoft.Identity.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="4.3.0" />
-    <PackageVersion Include="Microsoft.Identity.Web.Azure" Version="4.3.0" />
+    <PackageVersion Include="Microsoft.Identity.Abstractions" Version="11.0.0" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="4.4.0-preview.1" />
+    <PackageVersion Include="Microsoft.Identity.Web.Azure" Version="4.4.0-preview.1" />
     <PackageVersion Include="Microsoft.HybridRow" Version="1.1.0-preview4" />
     <PackageVersion Include="Microsoft.Azure.Cosmos.Aot" Version="0.1.4-preview.2" />
     <PackageVersion Include="Microsoft.Azure.Mcp.AzTypes.Internal.Compact" Version="0.2.804" />

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceStartCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceStartCommand.cs
@@ -13,14 +13,17 @@ using Azure.Mcp.Core.Services.Azure.Authentication;
 using Azure.Mcp.Core.Services.Caching;
 using Azure.Mcp.Core.Services.Telemetry;
 using Azure.Monitor.OpenTelemetry.Exporter;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Abstractions;
 using Microsoft.Identity.Web;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Extensions;
@@ -459,9 +462,13 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
         // Configure outgoing and incoming authentication and authorization.
         //
         // Configure incoming authentication and authorization.
-        MicrosoftIdentityWebApiAuthenticationBuilderWithConfiguration authBuilder = services
+        var azureAdSection = builder.Configuration.GetSection(Constants.AzureAd);
+        AuthenticationBuilder authBuilder = services
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-            .AddMicrosoftIdentityWebApi(builder.Configuration);
+            .AddMicrosoftIdentityWebApiAot(
+                options => azureAdSection.Bind(options),
+                JwtBearerDefaults.AuthenticationScheme,
+                null);
 
         // Configure incoming auth JWT Bearer events for OAuth protected resource metadata.
         services.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
@@ -506,7 +513,7 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
         // Configure outgoing authentication strategy
         if (serverOptions.OutgoingAuthStrategy == OutgoingAuthStrategy.UseOnBehalfOf)
         {
-            services.AddHttpOnBehalfOfTokenCredentialProvider(authBuilder);
+            services.AddHttpOnBehalfOfTokenCredentialProvider();
         }
         else
         {
@@ -545,10 +552,10 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
             if (context.Request.Path == "/.well-known/oauth-protected-resource" &&
                 context.Request.Method == "GET")
             {
-                IOptionsMonitor<MicrosoftIdentityOptions> azureAdOptionsMonitor = context
+                IOptionsMonitor<MicrosoftIdentityApplicationOptions> azureAdOptionsMonitor = context
                     .RequestServices
-                    .GetRequiredService<IOptionsMonitor<MicrosoftIdentityOptions>>();
-                MicrosoftIdentityOptions azureAdOptions = azureAdOptionsMonitor.Get(JwtBearerDefaults.AuthenticationScheme);
+                    .GetRequiredService<IOptionsMonitor<MicrosoftIdentityApplicationOptions>>();
+                MicrosoftIdentityApplicationOptions azureAdOptions = azureAdOptionsMonitor.Get(JwtBearerDefaults.AuthenticationScheme);
                 HttpRequest request = context.Request;
                 string baseUrl = $"{request.Scheme}://{request.Host}";
                 string? clientId = azureAdOptions.ClientId;

--- a/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
 
 namespace Azure.Mcp.Core.Services.Azure.Authentication;
 
@@ -52,24 +54,20 @@ public static class AuthenticationServiceCollectionExtensions
     /// into the service collection, along with all required dependencies.
     /// </summary>
     /// <param name="services">The service collection.</param>
-    /// <param name="authBuilder">
-    /// The authentication builder from <see cref="MicrosoftIdentityWebApiAuthenticationBuilderExtensions.AddMicrosoftIdentityWebApi"/>
-    /// that will be used to enable token acquisition for downstream API calls.
-    /// </param>
     /// <returns>The service collection.</returns>
     /// <remarks>
     /// This method will override any existing <see cref="IAzureTokenCredentialProvider"/> registration.
     /// </remarks>
     public static IServiceCollection AddHttpOnBehalfOfTokenCredentialProvider(
-        this IServiceCollection services,
-        MicrosoftIdentityWebApiAuthenticationBuilderWithConfiguration authBuilder)
+        this IServiceCollection services)
     {
         // Dependencies - directly in constructor.
         services.AddHttpContextAccessor();
 
-        // Dependencies - indirectly required to get MicrosoftIdentityTokenCredential.
-        authBuilder.EnableTokenAcquisitionToCallDownstreamApi()
-            .AddInMemoryTokenCaches();
+        // With AddMicrosoftIdentityWebApiAot, OBO works automatically via AddTokenAcquisition
+        // (no EnableTokenAcquisitionToCallDownstreamApi needed).
+        services.AddTokenAcquisition();
+        services.AddInMemoryTokenCaches();
         services.AddMicrosoftIdentityAzureTokenCredential();
 
         // Register the OBO token provider. This uses AddSingleton (not TryAdd) to override

--- a/eng/scripts/Build-Docker.ps1
+++ b/eng/scripts/Build-Docker.ps1
@@ -73,6 +73,7 @@ try {
                 "x64" { "amd64" }
                 "musl-x64" { "amd64" }
                 "arm64" { "arm64" }
+                "musl-arm64" { "arm64" }
                 default {
                     LogWarning "Skipping unsupported architecture $($platform.architecture) for server $serverName"
                     continue

--- a/eng/scripts/New-BuildInfo.ps1
+++ b/eng/scripts/New-BuildInfo.ps1
@@ -32,14 +32,20 @@ $excludedPlatforms = @(
 # Platforms outside of the standard combinations that should also be built.  Setting a "specialPurpose" allows then to
 # be targeted or excluded in packaging scripts
 $additionalPlatforms = @(
-    # Until https://github.com/microsoft/mcp/issues/1051 is fixed, to support hosted mcp servers, we need to ensure there
-    # are untrimmed versions of certain identity-compatible platforms available to the docker packaging step
+    # We currently use a prerelease version of Microsoft.Identity.Web with AOT-safe HTTP support,
+    # which allows shipping trimmed azmcp with http across all distributions (including Docker). 
+    # Previously, Docker was shipped untrimmed to enable http support, while only other distributions
+    # where trimmed without HTTP support. These additional Docker platforms are retained as a rollback safety net
+    # in case we need to revert to the non-prerelease version and limit HTTP support to Docker only.
+    # Once Microsoft.Identity.Web with AOT support reaches GA, additionalPlatforms should be removed
+    # and Docker builds should use the standard platform definitions.
+    # https://github.com/microsoft/mcp/issues/1764
     @{
         name = 'linux-musl-x64-docker'
         operatingSystem = 'linux'
         architecture = 'musl-x64'
         native = $false
-        trimmed = $false
+        trimmed = $true
         specialPurpose = 'docker'
     }
     @{
@@ -47,7 +53,7 @@ $additionalPlatforms = @(
         operatingSystem = 'linux'
         architecture = 'musl-arm64'
         native = $false
-        trimmed = $false
+        trimmed = $true
         specialPurpose = 'docker'
     }
 )

--- a/servers/Azure.Mcp.Server/changelog-entries/1771528377931.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1771528377931.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Features Added"
+    description: "Enabled trimmed binary for Docker and HTTP transport support for all distributions"


### PR DESCRIPTION
## What does this PR do?

This change enables:

1. HTTP transport (and thereby OBO authentication - remote) for all trimmed distributions we currently support (npm, NuGet, VSIX, etc.)
2. Trimmed support for Docker

To enable this, we took a dependency on a pre-release version of Microsoft.Identity.Web

`[Any additional context, screenshots, or information that helps reviewers]`

I’ve kept the existing enable_http directive (in code) and Docker platform (in build_info) separation in place rather than aggressively refactoring/removing them out. This preserves our ability to roll back to the previous form (trimmed non-http for non-docker distributions and untrimmed Docker) if needed during pre-release time. I’m planning to make those [cleanup](https://github.com/microsoft/mcp/issues/1764) changes as we get closer to IDWeb GA, when the surface is more stable.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
