### PR TITLE
fix(fabric): isolate tenant-switch auth path for cross-tenant MFA flows (#1797)

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Services/Azure/Authentication/CustomChainedCredentialTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Services/Azure/Authentication/CustomChainedCredentialTests.cs
@@ -443,7 +443,7 @@ public class CustomChainedCredentialTests
     /// <summary>
     /// Helper method to create CustomChainedCredential using reflection since it's an internal class.
     /// </summary>
-    private static TokenCredential CreateCustomChainedCredential(bool forceBrowserFallback = false)
+    private static TokenCredential CreateCustomChainedCredential(bool forceBrowserFallback = false, bool isolateTenantAuth = false)
     {
         var assembly = typeof(global::Microsoft.Mcp.Core.Services.Azure.Authentication.IAzureTokenCredentialProvider).Assembly;
         var customChainedCredentialType = assembly.GetType("Microsoft.Mcp.Core.Services.Azure.Authentication.CustomChainedCredential");
@@ -454,18 +454,34 @@ public class CustomChainedCredentialTests
             .FirstOrDefault(c =>
             {
                 var parameters = c.GetParameters();
-                return parameters.Length == 3 &&
+                return parameters.Length == 4 &&
                        parameters[0].ParameterType == typeof(string) &&
                        parameters[1].ParameterType == typeof(ILogger<>).MakeGenericType(customChainedCredentialType) &&
-                       parameters[2].ParameterType == typeof(bool);
+                       parameters[2].ParameterType == typeof(bool) &&
+                       parameters[3].ParameterType == typeof(bool);
             });
 
         Assert.NotNull(constructor);
 
-        var credential = constructor.Invoke([null, null, forceBrowserFallback]) as TokenCredential;
+        var credential = constructor.Invoke([null, null, forceBrowserFallback, isolateTenantAuth]) as TokenCredential;
         Assert.NotNull(credential);
 
         return credential;
+    }
+
+    /// <summary>
+    /// Tests that isolateTenantAuth=true creates a credential successfully for cross-tenant flows.
+    /// Expected: Returns a tenant-isolated credential that bypasses sticky broker account and cached auth records.
+    /// </summary>
+    [Fact]
+    public void IsolateTenantAuth_CreatesCredentialSuccessfully()
+    {
+        // Act
+        var credential = CreateCustomChainedCredential(isolateTenantAuth: true);
+
+        // Assert
+        Assert.NotNull(credential);
+        Assert.IsAssignableFrom<TokenCredential>(credential);
     }
 
     private static Type GetCustomChainedCredentialType()

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Services/Azure/Authentication/CustomChainedCredentialTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Services/Azure/Authentication/CustomChainedCredentialTests.cs
@@ -470,18 +470,45 @@ public class CustomChainedCredentialTests
     }
 
     /// <summary>
-    /// Tests that isolateTenantAuth=true creates a credential successfully for cross-tenant flows.
-    /// Expected: Returns a tenant-isolated credential that bypasses sticky broker account and cached auth records.
+    /// Tests that isolateTenantAuth=true bypasses a cached auth record, forcing a fresh login.
+    /// Expected: CreateCredential succeeds even when AZURE_MCP_AUTHENTICATION_RECORD contains invalid JSON,
+    /// because the early-return path never reads it.
     /// </summary>
     [Fact]
-    public void IsolateTenantAuth_CreatesCredentialSuccessfully()
+    public void IsolateTenantAuth_IgnoresCachedAuthRecord()
     {
-        // Act
-        var credential = CreateCustomChainedCredential(isolateTenantAuth: true);
+        using var env = new EnvironmentScope("AZURE_MCP_AUTHENTICATION_RECORD", "AZURE_TOKEN_CREDENTIALS");
+        Environment.SetEnvironmentVariable("AZURE_MCP_AUTHENTICATION_RECORD", "not-valid-json");
 
-        // Assert
-        Assert.NotNull(credential);
-        Assert.IsAssignableFrom<TokenCredential>(credential);
+        var type = GetCustomChainedCredentialType();
+        var createCredential = type.GetMethod("CreateCredential", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(createCredential);
+
+        // With isolation + non-null tenantId: fires before reading the auth record — must not throw
+        var result = createCredential.Invoke(null, ["test-tenant-id", null, false, true]);
+        Assert.NotNull(result);
+        Assert.IsAssignableFrom<TokenCredential>(result);
+    }
+
+    /// <summary>
+    /// Tests that isolateTenantAuth=true respects prod mode — no interactive browser in non-interactive environments.
+    /// Expected: When AZURE_TOKEN_CREDENTIALS=prod, the isolation early-return is skipped and the
+    /// prod credential chain is returned instead.
+    /// </summary>
+    [Fact]
+    public void IsolateTenantAuth_RespectsProductionMode()
+    {
+        using var env = new EnvironmentScope("AZURE_TOKEN_CREDENTIALS");
+        Environment.SetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS", "prod");
+
+        var type = GetCustomChainedCredentialType();
+        var createCredential = type.GetMethod("CreateCredential", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(createCredential);
+
+        // In prod mode, isolation early-return is skipped — must return the prod chain credential
+        var result = createCredential.Invoke(null, ["test-tenant-id", null, false, true]);
+        Assert.NotNull(result);
+        Assert.IsAssignableFrom<TokenCredential>(result);
     }
 
     private static Type GetCustomChainedCredentialType()

--- a/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/CustomChainedCredential.cs
+++ b/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/CustomChainedCredential.cs
@@ -234,14 +234,38 @@ internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomCh
 
     private static TokenCredential CreateBrowserCredential(string? tenantId, AuthenticationRecord? authRecord)
     {
-        string? clientId = Environment.GetEnvironmentVariable(ClientIdEnvVarName);
+        var browserCredential = CreateBrokerCredential(
+            tenantId,
+            !ShouldUseOnlyBrokerCredential() && authRecord is null,
+            authRecord);
 
+        return CreateTimeoutCredential(browserCredential);
+    }
+
+    private static TokenCredential CreateTenantIsolatedCredential(string tenantId)
+    {
+        var browserCredential = CreateBrokerCredential(
+            tenantId,
+            useDefaultBrokerAccount: false,
+            authRecord: null);
+
+        return new SafeTokenCredential(
+            CreateTimeoutCredential(browserCredential),
+            "InteractiveBrowserCredential");
+    }
+
+    private static InteractiveBrowserCredential CreateBrokerCredential(
+        string? tenantId,
+        bool useDefaultBrokerAccount,
+        AuthenticationRecord? authRecord)
+    {
         IntPtr handle = WindowHandleProvider.GetWindowHandle();
+        string? clientId = Environment.GetEnvironmentVariable(ClientIdEnvVarName);
 
         InteractiveBrowserCredentialBrokerOptions brokerOptions = new(handle)
         {
-            UseDefaultBrokerAccount = !ShouldUseOnlyBrokerCredential() && authRecord is null,
             TenantId = string.IsNullOrEmpty(tenantId) ? null : tenantId,
+            UseDefaultBrokerAccount = useDefaultBrokerAccount,
             AuthenticationRecord = authRecord,
             TokenCachePersistenceOptions = new TokenCachePersistenceOptions()
             {
@@ -259,46 +283,11 @@ internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomCh
             brokerOptions.ClientId = clientId;
         }
 
-        var browserCredential = new InteractiveBrowserCredential(brokerOptions);
-
-        // Check for timeout value in the environment variable
-        string? timeoutValue = Environment.GetEnvironmentVariable(BrowserAuthenticationTimeoutEnvVarName);
-        int timeoutSeconds = 300; // Default to 300 seconds (5 minutes)
-        if (!string.IsNullOrEmpty(timeoutValue) && int.TryParse(timeoutValue, out int parsedTimeout) && parsedTimeout > 0)
-        {
-            timeoutSeconds = parsedTimeout;
-        }
-        return new TimeoutTokenCredential(browserCredential, TimeSpan.FromSeconds(timeoutSeconds));
+        return new InteractiveBrowserCredential(brokerOptions);
     }
 
-    private static TokenCredential CreateTenantIsolatedCredential(string tenantId)
+    private static TokenCredential CreateTimeoutCredential(TokenCredential credential)
     {
-        IntPtr handle = WindowHandleProvider.GetWindowHandle();
-        string? clientId = Environment.GetEnvironmentVariable(ClientIdEnvVarName);
-
-        InteractiveBrowserCredentialBrokerOptions brokerOptions = new(handle)
-        {
-            TenantId = tenantId,
-            UseDefaultBrokerAccount = false,
-            AuthenticationRecord = null,
-            TokenCachePersistenceOptions = new TokenCachePersistenceOptions()
-            {
-                Name = TokenCacheName,
-            }
-        };
-
-        if (CloudConfiguration != null)
-        {
-            brokerOptions.AuthorityHost = CloudConfiguration.AuthorityHost;
-        }
-
-        if (clientId is not null)
-        {
-            brokerOptions.ClientId = clientId;
-        }
-
-        var browserCredential = new InteractiveBrowserCredential(brokerOptions);
-
         string? timeoutValue = Environment.GetEnvironmentVariable(BrowserAuthenticationTimeoutEnvVarName);
         int timeoutSeconds = 300;
         if (!string.IsNullOrEmpty(timeoutValue) && int.TryParse(timeoutValue, out int parsedTimeout) && parsedTimeout > 0)
@@ -306,9 +295,7 @@ internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomCh
             timeoutSeconds = parsedTimeout;
         }
 
-        return new SafeTokenCredential(
-            new TimeoutTokenCredential(browserCredential, TimeSpan.FromSeconds(timeoutSeconds)),
-            "InteractiveBrowserCredential");
+        return new TimeoutTokenCredential(credential, TimeSpan.FromSeconds(timeoutSeconds));
     }
 
     private static ChainedTokenCredential CreateDefaultCredential(string? tenantId)

--- a/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/CustomChainedCredential.cs
+++ b/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/CustomChainedCredential.cs
@@ -143,7 +143,8 @@ internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomCh
         }
 #endif
 
-        if (isolateTenantAuth && !string.IsNullOrEmpty(tenantId))
+        if (isolateTenantAuth && !string.IsNullOrEmpty(tenantId)
+            && !string.Equals(tokenCredentials, "prod", StringComparison.OrdinalIgnoreCase))
         {
             return CreateTenantIsolatedCredential(tenantId!);
         }

--- a/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/CustomChainedCredential.cs
+++ b/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/CustomChainedCredential.cs
@@ -80,11 +80,16 @@ namespace Microsoft.Mcp.Core.Services.Azure.Authentication;
 /// (CI, Managed Identity, Workload Identity) where a browser popup must never appear.
 /// </para>
 /// <para>
+/// The <c>isolateTenantAuth</c> constructor parameter forces a fresh interactive login scoped to
+/// the specified tenant. When <c>true</c>, the sticky broker account and any cached authentication
+/// record are bypassed so that MFA challenges specific to the target tenant are correctly triggered.
+/// </para>
+/// <para>
 /// For User-Assigned Managed Identity, set the AZURE_CLIENT_ID environment variable to the client ID of the managed identity.
 /// If not set, System-Assigned Managed Identity will be used.
 /// </para>
 /// </remarks>
-internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomChainedCredential>? logger = null, bool forceBrowserFallback = false) : TokenCredential
+internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomChainedCredential>? logger = null, bool forceBrowserFallback = false, bool isolateTenantAuth = false) : TokenCredential
 {
     private TokenCredential? _credential;
     private readonly ILogger<CustomChainedCredential>? _logger = logger;
@@ -102,13 +107,13 @@ internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomCh
 
     public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
     {
-        _credential ??= CreateCredential(tenantId, _logger, forceBrowserFallback);
+        _credential ??= CreateCredential(tenantId, _logger, forceBrowserFallback, isolateTenantAuth);
         return _credential.GetToken(requestContext, cancellationToken);
     }
 
     public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
     {
-        _credential ??= CreateCredential(tenantId, _logger, forceBrowserFallback);
+        _credential ??= CreateCredential(tenantId, _logger, forceBrowserFallback, isolateTenantAuth);
         return _credential.GetTokenAsync(requestContext, cancellationToken);
     }
 
@@ -123,7 +128,7 @@ internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomCh
         return EnvironmentHelpers.GetEnvironmentVariableAsBool(OnlyUseBrokerCredentialEnvVarName);
     }
 
-    private static TokenCredential CreateCredential(string? tenantId, ILogger<CustomChainedCredential>? logger = null, bool forceBrowserFallback = false)
+    private static TokenCredential CreateCredential(string? tenantId, ILogger<CustomChainedCredential>? logger = null, bool forceBrowserFallback = false, bool isolateTenantAuth = false)
     {
         // Check if AZURE_TOKEN_CREDENTIALS is explicitly set
         string? tokenCredentials = Environment.GetEnvironmentVariable(TokenCredentialsEnvVarName);
@@ -137,6 +142,11 @@ internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomCh
             return new PlaybackTokenCredential();
         }
 #endif
+
+        if (isolateTenantAuth && !string.IsNullOrEmpty(tenantId))
+        {
+            return CreateTenantIsolatedCredential(tenantId!);
+        }
 
         string? authRecordJson = Environment.GetEnvironmentVariable(AuthenticationRecordEnvVarName);
         AuthenticationRecord? authRecord = null;
@@ -258,6 +268,46 @@ internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomCh
             timeoutSeconds = parsedTimeout;
         }
         return new TimeoutTokenCredential(browserCredential, TimeSpan.FromSeconds(timeoutSeconds));
+    }
+
+    private static TokenCredential CreateTenantIsolatedCredential(string tenantId)
+    {
+        IntPtr handle = WindowHandleProvider.GetWindowHandle();
+        string? clientId = Environment.GetEnvironmentVariable(ClientIdEnvVarName);
+
+        InteractiveBrowserCredentialBrokerOptions brokerOptions = new(handle)
+        {
+            TenantId = tenantId,
+            UseDefaultBrokerAccount = false,
+            AuthenticationRecord = null,
+            TokenCachePersistenceOptions = new TokenCachePersistenceOptions()
+            {
+                Name = TokenCacheName,
+            }
+        };
+
+        if (CloudConfiguration != null)
+        {
+            brokerOptions.AuthorityHost = CloudConfiguration.AuthorityHost;
+        }
+
+        if (clientId is not null)
+        {
+            brokerOptions.ClientId = clientId;
+        }
+
+        var browserCredential = new InteractiveBrowserCredential(brokerOptions);
+
+        string? timeoutValue = Environment.GetEnvironmentVariable(BrowserAuthenticationTimeoutEnvVarName);
+        int timeoutSeconds = 300;
+        if (!string.IsNullOrEmpty(timeoutValue) && int.TryParse(timeoutValue, out int parsedTimeout) && parsedTimeout > 0)
+        {
+            timeoutSeconds = parsedTimeout;
+        }
+
+        return new SafeTokenCredential(
+            new TimeoutTokenCredential(browserCredential, TimeSpan.FromSeconds(timeoutSeconds)),
+            "InteractiveBrowserCredential");
     }
 
     private static ChainedTokenCredential CreateDefaultCredential(string? tenantId)

--- a/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/SingleIdentityTokenCredentialProvider.cs
+++ b/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/SingleIdentityTokenCredentialProvider.cs
@@ -44,7 +44,8 @@ public class SingleIdentityTokenCredentialProvider : IAzureTokenCredentialProvid
                 {
                     tenantCredential = new CustomChainedCredential(
                         tenantId,
-                        _loggerFactory.CreateLogger<CustomChainedCredential>()
+                        _loggerFactory.CreateLogger<CustomChainedCredential>(),
+                        isolateTenantAuth: true
                     );
                     _tenantSpecificCredentials[tenantId] = tenantCredential;
                 }

--- a/servers/Fabric.Mcp.Server/changelog-entries/newventurecap-fix-tenant-switch-auth-1797.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/newventurecap-fix-tenant-switch-auth-1797.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed cross-tenant authentication so that MFA challenges specific to the target tenant are correctly triggered when switching tenants."

--- a/servers/Fabric.Mcp.Server/changelog-entries/newventurecap-fix-tenant-switch-auth-1797.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/newventurecap-fix-tenant-switch-auth-1797.yaml
@@ -1,3 +1,3 @@
 changes:
-  - section: "Bugs Fixed"
+  - section: "Bug Fixes"
     description: "Fixed cross-tenant authentication so that MFA challenges specific to the target tenant are correctly triggered when switching tenants."


### PR DESCRIPTION
## What does this PR do?

When a user requests authentication against a different tenant, the broker's sticky default account and any cached `AuthenticationRecord` from the current tenant are reused — bypassing the MFA challenge specific to the target tenant. This surfaces as the Authenticator app prompt never appearing when switching tenants.

This PR fixes the issue by adding `isolateTenantAuth` to `CustomChainedCredential`. When `true`, the credential skips the cached auth record and sets `UseDefaultBrokerAccount = false`, forcing a fresh interactive login scoped to the target tenant. The default credential chain behavior is completely unchanged.

Production mode (`AZURE_TOKEN_CREDENTIALS=prod`) is explicitly respected — the isolation early-return is skipped so non-interactive environments (CI, Managed Identity, Workload Identity) are never presented with a browser prompt.

`TenantAwareCredential` from the original draft has been removed — the fix is now a small, additive change to the existing class. Shared broker credential setup is extracted into `CreateBrokerCredential` and `CreateTimeoutCredential` helpers to eliminate duplication between `CreateBrowserCredential` and `CreateTenantIsolatedCredential`.

## GitHub issue number?

Fixes #1797

## Pre-merge Checklist

- [x] Required for All PRs
    - [x] Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages — one commit per file
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `servers/Fabric.Mcp.Server/CHANGELOG.md` changelog entry for bug fix
- [x] Extra steps for Community (non-Microsoft team member) PRs:
    - [x] **Security review**: No new network calls, external endpoints, or serialization paths introduced. `CreateTenantIsolatedCredential` uses only existing `Azure.Identity.Broker` primitives (`InteractiveBrowserCredentialBrokerOptions`, `UseDefaultBrokerAccount`, `AuthenticationRecord`) already used throughout this class. The two flag changes (`UseDefaultBrokerAccount = false`, `AuthenticationRecord = null`) are standard Azure Identity options for tenant isolation.
    - [x] Manual tests — triggered `/azp run mcp - pullrequest - live` but Azure Pipelines returned "Commenter does not have sufficient privileges for PR 2052". (This is expected for community contributions). Requesting a maintainer to trigger the live test run.