### PR TITLE
Revert "Bump flatted from 3.3.3 to 3.4.1 in /eng/common/spelling"

### DIFF
--- a/eng/common/spelling/package-lock.json
+++ b/eng/common/spelling/package-lock.json
@@ -904,9 +904,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "license": "ISC"
     },
     "node_modules/gensequence": {


### PR DESCRIPTION
Reverts microsoft/mcp#2045.  This change should be performed in our eng sys repo and then merged back instead.