### PR TITLE
Add ElicitationRequired to BaseCommand

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -149,7 +149,7 @@ public sealed class CommandFactoryToolLoader(
 
         // Check if this tool requires elicitation for sensitive data
         var metadata = command.Metadata;
-        if (metadata.Secret)
+        if (metadata.Secret || command.ElicitationRequired)
         {
             var elicitationResult = await HandleSecretElicitationAsync(
                 request,

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
@@ -335,7 +335,7 @@ public sealed class NamespaceToolLoader(
 
             // Check if this tool requires elicitation for sensitive data
             var metadata = cmd.Metadata;
-            if (metadata.Secret)
+            if (metadata.Secret || cmd.ElicitationRequired)
             {
                 var elicitationResult = await HandleSecretElicitationAsync(
                     request,

--- a/core/Microsoft.Mcp.Core/src/Commands/BaseCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/BaseCommand.cs
@@ -31,6 +31,7 @@ public abstract class BaseCommand<TOptions> : IBaseCommand where TOptions : clas
     public abstract string Description { get; }
     public abstract string Title { get; }
     public abstract ToolMetadata Metadata { get; }
+    public virtual bool ElicitationRequired => Metadata.Secret;
 
     protected virtual void RegisterOptions(Command command)
     {

--- a/core/Microsoft.Mcp.Core/src/Commands/IBaseCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/IBaseCommand.cs
@@ -41,6 +41,12 @@ public interface IBaseCommand
     /// </summary>
     ToolMetadata Metadata { get; }
 
+    /// <summary> Gets a value indicating whether elicitation is required for this command.
+    /// If <see langword="true"/>, the MCP client should prompt the user for additional information before executing the command.
+    /// This is typically used for commands that require sensitive information (Metadata.Secret = true) or have other characteristics that necessitate user confirmation or input.
+    /// </summary>
+    bool ElicitationRequired { get; }
+
     /// <summary>
     /// Gets the command definition
     /// </summary>


### PR DESCRIPTION
## What does this PR do?

Adds `ElicitationRequired` to `IBaseCommand`, with default implementation in `BaseCommand` pointing to `ToolMetadata.Secret`, to allow tools to denote that they require elicitation before the tool can run. This allows for tools to elicit without needing to be marked as `Secret`, which affects other areas of the server other than the elicitation requirement before running the tool.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Azure.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
