### PR TITLE
Rename webapps to webapp

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json
@@ -3228,7 +3228,7 @@
         }
       },
       "mappedToolList": [
-        "appservice_webapps_get"
+        "appservice_webapp_get"
       ]
     }
   ]

--- a/servers/Azure.Mcp.Server/changelog-entries/1772033017162.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1772033017162.yaml
@@ -1,3 +1,3 @@
 changes:
   - section: "Features Added"
-    description: "Added appservice_webapps_get command to retrieve details about Web Apps"
+    description: "Added appservice_webapp_get command to retrieve details about Web Apps"

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -547,25 +547,25 @@ azmcp appservice database add --subscription "my-subscription" \
 ```bash
 # Get App Service Web App details
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp appservice webapps get --subscription <subscription> \
-                             [--resource-group <resource-group>] \
-                             [--app <app>]
+azmcp appservice webapp get --subscription <subscription> \
+                            [--resource-group <resource-group>] \
+                            [--app <app>]
 
 # Examples:
 # List the App Service Web Apps details in a subscription
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp appservice webapps get --subscription "my-subscription"
+azmcp appservice webapp get --subscription "my-subscription"
 
 # List the App Service Web Apps details in a resource group
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp appservice webapps get --subscription "my-subscription" \
-                             --resource-group "my-resource-group"
+azmcp appservice webapp get --subscription "my-subscription" \
+                            --resource-group "my-resource-group"
 
 # Get the details for a specific App Service Web App
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp appservice webapps get --subscription "my-subscription" \
-                             --resource-group "my-resource-group" \
-                             --app "my-app"
+azmcp appservice webapp get --subscription "my-subscription" \
+                            --resource-group "my-resource-group" \
+                            --app "my-app"
 ```
 
 ### Azure CLI Operations

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -105,9 +105,9 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | appservice_database_add | Connect database <database_name> to my app service <app_name> using connection string <connection_string> in resource group <resource_group> |
 | appservice_database_add | Set up database <database_name> for app service <app_name> with connection string <connection_string> under resource group <resource_group> |
 | appservice_database_add | Configure database <database_name> for app service <app_name> with the connection string <connection_string> in resource group <resource_group> |
-| appservice_webapps_get | List the web apps in my subscription |
-| appservice_webapps_get | Show me the web apps in my <resource_group> resource group |
-| appservice_webapps_get | Get the details for web app <webapp> in <resource_group> |
+| appservice_webapp_get | List the web apps in my subscription |
+| appservice_webapp_get | Show me the web apps in my <resource_group> resource group |
+| appservice_webapp_get | Get the details for web app <webapp> in <resource_group> |
 
 ## Azure Application Insights
 

--- a/tools/Azure.Mcp.Tools.AppService/src/AppServiceSetup.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/AppServiceSetup.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.AppService.Commands.Database;
-using Azure.Mcp.Tools.AppService.Commands.Webapps;
+using Azure.Mcp.Tools.AppService.Commands.Webapp;
 using Azure.Mcp.Tools.AppService.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Mcp.Core.Areas;
@@ -20,7 +20,7 @@ public class AppServiceSetup : IAreaSetup
     {
         services.AddSingleton<IAppServiceService, AppServiceService>();
         services.AddSingleton<DatabaseAddCommand>();
-        services.AddSingleton<WebappsGetCommand>();
+        services.AddSingleton<WebappGetCommand>();
     }
 
     public CommandGroup RegisterCommands(IServiceProvider serviceProvider)
@@ -37,13 +37,13 @@ public class AppServiceSetup : IAreaSetup
         var databaseAdd = serviceProvider.GetRequiredService<DatabaseAddCommand>();
         database.AddCommand(databaseAdd.Name, databaseAdd);
 
-        // Create webapps subgroup
-        var webapps = new CommandGroup("webapps", "Operations for managing Azure App Service web apps");
-        appService.AddSubGroup(webapps);
+        // Create webapp subgroup
+        var webapp = new CommandGroup("webapp", "Operations for managing Azure App Service web apps");
+        appService.AddSubGroup(webapp);
 
-        // Add webapps commands
-        var webappsGet = serviceProvider.GetRequiredService<WebappsGetCommand>();
-        webapps.AddCommand(webappsGet.Name, webappsGet);
+        // Add webapp commands
+        var webappGet = serviceProvider.GetRequiredService<WebappGetCommand>();
+        webapp.AddCommand(webappGet.Name, webappGet);
 
         return appService;
     }

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/AppServiceJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/AppServiceJsonContext.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json.Serialization;
 using Azure.Mcp.Tools.AppService.Commands.Database;
-using Azure.Mcp.Tools.AppService.Commands.Webapps;
+using Azure.Mcp.Tools.AppService.Commands.Webapp;
 using Azure.Mcp.Tools.AppService.Models;
 
 namespace Azure.Mcp.Tools.AppService.Commands;
@@ -11,5 +11,5 @@ namespace Azure.Mcp.Tools.AppService.Commands;
 [JsonSerializable(typeof(DatabaseAddCommand.DatabaseAddResult))]
 [JsonSerializable(typeof(DatabaseConnectionInfo))]
 [JsonSerializable(typeof(WebappDetails))]
-[JsonSerializable(typeof(WebappsGetCommand.WebappsGetResult))]
+[JsonSerializable(typeof(WebappGetCommand.WebappGetResult))]
 public partial class AppServiceJsonContext : JsonSerializerContext;

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/WebappGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/WebappGetCommand.cs
@@ -4,7 +4,6 @@
 using Azure.Mcp.Core.Models.Option;
 using Azure.Mcp.Tools.AppService.Models;
 using Azure.Mcp.Tools.AppService.Options;
-using Azure.Mcp.Tools.AppService.Options.Webapps;
 using Azure.Mcp.Tools.AppService.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
@@ -12,12 +11,12 @@ using Microsoft.Mcp.Core.Extensions;
 using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Models.Option;
 
-namespace Azure.Mcp.Tools.AppService.Commands.Webapps;
+namespace Azure.Mcp.Tools.AppService.Commands.Webapp;
 
-public sealed class WebappsGetCommand(ILogger<WebappsGetCommand> logger) : BaseAppServiceCommand<WebappsGetOptions>()
+public sealed class WebappGetCommand(ILogger<WebappGetCommand> logger) : BaseAppServiceCommand<BaseAppServiceOptions>()
 {
     private const string CommandTitle = "Gets Azure App Service Web App Details";
-    private readonly ILogger<WebappsGetCommand> _logger = logger;
+    private readonly ILogger<WebappGetCommand> _logger = logger;
     public override string Id => "4412f1af-16e7-46db-8305-33e3d7ae06de";
     public override string Name => "get";
 
@@ -56,7 +55,7 @@ public sealed class WebappsGetCommand(ILogger<WebappsGetCommand> logger) : BaseA
         });
     }
 
-    protected override WebappsGetOptions BindOptions(ParseResult parseResult)
+    protected override BaseAppServiceOptions BindOptions(ParseResult parseResult)
     {
         var options = base.BindOptions(parseResult);
         options.AppName = parseResult.GetValueOrDefault<string>(AppServiceOptionDefinitions.AppServiceName.Name);
@@ -78,7 +77,7 @@ public sealed class WebappsGetCommand(ILogger<WebappsGetCommand> logger) : BaseA
             context.Activity?.AddTag("subscription", options.Subscription);
 
             var appServiceService = context.GetService<IAppServiceService>();
-            var webappsDetails = await appServiceService.GetWebAppsAsync(
+            var webapps = await appServiceService.GetWebAppsAsync(
                 options.Subscription!,
                 options.ResourceGroup,
                 options.AppName,
@@ -86,7 +85,7 @@ public sealed class WebappsGetCommand(ILogger<WebappsGetCommand> logger) : BaseA
                 options.RetryPolicy,
                 cancellationToken);
 
-            context.Response.Results = ResponseResult.Create(new(webappsDetails), AppServiceJsonContext.Default.WebappsGetResult);
+            context.Response.Results = ResponseResult.Create(new(webapps), AppServiceJsonContext.Default.WebappGetResult);
         }
         catch (Exception ex)
         {
@@ -113,5 +112,5 @@ public sealed class WebappsGetCommand(ILogger<WebappsGetCommand> logger) : BaseA
         return context.Response;
     }
 
-    public record WebappsGetResult(List<WebappDetails> WebappDetails);
+    public record WebappGetResult(List<WebappDetails> Webapps);
 }

--- a/tools/Azure.Mcp.Tools.AppService/src/Options/Webapps/WebappsGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Options/Webapps/WebappsGetOptions.cs
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-namespace Azure.Mcp.Tools.AppService.Options.Webapps;
-
-public class WebappsGetOptions : BaseAppServiceOptions;

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/WebappGetCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/WebappGetCommandLiveTests.cs
@@ -8,10 +8,11 @@ using Azure.Mcp.Tests.Generated.Models;
 using Azure.Mcp.Tools.AppService.Commands;
 using Xunit;
 
-namespace Azure.Mcp.Tools.AppService.LiveTests.Webapps;
+namespace Azure.Mcp.Tools.AppService.LiveTests.Webapp;
 
-[Trait("Command", "WebappsGetCommand")]
-public class WebappsGetCommandLiveTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture) : RecordedCommandTestsBase(output, fixture, liveServerFixture)
+[Trait("Command", "WebappGetCommand")]
+public class WebappGetCommandLiveTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
+    : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
     public override List<BodyKeySanitizer> BodyKeySanitizers =>
     [
@@ -37,16 +38,16 @@ public class WebappsGetCommandLiveTests(ITestOutputHelper output, TestProxyFixtu
         var expectedWebappName = TestMode == Tests.Helpers.TestMode.Playback ? "Sanitized" : webappName;
 
         var result = await CallToolAsync(
-            "appservice_webapps_get",
+            "appservice_webapp_get",
             new()
             {
                 { "subscription", Settings.SubscriptionId }
             });
 
-        var getResult = JsonSerializer.Deserialize(result.Value.ToString(), AppServiceJsonContext.Default.WebappsGetResult);
+        var getResult = JsonSerializer.Deserialize(result.Value.ToString(), AppServiceJsonContext.Default.WebappGetResult);
         Assert.NotNull(getResult);
-        Assert.NotEmpty(getResult.WebappDetails);
-        Assert.True(getResult.WebappDetails.Any(detail => detail.Name == expectedWebappName), $"Expected to find web app with name '{expectedWebappName}' in the results.");
+        Assert.NotEmpty(getResult.Webapps);
+        Assert.True(getResult.Webapps.Any(detail => detail.Name == expectedWebappName), $"Expected to find web app with name '{expectedWebappName}' in the results.");
     }
 
     [Fact]
@@ -57,17 +58,17 @@ public class WebappsGetCommandLiveTests(ITestOutputHelper output, TestProxyFixtu
         var resourceGroupName = RegisterOrRetrieveVariable("resourceGroupName", Settings.ResourceGroupName);
 
         var result = await CallToolAsync(
-            "appservice_webapps_get",
+            "appservice_webapp_get",
             new()
             {
                 { "subscription", Settings.SubscriptionId },
                 { "resource-group", resourceGroupName }
             });
 
-        var getResult = JsonSerializer.Deserialize(result.Value.ToString(), AppServiceJsonContext.Default.WebappsGetResult);
+        var getResult = JsonSerializer.Deserialize(result.Value.ToString(), AppServiceJsonContext.Default.WebappGetResult);
         Assert.NotNull(getResult);
-        Assert.NotEmpty(getResult.WebappDetails);
-        Assert.True(getResult.WebappDetails.Any(detail => detail.Name == expectedWebappName), $"Expected to find web app with name '{expectedWebappName}' in the results.");
+        Assert.NotEmpty(getResult.Webapps);
+        Assert.True(getResult.Webapps.Any(detail => detail.Name == expectedWebappName), $"Expected to find web app with name '{expectedWebappName}' in the results.");
     }
 
     [Fact]
@@ -79,7 +80,7 @@ public class WebappsGetCommandLiveTests(ITestOutputHelper output, TestProxyFixtu
         var resourceGroupName = RegisterOrRetrieveVariable("resourceGroupName", Settings.ResourceGroupName);
 
         var result = await CallToolAsync(
-            "appservice_webapps_get",
+            "appservice_webapp_get",
             new()
             {
                 { "subscription", Settings.SubscriptionId },
@@ -87,9 +88,9 @@ public class WebappsGetCommandLiveTests(ITestOutputHelper output, TestProxyFixtu
                 { "app", webappName }
             });
 
-        var getResult = JsonSerializer.Deserialize(result.Value.ToString(), AppServiceJsonContext.Default.WebappsGetResult);
+        var getResult = JsonSerializer.Deserialize(result.Value.ToString(), AppServiceJsonContext.Default.WebappGetResult);
         Assert.NotNull(getResult);
-        Assert.Single(getResult.WebappDetails);
-        Assert.True(getResult.WebappDetails.All(detail => detail.Name == expectedWebappName), $"Expected to find a single web app with name '{expectedWebappName}' in the results.");
+        Assert.Single(getResult.Webapps);
+        Assert.True(getResult.Webapps.All(detail => detail.Name == expectedWebappName), $"Expected to find a single web app with name '{expectedWebappName}' in the results.");
     }
 }

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/assets.json
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/assets.json
@@ -2,5 +2,5 @@
     "AssetsRepo": "Azure/azure-sdk-assets",
     "AssetsRepoPrefixPath": "",
     "TagPrefix": "Azure.Mcp.Tools.AppService.LiveTests",
-    "Tag": "Azure.Mcp.Tools.AppService.LiveTests_b5ec999257"
+    "Tag": "Azure.Mcp.Tools.AppService.LiveTests_676b0065fe"
 }

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/WebappGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/WebappGetCommandTests.cs
@@ -6,7 +6,7 @@ using System.Net;
 using System.Text.Json;
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Tools.AppService.Commands;
-using Azure.Mcp.Tools.AppService.Commands.Webapps;
+using Azure.Mcp.Tools.AppService.Commands.Webapp;
 using Azure.Mcp.Tools.AppService.Models;
 using Azure.Mcp.Tools.AppService.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,22 +16,22 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
-namespace Azure.Mcp.Tools.AppService.UnitTests.Commands.Webapps;
+namespace Azure.Mcp.Tools.AppService.UnitTests.Commands.Webapp;
 
-[Trait("Command", "WebappsGet")]
-public class WebappsGetCommandTests
+[Trait("Command", "WebappGet")]
+public class WebappGetCommandTests
 {
     private readonly IAppServiceService _appServiceService;
     private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<WebappsGetCommand> _logger;
-    private readonly WebappsGetCommand _command;
+    private readonly ILogger<WebappGetCommand> _logger;
+    private readonly WebappGetCommand _command;
     private readonly CommandContext _context;
     private readonly Command _commandDefinition;
 
-    public WebappsGetCommandTests()
+    public WebappGetCommandTests()
     {
         _appServiceService = Substitute.For<IAppServiceService>();
-        _logger = Substitute.For<ILogger<WebappsGetCommand>>();
+        _logger = Substitute.For<ILogger<WebappGetCommand>>();
 
         var collection = new ServiceCollection().AddSingleton(_appServiceService);
         _serviceProvider = collection.BuildServiceProvider();
@@ -81,10 +81,10 @@ public class WebappsGetCommandTests
         Assert.NotNull(response.Results);
 
         var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AppServiceJsonContext.Default.WebappsGetResult);
+        var result = JsonSerializer.Deserialize(json, AppServiceJsonContext.Default.WebappGetResult);
 
         Assert.NotNull(result);
-        Assert.Equal(JsonSerializer.Serialize(expectedWebappDetails), JsonSerializer.Serialize(result.WebappDetails));
+        Assert.Equal(JsonSerializer.Serialize(expectedWebappDetails), JsonSerializer.Serialize(result.Webapps));
     }
 
     [Theory]


### PR DESCRIPTION
## What does this PR do?

Renames the `webapps` group in App Service to `webapp` to follow other resource concepts where they use singular (`blob`, `table`, etc).

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
