### PR TITLE
feat(cosmos): Add container copy job commands (copyJobs API)

### DIFF
--- a/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json
+++ b/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json
@@ -3529,6 +3529,45 @@
       "mappedToolList": [
         "deviceregistry_namespace_list"
       ]
+    },
+    {
+      "name": "manage_azure_cosmos_copy_jobs",
+      "description": "Create, monitor, and manage Cosmos DB container copy jobs (same as 'az cosmosdb copy'). Supports NoSQL-to-NoSQL, Cassandra-to-Cassandra, Mongo-to-Mongo, Mongo-to-MongoVCore, Cassandra-to-AzureBlob, and AzureBlob-to-Cassandra copy job types. Multi-task jobs can copy multiple container pairs in a single operation. Supports Offline and Online modes.",
+      "toolMetadata": {
+        "destructive": {
+          "value": true,
+          "description": "This tool can create and cancel copy jobs which move data between containers."
+        },
+        "idempotent": {
+          "value": false,
+          "description": "Creating a job with the same name may fail if a job already exists."
+        },
+        "openWorld": {
+          "value": false,
+          "description": "This tool's domain is limited to Cosmos DB Copy Job operations."
+        },
+        "readOnly": {
+          "value": false,
+          "description": "This tool can create jobs that copy data between containers."
+        },
+        "secret": {
+          "value": false,
+          "description": "This tool does not handle sensitive or secret information."
+        },
+        "localRequired": {
+          "value": false,
+          "description": "This tool is available in both local and remote server modes."
+        }
+      },
+      "mappedToolList": [
+        "cosmos_copyjob_create",
+        "cosmos_copyjob_get",
+        "cosmos_copyjob_list",
+        "cosmos_copyjob_cancel",
+        "cosmos_copyjob_pause",
+        "cosmos_copyjob_resume",
+        "cosmos_copyjob_complete"
+      ]
     }
   ]
 }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/BaseCopyJobCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/BaseCopyJobCommand.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using Azure.Mcp.Core.Commands.Subscription;
+using Azure.Mcp.Core.Extensions;
+using Azure.Mcp.Tools.Cosmos.Options;
+
+namespace Azure.Mcp.Tools.Cosmos.Commands.CopyJob;
+
+/// <summary>
+/// Base command for copy job operations. Extends SubscriptionCommand and adds
+/// --account and --job-name options.
+/// </summary>
+public abstract class BaseCopyJobCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions>
+    : SubscriptionCommand<TOptions> where TOptions : CopyJobOptions, new()
+{
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(CosmosOptionDefinitions.Account);
+        command.Options.Add(CosmosOptionDefinitions.JobName);
+    }
+
+    protected override TOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.Account = parseResult.GetValueOrDefault<string>(CosmosOptionDefinitions.Account.Name);
+        options.JobName = parseResult.GetValueOrDefault<string>(CosmosOptionDefinitions.JobName.Name);
+        return options;
+    }
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobCancelCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobCancelCommand.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Tools.Cosmos.Options;
+using Azure.Mcp.Tools.Cosmos.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.Cosmos.Commands.CopyJob;
+
+public sealed class CopyJobCancelCommand(ILogger<CopyJobCancelCommand> logger) : BaseCopyJobCommand<CopyJobOptions>()
+{
+    private const string CommandTitle = "Cancel Cosmos DB Copy Job";
+    private readonly ILogger<CopyJobCancelCommand> _logger = logger;
+
+    public override string Id => "cj-cancel-a1b2c3d4-e5f6-7890-abcd-000000000004";
+
+    public override string Name => "cancel";
+
+    public override string Description =>
+        "Cancel a running or pending Cosmos DB copy job. This action is irreversible — " +
+        "the job cannot be resumed after cancellation.";
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new()
+    {
+        Destructive = true,
+        Idempotent = false,
+        OpenWorld = false,
+        ReadOnly = false,
+        LocalRequired = false,
+        Secret = false
+    };
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            var service = context.GetService<ICopyJobService>() ?? throw new InvalidOperationException("Copy job service is not available.");
+
+            var result = await service.CancelJobAsync(
+                options.Subscription!,
+                options.Account!,
+                options.JobName!,
+                options.Tenant,
+                options.RetryPolicy,
+                cancellationToken);
+
+            context.Response.Results = ResponseResult.Create(
+                new CopyJobResult(result),
+                CosmosJsonContext.Default.CopyJobResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in {Operation}. Options: {@Options}", Name, options);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobCompleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobCompleteCommand.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Tools.Cosmos.Options;
+using Azure.Mcp.Tools.Cosmos.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.Cosmos.Commands.CopyJob;
+
+public sealed class CopyJobCompleteCommand(ILogger<CopyJobCompleteCommand> logger) : BaseCopyJobCommand<CopyJobOptions>()
+{
+    private const string CommandTitle = "Complete Cosmos DB Copy Job";
+    private readonly ILogger<CopyJobCompleteCommand> _logger = logger;
+
+    public override string Id => "cj-complete-a1b2c3d4-e5f6-7890-abcd-000000000007";
+
+    public override string Name => "complete";
+
+    public override string Description =>
+        "Complete an Online Cosmos DB copy job. This flushes remaining changes from the source " +
+        "to the destination and frees compute resources. Only applicable to jobs created with " +
+        "mode 'Online'.";
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new()
+    {
+        Destructive = true,
+        Idempotent = false,
+        OpenWorld = false,
+        ReadOnly = false,
+        LocalRequired = false,
+        Secret = false
+    };
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            var service = context.GetService<ICopyJobService>() ?? throw new InvalidOperationException("Copy job service is not available.");
+
+            var result = await service.CompleteJobAsync(
+                options.Subscription!,
+                options.Account!,
+                options.JobName!,
+                options.Tenant,
+                options.RetryPolicy,
+                cancellationToken);
+
+            context.Response.Results = ResponseResult.Create(
+                new CopyJobResult(result),
+                CosmosJsonContext.Default.CopyJobResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in {Operation}. Options: {@Options}", Name, options);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobCreateCommand.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Extensions;
+using Azure.Mcp.Tools.Cosmos.Options;
+using Azure.Mcp.Tools.Cosmos.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.Cosmos.Commands.CopyJob;
+
+public sealed class CopyJobCreateCommand(ILogger<CopyJobCreateCommand> logger) : BaseCopyJobCommand<CopyJobCreateOptions>()
+{
+    private const string CommandTitle = "Create Cosmos DB Copy Job";
+    private readonly ILogger<CopyJobCreateCommand> _logger = logger;
+
+    public override string Id => "cj-create-a1b2c3d4-e5f6-7890-abcd-000000000001";
+
+    public override string Name => "create";
+
+    public override string Description =>
+        "Create a new Cosmos DB container copy job. Use --job-properties to specify the job type, source, " +
+        "destination, and tasks in JSON format. Supported job types: NoSqlRUToNoSqlRU, CassandraRUToCassandraRU, " +
+        "MongoRUToMongoRU, MongoRUToMongoVCore, CassandraRUToAzureBlobStorage, AzureBlobStorageToCassandraRU. " +
+        "Example --job-properties: {\"jobType\":\"NoSqlRUToNoSqlRU\",\"tasks\":[{\"source\":{\"databaseName\":\"db1\"," +
+        "\"containerName\":\"src\"},\"destination\":{\"databaseName\":\"db1\",\"containerName\":\"dest\"}}]}";
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new()
+    {
+        Destructive = true,
+        Idempotent = false,
+        OpenWorld = false,
+        ReadOnly = false,
+        LocalRequired = false,
+        Secret = false
+    };
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(CosmosOptionDefinitions.JobProperties);
+        command.Options.Add(CosmosOptionDefinitions.Mode);
+        command.Options.Add(CosmosOptionDefinitions.WorkerCount);
+    }
+
+    protected override CopyJobCreateOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.JobProperties = parseResult.GetValueOrDefault<string>(CosmosOptionDefinitions.JobProperties.Name);
+        options.Mode = parseResult.GetValueOrDefault<string?>(CosmosOptionDefinitions.Mode.Name);
+        options.WorkerCount = parseResult.GetValueOrDefault<int?>(CosmosOptionDefinitions.WorkerCount.Name);
+        return options;
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            var service = context.GetService<ICopyJobService>() ?? throw new InvalidOperationException("Copy job service is not available.");
+
+            var result = await service.CreateJobAsync(
+                options.Subscription!,
+                options.Account!,
+                options.JobName!,
+                options.JobProperties!,
+                options.Mode,
+                options.WorkerCount,
+                options.Tenant,
+                options.RetryPolicy,
+                cancellationToken);
+
+            context.Response.Results = ResponseResult.Create(
+                new CopyJobResult(result),
+                CosmosJsonContext.Default.CopyJobResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in {Operation}. Options: {@Options}", Name, options);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobGetCommand.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Tools.Cosmos.Options;
+using Azure.Mcp.Tools.Cosmos.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.Cosmos.Commands.CopyJob;
+
+public sealed class CopyJobGetCommand(ILogger<CopyJobGetCommand> logger) : BaseCopyJobCommand<CopyJobOptions>()
+{
+    private const string CommandTitle = "Get Cosmos DB Copy Job Status";
+    private readonly ILogger<CopyJobGetCommand> _logger = logger;
+
+    public override string Id => "cj-get-a1b2c3d4-e5f6-7890-abcd-000000000002";
+
+    public override string Name => "get";
+
+    public override string Description =>
+        "Get the status and details of a Cosmos DB copy job. Returns job status, progress, " +
+        "per-task completion percentages, and error information if the job faulted.";
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new()
+    {
+        Destructive = false,
+        Idempotent = true,
+        OpenWorld = false,
+        ReadOnly = true,
+        LocalRequired = false,
+        Secret = false
+    };
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            var service = context.GetService<ICopyJobService>() ?? throw new InvalidOperationException("Copy job service is not available.");
+
+            var result = await service.GetJobAsync(
+                options.Subscription!,
+                options.Account!,
+                options.JobName!,
+                options.Tenant,
+                options.RetryPolicy,
+                cancellationToken);
+
+            context.Response.Results = ResponseResult.Create(
+                new CopyJobResult(result),
+                CosmosJsonContext.Default.CopyJobResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in {Operation}. Options: {@Options}", Name, options);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobListCommand.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Commands.Subscription;
+using Azure.Mcp.Core.Extensions;
+using Azure.Mcp.Tools.Cosmos.Options;
+using Azure.Mcp.Tools.Cosmos.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.Cosmos.Commands.CopyJob;
+
+/// <summary>
+/// Lists all copy jobs on a Cosmos DB account. Only needs --account (no --job-name).
+/// </summary>
+public sealed class CopyJobListCommand(ILogger<CopyJobListCommand> logger) : SubscriptionCommand<BaseCosmosOptions>()
+{
+    private const string CommandTitle = "List Cosmos DB Copy Jobs";
+    private readonly ILogger<CopyJobListCommand> _logger = logger;
+
+    public override string Id => "cj-list-a1b2c3d4-e5f6-7890-abcd-000000000003";
+
+    public override string Name => "list";
+
+    public override string Description =>
+        "List all copy jobs on a Cosmos DB account. Returns job names, statuses, types, " +
+        "and progress for each job.";
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new()
+    {
+        Destructive = false,
+        Idempotent = true,
+        OpenWorld = false,
+        ReadOnly = true,
+        LocalRequired = false,
+        Secret = false
+    };
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(CosmosOptionDefinitions.Account);
+    }
+
+    protected override BaseCosmosOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.Account = parseResult.GetValueOrDefault<string>(CosmosOptionDefinitions.Account.Name);
+        return options;
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            var service = context.GetService<ICopyJobService>() ?? throw new InvalidOperationException("Copy job service is not available.");
+
+            var result = await service.ListJobsAsync(
+                options.Subscription!,
+                options.Account!,
+                options.Tenant,
+                options.RetryPolicy,
+                cancellationToken);
+
+            context.Response.Results = ResponseResult.Create(
+                new CopyJobListResult(result),
+                CosmosJsonContext.Default.CopyJobListResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in {Operation}. Options: {@Options}", Name, options);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobPauseCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobPauseCommand.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Tools.Cosmos.Options;
+using Azure.Mcp.Tools.Cosmos.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.Cosmos.Commands.CopyJob;
+
+public sealed class CopyJobPauseCommand(ILogger<CopyJobPauseCommand> logger) : BaseCopyJobCommand<CopyJobOptions>()
+{
+    private const string CommandTitle = "Pause Cosmos DB Copy Job";
+    private readonly ILogger<CopyJobPauseCommand> _logger = logger;
+
+    public override string Id => "cj-pause-a1b2c3d4-e5f6-7890-abcd-000000000005";
+
+    public override string Name => "pause";
+
+    public override string Description =>
+        "Pause a running Cosmos DB copy job. The job can be resumed later " +
+        "using the resume command.";
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new()
+    {
+        Destructive = true,
+        Idempotent = true,
+        OpenWorld = false,
+        ReadOnly = false,
+        LocalRequired = false,
+        Secret = false
+    };
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            var service = context.GetService<ICopyJobService>() ?? throw new InvalidOperationException("Copy job service is not available.");
+
+            var result = await service.PauseJobAsync(
+                options.Subscription!,
+                options.Account!,
+                options.JobName!,
+                options.Tenant,
+                options.RetryPolicy,
+                cancellationToken);
+
+            context.Response.Results = ResponseResult.Create(
+                new CopyJobResult(result),
+                CosmosJsonContext.Default.CopyJobResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in {Operation}. Options: {@Options}", Name, options);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobResults.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobResults.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Cosmos.Commands.CopyJob;
+
+internal record CopyJobResult(JsonElement Job);
+
+internal record CopyJobListResult(List<JsonElement> Jobs);

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobResumeCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CopyJob/CopyJobResumeCommand.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Tools.Cosmos.Options;
+using Azure.Mcp.Tools.Cosmos.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.Cosmos.Commands.CopyJob;
+
+public sealed class CopyJobResumeCommand(ILogger<CopyJobResumeCommand> logger) : BaseCopyJobCommand<CopyJobOptions>()
+{
+    private const string CommandTitle = "Resume Cosmos DB Copy Job";
+    private readonly ILogger<CopyJobResumeCommand> _logger = logger;
+
+    public override string Id => "cj-resume-a1b2c3d4-e5f6-7890-abcd-000000000006";
+
+    public override string Name => "resume";
+
+    public override string Description =>
+        "Resume a previously paused Cosmos DB copy job.";
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new()
+    {
+        Destructive = true,
+        Idempotent = true,
+        OpenWorld = false,
+        ReadOnly = false,
+        LocalRequired = false,
+        Secret = false
+    };
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            var service = context.GetService<ICopyJobService>() ?? throw new InvalidOperationException("Copy job service is not available.");
+
+            var result = await service.ResumeJobAsync(
+                options.Subscription!,
+                options.Account!,
+                options.JobName!,
+                options.Tenant,
+                options.RetryPolicy,
+                cancellationToken);
+
+            context.Response.Results = ResponseResult.Create(
+                new CopyJobResult(result),
+                CosmosJsonContext.Default.CopyJobResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in {Operation}. Options: {@Options}", Name, options);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CosmosJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CosmosJsonContext.cs
@@ -2,11 +2,14 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
+using Azure.Mcp.Tools.Cosmos.Commands.CopyJob;
 
 namespace Azure.Mcp.Tools.Cosmos.Commands;
 
 [JsonSerializable(typeof(CosmosListCommand.CosmosListCommandResult))]
 [JsonSerializable(typeof(ItemQueryCommand.ItemQueryCommandResult))]
+[JsonSerializable(typeof(CopyJobResult))]
+[JsonSerializable(typeof(CopyJobListResult))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]

--- a/tools/Azure.Mcp.Tools.Cosmos/src/CosmosSetup.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/CosmosSetup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.Cosmos.Commands;
+using Azure.Mcp.Tools.Cosmos.Commands.CopyJob;
 using Azure.Mcp.Tools.Cosmos.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Mcp.Core.Areas;
@@ -18,15 +19,24 @@ public class CosmosSetup : IAreaSetup
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddSingleton<ICosmosService, CosmosService>();
+        services.AddSingleton<ICopyJobService, CopyJobService>();
 
         services.AddSingleton<CosmosListCommand>();
         services.AddSingleton<ItemQueryCommand>();
+
+        services.AddSingleton<CopyJobCreateCommand>();
+        services.AddSingleton<CopyJobGetCommand>();
+        services.AddSingleton<CopyJobListCommand>();
+        services.AddSingleton<CopyJobCancelCommand>();
+        services.AddSingleton<CopyJobPauseCommand>();
+        services.AddSingleton<CopyJobResumeCommand>();
+        services.AddSingleton<CopyJobCompleteCommand>();
     }
 
     public CommandGroup RegisterCommands(IServiceProvider serviceProvider)
     {
         // Create Cosmos command group
-        var cosmos = new CommandGroup(Name, "Cosmos DB operations - Commands for managing and querying Azure Cosmos DB resources. Includes operations for accounts, databases, containers, and document queries.", Title);
+        var cosmos = new CommandGroup(Name, "Cosmos DB operations - Commands for managing and querying Azure Cosmos DB resources. Includes operations for accounts, databases, containers, document queries, and container copy jobs.", Title);
 
         // Consolidated hierarchical list command
         var cosmosList = serviceProvider.GetRequiredService<CosmosListCommand>();
@@ -45,6 +55,34 @@ public class CosmosSetup : IAreaSetup
 
         var itemQuery = serviceProvider.GetRequiredService<ItemQueryCommand>();
         cosmosItem.AddCommand(itemQuery.Name, itemQuery);
+
+        // Copy Job command group
+        var copyJob = new CommandGroup("copyjob",
+            "Cosmos DB Copy Job operations - Create, monitor, and manage container copy jobs " +
+            "(same as 'az cosmosdb copy'). Supports NoSQL, Cassandra, MongoDB, and Azure Blob " +
+            "source/destination types with multi-task support.");
+        cosmos.AddSubGroup(copyJob);
+
+        var cjCreate = serviceProvider.GetRequiredService<CopyJobCreateCommand>();
+        copyJob.AddCommand(cjCreate.Name, cjCreate);
+
+        var cjGet = serviceProvider.GetRequiredService<CopyJobGetCommand>();
+        copyJob.AddCommand(cjGet.Name, cjGet);
+
+        var cjList = serviceProvider.GetRequiredService<CopyJobListCommand>();
+        copyJob.AddCommand(cjList.Name, cjList);
+
+        var cjCancel = serviceProvider.GetRequiredService<CopyJobCancelCommand>();
+        copyJob.AddCommand(cjCancel.Name, cjCancel);
+
+        var cjPause = serviceProvider.GetRequiredService<CopyJobPauseCommand>();
+        copyJob.AddCommand(cjPause.Name, cjPause);
+
+        var cjResume = serviceProvider.GetRequiredService<CopyJobResumeCommand>();
+        copyJob.AddCommand(cjResume.Name, cjResume);
+
+        var cjComplete = serviceProvider.GetRequiredService<CopyJobCompleteCommand>();
+        copyJob.AddCommand(cjComplete.Name, cjComplete);
 
         return cosmos;
     }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Options/CopyJobCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Options/CopyJobCreateOptions.cs
@@ -7,12 +7,12 @@ namespace Azure.Mcp.Tools.Cosmos.Options;
 
 public class CopyJobCreateOptions : CopyJobOptions
 {
-    [JsonPropertyName(CosmosOptionDefinitions.JobPropertiesConst)]
+    [JsonPropertyName(CosmosOptionDefinitions.JobPropertiesName)]
     public string? JobProperties { get; set; }
 
-    [JsonPropertyName(CosmosOptionDefinitions.ModeConst)]
+    [JsonPropertyName(CosmosOptionDefinitions.ModeName)]
     public string? Mode { get; set; }
 
-    [JsonPropertyName(CosmosOptionDefinitions.WorkerCountConst)]
+    [JsonPropertyName(CosmosOptionDefinitions.WorkerCountName)]
     public int? WorkerCount { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Options/CopyJobCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Options/CopyJobCreateOptions.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Mcp.Tools.Cosmos.Options;
+
+public class CopyJobCreateOptions : CopyJobOptions
+{
+    [JsonPropertyName(CosmosOptionDefinitions.JobPropertiesConst)]
+    public string? JobProperties { get; set; }
+
+    [JsonPropertyName(CosmosOptionDefinitions.ModeConst)]
+    public string? Mode { get; set; }
+
+    [JsonPropertyName(CosmosOptionDefinitions.WorkerCountConst)]
+    public int? WorkerCount { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Options/CopyJobOptions.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Options/CopyJobOptions.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Mcp.Tools.Cosmos.Options;
+
+public class CopyJobOptions : BaseCosmosOptions
+{
+    [JsonPropertyName(CosmosOptionDefinitions.JobNameConst)]
+    public string? JobName { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Options/CopyJobOptions.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Options/CopyJobOptions.cs
@@ -7,6 +7,6 @@ namespace Azure.Mcp.Tools.Cosmos.Options;
 
 public class CopyJobOptions : BaseCosmosOptions
 {
-    [JsonPropertyName(CosmosOptionDefinitions.JobNameConst)]
+    [JsonPropertyName(CosmosOptionDefinitions.CopyJobName)]
     public string? JobName { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Options/CosmosOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Options/CosmosOptionDefinitions.cs
@@ -56,4 +56,42 @@ public static class CosmosOptionDefinitions
         Required = false,
         DefaultValueFactory = _ => "SELECT * FROM c"
     };
+
+    // Copy Job option definitions
+    public const string JobNameConst = "job-name";
+    public const string JobPropertiesConst = "job-properties";
+    public const string ModeConst = "mode";
+    public const string WorkerCountConst = "worker-count";
+
+    public static readonly Option<string> JobName = new(
+        $"--{JobNameConst}"
+    )
+    {
+        Description = "The name of the copy job (e.g., my-copy-job-1).",
+        Required = true
+    };
+
+    public static readonly Option<string> JobProperties = new(
+        $"--{JobPropertiesConst}"
+    )
+    {
+        Description = "JSON string describing the copy job type and tasks. Must include 'jobType' and 'tasks' array. " +
+            "Supported jobTypes: NoSqlRUToNoSqlRU, CassandraRUToCassandraRU, MongoRUToMongoRU, " +
+            "MongoRUToMongoVCore, CassandraRUToAzureBlobStorage, AzureBlobStorageToCassandraRU.",
+        Required = true
+    };
+
+    public static readonly Option<string?> Mode = new(
+        $"--{ModeConst}"
+    )
+    {
+        Description = "Copy mode: 'Offline' (one-time, default) or 'Online' (continuous sync until completed)."
+    };
+
+    public static readonly Option<int?> WorkerCount = new(
+        $"--{WorkerCountConst}"
+    )
+    {
+        Description = "Number of workers for the copy job. Set to 0 for auto-scaling (default)."
+    };
 }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Options/CosmosOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Options/CosmosOptionDefinitions.cs
@@ -58,13 +58,13 @@ public static class CosmosOptionDefinitions
     };
 
     // Copy Job option definitions
-    public const string JobNameConst = "job-name";
-    public const string JobPropertiesConst = "job-properties";
-    public const string ModeConst = "mode";
-    public const string WorkerCountConst = "worker-count";
+    public const string CopyJobName = "job-name";
+    public const string JobPropertiesName = "job-properties";
+    public const string ModeName = "mode";
+    public const string WorkerCountName = "worker-count";
 
     public static readonly Option<string> JobName = new(
-        $"--{JobNameConst}"
+        $"--{CopyJobName}"
     )
     {
         Description = "The name of the copy job (e.g., my-copy-job-1).",
@@ -72,7 +72,7 @@ public static class CosmosOptionDefinitions
     };
 
     public static readonly Option<string> JobProperties = new(
-        $"--{JobPropertiesConst}"
+        $"--{JobPropertiesName}"
     )
     {
         Description = "JSON string describing the copy job type and tasks. Must include 'jobType' and 'tasks' array. " +
@@ -82,14 +82,14 @@ public static class CosmosOptionDefinitions
     };
 
     public static readonly Option<string?> Mode = new(
-        $"--{ModeConst}"
+        $"--{ModeName}"
     )
     {
         Description = "Copy mode: 'Offline' (one-time, default) or 'Online' (continuous sync until completed)."
     };
 
     public static readonly Option<int?> WorkerCount = new(
-        $"--{WorkerCountConst}"
+        $"--{WorkerCountName}"
     )
     {
         Description = "Number of workers for the copy job. Set to 0 for auto-scaling (default)."

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Services/CopyJobService.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Services/CopyJobService.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using Azure.Mcp.Core.Options;
@@ -50,18 +49,21 @@ public sealed class CopyJobService(
     }
 
     /// <summary>
-    /// Gets an HttpClient with ARM auth token set.
+    /// Creates an HttpRequestMessage with ARM auth headers set per-request.
     /// </summary>
-    private async Task<HttpClient> GetAuthenticatedHttpClientAsync(
+    private async Task<HttpRequestMessage> CreateAuthenticatedRequestAsync(
+        HttpMethod method,
+        string url,
         string? tenant = null,
+        HttpContent? content = null,
         CancellationToken cancellationToken = default)
     {
         var accessToken = await GetArmAccessTokenAsync(tenant, cancellationToken);
 
-        var client = new HttpClient();
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
-        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        return client;
+        var request = new HttpRequestMessage(method, url) { Content = content };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        return request;
     }
 
     /// <summary>
@@ -73,7 +75,7 @@ public sealed class CopyJobService(
         var url = $"{armEndpoint}{accountResourceId}/copyJobs";
         if (!string.IsNullOrEmpty(jobName))
         {
-            url += $"/{jobName}";
+            url += $"/{Uri.EscapeDataString(jobName)}";
         }
         url += $"?api-version={ApiVersion}";
         return url;
@@ -100,7 +102,8 @@ public sealed class CopyJobService(
         JsonElement jobProps;
         try
         {
-            jobProps = JsonDocument.Parse(jobPropertiesJson).RootElement;
+            using var propsDoc = JsonDocument.Parse(jobPropertiesJson);
+            jobProps = propsDoc.RootElement.Clone();
         }
         catch (JsonException ex)
         {
@@ -125,12 +128,16 @@ public sealed class CopyJobService(
 
         var body = JsonSerializer.Serialize(new { properties });
 
-        using var client = await GetAuthenticatedHttpClientAsync(tenant, cancellationToken);
+        var client = TenantService.GetClient();
         var url = BuildCopyJobsUrl(accountResourceId, jobName);
 
         _logger.LogInformation("Creating copy job '{JobName}' on account '{Account}'", jobName, accountName);
 
-        var response = await client.PutAsync(url, new StringContent(body, Encoding.UTF8, "application/json"), cancellationToken);
+        using var request = await CreateAuthenticatedRequestAsync(
+            HttpMethod.Put, url, tenant,
+            new StringContent(body, Encoding.UTF8, "application/json"),
+            cancellationToken);
+        var response = await client.SendAsync(request, cancellationToken);
         var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
 
         if (!response.IsSuccessStatusCode)
@@ -138,7 +145,8 @@ public sealed class CopyJobService(
             throw new HttpRequestException($"Failed to create copy job (HTTP {(int)response.StatusCode}): {responseBody}");
         }
 
-        return JsonDocument.Parse(responseBody).RootElement;
+        using var doc = JsonDocument.Parse(responseBody);
+        return doc.RootElement.Clone();
     }
 
     public async Task<JsonElement> GetJobAsync(
@@ -156,10 +164,11 @@ public sealed class CopyJobService(
 
         var accountResourceId = await GetAccountResourceIdAsync(subscription, accountName, tenant, retryPolicy, cancellationToken);
 
-        using var client = await GetAuthenticatedHttpClientAsync(tenant, cancellationToken);
+        var client = TenantService.GetClient();
         var url = BuildCopyJobsUrl(accountResourceId, jobName);
 
-        var response = await client.GetAsync(url, cancellationToken);
+        using var request = await CreateAuthenticatedRequestAsync(HttpMethod.Get, url, tenant, cancellationToken: cancellationToken);
+        var response = await client.SendAsync(request, cancellationToken);
         var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
 
         if (!response.IsSuccessStatusCode)
@@ -167,7 +176,8 @@ public sealed class CopyJobService(
             throw new HttpRequestException($"Failed to get copy job (HTTP {(int)response.StatusCode}): {responseBody}");
         }
 
-        return JsonDocument.Parse(responseBody).RootElement;
+        using var doc = JsonDocument.Parse(responseBody);
+        return doc.RootElement.Clone();
     }
 
     public async Task<List<JsonElement>> ListJobsAsync(
@@ -183,13 +193,14 @@ public sealed class CopyJobService(
 
         var accountResourceId = await GetAccountResourceIdAsync(subscription, accountName, tenant, retryPolicy, cancellationToken);
 
-        using var client = await GetAuthenticatedHttpClientAsync(tenant, cancellationToken);
+        var client = TenantService.GetClient();
         var jobs = new List<JsonElement>();
         var url = BuildCopyJobsUrl(accountResourceId);
 
         while (!string.IsNullOrEmpty(url))
         {
-            var response = await client.GetAsync(url, cancellationToken);
+            using var request = await CreateAuthenticatedRequestAsync(HttpMethod.Get, url, tenant, cancellationToken: cancellationToken);
+            var response = await client.SendAsync(request, cancellationToken);
             var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
 
             if (!response.IsSuccessStatusCode)
@@ -197,7 +208,7 @@ public sealed class CopyJobService(
                 throw new HttpRequestException($"Failed to list copy jobs (HTTP {(int)response.StatusCode}): {responseBody}");
             }
 
-            var doc = JsonDocument.Parse(responseBody);
+            using var doc = JsonDocument.Parse(responseBody);
             if (doc.RootElement.TryGetProperty("value", out var valueArray))
             {
                 foreach (var item in valueArray.EnumerateArray())
@@ -231,13 +242,17 @@ public sealed class CopyJobService(
 
         var accountResourceId = await GetAccountResourceIdAsync(subscription, accountName, tenant, retryPolicy, cancellationToken);
 
-        using var client = await GetAuthenticatedHttpClientAsync(tenant, cancellationToken);
+        var client = TenantService.GetClient();
         var armEndpoint = TenantService.CloudConfiguration.ArmEnvironment.Endpoint.ToString().TrimEnd('/');
-        var url = $"{armEndpoint}{accountResourceId}/copyJobs/{jobName}/{action}?api-version={ApiVersion}";
+        var url = $"{armEndpoint}{accountResourceId}/copyJobs/{Uri.EscapeDataString(jobName)}/{action}?api-version={ApiVersion}";
 
         _logger.LogInformation("{Action} copy job '{JobName}' on account '{Account}'", action, jobName, accountName);
 
-        var response = await client.PostAsync(url, new StringContent("{}", Encoding.UTF8, "application/json"), cancellationToken);
+        using var request = await CreateAuthenticatedRequestAsync(
+            HttpMethod.Post, url, tenant,
+            new StringContent("{}", Encoding.UTF8, "application/json"),
+            cancellationToken);
+        var response = await client.SendAsync(request, cancellationToken);
         var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
 
         if (!response.IsSuccessStatusCode)
@@ -248,10 +263,13 @@ public sealed class CopyJobService(
         // Some actions return empty body on success (e.g., 202 Accepted)
         if (string.IsNullOrWhiteSpace(responseBody))
         {
-            return JsonDocument.Parse($"{{\"status\":\"{action} accepted\",\"jobName\":\"{jobName}\"}}").RootElement;
+            var fallback = JsonSerializer.Serialize(new { status = $"{action} accepted", jobName });
+            using var fallbackDoc = JsonDocument.Parse(fallback);
+            return fallbackDoc.RootElement.Clone();
         }
 
-        return JsonDocument.Parse(responseBody).RootElement;
+        using var doc = JsonDocument.Parse(responseBody);
+        return doc.RootElement.Clone();
     }
 
     public Task<JsonElement> CancelJobAsync(string subscription, string accountName, string jobName,

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Services/CopyJobService.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Services/CopyJobService.cs
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Core.Services.Azure;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Core.Services.Azure.Tenant;
+using Azure.ResourceManager.CosmosDB;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Mcp.Tools.Cosmos.Services;
+
+public sealed class CopyJobService(
+    ISubscriptionService subscriptionService,
+    ITenantService tenantService,
+    ILogger<CopyJobService> logger)
+    : BaseAzureService(tenantService), ICopyJobService
+{
+    private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
+    private readonly ILogger<CopyJobService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    private const string ApiVersion = "2025-05-01-preview";
+
+    /// <summary>
+    /// Finds the Cosmos DB account by name and returns its ARM resource ID.
+    /// </summary>
+    private async Task<string> GetAccountResourceIdAsync(
+        string subscription,
+        string accountName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(accountName), accountName));
+
+        var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+
+        await foreach (var account in subscriptionResource.GetCosmosDBAccountsAsync(cancellationToken))
+        {
+            if (string.Equals(account.Data.Name, accountName, StringComparison.OrdinalIgnoreCase))
+            {
+                return account.Id.ToString();
+            }
+        }
+
+        throw new Exception($"Cosmos DB account '{accountName}' not found in subscription '{subscription}'.");
+    }
+
+    /// <summary>
+    /// Gets an HttpClient with ARM auth token set.
+    /// </summary>
+    private async Task<HttpClient> GetAuthenticatedHttpClientAsync(
+        string? tenant = null,
+        CancellationToken cancellationToken = default)
+    {
+        var accessToken = await GetArmAccessTokenAsync(tenant, cancellationToken);
+
+        var client = new HttpClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        return client;
+    }
+
+    /// <summary>
+    /// Builds the base URL for copyJobs operations.
+    /// </summary>
+    private string BuildCopyJobsUrl(string accountResourceId, string? jobName = null)
+    {
+        var armEndpoint = TenantService.CloudConfiguration.ArmEnvironment.Endpoint.ToString().TrimEnd('/');
+        var url = $"{armEndpoint}{accountResourceId}/copyJobs";
+        if (!string.IsNullOrEmpty(jobName))
+        {
+            url += $"/{jobName}";
+        }
+        url += $"?api-version={ApiVersion}";
+        return url;
+    }
+
+    public async Task<JsonElement> CreateJobAsync(
+        string subscription,
+        string accountName,
+        string jobName,
+        string jobPropertiesJson,
+        string? mode = null,
+        int? workerCount = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(accountName), accountName),
+            (nameof(jobName), jobName),
+            (nameof(jobPropertiesJson), jobPropertiesJson));
+
+        // Parse and validate the job properties JSON
+        JsonElement jobProps;
+        try
+        {
+            jobProps = JsonDocument.Parse(jobPropertiesJson).RootElement;
+        }
+        catch (JsonException ex)
+        {
+            throw new ArgumentException($"Invalid JSON in jobProperties: {ex.Message}", ex);
+        }
+
+        var accountResourceId = await GetAccountResourceIdAsync(subscription, accountName, tenant, retryPolicy, cancellationToken);
+
+        // Build the request body
+        var properties = new Dictionary<string, object>
+        {
+            ["jobProperties"] = jobProps
+        };
+        if (!string.IsNullOrEmpty(mode))
+        {
+            properties["mode"] = mode;
+        }
+        if (workerCount.HasValue)
+        {
+            properties["workerCount"] = workerCount.Value;
+        }
+
+        var body = JsonSerializer.Serialize(new { properties });
+
+        using var client = await GetAuthenticatedHttpClientAsync(tenant, cancellationToken);
+        var url = BuildCopyJobsUrl(accountResourceId, jobName);
+
+        _logger.LogInformation("Creating copy job '{JobName}' on account '{Account}'", jobName, accountName);
+
+        var response = await client.PutAsync(url, new StringContent(body, Encoding.UTF8, "application/json"), cancellationToken);
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException($"Failed to create copy job (HTTP {(int)response.StatusCode}): {responseBody}");
+        }
+
+        return JsonDocument.Parse(responseBody).RootElement;
+    }
+
+    public async Task<JsonElement> GetJobAsync(
+        string subscription,
+        string accountName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(accountName), accountName),
+            (nameof(jobName), jobName));
+
+        var accountResourceId = await GetAccountResourceIdAsync(subscription, accountName, tenant, retryPolicy, cancellationToken);
+
+        using var client = await GetAuthenticatedHttpClientAsync(tenant, cancellationToken);
+        var url = BuildCopyJobsUrl(accountResourceId, jobName);
+
+        var response = await client.GetAsync(url, cancellationToken);
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException($"Failed to get copy job (HTTP {(int)response.StatusCode}): {responseBody}");
+        }
+
+        return JsonDocument.Parse(responseBody).RootElement;
+    }
+
+    public async Task<List<JsonElement>> ListJobsAsync(
+        string subscription,
+        string accountName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(accountName), accountName));
+
+        var accountResourceId = await GetAccountResourceIdAsync(subscription, accountName, tenant, retryPolicy, cancellationToken);
+
+        using var client = await GetAuthenticatedHttpClientAsync(tenant, cancellationToken);
+        var jobs = new List<JsonElement>();
+        var url = BuildCopyJobsUrl(accountResourceId);
+
+        while (!string.IsNullOrEmpty(url))
+        {
+            var response = await client.GetAsync(url, cancellationToken);
+            var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException($"Failed to list copy jobs (HTTP {(int)response.StatusCode}): {responseBody}");
+            }
+
+            var doc = JsonDocument.Parse(responseBody);
+            if (doc.RootElement.TryGetProperty("value", out var valueArray))
+            {
+                foreach (var item in valueArray.EnumerateArray())
+                {
+                    jobs.Add(item.Clone());
+                }
+            }
+
+            // Handle pagination
+            url = doc.RootElement.TryGetProperty("nextLink", out var nextLink)
+                ? nextLink.GetString()
+                : null;
+        }
+
+        return jobs;
+    }
+
+    private async Task<JsonElement> PostJobActionAsync(
+        string subscription,
+        string accountName,
+        string jobName,
+        string action,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(accountName), accountName),
+            (nameof(jobName), jobName));
+
+        var accountResourceId = await GetAccountResourceIdAsync(subscription, accountName, tenant, retryPolicy, cancellationToken);
+
+        using var client = await GetAuthenticatedHttpClientAsync(tenant, cancellationToken);
+        var armEndpoint = TenantService.CloudConfiguration.ArmEnvironment.Endpoint.ToString().TrimEnd('/');
+        var url = $"{armEndpoint}{accountResourceId}/copyJobs/{jobName}/{action}?api-version={ApiVersion}";
+
+        _logger.LogInformation("{Action} copy job '{JobName}' on account '{Account}'", action, jobName, accountName);
+
+        var response = await client.PostAsync(url, new StringContent("{}", Encoding.UTF8, "application/json"), cancellationToken);
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException($"Failed to {action} copy job (HTTP {(int)response.StatusCode}): {responseBody}");
+        }
+
+        // Some actions return empty body on success (e.g., 202 Accepted)
+        if (string.IsNullOrWhiteSpace(responseBody))
+        {
+            return JsonDocument.Parse($"{{\"status\":\"{action} accepted\",\"jobName\":\"{jobName}\"}}").RootElement;
+        }
+
+        return JsonDocument.Parse(responseBody).RootElement;
+    }
+
+    public Task<JsonElement> CancelJobAsync(string subscription, string accountName, string jobName,
+        string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default)
+        => PostJobActionAsync(subscription, accountName, jobName, "cancel", tenant, retryPolicy, cancellationToken);
+
+    public Task<JsonElement> PauseJobAsync(string subscription, string accountName, string jobName,
+        string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default)
+        => PostJobActionAsync(subscription, accountName, jobName, "pause", tenant, retryPolicy, cancellationToken);
+
+    public Task<JsonElement> ResumeJobAsync(string subscription, string accountName, string jobName,
+        string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default)
+        => PostJobActionAsync(subscription, accountName, jobName, "resume", tenant, retryPolicy, cancellationToken);
+
+    public Task<JsonElement> CompleteJobAsync(string subscription, string accountName, string jobName,
+        string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default)
+        => PostJobActionAsync(subscription, accountName, jobName, "complete", tenant, retryPolicy, cancellationToken);
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Services/ICopyJobService.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Services/ICopyJobService.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Options;
+
+namespace Azure.Mcp.Tools.Cosmos.Services;
+
+/// <summary>
+/// Service interface for managing Cosmos DB container copy jobs
+/// via the ARM copyJobs API (Microsoft.DocumentDB/databaseAccounts/copyJobs).
+/// </summary>
+public interface ICopyJobService
+{
+    /// <summary>Creates a new copy job on the specified account.</summary>
+    Task<JsonElement> CreateJobAsync(
+        string subscription,
+        string accountName,
+        string jobName,
+        string jobPropertiesJson,
+        string? mode = null,
+        int? workerCount = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Gets the status of an existing copy job.</summary>
+    Task<JsonElement> GetJobAsync(
+        string subscription,
+        string accountName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Lists all copy jobs on the specified account.</summary>
+    Task<List<JsonElement>> ListJobsAsync(
+        string subscription,
+        string accountName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Cancels a running or pending copy job.</summary>
+    Task<JsonElement> CancelJobAsync(
+        string subscription,
+        string accountName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Pauses a running copy job.</summary>
+    Task<JsonElement> PauseJobAsync(
+        string subscription,
+        string accountName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Resumes a paused copy job.</summary>
+    Task<JsonElement> ResumeJobAsync(
+        string subscription,
+        string accountName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Completes an Online copy job (flushes remaining changes).</summary>
+    Task<JsonElement> CompleteJobAsync(
+        string subscription,
+        string accountName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+}

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/CopyJobCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.UnitTests/CopyJobCommandTests.cs
@@ -1,0 +1,500 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.Net;
+using System.Text.Json;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Tools.Cosmos.Commands.CopyJob;
+using Azure.Mcp.Tools.Cosmos.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Command;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Cosmos.UnitTests;
+
+public class CopyJobGetCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ICopyJobService _copyJobService;
+    private readonly ILogger<CopyJobGetCommand> _logger;
+    private readonly CopyJobGetCommand _command;
+    private readonly Command _commandDefinition;
+    private readonly CommandContext _context;
+
+    public CopyJobGetCommandTests()
+    {
+        _copyJobService = Substitute.For<ICopyJobService>();
+        _logger = Substitute.For<ILogger<CopyJobGetCommand>>();
+        _command = new(_logger);
+        _commandDefinition = _command.GetCommand();
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_copyJobService)
+            .BuildServiceProvider();
+        _context = new(_serviceProvider);
+    }
+
+    [Fact]
+    public void Name_IsCorrect()
+    {
+        Assert.Equal("get", _command.Name);
+    }
+
+    [Fact]
+    public void Metadata_IsConfiguredCorrectly()
+    {
+        Assert.False(_command.Metadata.Destructive);
+        Assert.True(_command.Metadata.ReadOnly);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsJob_WhenAllParametersProvided()
+    {
+        // Arrange
+        using var expectedDoc = JsonDocument.Parse("{\"id\":\"job1\",\"properties\":{\"status\":\"Completed\"}}");
+        var expectedJob = expectedDoc.RootElement.Clone();
+
+        _copyJobService.GetJobAsync(
+            Arg.Is("sub123"),
+            Arg.Is("myaccount"),
+            Arg.Is("myjob"),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedJob);
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub123",
+            "--account", "myaccount",
+            "--job-name", "myjob"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns500_WhenServiceThrows()
+    {
+        // Arrange
+        _copyJobService.GetJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Service error"));
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub123",
+            "--account", "myaccount",
+            "--job-name", "myjob"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Contains("Service error", response.Message);
+    }
+
+    [Theory]
+    [InlineData("--account", "myaccount", "--job-name", "myjob")] // Missing subscription
+    [InlineData("--subscription", "sub123", "--job-name", "myjob")] // Missing account
+    [InlineData("--subscription", "sub123", "--account", "myaccount")] // Missing job-name
+    public async Task ExecuteAsync_Returns400_WhenRequiredParametersAreMissing(params string[] args)
+    {
+        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse(args), TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+}
+
+public class CopyJobCreateCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ICopyJobService _copyJobService;
+    private readonly ILogger<CopyJobCreateCommand> _logger;
+    private readonly CopyJobCreateCommand _command;
+    private readonly Command _commandDefinition;
+    private readonly CommandContext _context;
+
+    private const string SampleJobProperties =
+        "{\"jobType\":\"NoSqlRUToNoSqlRU\",\"tasks\":[{\"source\":{\"databaseName\":\"db1\",\"containerName\":\"src\"},\"destination\":{\"databaseName\":\"db1\",\"containerName\":\"dest\"}}]}";
+
+    public CopyJobCreateCommandTests()
+    {
+        _copyJobService = Substitute.For<ICopyJobService>();
+        _logger = Substitute.For<ILogger<CopyJobCreateCommand>>();
+        _command = new(_logger);
+        _commandDefinition = _command.GetCommand();
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_copyJobService)
+            .BuildServiceProvider();
+        _context = new(_serviceProvider);
+    }
+
+    [Fact]
+    public void Name_IsCorrect()
+    {
+        Assert.Equal("create", _command.Name);
+    }
+
+    [Fact]
+    public void Metadata_IsDestructive()
+    {
+        Assert.True(_command.Metadata.Destructive);
+        Assert.False(_command.Metadata.ReadOnly);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreatesJob_WithRequiredParameters()
+    {
+        // Arrange
+        using var expectedDoc = JsonDocument.Parse("{\"id\":\"job1\",\"properties\":{\"status\":\"Created\"}}");
+        var expectedJob = expectedDoc.RootElement.Clone();
+
+        _copyJobService.CreateJobAsync(
+            Arg.Is("sub123"),
+            Arg.Is("myaccount"),
+            Arg.Is("myjob"),
+            Arg.Is(SampleJobProperties),
+            Arg.Any<string?>(),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedJob);
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub123",
+            "--account", "myaccount",
+            "--job-name", "myjob",
+            "--job-properties", SampleJobProperties
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreatesJob_WithOptionalParameters()
+    {
+        // Arrange
+        using var expectedDoc = JsonDocument.Parse("{\"id\":\"job1\"}");
+        var expectedJob = expectedDoc.RootElement.Clone();
+
+        _copyJobService.CreateJobAsync(
+            Arg.Is("sub123"),
+            Arg.Is("myaccount"),
+            Arg.Is("myjob"),
+            Arg.Is(SampleJobProperties),
+            Arg.Is("Online"),
+            Arg.Is(4),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedJob);
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub123",
+            "--account", "myaccount",
+            "--job-name", "myjob",
+            "--job-properties", SampleJobProperties,
+            "--mode", "Online",
+            "--worker-count", "4"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns500_WhenServiceThrows()
+    {
+        // Arrange
+        _copyJobService.CreateJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Create failed"));
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub123",
+            "--account", "myaccount",
+            "--job-name", "myjob",
+            "--job-properties", SampleJobProperties
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Contains("Create failed", response.Message);
+    }
+
+    [Theory]
+    [InlineData("--account", "myaccount", "--job-name", "myjob", "--job-properties", "{}")] // Missing subscription
+    [InlineData("--subscription", "sub123", "--job-name", "myjob", "--job-properties", "{}")] // Missing account
+    [InlineData("--subscription", "sub123", "--account", "myaccount", "--job-properties", "{}")] // Missing job-name
+    [InlineData("--subscription", "sub123", "--account", "myaccount", "--job-name", "myjob")] // Missing job-properties
+    public async Task ExecuteAsync_Returns400_WhenRequiredParametersAreMissing(params string[] args)
+    {
+        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse(args), TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+}
+
+public class CopyJobListCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ICopyJobService _copyJobService;
+    private readonly ILogger<CopyJobListCommand> _logger;
+    private readonly CopyJobListCommand _command;
+    private readonly Command _commandDefinition;
+    private readonly CommandContext _context;
+
+    public CopyJobListCommandTests()
+    {
+        _copyJobService = Substitute.For<ICopyJobService>();
+        _logger = Substitute.For<ILogger<CopyJobListCommand>>();
+        _command = new(_logger);
+        _commandDefinition = _command.GetCommand();
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_copyJobService)
+            .BuildServiceProvider();
+        _context = new(_serviceProvider);
+    }
+
+    [Fact]
+    public void Name_IsCorrect()
+    {
+        Assert.Equal("list", _command.Name);
+    }
+
+    [Fact]
+    public void Metadata_IsReadOnly()
+    {
+        Assert.False(_command.Metadata.Destructive);
+        Assert.True(_command.Metadata.ReadOnly);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsJobs_WhenJobsExist()
+    {
+        // Arrange
+        using var doc1 = JsonDocument.Parse("{\"name\":\"job1\",\"properties\":{\"status\":\"Completed\"}}");
+        using var doc2 = JsonDocument.Parse("{\"name\":\"job2\",\"properties\":{\"status\":\"Running\"}}");
+        var expectedJobs = new List<JsonElement>
+        {
+            doc1.RootElement.Clone(),
+            doc2.RootElement.Clone()
+        };
+
+        _copyJobService.ListJobsAsync(
+            Arg.Is("sub123"),
+            Arg.Is("myaccount"),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedJobs);
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub123",
+            "--account", "myaccount"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsEmpty_WhenNoJobsExist()
+    {
+        // Arrange
+        _copyJobService.ListJobsAsync(
+            Arg.Is("sub123"),
+            Arg.Is("myaccount"),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new List<JsonElement>());
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub123",
+            "--account", "myaccount"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns500_WhenServiceThrows()
+    {
+        _copyJobService.ListJobsAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("List failed"));
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub123",
+            "--account", "myaccount"
+        ]);
+
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Contains("List failed", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns400_WhenSubscriptionMissing()
+    {
+        var args = _commandDefinition.Parse(["--account", "myaccount"]);
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+}
+
+public class CopyJobCancelCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ICopyJobService _copyJobService;
+    private readonly ILogger<CopyJobCancelCommand> _logger;
+    private readonly CopyJobCancelCommand _command;
+    private readonly Command _commandDefinition;
+    private readonly CommandContext _context;
+
+    public CopyJobCancelCommandTests()
+    {
+        _copyJobService = Substitute.For<ICopyJobService>();
+        _logger = Substitute.For<ILogger<CopyJobCancelCommand>>();
+        _command = new(_logger);
+        _commandDefinition = _command.GetCommand();
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_copyJobService)
+            .BuildServiceProvider();
+        _context = new(_serviceProvider);
+    }
+
+    [Fact]
+    public void Name_IsCorrect()
+    {
+        Assert.Equal("cancel", _command.Name);
+    }
+
+    [Fact]
+    public void Metadata_IsDestructive()
+    {
+        Assert.True(_command.Metadata.Destructive);
+        Assert.False(_command.Metadata.ReadOnly);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CancelsJob_WhenAllParametersProvided()
+    {
+        // Arrange
+        using var expectedDoc = JsonDocument.Parse("{\"status\":\"cancel accepted\",\"jobName\":\"myjob\"}");
+        var expectedResult = expectedDoc.RootElement.Clone();
+
+        _copyJobService.CancelJobAsync(
+            Arg.Is("sub123"),
+            Arg.Is("myaccount"),
+            Arg.Is("myjob"),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedResult);
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub123",
+            "--account", "myaccount",
+            "--job-name", "myjob"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns500_WhenServiceThrows()
+    {
+        _copyJobService.CancelJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Cancel failed"));
+
+        var args = _commandDefinition.Parse([
+            "--subscription", "sub123",
+            "--account", "myaccount",
+            "--job-name", "myjob"
+        ]);
+
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Contains("Cancel failed", response.Message);
+    }
+
+    [Theory]
+    [InlineData("--account", "myaccount", "--job-name", "myjob")] // Missing subscription
+    [InlineData("--subscription", "sub123", "--job-name", "myjob")] // Missing account
+    [InlineData("--subscription", "sub123", "--account", "myaccount")] // Missing job-name
+    public async Task ExecuteAsync_Returns400_WhenRequiredParametersAreMissing(params string[] args)
+    {
+        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse(args), TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+}


### PR DESCRIPTION
Add 7 new MCP commands under 'cosmos copyjob' group for managing Cosmos DB container copy jobs via the copyJobs ARM REST API (Microsoft.DocumentDB/databaseAccounts/copyJobs).

Commands:
- cosmos_copyjob_create: Create a new copy job
- cosmos_copyjob_get: Get job status and progress
- cosmos_copyjob_list: List all copy jobs on an account
- cosmos_copyjob_cancel: Cancel a running/pending job
- cosmos_copyjob_pause: Pause a running job
- cosmos_copyjob_resume: Resume a paused job
- cosmos_copyjob_complete: Complete an Online copy job

Supports all 6 job types (NoSqlRUToNoSqlRU, CassandraRUToCassandraRU, MongoRUToMongoRU, MongoRUToMongoVCore, CassandraRUToAzureBlobStorage, AzureBlobStorageToCassandraRU), multi-task jobs, and Offline/Online modes.

Uses direct ARM REST API calls for portability across SDK versions.

## What does this PR do?
`[Provide a clear, concise description of the changes]`

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `servers/Azure.Mcp.Server/CHANGELOG.md` and/or `servers/Fabric.Mcp.Server/CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate README.md changes using script at `eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] Updated command list in `/servers/Azure.Mcp.Server/docs/azmcp-commands.md` and/or `/docs/fabric-commands.md`
    - [ ] Run `.\eng\scripts\Update-AzCommandsMetadata.ps1` to update tool metadata in azmcp-commands.md (required for CI)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/core/Microsoft.Mcp.Core/src/Areas/Server/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated test prompts in `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
