### PR TITLE
kusto_query: migrate query path/parsing to v2 and add --show-stats

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/copilot-kusto-query-v2-show-stats.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/copilot-kusto-query-v2-show-stats.yaml
@@ -1,0 +1,5 @@
+changes:
+  - section: "Features Added"
+    description: "Added --show-stats option for kusto query to return structured execution statistics from QueryCompletionInformation frames."
+  - section: "Other Changes"
+    description: "Migrated kusto query execution to /v2/rest/query with v2 frame parsing, PrimaryResult/DataSetCompletion handling, and query request headers for read-only, compression, and keep-alive behavior."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -905,7 +905,8 @@ azmcp kusto table schema [--cluster-uri <cluster-uri> | --subscription <subscrip
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp kusto query [--cluster-uri <cluster-uri> | --subscription <subscription> --cluster <cluster>] \
                   --database <database> \
-                  --query <kql-query>
+                  --query <kql-query> \
+                  [--show-stats]
 
 ```
 

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -234,6 +234,7 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | kusto_database_list | List all databases in the Data Explorer cluster <cluster_name> |
 | kusto_database_list | Show me the databases in the Data Explorer cluster <cluster_name> |
 | kusto_query | Show me all items that contain the word <search_term> in the Data Explorer table <table_name> in cluster <cluster_name> |
+| kusto_query | Run a Kusto query against <database_name> in cluster <cluster_name> and include execution statistics like CPU, memory, and cache usage |
 | kusto_sample | Show me a data sample from the Data Explorer table <table_name> in cluster <cluster_name> |
 | kusto_table_list | List all tables in the Data Explorer database <database_name> in cluster <cluster_name> |
 | kusto_table_list | Show me the tables in the Data Explorer database <database_name> in cluster <cluster_name> |

--- a/tools/Azure.Mcp.Tools.Kusto/src/KustoSetup.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/KustoSetup.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net;
 using Azure.Mcp.Tools.Kusto.Commands;
 using Azure.Mcp.Tools.Kusto.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,6 +18,12 @@ public class KustoSetup : IAreaSetup
 
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddHttpClient(KustoClient.HttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(static () => new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            });
+
         services.AddSingleton<IKustoService, KustoService>();
 
         services.AddSingleton<SampleCommand>();

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/KustoOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/KustoOptionDefinitions.cs
@@ -11,6 +11,7 @@ public static class KustoOptionDefinitions
     public const string TableName = "table";
     public const string LimitName = "limit";
     public const string QueryText = "query";
+    public const string ShowStatsName = "show-stats";
 
 
     public static readonly Option<string> Cluster = new(
@@ -60,5 +61,14 @@ public static class KustoOptionDefinitions
     {
         Description = "Kusto query to execute. Uses KQL syntax.",
         Required = true
+    };
+
+    public static readonly Option<bool> ShowStats = new(
+        $"--{ShowStatsName}"
+    )
+    {
+        Description = "Include query execution statistics (CPU, memory, cache, network) in the response.",
+        DefaultValueFactory = _ => false,
+        Required = false
     };
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/QueryOptions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/QueryOptions.cs
@@ -9,4 +9,7 @@ public class QueryOptions : BaseDatabaseOptions
 {
     [JsonPropertyName(KustoOptionDefinitions.QueryText)]
     public string? Query { get; set; }
+
+    [JsonPropertyName(KustoOptionDefinitions.ShowStatsName)]
+    public bool ShowStats { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Services/IKustoService.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Services/IKustoService.cs
@@ -46,11 +46,32 @@ public interface IKustoService
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
+    Task<(List<JsonElement> Items, JsonElement? Statistics)> QueryItemsWithStatisticsAsync(
+        string clusterUri,
+        string databaseName,
+        string query,
+        bool showStats = false,
+        string? tenant = null,
+        AuthMethod? authMethod = AuthMethod.Credential,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
     Task<List<JsonElement>> QueryItemsAsync(
         string subscriptionId,
         string clusterName,
         string databaseName,
         string query,
+        string? tenant = null,
+        AuthMethod? authMethod = AuthMethod.Credential,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<(List<JsonElement> Items, JsonElement? Statistics)> QueryItemsWithStatisticsAsync(
+        string subscriptionId,
+        string clusterName,
+        string databaseName,
+        string query,
+        bool showStats = false,
         string? tenant = null,
         AuthMethod? authMethod = AuthMethod.Credential,
         RetryPolicyOptions? retryPolicy = null,

--- a/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoClient.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoClient.cs
@@ -12,6 +12,8 @@ public sealed class KustoClient(
     string userAgent,
     IHttpClientFactory httpClientFactory)
 {
+    internal const string HttpClientName = "KustoClient";
+
     // Valid Kusto cluster domain suffixes from official Kusto endpoints configuration
     private static readonly string[] s_validKustoDomainSuffixes =
     [
@@ -194,7 +196,7 @@ public sealed class KustoClient(
     }
 
     public Task<KustoResult> ExecuteQueryCommandAsync(string database, string text, CancellationToken cancellationToken)
-        => ExecuteCommandAsync("/v1/rest/query", database, text, cancellationToken);
+        => ExecuteCommandAsync("/v2/rest/query", database, text, cancellationToken);
 
     public Task<KustoResult> ExecuteControlCommandAsync(string database, string text, CancellationToken cancellationToken)
         => ExecuteCommandAsync("/v1/rest/mgmt", database, text, cancellationToken);
@@ -203,7 +205,7 @@ public sealed class KustoClient(
     {
         var uri = _clusterUri + endpoint;
         var httpRequest = await GenerateRequestAsync(uri, database, text, cancellationToken).ConfigureAwait(false);
-        var client = _httpClientFactory.CreateClient();
+        var client = _httpClientFactory.CreateClient(HttpClientName);
         client.Timeout = s_httpClientTimeout;
         return await SendRequestAsync(client, httpRequest, cancellationToken).ConfigureAwait(false);
     }
@@ -224,6 +226,10 @@ public sealed class KustoClient(
         httpRequest.Headers.Add("x-ms-app", s_application);
         httpRequest.Headers.Add("x-ms-client-version", "Kusto.Client.Light");
         httpRequest.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
+        httpRequest.Headers.Add("x-ms-readonly", "true");
+        httpRequest.Headers.AcceptEncoding.Add(new System.Net.Http.Headers.StringWithQualityHeaderValue("gzip"));
+        httpRequest.Headers.AcceptEncoding.Add(new System.Net.Http.Headers.StringWithQualityHeaderValue("deflate"));
+        httpRequest.Headers.Connection.Add("Keep-Alive");
 
         var body = new JsonObject
         {

--- a/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoService.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoService.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Globalization;
+using System.Text.Json.Nodes;
 using Azure.Core;
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Core.Services.Azure;
@@ -223,8 +225,47 @@ public sealed class KustoService(
             (nameof(databaseName), databaseName),
             (nameof(query), query));
 
+        var result = await QueryItemsWithStatisticsAsync(
+            subscriptionId,
+            clusterName,
+            databaseName,
+            query,
+            showStats: false,
+            tenant,
+            authMethod,
+            retryPolicy,
+            cancellationToken);
+
+        return result.Items;
+    }
+
+    public async Task<(List<JsonElement> Items, JsonElement? Statistics)> QueryItemsWithStatisticsAsync(
+        string subscriptionId,
+        string clusterName,
+        string databaseName,
+        string query,
+        bool showStats = false,
+        string? tenant = null,
+        AuthMethod? authMethod = AuthMethod.Credential,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscriptionId), subscriptionId),
+            (nameof(clusterName), clusterName),
+            (nameof(databaseName), databaseName),
+            (nameof(query), query));
+
         string clusterUri = await GetClusterUriAsync(subscriptionId, clusterName, tenant, retryPolicy);
-        return await QueryItemsAsync(clusterUri, databaseName, query, tenant, authMethod, retryPolicy, cancellationToken);
+        return await QueryItemsWithStatisticsAsync(
+            clusterUri,
+            databaseName,
+            query,
+            showStats,
+            tenant,
+            authMethod,
+            retryPolicy,
+            cancellationToken);
     }
 
     public async Task<List<JsonElement>> QueryItemsAsync(
@@ -241,50 +282,684 @@ public sealed class KustoService(
             (nameof(databaseName), databaseName),
             (nameof(query), query));
 
+        var result = await QueryItemsWithStatisticsAsync(
+            clusterUri,
+            databaseName,
+            query,
+            showStats: false,
+            tenant,
+            authMethod,
+            retryPolicy,
+            cancellationToken);
+
+        return result.Items;
+    }
+
+    public async Task<(List<JsonElement> Items, JsonElement? Statistics)> QueryItemsWithStatisticsAsync(
+        string clusterUri,
+        string databaseName,
+        string query,
+        bool showStats = false,
+        string? tenant = null,
+        AuthMethod? authMethod = AuthMethod.Credential,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(clusterUri), clusterUri),
+            (nameof(databaseName), databaseName),
+            (nameof(query), query));
+
         var cslQueryProvider = await GetOrCreateCslQueryProviderAsync(clusterUri, tenant, cancellationToken);
-        var result = new List<JsonElement>();
         var kustoResult = await cslQueryProvider.ExecuteQueryCommandAsync(databaseName, query, cancellationToken);
         if (kustoResult.RootElement.ValueKind == JsonValueKind.Null)
         {
-            return result;
+            return ([], null);
         }
+
         var root = kustoResult.RootElement;
-        if (!root.TryGetProperty("Tables", out var tablesElement) || tablesElement.ValueKind != JsonValueKind.Array || tablesElement.GetArrayLength() == 0)
+        if (root.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidOperationException("Kusto query response was not in expected v2 frame format.");
+        }
+
+        var hasPrimaryResult = false;
+        var hasQueryCompletionInformation = false;
+        var hasErrors = false;
+        JsonElement primaryResultFrame = default;
+        JsonElement queryCompletionInformationFrame = default;
+        string? oneApiErrors = null;
+
+        foreach (var frame in root.EnumerateArray())
+        {
+            if (frame.ValueKind != JsonValueKind.Object
+                || !frame.TryGetProperty("FrameType", out var frameTypeElement)
+                || frameTypeElement.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var frameType = frameTypeElement.GetString();
+            if (string.Equals(frameType, "DataSetCompletion", StringComparison.OrdinalIgnoreCase))
+            {
+                if (frame.TryGetProperty("HasErrors", out var hasErrorsElement)
+                    && TryGetBooleanValue(hasErrorsElement, out var frameHasErrors)
+                    && frameHasErrors)
+                {
+                    hasErrors = true;
+                    if (frame.TryGetProperty("OneApiErrors", out var oneApiErrorsElement))
+                    {
+                        oneApiErrors = oneApiErrorsElement.GetRawText();
+                    }
+                }
+
+                continue;
+            }
+
+            if (!string.Equals(frameType, "DataTable", StringComparison.OrdinalIgnoreCase)
+                || !frame.TryGetProperty("TableKind", out var tableKindElement)
+                || tableKindElement.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var tableKind = tableKindElement.GetString();
+            if (!hasPrimaryResult && string.Equals(tableKind, "PrimaryResult", StringComparison.OrdinalIgnoreCase))
+            {
+                hasPrimaryResult = true;
+                primaryResultFrame = frame;
+                continue;
+            }
+
+            if (showStats && !hasQueryCompletionInformation
+                && string.Equals(tableKind, "QueryCompletionInformation", StringComparison.OrdinalIgnoreCase))
+            {
+                hasQueryCompletionInformation = true;
+                queryCompletionInformationFrame = frame;
+            }
+        }
+
+        if (hasErrors)
+        {
+            throw new InvalidOperationException($"Kusto query completed with errors: {oneApiErrors ?? "No OneApiErrors details were returned."}");
+        }
+
+        if (!hasPrimaryResult)
+        {
+            throw new InvalidOperationException("Kusto query response did not contain a PrimaryResult frame.");
+        }
+
+        var items = ConvertPrimaryResultToItems(primaryResultFrame);
+        JsonElement? statistics = null;
+        if (showStats && hasQueryCompletionInformation)
+        {
+            try
+            {
+                statistics = ParseStatistics(queryCompletionInformationFrame);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to parse Kusto query statistics.");
+            }
+        }
+
+        return (items, statistics);
+    }
+
+    private static List<JsonElement> ConvertPrimaryResultToItems(JsonElement primaryResultFrame)
+    {
+        var result = new List<JsonElement>();
+        if (!primaryResultFrame.TryGetProperty("Columns", out var columnsElement)
+            || columnsElement.ValueKind != JsonValueKind.Array)
         {
             return result;
         }
-        var table = tablesElement[0];
-        if (!table.TryGetProperty("Columns", out var columnsElement) || columnsElement.ValueKind != JsonValueKind.Array)
-        {
-            return result;
-        }
+
         var columnsDict = columnsElement.EnumerateArray()
+            .Where(column => column.TryGetProperty("ColumnName", out var nameElement) && nameElement.ValueKind == JsonValueKind.String)
             .ToDictionary(
                 column => column.GetProperty("ColumnName").GetString()!,
-                column => column.GetProperty("ColumnType").GetString()!
-            );
+                column =>
+                {
+                    if (!column.TryGetProperty("ColumnType", out var typeElement) || typeElement.ValueKind != JsonValueKind.String)
+                    {
+                        return string.Empty;
+                    }
+
+                    return typeElement.GetString() ?? string.Empty;
+                });
 
         var columnsDictJson = "{" + string.Join(",", columnsDict.Select(kvp =>
-                    $"\"{JsonEncodedText.Encode(kvp.Key)}\":\"{JsonEncodedText.Encode(kvp.Value)}\"")) + "}";
+            $"\"{JsonEncodedText.Encode(kvp.Key)}\":\"{JsonEncodedText.Encode(kvp.Value)}\"")) + "}";
         using (var jsonDoc = JsonDocument.Parse(columnsDictJson))
         {
             result.Add(jsonDoc.RootElement.Clone());
         }
 
-        if (!table.TryGetProperty("Rows", out var items) || items.ValueKind != JsonValueKind.Array)
+        if (!primaryResultFrame.TryGetProperty("Rows", out var rowsElement)
+            || rowsElement.ValueKind != JsonValueKind.Array)
         {
             return result;
         }
-        foreach (var item in items.EnumerateArray())
+
+        foreach (var row in rowsElement.EnumerateArray())
         {
-            var json = item.ToString();
-            using (var jsonDoc = JsonDocument.Parse(json))
-            {
-                result.Add(jsonDoc.RootElement.Clone());
-            }
+            using var jsonDoc = JsonDocument.Parse(row.GetRawText());
+            result.Add(jsonDoc.RootElement.Clone());
         }
 
         return result;
+    }
+
+    private static JsonElement? ParseStatistics(JsonElement queryCompletionInformationFrame)
+    {
+        if (!queryCompletionInformationFrame.TryGetProperty("Columns", out var columnsElement)
+            || columnsElement.ValueKind != JsonValueKind.Array
+            || !queryCompletionInformationFrame.TryGetProperty("Rows", out var rowsElement)
+            || rowsElement.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var severityNameColumnIndex = GetColumnIndex(columnsElement, "SeverityName");
+        var statusDescriptionColumnIndex = GetColumnIndex(columnsElement, "StatusDescription");
+        if (severityNameColumnIndex < 0 || statusDescriptionColumnIndex < 0)
+        {
+            return null;
+        }
+
+        foreach (var row in rowsElement.EnumerateArray())
+        {
+            if (row.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            var severityName = GetRowStringValue(row, severityNameColumnIndex);
+            if (!string.Equals(severityName, "Stats", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var statusDescription = GetRowStringValue(row, statusDescriptionColumnIndex);
+            if (string.IsNullOrWhiteSpace(statusDescription))
+            {
+                return null;
+            }
+
+            using var statsDocument = JsonDocument.Parse(statusDescription);
+            return ConvertStatisticsToResult(statsDocument.RootElement);
+        }
+
+        return null;
+    }
+
+    private static JsonElement? ConvertStatisticsToResult(JsonElement source)
+    {
+        var result = new JsonObject();
+        if (TryGetDoubleProperty(source, "ExecutionTime", out var executionTime))
+        {
+            result["execution_time_sec"] = executionTime;
+        }
+
+        if (source.TryGetProperty("resource_usage", out var resourceUsage)
+            && resourceUsage.ValueKind == JsonValueKind.Object)
+        {
+            AddCpuStats(result, resourceUsage);
+            AddMemoryStats(result, resourceUsage);
+            AddCacheStats(result, resourceUsage);
+            AddNetworkStats(result, resourceUsage);
+        }
+
+        AddInputDatasetStats(result, source);
+        AddResultDatasetStats(result, source);
+        AddCrossClusterBreakdown(result, source);
+
+        if (result.Count == 0)
+        {
+            return null;
+        }
+
+        using var document = JsonDocument.Parse(result.ToJsonString());
+        return document.RootElement.Clone();
+    }
+
+    private static void AddCpuStats(JsonObject result, JsonElement resourceUsage)
+    {
+        if (!resourceUsage.TryGetProperty("cpu", out var cpu) || cpu.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        var cpuResult = new JsonObject();
+        if (TryGetStringProperty(cpu, "total cpu", out var totalCpu))
+        {
+            cpuResult["total"] = totalCpu;
+        }
+
+        if (cpu.TryGetProperty("breakdown", out var breakdown) && breakdown.ValueKind == JsonValueKind.Object)
+        {
+            if (TryGetStringProperty(breakdown, "query execution", out var queryExecution))
+            {
+                cpuResult["query_execution"] = queryExecution;
+            }
+
+            if (TryGetStringProperty(breakdown, "query planning", out var queryPlanning))
+            {
+                cpuResult["query_planning"] = queryPlanning;
+            }
+        }
+
+        if (cpuResult.Count > 0)
+        {
+            result["cpu"] = cpuResult;
+        }
+    }
+
+    private static void AddMemoryStats(JsonObject result, JsonElement resourceUsage)
+    {
+        if (!resourceUsage.TryGetProperty("memory", out var memory)
+            || memory.ValueKind != JsonValueKind.Object
+            || !TryGetDoubleProperty(memory, "peak_per_node", out var peakPerNodeBytes))
+        {
+            return;
+        }
+
+        result["memory_peak_per_node_mb"] = BytesToMegabytes(peakPerNodeBytes);
+    }
+
+    private static void AddCacheStats(JsonObject result, JsonElement resourceUsage)
+    {
+        if (!resourceUsage.TryGetProperty("cache", out var cache)
+            || cache.ValueKind != JsonValueKind.Object
+            || !cache.TryGetProperty("shards", out var shards)
+            || shards.ValueKind != JsonValueKind.Object
+            || !shards.TryGetProperty("hot", out var hot)
+            || hot.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        var cacheResult = new JsonObject();
+        if (TryGetDoubleProperty(hot, "hitbytes", out var hitBytes))
+        {
+            cacheResult["hot_hit_mb"] = BytesToMegabytes(hitBytes);
+        }
+
+        if (TryGetDoubleProperty(hot, "missbytes", out var missBytes))
+        {
+            cacheResult["hot_miss_mb"] = BytesToMegabytes(missBytes);
+        }
+
+        if (cacheResult.Count > 0)
+        {
+            result["cache"] = cacheResult;
+        }
+    }
+
+    private static void AddInputDatasetStats(JsonObject result, JsonElement source)
+    {
+        if (!source.TryGetProperty("input_dataset_statistics", out var inputDatasetStatistics)
+            || inputDatasetStatistics.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        if (inputDatasetStatistics.TryGetProperty("extents", out var extents)
+            && extents.ValueKind == JsonValueKind.Object)
+        {
+            var extentsResult = new JsonObject();
+            if (TryGetLongProperty(extents, "scanned", out var scannedExtents))
+            {
+                extentsResult["scanned"] = scannedExtents;
+            }
+
+            if (TryGetLongProperty(extents, "total", out var totalExtents))
+            {
+                extentsResult["total"] = totalExtents;
+            }
+
+            if (extentsResult.Count > 0)
+            {
+                result["extents"] = extentsResult;
+            }
+        }
+
+        if (inputDatasetStatistics.TryGetProperty("rows", out var rows)
+            && rows.ValueKind == JsonValueKind.Object)
+        {
+            var rowsResult = new JsonObject();
+            if (TryGetLongProperty(rows, "scanned", out var scannedRows))
+            {
+                rowsResult["scanned"] = scannedRows;
+            }
+
+            if (TryGetLongProperty(rows, "total", out var totalRows))
+            {
+                rowsResult["total"] = totalRows;
+            }
+
+            if (rowsResult.Count > 0)
+            {
+                result["rows"] = rowsResult;
+            }
+        }
+    }
+
+    private static void AddResultDatasetStats(JsonObject result, JsonElement source)
+    {
+        if (!source.TryGetProperty("dataset_statistics", out var datasetStatistics)
+            || datasetStatistics.ValueKind != JsonValueKind.Array
+            || datasetStatistics.GetArrayLength() == 0)
+        {
+            return;
+        }
+
+        var firstDataset = datasetStatistics[0];
+        if (firstDataset.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        var datasetResult = new JsonObject();
+        if (TryGetLongProperty(firstDataset, "table_row_count", out var rowCount))
+        {
+            datasetResult["row_count"] = rowCount;
+        }
+
+        if (TryGetDoubleProperty(firstDataset, "table_size", out var tableSizeBytes))
+        {
+            datasetResult["size_kb"] = BytesToKilobytes(tableSizeBytes);
+        }
+
+        if (datasetResult.Count > 0)
+        {
+            result["result"] = datasetResult;
+        }
+    }
+
+    private static void AddNetworkStats(JsonObject result, JsonElement resourceUsage)
+    {
+        if (!resourceUsage.TryGetProperty("network", out var network)
+            || network.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        var networkResult = new JsonObject();
+        if (TryGetDoubleProperty(network, "cross_cluster_total_bytes", out var crossClusterBytes))
+        {
+            networkResult["cross_cluster_mb"] = BytesToMegabytes(crossClusterBytes);
+        }
+
+        if (TryGetDoubleProperty(network, "inter_cluster_total_bytes", out var interClusterBytes))
+        {
+            networkResult["inter_cluster_mb"] = BytesToMegabytes(interClusterBytes);
+        }
+
+        if (networkResult.Count > 0)
+        {
+            result["network"] = networkResult;
+        }
+    }
+
+    private static void AddCrossClusterBreakdown(JsonObject result, JsonElement source)
+    {
+        if (!source.TryGetProperty("cross_cluster_resource_usage", out var crossClusterResourceUsage)
+            || crossClusterResourceUsage.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        var crossClusterResult = new JsonObject();
+        foreach (var clusterUsage in crossClusterResourceUsage.EnumerateObject())
+        {
+            if (clusterUsage.Value.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var clusterResult = new JsonObject();
+            if (clusterUsage.Value.TryGetProperty("cpu", out var cpu)
+                && cpu.ValueKind == JsonValueKind.Object
+                && TryGetStringProperty(cpu, "total cpu", out var totalCpu))
+            {
+                clusterResult["cpu_total"] = totalCpu;
+            }
+
+            if (clusterUsage.Value.TryGetProperty("memory", out var memory)
+                && memory.ValueKind == JsonValueKind.Object
+                && TryGetDoubleProperty(memory, "peak_per_node", out var peakPerNodeBytes))
+            {
+                clusterResult["memory_peak_mb"] = BytesToMegabytes(peakPerNodeBytes);
+            }
+
+            if (clusterUsage.Value.TryGetProperty("cache", out var cache)
+                && cache.ValueKind == JsonValueKind.Object
+                && cache.TryGetProperty("shards", out var shards)
+                && shards.ValueKind == JsonValueKind.Object
+                && shards.TryGetProperty("hot", out var hot)
+                && hot.ValueKind == JsonValueKind.Object)
+            {
+                if (TryGetDoubleProperty(hot, "hitbytes", out var hitBytes))
+                {
+                    clusterResult["cache_hit_mb"] = BytesToMegabytes(hitBytes);
+                }
+
+                if (TryGetDoubleProperty(hot, "missbytes", out var missBytes))
+                {
+                    clusterResult["cache_miss_mb"] = BytesToMegabytes(missBytes);
+                }
+            }
+
+            if (clusterResult.Count == 0)
+            {
+                continue;
+            }
+
+            var clusterName = NormalizeClusterName(clusterUsage.Name);
+            if (!string.IsNullOrWhiteSpace(clusterName))
+            {
+                crossClusterResult[clusterName] = clusterResult;
+            }
+        }
+
+        if (crossClusterResult.Count > 0)
+        {
+            result["cross_cluster_breakdown"] = crossClusterResult;
+        }
+    }
+
+    private static int GetColumnIndex(JsonElement columnsElement, string targetColumnName)
+    {
+        var index = 0;
+        foreach (var column in columnsElement.EnumerateArray())
+        {
+            if (column.ValueKind == JsonValueKind.Object
+                && column.TryGetProperty("ColumnName", out var columnNameElement)
+                && columnNameElement.ValueKind == JsonValueKind.String
+                && string.Equals(columnNameElement.GetString(), targetColumnName, StringComparison.Ordinal))
+            {
+                return index;
+            }
+
+            index++;
+        }
+
+        return -1;
+    }
+
+    private static string? GetRowStringValue(JsonElement row, int index)
+    {
+        if (index < 0)
+        {
+            return null;
+        }
+
+        var currentIndex = 0;
+        foreach (var value in row.EnumerateArray())
+        {
+            if (currentIndex == index)
+            {
+                return value.ValueKind switch
+                {
+                    JsonValueKind.String => value.GetString(),
+                    JsonValueKind.Null => null,
+                    _ => value.GetRawText()
+                };
+            }
+
+            currentIndex++;
+        }
+
+        return null;
+    }
+
+    private static bool TryGetStringProperty(JsonElement element, string propertyName, out string? value)
+    {
+        value = null;
+        if (!element.TryGetProperty(propertyName, out var property) || property.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        value = property.GetString();
+        return !string.IsNullOrEmpty(value);
+    }
+
+    private static bool TryGetDoubleProperty(JsonElement element, string propertyName, out double value)
+    {
+        value = 0;
+        return element.TryGetProperty(propertyName, out var property) && TryGetDoubleValue(property, out value);
+    }
+
+    private static bool TryGetLongProperty(JsonElement element, string propertyName, out long value)
+    {
+        value = 0;
+        return element.TryGetProperty(propertyName, out var property) && TryGetLongValue(property, out value);
+    }
+
+    private static bool TryGetBooleanValue(JsonElement element, out bool value)
+    {
+        value = false;
+        return element.ValueKind switch
+        {
+            JsonValueKind.True => SetBooleanResult(true, out value),
+            JsonValueKind.False => SetBooleanResult(false, out value),
+            JsonValueKind.String => bool.TryParse(element.GetString(), out value),
+            JsonValueKind.Number => TryConvertNumberToBoolean(element, out value),
+            _ => false
+        };
+    }
+
+    private static bool TryGetDoubleValue(JsonElement element, out double value)
+    {
+        value = 0;
+        return element.ValueKind switch
+        {
+            JsonValueKind.Number => element.TryGetDouble(out value),
+            JsonValueKind.String => double.TryParse(element.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out value),
+            _ => false
+        };
+    }
+
+    private static bool TryGetLongValue(JsonElement element, out long value)
+    {
+        value = 0;
+        return element.ValueKind switch
+        {
+            JsonValueKind.Number => element.TryGetInt64(out value),
+            JsonValueKind.String => long.TryParse(element.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value),
+            _ => false
+        };
+    }
+
+    private static bool SetBooleanResult(bool result, out bool value)
+    {
+        value = result;
+        return true;
+    }
+
+    private static bool TryConvertNumberToBoolean(JsonElement element, out bool value)
+    {
+        value = false;
+        if (!element.TryGetInt32(out var intValue))
+        {
+            return false;
+        }
+
+        value = intValue != 0;
+        return true;
+    }
+
+    private static double BytesToMegabytes(double bytes) => Math.Round(bytes / 1048576d, 2);
+
+    private static double BytesToKilobytes(double bytes) => Math.Round(bytes / 1024d, 2);
+
+    private static string NormalizeClusterName(string clusterIdentifier)
+    {
+        if (Uri.TryCreate(clusterIdentifier, UriKind.Absolute, out var clusterUri))
+        {
+            return clusterUri.Host;
+        }
+
+        var normalizedClusterIdentifier = clusterIdentifier.Trim().TrimEnd('/');
+        normalizedClusterIdentifier = normalizedClusterIdentifier.Replace("https://", string.Empty, StringComparison.OrdinalIgnoreCase);
+        normalizedClusterIdentifier = normalizedClusterIdentifier.Replace("http://", string.Empty, StringComparison.OrdinalIgnoreCase);
+        return normalizedClusterIdentifier;
+    }
+
+    private static bool TryGetFirstResultTable(JsonElement root, out JsonElement table)
+    {
+        table = default;
+        if (root.ValueKind == JsonValueKind.Object
+            && root.TryGetProperty("Tables", out var tablesElement)
+            && tablesElement.ValueKind == JsonValueKind.Array
+            && tablesElement.GetArrayLength() > 0)
+        {
+            table = tablesElement[0];
+            return true;
+        }
+
+        if (root.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        var hasFallbackDataTable = false;
+        JsonElement fallbackDataTable = default;
+        foreach (var frame in root.EnumerateArray())
+        {
+            if (frame.ValueKind != JsonValueKind.Object
+                || !frame.TryGetProperty("FrameType", out var frameType)
+                || frameType.ValueKind != JsonValueKind.String
+                || !string.Equals(frameType.GetString(), "DataTable", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!hasFallbackDataTable)
+            {
+                fallbackDataTable = frame;
+                hasFallbackDataTable = true;
+            }
+
+            if (frame.TryGetProperty("TableKind", out var tableKind)
+                && tableKind.ValueKind == JsonValueKind.String
+                && string.Equals(tableKind.GetString(), "PrimaryResult", StringComparison.OrdinalIgnoreCase))
+            {
+                table = frame;
+                return true;
+            }
+        }
+
+        if (hasFallbackDataTable)
+        {
+            table = fallbackDataTable;
+            return true;
+        }
+
+        return false;
     }
 
     private List<string> KustoResultToStringList(KustoResult kustoResult)
@@ -295,11 +970,11 @@ public sealed class KustoService(
             return result;
         }
         var root = kustoResult.RootElement;
-        if (!root.TryGetProperty("Tables", out var tablesElement) || tablesElement.ValueKind != JsonValueKind.Array || tablesElement.GetArrayLength() == 0)
+        if (!TryGetFirstResultTable(root, out var table))
         {
             return result;
         }
-        var table = tablesElement[0];
+
         if (!table.TryGetProperty("Columns", out var columnsElement) || columnsElement.ValueKind != JsonValueKind.Array)
         {
             return result;

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/KustoServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/KustoServiceTests.cs
@@ -1,0 +1,254 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Azure.Core;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Core.Services.Azure.Tenant;
+using Azure.Mcp.Core.Services.Caching;
+using Azure.Mcp.Tools.Kusto.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Kusto.UnitTests;
+
+public sealed class KustoServiceTests
+{
+    [Fact]
+    public async Task QueryItemsWithStatisticsAsync_V2PrimaryResult_ExtractsItems()
+    {
+        var service = CreateService(
+            """
+            [
+              {"FrameType":"DataSetHeader","IsProgressive":false,"Version":"v2.0"},
+              {"FrameType":"DataTable","TableId":5,"TableKind":"QueryProperties","TableName":"@ExtendedProperties","Columns":[],"Rows":[]},
+              {"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"PrimaryResult","Columns":[{"ColumnName":"name","ColumnType":"string"},{"ColumnName":"count","ColumnType":"int"}],"Rows":[["alpha",1],["beta",2]]},
+              {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+            ]
+            """,
+            out var handler);
+
+        var result = await service.QueryItemsWithStatisticsAsync(
+            "https://test.kusto.windows.net",
+            "db1",
+            "StormEvents | take 2",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("/v2/rest/query", handler.LastRequest!.RequestUri!.AbsolutePath);
+        Assert.Equal(3, result.Items.Count);
+        Assert.Equal("string", result.Items[0].GetProperty("name").GetString());
+        Assert.Equal("alpha", result.Items[1][0].GetString());
+        Assert.Equal(2, result.Items[2][1].GetInt32());
+    }
+
+    [Fact]
+    public async Task QueryItemsWithStatisticsAsync_DataSetCompletionHasErrors_Throws()
+    {
+        var service = CreateService(
+            """
+            [
+              {"FrameType":"DataSetHeader","IsProgressive":false,"Version":"v2.0"},
+              {"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"PrimaryResult","Columns":[{"ColumnName":"name","ColumnType":"string"}],"Rows":[["alpha"]]},
+              {"FrameType":"DataSetCompletion","HasErrors":true,"Cancelled":false,"OneApiErrors":{"code":"BadRequest","message":"boom"}}
+            ]
+            """,
+            out _);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.QueryItemsWithStatisticsAsync(
+            "https://test.kusto.windows.net",
+            "db1",
+            "StormEvents | take 1",
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Contains("BadRequest", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task QueryItemsWithStatisticsAsync_MissingPrimaryResult_Throws()
+    {
+        var service = CreateService(
+            """
+            [
+              {"FrameType":"DataSetHeader","IsProgressive":false,"Version":"v2.0"},
+              {"FrameType":"DataTable","TableId":1,"TableKind":"QueryCompletionInformation","TableName":"QueryStatus","Columns":[],"Rows":[]},
+              {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+            ]
+            """,
+            out _);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.QueryItemsWithStatisticsAsync(
+            "https://test.kusto.windows.net",
+            "db1",
+            "StormEvents | take 1",
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Contains("PrimaryResult", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task QueryItemsWithStatisticsAsync_ShowStatsFalse_ReturnsNullStatistics()
+    {
+        var service = CreateService(CreateStatsResponse(), out _);
+
+        var result = await service.QueryItemsWithStatisticsAsync(
+            "https://test.kusto.windows.net",
+            "db1",
+            "StormEvents | take 1",
+            showStats: false,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Null(result.Statistics);
+        Assert.Equal(2, result.Items.Count);
+    }
+
+    [Fact]
+    public async Task QueryItemsWithStatisticsAsync_ShowStatsTrue_ExtractsStatistics()
+    {
+        var service = CreateService(CreateStatsResponse(), out _);
+
+        var result = await service.QueryItemsWithStatisticsAsync(
+            "https://test.kusto.windows.net",
+            "db1",
+            "StormEvents | take 1",
+            showStats: true,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result.Statistics);
+        Assert.Equal(1.234, result.Statistics!.Value.GetProperty("execution_time_sec").GetDouble());
+        Assert.Equal(45.2, result.Statistics!.Value.GetProperty("memory_peak_per_node_mb").GetDouble());
+        Assert.Equal(5.2, result.Statistics!.Value.GetProperty("network").GetProperty("cross_cluster_mb").GetDouble());
+    }
+
+    [Fact]
+    public async Task QueryItemsWithStatisticsAsync_ShowStatsTrue_MissingStatsFrame_ReturnsNullStatistics()
+    {
+        var service = CreateService(
+            """
+            [
+              {"FrameType":"DataSetHeader","IsProgressive":false,"Version":"v2.0"},
+              {"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"PrimaryResult","Columns":[{"ColumnName":"name","ColumnType":"string"}],"Rows":[["alpha"]]},
+              {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+            ]
+            """,
+            out _);
+
+        var result = await service.QueryItemsWithStatisticsAsync(
+            "https://test.kusto.windows.net",
+            "db1",
+            "StormEvents | take 1",
+            showStats: true,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Null(result.Statistics);
+    }
+
+    [Fact]
+    public async Task QueryItemsWithStatisticsAsync_ShowStatsTrue_ParsesCrossClusterBreakdown()
+    {
+        var service = CreateService(CreateStatsResponse(), out _);
+
+        var result = await service.QueryItemsWithStatisticsAsync(
+            "https://test.kusto.windows.net",
+            "db1",
+            "StormEvents | take 1",
+            showStats: true,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result.Statistics);
+        var cluster = result.Statistics!.Value
+            .GetProperty("cross_cluster_breakdown")
+            .GetProperty("clustername.region.kusto.windows.net");
+        Assert.Equal("00:00:00.8", cluster.GetProperty("cpu_total").GetString());
+        Assert.Equal(22.1, cluster.GetProperty("memory_peak_mb").GetDouble());
+        Assert.Equal(50.0, cluster.GetProperty("cache_hit_mb").GetDouble());
+        Assert.Equal(1.0, cluster.GetProperty("cache_miss_mb").GetDouble());
+    }
+
+    private static KustoService CreateService(string responsePayload, out MockHttpMessageHandler handler)
+    {
+        var subscriptionService = Substitute.For<ISubscriptionService>();
+        var tenantService = Substitute.For<ITenantService>();
+        var cacheService = Substitute.For<ICacheService>();
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        var logger = Substitute.For<ILogger<KustoService>>();
+
+        var tokenCredential = Substitute.For<TokenCredential>();
+        tokenCredential.GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<AccessToken>(new AccessToken("noop-token", DateTimeOffset.UtcNow.AddHours(1))));
+        tenantService.GetTokenCredentialAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TokenCredential>(tokenCredential));
+
+        cacheService.GetAsync<KustoClient>(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<KustoClient?>((KustoClient?)null));
+
+        handler = new MockHttpMessageHandler(responsePayload);
+        httpClientFactory.CreateClient(Arg.Any<string>())
+            .Returns(new HttpClient(handler));
+
+        return new KustoService(subscriptionService, tenantService, cacheService, httpClientFactory, logger);
+    }
+
+    private static string CreateStatsResponse()
+    {
+        var statsJson = """
+            {
+              "ExecutionTime": 1.234,
+              "resource_usage": {
+                "cpu": {
+                  "total cpu": "00:00:01.5",
+                  "breakdown": {
+                    "query execution": "00:00:01.2",
+                    "query planning": "00:00:00.3"
+                  }
+                },
+                "memory": { "peak_per_node": 47395635 },
+                "cache": { "shards": { "hot": { "hitbytes": 126353408, "missbytes": 3355443 } } },
+                "network": { "cross_cluster_total_bytes": 5452595, "inter_cluster_total_bytes": 0 }
+              },
+              "input_dataset_statistics": {
+                "extents": { "scanned": 42, "total": 1000 },
+                "rows": { "scanned": 50000, "total": 1000000 }
+              },
+              "dataset_statistics": [{ "table_row_count": 150, "table_size": 12800 }],
+              "cross_cluster_resource_usage": {
+                "https://clustername.region.kusto.windows.net/": {
+                  "cpu": { "total cpu": "00:00:00.8" },
+                  "memory": { "peak_per_node": 23173530 },
+                  "cache": { "shards": { "hot": { "hitbytes": 52428800, "missbytes": 1048576 } } }
+                }
+              }
+            }
+            """;
+
+        return """
+            [
+              {"FrameType":"DataSetHeader","IsProgressive":false,"Version":"v2.0"},
+              {"FrameType":"DataTable","TableId":0,"TableKind":"PrimaryResult","TableName":"PrimaryResult","Columns":[{"ColumnName":"name","ColumnType":"string"}],"Rows":[["alpha"]]},
+              {"FrameType":"DataTable","TableId":1,"TableKind":"QueryCompletionInformation","TableName":"QueryStatus","Columns":[{"ColumnName":"Timestamp","ColumnType":"datetime"},{"ColumnName":"Severity","ColumnType":"int"},{"ColumnName":"SeverityName","ColumnType":"string"},{"ColumnName":"StatusCode","ColumnType":"int"},{"ColumnName":"StatusDescription","ColumnType":"string"},{"ColumnName":"Count","ColumnType":"int"},{"ColumnName":"RequestId","ColumnType":"guid"},{"ColumnName":"ActivityId","ColumnType":"guid"},{"ColumnName":"SubActivityId","ColumnType":"guid"},{"ColumnName":"ClientActivityId","ColumnType":"string"}],"Rows":[["2024-01-01T00:00:00Z",4,"Info",0,"Query completed",1,"...","...","...","..."],["2024-01-01T00:00:00Z",4,"Stats",0,__STATUS_DESCRIPTION__,1,"...","...","...","..."]]},
+              {"FrameType":"DataSetCompletion","HasErrors":false,"Cancelled":false}
+            ]
+            """.Replace("__STATUS_DESCRIPTION__", JsonSerializer.Serialize(statsJson), StringComparison.Ordinal);
+    }
+
+    private sealed class MockHttpMessageHandler(string responsePayload) : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responsePayload, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/QueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/QueryCommandTests.cs
@@ -40,33 +40,42 @@ public sealed class QueryCommandTests
     [MemberData(nameof(QueryArgumentMatrix))]
     public async Task ExecuteAsync_ReturnsQueryResults(string cliArgs, bool useClusterUri)
     {
-        // Arrange
         var expectedJson = JsonDocument.Parse("[{\"foo\":42}]").RootElement.EnumerateArray().Select(e => e.Clone()).ToList();
         if (useClusterUri)
         {
-            _kusto.QueryItemsAsync(
+            _kusto.QueryItemsWithStatisticsAsync(
                 "https://mycluster.kusto.windows.net",
                 "db1",
                 "StormEvents | take 1",
-                Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
-                .Returns(expectedJson);
+                false,
+                Arg.Any<string>(),
+                Arg.Any<AuthMethod?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+                .Returns((expectedJson, (JsonElement?)null));
         }
         else
         {
-            _kusto.QueryItemsAsync(
-                "sub1", "mycluster", "db1", "StormEvents | take 1",
-                Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
-                .Returns(expectedJson);
+            _kusto.QueryItemsWithStatisticsAsync(
+                "sub1",
+                "mycluster",
+                "db1",
+                "StormEvents | take 1",
+                false,
+                Arg.Any<string>(),
+                Arg.Any<AuthMethod?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+                .Returns((expectedJson, (JsonElement?)null));
         }
+
         var command = new QueryCommand(_logger);
 
         var args = command.GetCommand().Parse(cliArgs);
         var context = new CommandContext(_serviceProvider);
 
-        // Act
         var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
 
-        // Assert
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
         var json = JsonSerializer.Serialize(response.Results);
@@ -77,6 +86,7 @@ public sealed class QueryCommandTests
         var actualJson = result.Items[0].ToString();
         var expectedJsonText = expectedJson[0].ToString();
         Assert.Equal(expectedJsonText, actualJson);
+        Assert.Null(result.Statistics);
     }
 
     [Theory]
@@ -85,20 +95,32 @@ public sealed class QueryCommandTests
     {
         if (useClusterUri)
         {
-            _kusto.QueryItemsAsync(
+            _kusto.QueryItemsWithStatisticsAsync(
                 "https://mycluster.kusto.windows.net",
                 "db1",
                 "StormEvents | take 1",
-                Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
-                .Returns([]);
+                false,
+                Arg.Any<string>(),
+                Arg.Any<AuthMethod?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+                .Returns((new List<JsonElement>(), (JsonElement?)null));
         }
         else
         {
-            _kusto.QueryItemsAsync(
-                "sub1", "mycluster", "db1", "StormEvents | take 1",
-                Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
-                .Returns([]);
+            _kusto.QueryItemsWithStatisticsAsync(
+                "sub1",
+                "mycluster",
+                "db1",
+                "StormEvents | take 1",
+                false,
+                Arg.Any<string>(),
+                Arg.Any<AuthMethod?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+                .Returns((new List<JsonElement>(), (JsonElement?)null));
         }
+
         var command = new QueryCommand(_logger);
 
         var args = command.GetCommand().Parse(cliArgs);
@@ -115,26 +137,89 @@ public sealed class QueryCommandTests
     }
 
     [Theory]
+    [InlineData("--subscription sub1 --cluster mycluster --database db1 --query \"StormEvents | take 1\" --show-stats", false)]
+    [InlineData("--cluster-uri https://mycluster.kusto.windows.net --database db1 --query \"StormEvents | take 1\" --show-stats", true)]
+    public async Task ExecuteAsync_WithShowStats_ReturnsStatistics(string cliArgs, bool useClusterUri)
+    {
+        var expectedJson = JsonDocument.Parse("[{\"foo\":42}]").RootElement.EnumerateArray().Select(e => e.Clone()).ToList();
+        var statistics = JsonDocument.Parse("""{"execution_time_sec":1.23}""").RootElement.Clone();
+
+        if (useClusterUri)
+        {
+            _kusto.QueryItemsWithStatisticsAsync(
+                "https://mycluster.kusto.windows.net",
+                "db1",
+                "StormEvents | take 1",
+                true,
+                Arg.Any<string>(),
+                Arg.Any<AuthMethod?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+                .Returns((expectedJson, statistics));
+        }
+        else
+        {
+            _kusto.QueryItemsWithStatisticsAsync(
+                "sub1",
+                "mycluster",
+                "db1",
+                "StormEvents | take 1",
+                true,
+                Arg.Any<string>(),
+                Arg.Any<AuthMethod?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+                .Returns((expectedJson, statistics));
+        }
+
+        var command = new QueryCommand(_logger);
+        var args = command.GetCommand().Parse(cliArgs);
+        var context = new CommandContext(_serviceProvider);
+
+        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize(json, KustoJsonContext.Default.QueryCommandResult);
+        Assert.NotNull(result);
+        Assert.NotNull(result.Statistics);
+        Assert.Equal(statistics.GetProperty("execution_time_sec").GetDouble(), result.Statistics.Value.GetProperty("execution_time_sec").GetDouble());
+    }
+
+    [Theory]
     [MemberData(nameof(QueryArgumentMatrix))]
     public async Task ExecuteAsync_HandlesException_AndSetsException(string cliArgs, bool useClusterUri)
     {
         var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
         if (useClusterUri)
         {
-            _kusto.QueryItemsAsync(
+            _kusto.QueryItemsWithStatisticsAsync(
                 "https://mycluster.kusto.windows.net",
                 "db1",
                 "StormEvents | take 1",
-                Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromException<List<JsonElement>>(new Exception("Test error")));
+                false,
+                Arg.Any<string>(),
+                Arg.Any<AuthMethod?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+                .Returns(Task.FromException<(List<JsonElement> Items, JsonElement? Statistics)>(new Exception("Test error")));
         }
         else
         {
-            _kusto.QueryItemsAsync(
-                "sub1", "mycluster", "db1", "StormEvents | take 1",
-                Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromException<List<JsonElement>>(new Exception("Test error")));
+            _kusto.QueryItemsWithStatisticsAsync(
+                "sub1",
+                "mycluster",
+                "db1",
+                "StormEvents | take 1",
+                false,
+                Arg.Any<string>(),
+                Arg.Any<AuthMethod?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+                .Returns(Task.FromException<(List<JsonElement> Items, JsonElement? Statistics)>(new Exception("Test error")));
         }
+
         var command = new QueryCommand(_logger);
 
         var args = command.GetCommand().Parse(cliArgs);


### PR DESCRIPTION
## What does this PR do?
This PR updates the existing `kusto_query` tool to use Kusto query v2 response handling and adds an optional `--show-stats` parameter so users can retrieve execution statistics (CPU, memory, cache, extents, network, and cross-cluster breakdown) alongside query results.

It also updates tests and docs for the new behavior, keeps `/v1/rest/mgmt` unchanged, and adds a changelog entry.

## GitHub issue number?
Closes #1786

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated changelog entry under `servers/Azure.Mcp.Server/changelog-entries/`
- [x] For MCP tool changes:
    - [x] **One tool per PR**: This PR modifies only `kusto_query`
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using `eng/scripts/Process-PackageReadMe.ps1` (not applicable - README not changed)
    - [x] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md`
    - [x] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md
    - [x] For modified tool descriptions, ran `ToolDescriptionEvaluator` with score >= 0.4 and top-3 ranking for related prompts
    - [ ] For tools with new names, update `consolidated-tools.json` (not applicable - no new tool name)
- [x] Extra steps for **Azure MCP Server** tool changes:
    - [x] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`

### Validation run
- `dotnet build .\mcp.sln`
- `./eng/scripts/Test-Code.ps1 -Paths Kusto`
- MCP smoke test over stdio protocol (`initialize` + `tools/list` + `kusto_query`) against `https://help.kusto.windows.net` with and without `show-stats`

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.