### PR TITLE
R2R only System.Private.CoreLib in Azure.Mcp.Server

### DIFF
--- a/servers/Azure.Mcp.Server/src/Azure.Mcp.Server.csproj
+++ b/servers/Azure.Mcp.Server/src/Azure.Mcp.Server.csproj
@@ -40,7 +40,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <PublishSingleFile>false</PublishSingleFile>
     <SelfContained>false</SelfContained>
-    <PublishReadyToRun>false</PublishReadyToRun>
+    <PublishReadyToRun>true</PublishReadyToRun>
     <PublishTrimmed>false</PublishTrimmed>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
@@ -95,4 +95,15 @@
     <None Include="..\docs\e2eTestPrompts.md" />
     <None Include="..\docs\new-command.md" />
   </ItemGroup>
+  <!-- R2R only System.Private.CoreLib — exclude all other DLLs dynamically -->
+  <Target Name="_ExcludeNonSpclFromReadyToRun"
+          BeforeTargets="_PrepareForReadyToRunCompilation"
+          DependsOnTargets="_ComputeAssembliesToPostprocessOnPublish"
+          Condition="'$(PublishReadyToRun)' == 'true'">
+    <ItemGroup>
+      <_NonSpclDlls Include="@(ResolvedFileToPublish)"
+          Condition="'%(Extension)' == '.dll' and '%(Filename)' != 'System.Private.CoreLib'" />
+      <PublishReadyToRunExclude Include="@(_NonSpclDlls->'%(Filename)%(Extension)')" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
System.Private.CoreLib can be R2R compiled for about a 5mb increase in uncompressed size with up to ~20% startup increase in my tests.

## What does this PR do?
This PR changes the default configuration for Azure.MCP.Server to ReadyToRun compile System.Private.CoreLib.dll. The final single-file app is about 5mb larger on win-x64 with significantly faster startup.

## GitHub issue number?
None

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [x] For MCP tool changes:
    - [x] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [x] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [x] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [x] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [x] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [x] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [x] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [x] Extra steps for **Azure MCP Server** tool changes:
    - [x] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [x] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [x] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [x] 👉 For Community (non-Microsoft team member) PRs:
        - [x] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [x] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
