### PR TITLE
Remove pipeline package parameters in favor of default values for Azure and Fabric MCP servers

### DIFF
--- a/servers/Azure.Mcp.Server/build.yml
+++ b/servers/Azure.Mcp.Server/build.yml
@@ -3,18 +3,6 @@ parameters:
   type: string
   values: [ none, internal, public ]
   default: 'none'
-- name: PackageDocker
-  type: boolean
-  default: true
-- name: PackageVSIX
-  type: boolean
-  default: true
-- name: PackagePyPI
-  type: boolean
-  default: true
-- name: PackageMCPB
-  type: boolean
-  default: true
 - name: IncludeNative
   type: boolean
   default: true
@@ -32,9 +20,9 @@ extends:
     ServerName: Azure.Mcp.Server
     PublishTarget: ${{ parameters.PublishTarget }}
     RunLiveTests: true
-    PackageDocker: ${{ parameters.PackageDocker }}
-    PackageVSIX: ${{ parameters.PackageVSIX }}
-    PackagePyPI: ${{ parameters.PackagePyPI }}
-    PackageMCPB: ${{ parameters.PackageMCPB }}
+    PackageDocker: true
+    PackageVSIX: true
+    PackagePyPI: true
+    PackageMCPB: true
     IncludeNative: ${{ parameters.IncludeNative }}
     TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}

--- a/servers/Fabric.Mcp.Server/build.yml
+++ b/servers/Fabric.Mcp.Server/build.yml
@@ -3,12 +3,6 @@ parameters:
   type: string
   values: [ none, internal, public ]
   default: 'none'
-- name: PackageDocker
-  type: boolean
-  default: true
-- name: PackageVSIX
-  type: boolean
-  default: true
 - name: IncludeNative
   type: boolean
   default: true
@@ -26,8 +20,8 @@ extends:
     ServerName: Fabric.Mcp.Server
     PublishTarget: ${{ parameters.PublishTarget }}
     RunLiveTests: true
-    PackageDocker: ${{ parameters.PackageDocker }}
-    PackageVSIX: ${{ parameters.PackageVSIX }}
+    PackageDocker: true
+    PackageVSIX: true
     PackagePyPI: false
     PackageMCPB: false
     IncludeNative: ${{ parameters.IncludeNative }}


### PR DESCRIPTION
## What does this PR do?
Removes package parameters from `build.yml` and sets default values directly for the Azure and Fabric MCP servers.

## GitHub issue number?
Fixes: #1769

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
