### PR TITLE
Capture telemetry when CLI is used to invoke tools directly

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/CliToolCallCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/CliToolCallCommand.cs
@@ -1,0 +1,264 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using Azure.Mcp.Core.Areas.Server.Commands;
+using Azure.Mcp.Core.Areas.Server.Options;
+using Azure.Mcp.Core.Commands;
+using Azure.Mcp.Core.Logging;
+using Azure.Mcp.Core.Services.Azure;
+using Azure.Mcp.Core.Services.Azure.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Mcp.Core.Areas.Server.Options;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
+using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Core.Models.Option;
+using Microsoft.Mcp.Core.Services.Telemetry;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Mcp.Core.Areas.Server.Commands;
+
+/// <summary>
+/// Command that is ran when a CLI tool call is made, ex. 'dotnet azmcp.dll storage account get' or 'fabmcp publicapis list'.
+/// </summary>
+[HiddenCommand]
+public sealed class CliToolCallCommand : BaseCommand<CliToolCallOptions>
+{
+    private const string CommandTitle = "CLI Tool Call";
+
+    /// <summary>
+    /// Gets the name of the command.
+    /// </summary>
+    public override string Name => "cli-tool-call";
+
+
+    /// <summary>
+    /// Gets the description of the command.
+    /// </summary>
+    public override string Description => 
+        """
+        Handles tool calls made using a CLI instead of the MCP server, ex. 'dotnet azmcp.dll storage account get'
+        or 'fabmcp publicapis list'.
+        """;
+
+    /// <summary>
+    /// Gets the title of the command.
+    /// </summary>
+    public override string Title => CommandTitle;
+
+    /// <summary>
+    /// Gets the metadata for this command.
+    /// </summary>
+    // TODO (alzimmer): What to do about Metadata, as this can call any tool, so is everything true?
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
+
+    public static Action<IServiceCollection> ConfigureServices { get; set; } = _ => { };
+
+    public static Func<IServiceProvider, Task> InitializeServicesAsync { get; set; } = _ => Task.CompletedTask;
+
+    public override string Id => "e431dec9-3f08-49d0-aaf1-8a66a749ec78";
+
+    /// <summary>
+    /// Registers command options for the service start command.
+    /// </summary>
+    /// <param name="command">The command to register options with.</param>
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(ServiceOptionDefinitions.Tool.AsRequired());
+        command.Options.Add(ServiceOptionDefinitions.ReadOnly);
+        command.Options.Add(ServiceOptionDefinitions.Debug);
+        command.Options.Add(ServiceOptionDefinitions.DangerouslyDisableElicitation);
+        command.Options.Add(ServiceOptionDefinitions.DangerouslyWriteSupportLogsToDir);
+        command.Options.Add(ServiceOptionDefinitions.Cloud);
+        command.Validators.Add(ValidateSupportLoggingFolder);
+    }
+
+    /// <summary>
+    /// Validates that the support logging folder path is valid when specified.
+    /// </summary>
+    /// <param name="commandResult">Command result to update on failure.</param>
+    private static void ValidateSupportLoggingFolder(CommandResult commandResult)
+    {
+        string? folderPath = commandResult.GetValueOrDefault<string?>(ServiceOptionDefinitions.DangerouslyWriteSupportLogsToDir.Name);
+
+        if (folderPath is null)
+        {
+            return; // Option not specified, nothing to validate
+        }
+
+        // Validate the folder path is not empty or whitespace
+        if (string.IsNullOrWhiteSpace(folderPath))
+        {
+            commandResult.AddError("The --dangerously-write-support-logs-to-dir option requires a valid folder path.");
+            return;
+        }
+
+        // Validate the folder path is actually a valid path format
+        try
+        {
+            // GetFullPath will throw for invalid path characters and other path format issues
+            _ = Path.GetFullPath(folderPath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
+        {
+            commandResult.AddError($"The --dangerously-write-support-logs-to-dir option contains an invalid folder path '{folderPath}': {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Binds the parsed command line arguments to the CliToolCallOptions object.
+    /// </summary>
+    /// <param name="parseResult">The parsed command line arguments.</param>
+    /// <returns>A configured CliToolCallOptions instance.</returns>
+    protected override CliToolCallOptions BindOptions(ParseResult parseResult)
+    {
+        var options = new CliToolCallOptions
+        {
+            Namespace = parseResult.GetValueOrDefault<string[]?>(ServiceOptionDefinitions.Namespace.Name),
+            Mode = ModeTypes.All,
+            Tool = parseResult.GetValueOrDefault<string[]?>(ServiceOptionDefinitions.Tool.Name),
+            ReadOnly = parseResult.GetValueOrDefault<bool?>(ServiceOptionDefinitions.ReadOnly.Name),
+            Debug = parseResult.GetValueOrDefault<bool>(ServiceOptionDefinitions.Debug.Name),
+            DangerouslyDisableElicitation = parseResult.GetValueOrDefault<bool>(ServiceOptionDefinitions.DangerouslyDisableElicitation.Name),
+            OutgoingAuthStrategy = OutgoingAuthStrategy.UseHostingEnvironmentIdentity, // OBO is not supported for CLI tool calls as there is no incoming token to exchange
+            SupportLoggingFolder = parseResult.GetValueOrDefault<string?>(ServiceOptionDefinitions.DangerouslyWriteSupportLogsToDir.Name),
+            Cloud = parseResult.GetValueOrDefault<string?>(ServiceOptionDefinitions.Cloud.Name)
+        };
+        return options;
+    }
+
+    /// <summary>
+    /// Executes the CLI tool call command, creats and starts an MCP server, executes the tool call, and shutsdown the MCP server.
+    /// </summary>
+    /// <param name="context">The command execution context.</param>
+    /// <param name="parseResult">The parsed command options.</param>
+    /// <returns>A command response indicating the result of the operation.</returns>
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
+        var options = BindOptions(parseResult);
+
+        // Update the UserAgentPolicy for all Azure service calls to include the transport type.
+        BaseAzureService.InitializeUserAgentPolicy(TransportTypes.StdIo);
+
+        try
+        {
+            using var host = CreateStdioHost(options);
+
+            await InitializeServicesAsync(host.Services);
+
+            await host.StartAsync(cancellationToken);
+
+            var telemetryService = host.Services.GetRequiredService<ITelemetryService>();
+            LogCliToolCallTelemetry(telemetryService, options);
+
+            var commandFactory = host.Services.GetRequiredService<ICommandFactory>();
+            var rootCommand = commandFactory.RootCommand;
+            var commandParseResult = rootCommand.Parse(parseResult.UnmatchedTokens);
+            var status = await commandParseResult.InvokeAsync(cancellationToken: cancellationToken);
+
+            await host.StopAsync(cancellationToken);
+            await host.WaitForShutdownAsync(cancellationToken);
+
+            return context.Response;
+        }
+        catch (Exception ex)
+        {
+            HandleException(context, ex);
+            return context.Response;
+        }
+    }
+
+    internal static void LogCliToolCallTelemetry(ITelemetryService telemetryService, CliToolCallOptions options)
+    {
+        using var activity = telemetryService.StartActivity(ActivityName.CliToolCall);
+
+        if (activity != null)
+        {
+            activity.SetTag(TagName.Transport, TransportTypes.StdIo);
+            activity.SetTag(TagName.ServerMode, options.Mode);
+            activity.SetTag(TagName.IsReadOnly, options.ReadOnly);
+            activity.SetTag(TagName.DangerouslyDisableElicitation, options.DangerouslyDisableElicitation);
+            activity.SetTag(TagName.DangerouslyDisableHttpIncomingAuth, false);
+            activity.SetTag(TagName.IsDebug, options.Debug);
+            if (options.Tool != null && options.Tool.Length > 0)
+            {
+                activity.SetTag(TagName.Tool, string.Join(",", options.Tool));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Configures support logging when a support logging folder is specified.
+    /// This enables debug-level logging for troubleshooting and support purposes.
+    /// </summary>
+    /// <param name="logging">The logging builder to configure.</param>
+    /// <param name="options">The CLI tool call configuration options.</param>
+    private static void ConfigureSupportLogging(ILoggingBuilder logging, CliToolCallOptions options)
+    {
+        if (options.SupportLoggingFolder is null)
+        {
+            return;
+        }
+
+        // Set minimum log level to Debug when support logging is enabled
+        logging.SetMinimumLevel(LogLevel.Debug);
+
+        // Add file logging to the specified folder
+        logging.AddSupportFileLogging(options.SupportLoggingFolder);
+    }
+
+    /// <summary>
+    /// Creates a host for STDIO transport.
+    /// </summary>
+    /// <param name="options">The CLI tool call configuration options.</param>
+    /// <returns>An IHost instance configured for STDIO transport.</returns>
+    private IHost CreateStdioHost(CliToolCallOptions options)
+    {
+        return Host.CreateDefaultBuilder()
+            .ConfigureLogging(logging =>
+            {
+                logging.ClearProviders();
+                logging.AddEventSourceLogger();
+
+                if (options.Debug)
+                {
+                    // Configure console logger to emit Debug+ to stderr so tests can capture logs from StandardError
+                    logging.AddConsole(options =>
+                    {
+                        options.LogToStandardErrorThreshold = LogLevel.Debug;
+                        options.FormatterName = ConsoleFormatterNames.Simple;
+                    });
+                    logging.AddSimpleConsole(simple =>
+                    {
+                        simple.ColorBehavior = LoggerColorBehavior.Disabled;
+                        simple.IncludeScopes = false;
+                        simple.SingleLine = true;
+                        simple.TimestampFormat = "[HH:mm:ss] ";
+                    });
+                    logging.AddFilter("Microsoft.Extensions.Logging.Console.ConsoleLoggerProvider", LogLevel.Debug);
+                    logging.SetMinimumLevel(LogLevel.Debug);
+                }
+
+                ConfigureSupportLogging(logging, options);
+            })
+            .ConfigureServices(services =>
+            {
+                // Configure the outgoing authentication strategy.
+                services.AddSingleIdentityTokenCredentialProvider();
+
+                ConfigureServices(services);
+                services.AddAzureMcpServer(options);
+            })
+            .Build();
+    }
+}

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
@@ -6,10 +6,10 @@ using System.Net;
 using System.Text.Json.Nodes;
 using Azure.Mcp.Core.Areas.Server.Commands.Discovery;
 using Azure.Mcp.Core.Areas.Server.Models;
-using Azure.Mcp.Core.Areas.Server.Options;
 using Azure.Mcp.Core.Commands;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Mcp.Core.Areas.Server.Options;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Models.Command;
@@ -25,13 +25,13 @@ namespace Azure.Mcp.Core.Areas.Server.Commands.ToolLoading;
 /// </summary>
 public sealed class NamespaceToolLoader(
     ICommandFactory commandFactory,
-    IOptions<ServiceStartOptions> options,
+    IOptions<ServerOptions> options,
     IServiceProvider serviceProvider,
     ILogger<NamespaceToolLoader> logger,
     bool applyFilter = true) : BaseToolLoader(logger)
 {
     private readonly ICommandFactory _commandFactory = commandFactory ?? throw new ArgumentNullException(nameof(commandFactory));
-    private readonly IOptions<ServiceStartOptions> _options = options ?? throw new ArgumentNullException(nameof(options));
+    private readonly IOptions<ServerOptions> _options = options ?? throw new ArgumentNullException(nameof(options));
     private readonly IServiceProvider _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
 
     private readonly Lazy<IReadOnlyList<string>> _availableNamespaces = new(() =>

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Options/CliToolCallOptions.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Options/CliToolCallOptions.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Mcp.Core.Areas.Server.Options;
+
+/// <summary>
+/// Configuration options for CLI tool calls.
+/// </summary>
+public sealed class CliToolCallOptions : ServerOptions;

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Options/ServerOptions.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Options/ServerOptions.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using Azure.Mcp.Core.Areas.Server.Options;
+
+namespace Microsoft.Mcp.Core.Areas.Server.Options;
+
+/// <summary>
+/// Configuration options for CLI tool calls.
+/// </summary>
+public class ServerOptions
+{
+    /// <summary>
+    /// Gets or sets the service namespaces to expose through the server.
+    /// When null, all available namespaces are exposed.
+    /// </summary>
+    [JsonPropertyName("namespace")]
+    public string[]? Namespace { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets the mode mode for the server.
+    /// Defaults to 'namespace' mode which exposes one tool per service namespace.
+    /// </summary>
+    [JsonPropertyName("mode")]
+    public string? Mode { get; set; } = ModeTypes.NamespaceProxy;
+
+    /// <summary>
+    /// Gets or sets the specific tool names to expose.
+    /// When specified, only these tools will be available.
+    /// </summary>
+    [JsonPropertyName("tool")]
+    public string[]? Tool { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets whether the server should operate in read-only mode.
+    /// When true, only tools marked as read-only will be available.
+    /// </summary>
+    [JsonPropertyName("readOnly")]
+    public bool? ReadOnly { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets whether debug mode is enabled.
+    /// When true, verbose logging will be sent to stderr.
+    /// </summary>
+    [JsonPropertyName("debug")]
+    public bool Debug { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets whether elicitation (user confirmation for high-risk operations like accessing secrets) is disabled (dangerous mode).
+    /// When true, elicitation will always be treated as accepted without user confirmation.
+    /// </summary>
+    [JsonPropertyName("dangerouslyDisableElicitation")]
+    public bool DangerouslyDisableElicitation { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the outgoing authentication strategy for Azure service requests.
+    /// Determines whether to use hosting environment identity or on-behalf-of flow.
+    /// </summary>
+    [JsonPropertyName("outgoingAuthStrategy")]
+    public OutgoingAuthStrategy OutgoingAuthStrategy { get; set; } = OutgoingAuthStrategy.NotSet;
+
+    /// <summary>
+    /// Gets or sets the folder path for support logging.
+    /// When specified, detailed debug-level logging is enabled and logs are written to
+    /// automatically generated files in this folder with timestamp-based filenames.
+    /// Warning: This may include sensitive information in logs.
+    /// </summary>
+    [JsonPropertyName("supportLoggingFolder")]
+    public string? SupportLoggingFolder { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets the Azure cloud environment for authentication.
+    /// Supports well-known cloud names (AzureCloud, AzureChinaCloud, AzureUSGovernment)
+    /// or custom authority host URLs starting with https://.
+    /// </summary>
+    [JsonPropertyName("cloud")]
+    public string? Cloud { get; set; } = null;
+}

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Options/ServiceOptionDefinitions.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Options/ServiceOptionDefinitions.cs
@@ -24,9 +24,7 @@ public static class ServiceOptionDefinitions
         Required = false
     };
 
-    public static readonly Option<string[]?> Namespace = new(
-        $"--{NamespaceName}"
-    )
+    public static readonly Option<string[]?> Namespace = new($"--{NamespaceName}")
     {
         Description = "The Azure service namespaces to expose on the MCP server (e.g., storage, keyvault, cosmos).",
         Required = false,
@@ -35,9 +33,7 @@ public static class ServiceOptionDefinitions
         DefaultValueFactory = _ => null
     };
 
-    public static readonly Option<string?> Mode = new Option<string?>(
-        $"--{ModeName}"
-    )
+    public static readonly Option<string?> Mode = new($"--{ModeName}")
     {
         Description = "Mode for the MCP server. 'single' exposes one azure tool that routes to all services. 'namespace' (default) exposes one tool per service namespace. 'all' exposes all tools individually.",
         Required = false,
@@ -45,9 +41,7 @@ public static class ServiceOptionDefinitions
         DefaultValueFactory = _ => (string?)ModeTypes.NamespaceProxy
     };
 
-    public static readonly Option<string[]?> Tool = new Option<string[]?>(
-        $"--{ToolName}"
-    )
+    public static readonly Option<string[]?> Tool = new($"--{ToolName}")
     {
         Description = "Expose only specific tools by name (e.g., 'acr_registry_list'). Repeat this option to include multiple tools, e.g., --tool \"acr_registry_list\" --tool \"group_list\". It automatically switches to \"all\" mode when \"--tool\" is used. It can't be used together with \"--namespace\".",
         Required = false,
@@ -56,54 +50,47 @@ public static class ServiceOptionDefinitions
         DefaultValueFactory = _ => null
     };
 
-    public static readonly Option<bool?> ReadOnly = new(
-        $"--{ReadOnlyName}")
+    public static readonly Option<bool?> ReadOnly = new($"--{ReadOnlyName}")
     {
         Description = "Whether the MCP server should be read-only. If true, no write operations will be allowed.",
         DefaultValueFactory = _ => false
     };
 
-    public static readonly Option<bool> Debug = new(
-        $"--{DebugName}")
+    public static readonly Option<bool> Debug = new($"--{DebugName}")
     {
         Description = "Enable debug mode with verbose logging to stderr.",
         DefaultValueFactory = _ => false
     };
 
-    public static readonly Option<bool> DangerouslyDisableHttpIncomingAuth = new(
-        $"--{DangerouslyDisableHttpIncomingAuthName}")
+    public static readonly Option<bool> DangerouslyDisableHttpIncomingAuth = new($"--{DangerouslyDisableHttpIncomingAuthName}")
     {
         Required = false,
         Description = "Dangerously disables HTTP incoming authentication, exposing the server to unauthenticated access over HTTP. Use with extreme caution, this disables all transport security and may expose sensitive data to interception.",
         DefaultValueFactory = _ => false
     };
 
-    public static readonly Option<bool> DangerouslyDisableElicitation = new(
-        $"--{DangerouslyDisableElicitationName}")
+    public static readonly Option<bool> DangerouslyDisableElicitation = new($"--{DangerouslyDisableElicitationName}")
     {
         Required = false,
         Description = "Disable elicitation (user confirmation) before allowing high risk commands to run, such as returning Secrets (passwords) from KeyVault.",
         DefaultValueFactory = _ => false
     };
 
-    public static readonly Option<OutgoingAuthStrategy> OutgoingAuthStrategy = new(
-        $"--{OutgoingAuthStrategyName}")
+    public static readonly Option<OutgoingAuthStrategy> OutgoingAuthStrategy = new($"--{OutgoingAuthStrategyName}")
     {
         Required = false,
         Description = "Outgoing authentication strategy for Azure service requests. Valid values: NotSet, UseHostingEnvironmentIdentity, UseOnBehalfOf.",
         DefaultValueFactory = _ => Options.OutgoingAuthStrategy.NotSet
     };
 
-    public static readonly Option<string?> DangerouslyWriteSupportLogsToDir = new(
-        $"--{DangerouslyWriteSupportLogsToDirName}")
+    public static readonly Option<string?> DangerouslyWriteSupportLogsToDir = new($"--{DangerouslyWriteSupportLogsToDirName}")
     {
         Required = false,
         Description = "Dangerously enables detailed debug-level logging for support and troubleshooting purposes. Specify a folder path where log files will be automatically created with timestamp-based filenames (e.g., azmcp_20251202_143052.log). This may include sensitive information in logs. Use with extreme caution and only when requested by support.",
         DefaultValueFactory = _ => null
     };
 
-    public static readonly Option<string?> Cloud = new(
-        $"--{CloudName}")
+    public static readonly Option<string?> Cloud = new($"--{CloudName}")
     {
         Required = false,
         Description = "Azure cloud environment for authentication. Valid values: AzureCloud (default), AzureChinaCloud, AzureUSGovernment, or a custom authority host URL starting with https://",

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Options/ServiceStartOptions.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Options/ServiceStartOptions.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
+using Microsoft.Mcp.Core.Areas.Server.Options;
 
 namespace Azure.Mcp.Core.Areas.Server.Options;
 
 /// <summary>
 /// Configuration options for starting the Azure MCP server service.
 /// </summary>
-public class ServiceStartOptions
+public sealed class ServiceStartOptions : ServerOptions
 {
     /// <summary>
     /// Gets or sets the transport mechanism for the server.
@@ -18,75 +19,9 @@ public class ServiceStartOptions
     public string Transport { get; set; } = TransportTypes.StdIo;
 
     /// <summary>
-    /// Gets or sets the service namespaces to expose through the server.
-    /// When null, all available namespaces are exposed.
-    /// </summary>
-    [JsonPropertyName("namespace")]
-    public string[]? Namespace { get; set; } = null;
-
-    /// <summary>
-    /// Gets or sets the mode mode for the server.
-    /// Defaults to 'namespace' mode which exposes one tool per service namespace.
-    /// </summary>
-    [JsonPropertyName("mode")]
-    public string? Mode { get; set; } = ModeTypes.NamespaceProxy;
-
-    /// <summary>
-    /// Gets or sets the specific tool names to expose.
-    /// When specified, only these tools will be available.
-    /// </summary>
-    [JsonPropertyName("tool")]
-    public string[]? Tool { get; set; } = null;
-
-    /// <summary>
-    /// Gets or sets whether the server should operate in read-only mode.
-    /// When true, only tools marked as read-only will be available.
-    /// </summary>
-    [JsonPropertyName("readOnly")]
-    public bool? ReadOnly { get; set; } = null;
-
-    /// <summary>
-    /// Gets or sets whether debug mode is enabled.
-    /// When true, verbose logging will be sent to stderr.
-    /// </summary>
-    [JsonPropertyName("debug")]
-    public bool Debug { get; set; } = false;
-
-    /// <summary>
     /// Gets or sets whether HTTP incoming authentication is disabled.
     /// When true, the server accepts unauthenticated HTTP requests.
     /// </summary>
     [JsonPropertyName("dangerouslyDisableHttpIncomingAuth")]
     public bool DangerouslyDisableHttpIncomingAuth { get; set; } = false;
-
-    /// <summary>
-    /// Gets or sets whether elicitation (user confirmation for high-risk operations like accessing secrets) is disabled (dangerous mode).
-    /// When true, elicitation will always be treated as accepted without user confirmation.
-    /// </summary>
-    [JsonPropertyName("dangerouslyDisableElicitation")]
-    public bool DangerouslyDisableElicitation { get; set; } = false;
-
-    /// <summary>
-    /// Gets or sets the outgoing authentication strategy for Azure service requests.
-    /// Determines whether to use hosting environment identity or on-behalf-of flow.
-    /// </summary>
-    [JsonPropertyName("outgoingAuthStrategy")]
-    public OutgoingAuthStrategy OutgoingAuthStrategy { get; set; } = OutgoingAuthStrategy.NotSet;
-
-    /// <summary>
-    /// Gets or sets the folder path for support logging.
-    /// When specified, detailed debug-level logging is enabled and logs are written to
-    /// automatically generated files in this folder with timestamp-based filenames.
-    /// Warning: This may include sensitive information in logs.
-    /// </summary>
-    [JsonPropertyName("supportLoggingFolder")]
-    public string? SupportLoggingFolder { get; set; } = null;
-
-    /// <summary>
-    /// Gets or sets the Azure cloud environment for authentication.
-    /// Supports well-known cloud names (AzureCloud, AzureChinaCloud, AzureUSGovernment)
-    /// or custom authority host URLs starting with https://.
-    /// </summary>
-    [JsonPropertyName("cloud")]
-    public string? Cloud { get; set; } = null;
 }

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/ServerSetup.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/ServerSetup.cs
@@ -4,6 +4,7 @@
 using Azure.Mcp.Core.Areas.Server.Commands;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Mcp.Core.Areas;
+using Microsoft.Mcp.Core.Areas.Server.Commands;
 using Microsoft.Mcp.Core.Commands;
 
 namespace Azure.Mcp.Core.Areas.Server;
@@ -13,7 +14,8 @@ namespace Azure.Mcp.Core.Areas.Server;
 /// </summary>
 public sealed class ServerSetup : IAreaSetup
 {
-    public string Name => "server";
+    public const string AreaName = "server";
+    public string Name => AreaName;
 
     public string Title => "MCP Server Management";
 
@@ -27,6 +29,7 @@ public sealed class ServerSetup : IAreaSetup
     {
         services.AddSingleton<ServiceStartCommand>();
         services.AddSingleton<ServiceInfoCommand>();
+        services.AddSingleton<CliToolCallCommand>();
     }
 
     /// <summary>
@@ -45,6 +48,9 @@ public sealed class ServerSetup : IAreaSetup
 
         var infoCommand = serviceProvider.GetRequiredService<ServiceInfoCommand>();
         mcpServer.AddCommand(infoCommand.Name, infoCommand);
+
+        var cliToolCallCommand = serviceProvider.GetRequiredService<CliToolCallCommand>();
+        mcpServer.AddCommand(cliToolCallCommand.Name, cliToolCallCommand);
 
         return mcpServer;
     }

--- a/core/Microsoft.Mcp.Core/src/Commands/CommandFactory.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/CommandFactory.cs
@@ -208,7 +208,7 @@ public class CommandFactory : ICommandFactory
 
                 if (response.Status == HttpStatusCode.OK && response.Results == null)
                 {
-                    response.Results = ResponseResult.Create(new List<string>(), JsonSourceGenerationContext.Default.ListString);
+                    response.Results = ResponseResult.Create([], JsonSourceGenerationContext.Default.ListString);
                 }
 
                 var isServiceStartCommand = implementation is Areas.Server.Commands.ServiceStartCommand;

--- a/core/Microsoft.Mcp.Core/src/Commands/TelemetryConstants.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/TelemetryConstants.cs
@@ -41,6 +41,7 @@ public class ActivityName
     public const string ListToolsHandler = "ListToolsHandler";
     public const string ToolExecuted = "ToolExecuted";
     public const string ServerStarted = "ServerStarted";
+    public const string CliToolCall = "CliToolCall";
 }
 
 public class AppInsightsInstanceType

--- a/core/Microsoft.Mcp.Core/src/Extensions/OpenTelemetryExtensions.cs
+++ b/core/Microsoft.Mcp.Core/src/Extensions/OpenTelemetryExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Azure.Monitor.OpenTelemetry.Exporter;


### PR DESCRIPTION
## What does this PR do?

Adds a new hidden server command `cli-tool-call` that handles cases when the executable is called directly on the command-line for specific commands, such as `dotnet azmcp.dll storage account get` or `fabmcp publicapis list`.

In `Program.cs` for each server that wants to support capturing CLI tool call telemetry, a check will need to be made on whether the tool being called is the `ServiceStartCommand` (tool that starts the MCP server process) or not. If it is not `ServiceStartCommand`, additional handling will need to be performed to call `CliToolCallCommand` instead of the specific command requested based on the CLI arguments (ex, `StorageAccountGet`) and wrap that command invocation with `CliToolCallCommand`.

`CliToolCallCommand` is a pared down version of `ServiceStartCommand` where HTTP support is dropped (only TransportTypes.Stdio` is used), only `--mode all` is supported, and a specific `--tool` matching what was determined based on the CLI arguments must be passed. Since `TransportTypes.Stdio` is used, much of the validation and setup copied from `ServiceStartCommand` is removed.

This change introduces `ActivityName.CliToolCall` to differentiate CLI invocations from MCP tool invocations and now `ActivityName.CommandExecuted` should show up as the matching tool invocation telemetry instead of `ActivityName.ToolExecuted`.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
