### PR TITLE
Add ElicitationRequired to ToolMetadata

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
@@ -335,7 +335,7 @@ public sealed class NamespaceToolLoader(
 
             // Check if this tool requires elicitation for sensitive data
             var metadata = cmd.Metadata;
-            if (metadata.Secret)
+            if (metadata.Secret || metadata.ElicitationRequired)
             {
                 var elicitationResult = await HandleSecretElicitationAsync(
                     request,

--- a/core/Microsoft.Mcp.Core/src/Commands/ToolMetadata.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/ToolMetadata.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
-using Azure.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Metadata;
 
 namespace Microsoft.Mcp.Core.Commands;
@@ -14,19 +13,6 @@ namespace Microsoft.Mcp.Core.Commands;
 [JsonConverter(typeof(ToolMetadataConverter))]
 public sealed class ToolMetadata
 {
-    private bool _destructive = true;
-    private bool _idempotent = false;
-    private bool _openWorld = true;
-    private bool _readOnly = false;
-    private bool _secret = false;
-    private bool _localRequired = false;
-
-    private MetadataDefinition? _destructiveProperty;
-    private MetadataDefinition? _idempotentProperty;
-    private MetadataDefinition? _openWorldProperty;
-    private MetadataDefinition? _readOnlyProperty;
-    private MetadataDefinition? _secretProperty;
-    private MetadataDefinition? _localRequiredProperty;
     /// <summary>
     /// Gets or sets whether the tool may perform destructive updates to its environment.
     /// </summary>
@@ -41,18 +27,14 @@ public sealed class ToolMetadata
     /// </para>
     /// </remarks>
     [JsonIgnore]
-    public bool Destructive
-    {
-        get => _destructive;
-        init => _destructive = value;
-    }
+    public bool Destructive { get; init; } = true;
 
 
     [JsonPropertyName("destructive")]
-    public MetadataDefinition DestructiveProperty => _destructiveProperty ??= new MetadataDefinition
+    public MetadataDefinition DestructiveProperty => field ??= new MetadataDefinition
     {
-        Value = _destructive,
-        Description = _destructive
+        Value = Destructive,
+        Description = Destructive
             ? "This tool may delete or modify existing resources in its environment."
             : "This tool performs only additive updates without deleting or modifying existing resources."
     };
@@ -70,17 +52,13 @@ public sealed class ToolMetadata
     /// </para>
     /// </remarks>
     [JsonIgnore]
-    public bool Idempotent
-    {
-        get => _idempotent;
-        init => _idempotent = value;
-    }
+    public bool Idempotent { get; init; } = false;
 
     [JsonPropertyName("idempotent")]
-    public MetadataDefinition IdempotentProperty => _idempotentProperty ??= new MetadataDefinition
+    public MetadataDefinition IdempotentProperty => field ??= new MetadataDefinition
     {
-        Value = _idempotent,
-        Description = _idempotent
+        Value = Idempotent,
+        Description = Idempotent
             ? "Running this operation multiple times with the same arguments produces the same result without additional effects."
             : "Running this operation multiple times with the same arguments may have additional effects or produce different results."
     };
@@ -98,17 +76,13 @@ public sealed class ToolMetadata
     /// </para>
     /// </remarks>
     [JsonIgnore]
-    public bool OpenWorld
-    {
-        get => _openWorld;
-        init => _openWorld = value;
-    }
+    public bool OpenWorld { get; init; } = true;
 
     [JsonPropertyName("openWorld")]
-    public MetadataDefinition OpenWorldProperty => _openWorldProperty ??= new MetadataDefinition
+    public MetadataDefinition OpenWorldProperty => field ??= new MetadataDefinition
     {
-        Value = _openWorld,
-        Description = _openWorld
+        Value = OpenWorld,
+        Description = OpenWorld
             ? "This tool may interact with an unpredictable or dynamic set of entities (like web search)."
             : "This tool's domain of interaction is closed and well-defined, limited to a specific set of entities (like memory access)."
     };
@@ -130,17 +104,13 @@ public sealed class ToolMetadata
     /// </para>
     /// </remarks>
     [JsonIgnore]
-    public bool ReadOnly
-    {
-        get => _readOnly;
-        init => _readOnly = value;
-    }
+    public bool ReadOnly { get; init; } = false;
 
     [JsonPropertyName("readOnly")]
-    public MetadataDefinition ReadOnlyProperty => _readOnlyProperty ??= new MetadataDefinition
+    public MetadataDefinition ReadOnlyProperty => field ??= new MetadataDefinition
     {
-        Value = _readOnly,
-        Description = _readOnly
+        Value = ReadOnly,
+        Description = ReadOnly
             ? "This tool only performs read operations without modifying any state or data."
             : "This tool may modify its environment and perform write operations (create, update, delete)."
     };
@@ -162,19 +132,43 @@ public sealed class ToolMetadata
     /// </para>
     /// </remarks>
     [JsonIgnore]
-    public bool Secret
-    {
-        get => _secret;
-        init => _secret = value;
-    }
+    public bool Secret { get; init; } = false;
 
     [JsonPropertyName("secret")]
-    public MetadataDefinition SecretProperty => _secretProperty ??= new MetadataDefinition
+    public MetadataDefinition SecretProperty => field ??= new MetadataDefinition
     {
-        Value = _secret,
-        Description = _secret
+        Value = Secret,
+        Description = Secret
             ? "This tool handles sensitive data such as secrets, credentials, keys, or other confidential information."
             : "This tool does not handle sensitive or secret information."
+    };
+
+    /// <summary>
+    /// Gets or sets whether this tool requires elicitation to gather user input before execution.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If <see langword="true"/>, the tool requires elicitation to gather user input before execution.
+    /// If <see langword="false"/>, the tool can be executed without additional user input.
+    /// </para>
+    /// <para>
+    /// This metadata helps MCP clients understand when they need to trigger elicitation flows to gather necessary
+    /// information from users before executing the tool.
+    /// </para>
+    /// <para>
+    /// The default is <see langword="false"/>.
+    /// </para>
+    /// </remarks>
+    [JsonIgnore]
+    public bool ElicitationRequired { get; init; } = false;
+
+    [JsonPropertyName("elicitationRequired")]
+    public MetadataDefinition ElicitationRequiredProperty => field ??= new MetadataDefinition
+    {
+        Value = ElicitationRequired,
+        Description = ElicitationRequired
+            ? "This tool requires elicitation to gather user input before execution."
+            : "This tool does not require elicitation and can be executed without additional user input."
     };
 
     /// <summary>
@@ -194,20 +188,16 @@ public sealed class ToolMetadata
     /// </para>
     /// </remarks>
     [JsonIgnore]
-    public bool LocalRequired
-    {
-        get => _localRequired;
-        init => _localRequired = value;
-    }
+    public bool LocalRequired { get; init; } = false;
 
     /// <summary>
     /// Gets the localRequired metadata property with value and description for serialization.
     /// </summary>
     [JsonPropertyName("localRequired")]
-    public MetadataDefinition LocalRequiredProperty => _localRequiredProperty ??= new MetadataDefinition
+    public MetadataDefinition LocalRequiredProperty => field ??= new MetadataDefinition
     {
-        Value = _localRequired,
-        Description = _localRequired
+        Value = LocalRequired,
+        Description = LocalRequired
             ? "This tool is only available when the Azure MCP server is configured to run as a Local MCP Server (STDIO)."
             : "This tool is available in both local and remote server modes."
     };
@@ -227,14 +217,16 @@ public sealed class ToolMetadata
         MetadataDefinition openWorld,
         MetadataDefinition readOnly,
         MetadataDefinition secret,
-        MetadataDefinition localRequired)
+        MetadataDefinition localRequired,
+        MetadataDefinition elicitationRequired)
     {
-        _destructive = destructive?.Value ?? true;
-        _idempotent = idempotent?.Value ?? false;
-        _openWorld = openWorld?.Value ?? true;
-        _readOnly = readOnly?.Value ?? false;
-        _secret = secret?.Value ?? false;
-        _localRequired = localRequired?.Value ?? false;
+        Destructive = destructive?.Value ?? true;
+        Idempotent = idempotent?.Value ?? false;
+        OpenWorld = openWorld?.Value ?? true;
+        ReadOnly = readOnly?.Value ?? false;
+        Secret = secret?.Value ?? false;
+        LocalRequired = localRequired?.Value ?? false;
+        ElicitationRequired = elicitationRequired?.Value ?? false;
     }
 
 }

--- a/core/Microsoft.Mcp.Core/src/Commands/ToolMetadataJsonConverter.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/ToolMetadataJsonConverter.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using Azure.Mcp.Core.Areas.Server;
-using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Metadata;
 
-namespace Azure.Mcp.Core.Commands;
+namespace Microsoft.Mcp.Core.Commands;
 
 /// <summary>
 /// Custom JSON converter for <see cref="ToolMetadata"/> that handles serialization and deserialization
@@ -35,7 +33,8 @@ public sealed class ToolMetadataConverter : JsonConverter<ToolMetadata>
             GetMetadata("openWorld", true),
             GetMetadata("readOnly", false),
             GetMetadata("secret", false),
-            GetMetadata("localRequired", false)
+            GetMetadata("localRequired", false),
+            GetMetadata("elicitationRequired", false)
         );
     }
 
@@ -55,6 +54,7 @@ public sealed class ToolMetadataConverter : JsonConverter<ToolMetadata>
         WriteMetadata("readOnly", value.ReadOnlyProperty);
         WriteMetadata("secret", value.SecretProperty);
         WriteMetadata("localRequired", value.LocalRequiredProperty);
+        WriteMetadata("elicitationRequired", value.ElicitationRequiredProperty);
 
         writer.WriteEndObject();
     }

--- a/core/Microsoft.Mcp.Core/src/Extensions/McpServerElicitationExtensions.cs
+++ b/core/Microsoft.Mcp.Core/src/Extensions/McpServerElicitationExtensions.cs
@@ -60,9 +60,7 @@ public static class McpServerElicitationExtensions
     /// <param name="server">The MCP server instance.</param>
     /// <returns>True if the client supports elicitation, false otherwise.</returns>
     public static bool SupportsElicitation(this McpServer server)
-    {
-        return server?.ClientCapabilities?.Elicitation != null;
-    }
+        => server?.ClientCapabilities?.Elicitation != null;
 
     /// <summary>
     /// Checks if elicitation should be triggered for a tool based on its metadata.
@@ -81,10 +79,17 @@ public static class McpServerElicitationExtensions
         // Check if the metadata indicates this is a secret/sensitive tool
         if (toolMetadata is JsonObject jsonMetadata)
         {
-            return jsonMetadata.TryGetPropertyValue("Secret", out var secretValue) &&
-                   secretValue is JsonValue jsonValue &&
-                   jsonValue.TryGetValue(out bool isSecret) &&
-                   isSecret;
+            var secret = jsonMetadata.TryGetPropertyValue("Secret", out var secretValue) &&
+                secretValue is JsonValue jsonValue &&
+                jsonValue.TryGetValue(out bool isSecret) &&
+                isSecret;
+
+            var elicitationRequired = jsonMetadata.TryGetPropertyValue("ElicitationRequired", out var elicitationValue) &&
+                elicitationValue is JsonValue elicitationJsonValue &&
+                elicitationJsonValue.TryGetValue(out bool isElicitationRequired) &&
+                isElicitationRequired;
+
+            return secret || elicitationRequired;
         }
 
         return false;


### PR DESCRIPTION
## What does this PR do?

Adds `ElicitationRequired` to `ToolMetadata` to allow tools to denote that they require elicitation before the tool can run. This allows for tools to elicit without needing to be marked as `Secret`, which affects other areas of the server other than the elicitation requirement before running the tool.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
