### PR TITLE
Domain name validations

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1774280923625.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1774280923625.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed PostgreSQL and MySQL server name validation to strictly require allowed Azure domain suffixes when a fully qualified domain name is provided."

--- a/tools/Azure.Mcp.Tools.MySql/src/Services/MySqlService.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Services/MySqlService.cs
@@ -103,6 +103,13 @@ public class MySqlService(IResourceGroupService resourceGroupService, ITenantSer
         };
     }
 
+    private static readonly string[] AllowedMySqlSuffixes =
+    [
+        ".mysql.database.azure.com",
+        ".mysql.database.usgovcloudapi.net",
+        ".mysql.database.chinacloudapi.cn",
+    ];
+
     private string NormalizeServerName(string server)
     {
         if (!server.Contains('.'))
@@ -119,13 +126,21 @@ public class MySqlService(IResourceGroupService resourceGroupService, ITenantSer
                     server + ".mysql.database.azure.com"
             };
         }
+
+        if (!Array.Exists(AllowedMySqlSuffixes, suffix => server.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new ArgumentException(
+                $"The server name '{server}' is not a valid Azure Database for MySQL hostname. " +
+                $"Fully qualified server names must end with one of: {string.Join(", ", AllowedMySqlSuffixes)}.");
+        }
+
         return server;
     }
 
     private async Task<string> BuildConnectionStringAsync(string server, string user, string database, CancellationToken cancellationToken)
     {
-        var entraIdAccessToken = await GetEntraIdAccessTokenAsync(cancellationToken);
         var host = NormalizeServerName(server);
+        var entraIdAccessToken = await GetEntraIdAccessTokenAsync(cancellationToken);
         return BuildConnectionString(host, database, user, entraIdAccessToken);
     }
 

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Services/MySqlServiceServerNameValidationTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Services/MySqlServiceServerNameValidationTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Services.Azure.ResourceGroup;
+using Azure.Mcp.Core.Services.Azure.Tenant;
+using Azure.Mcp.Tools.MySql.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Mcp.Tools.MySql.UnitTests.Services;
+
+/// <summary>
+/// Tests to verify that NormalizeServerName rejects non-Azure hostnames,
+/// preventing credential exfiltration to attacker-controlled servers.
+/// </summary>
+public class MySqlServiceServerNameValidationTests
+{
+    private readonly MySqlService _mysqlService;
+
+    public MySqlServiceServerNameValidationTests()
+    {
+        var resourceGroupService = Substitute.For<IResourceGroupService>();
+        var tenantService = Substitute.For<ITenantService>();
+        var logger = Substitute.For<ILogger<MySqlService>>();
+
+        _mysqlService = new MySqlService(resourceGroupService, tenantService, logger);
+    }
+
+    [Theory]
+    [InlineData("attacker.com")]
+    [InlineData("evil.example.org")]
+    [InlineData("fake.mysql.database.azure.com.attacker.com")]
+    [InlineData("myserver.mysql.database.azure.com.evil.org")]
+    [InlineData("mysql.database.azure.com.attacker.net")]
+    [InlineData("malicious.host")]
+    public async Task ListDatabasesAsync_WithNonAzureServerFQDN_ThrowsArgumentException(string maliciousServer)
+    {
+        // NormalizeServerName runs before token acquisition, so ArgumentException
+        // is thrown before any credential or network operation.
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _mysqlService.ListDatabasesAsync(
+                "test-sub", "test-rg", "test-user",
+                maliciousServer,
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("not a valid Azure Database for MySQL hostname", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("attacker.com")]
+    [InlineData("evil.example.org")]
+    public async Task ExecuteQueryAsync_WithNonAzureServerFQDN_ThrowsArgumentException(string maliciousServer)
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _mysqlService.ExecuteQueryAsync(
+                "test-sub", "test-rg", "test-user",
+                maliciousServer, "testdb", "SELECT 1",
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("not a valid Azure Database for MySQL hostname", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("attacker.com")]
+    [InlineData("evil.example.org")]
+    public async Task GetTablesAsync_WithNonAzureServerFQDN_ThrowsArgumentException(string maliciousServer)
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _mysqlService.GetTablesAsync(
+                "test-sub", "test-rg", "test-user",
+                maliciousServer, "testdb",
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("not a valid Azure Database for MySQL hostname", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("attacker.com")]
+    [InlineData("evil.example.org")]
+    public async Task GetTableSchemaAsync_WithNonAzureServerFQDN_ThrowsArgumentException(string maliciousServer)
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _mysqlService.GetTableSchemaAsync(
+                "test-sub", "test-rg", "test-user",
+                maliciousServer, "testdb", "test_table",
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("not a valid Azure Database for MySQL hostname", ex.Message);
+    }
+}

--- a/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
@@ -43,6 +43,13 @@ public class PostgresService(
         return accessToken.Token;
     }
 
+    private static readonly string[] AllowedPostgresSuffixes =
+    [
+        ".postgres.database.azure.com",
+        ".postgres.database.usgovcloudapi.net",
+        ".postgres.database.chinacloudapi.cn",
+    ];
+
     private string NormalizeServerName(string server)
     {
         if (!server.Contains('.'))
@@ -59,6 +66,14 @@ public class PostgresService(
                     server + ".postgres.database.azure.com"
             };
         }
+
+        if (!Array.Exists(AllowedPostgresSuffixes, suffix => server.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new ArgumentException(
+                $"The server name '{server}' is not a valid Azure Database for PostgreSQL hostname. " +
+                $"Fully qualified server names must end with one of: {string.Join(", ", AllowedPostgresSuffixes)}.");
+        }
+
         return server;
     }
 

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Services/PostgresServiceServerNameValidationTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.UnitTests/Services/PostgresServiceServerNameValidationTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Data.Common;
+using Azure.Core;
+using Azure.Mcp.Core.Services.Azure.Authentication;
+using Azure.Mcp.Core.Services.Azure.ResourceGroup;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Core.Services.Azure.Tenant;
+using Azure.Mcp.Tools.Postgres.Auth;
+using Azure.Mcp.Tools.Postgres.Options;
+using Azure.Mcp.Tools.Postgres.Providers;
+using Azure.Mcp.Tools.Postgres.Services;
+using Npgsql;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Postgres.UnitTests.Services;
+
+/// <summary>
+/// Tests to verify that NormalizeServerName rejects non-Azure hostnames,
+/// preventing credential exfiltration to attacker-controlled servers.
+/// </summary>
+public class PostgresServiceServerNameValidationTests
+{
+    private readonly IDbProvider _dbProvider;
+    private readonly PostgresService _postgresService;
+    private string? _capturedConnectionString;
+
+    public PostgresServiceServerNameValidationTests()
+    {
+        var resourceGroupService = Substitute.For<IResourceGroupService>();
+        var tenantService = Substitute.For<ITenantService>();
+        var subscriptionService = Substitute.For<ISubscriptionService>();
+
+        var entraTokenAuth = Substitute.For<IEntraTokenProvider>();
+        entraTokenAuth.GetEntraToken(Arg.Any<TokenCredential>(), Arg.Any<CancellationToken>())
+            .Returns(new AccessToken("fake-token", DateTime.UtcNow.AddHours(1)));
+
+        _dbProvider = Substitute.For<IDbProvider>();
+        _dbProvider.GetPostgresResource(Arg.Do<string>(cs => _capturedConnectionString = cs), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Substitute.For<IPostgresResource>());
+        _dbProvider.GetCommand(Arg.Any<string>(), Arg.Any<IPostgresResource>())
+            .Returns(Substitute.For<NpgsqlCommand>());
+        _dbProvider.ExecuteReaderAsync(Arg.Any<NpgsqlCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Substitute.For<DbDataReader>());
+
+        _postgresService = new PostgresService(resourceGroupService, subscriptionService, tenantService, entraTokenAuth, _dbProvider);
+    }
+
+    [Theory]
+    [InlineData("attacker.com")]
+    [InlineData("evil.example.org")]
+    [InlineData("fake.postgres.database.azure.com.attacker.com")]
+    [InlineData("myserver.postgres.database.azure.com.evil.org")]
+    [InlineData("postgres.database.azure.com.attacker.net")]
+    [InlineData("malicious.host")]
+    public async Task ExecuteQueryAsync_WithNonAzureServerFQDN_ThrowsArgumentException(string maliciousServer)
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _postgresService.ExecuteQueryAsync(
+                "test-sub", "test-rg", AuthTypes.MicrosoftEntra, "test-user", null,
+                maliciousServer, "testdb", "SELECT 1",
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("not a valid Azure Database for PostgreSQL hostname", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("attacker.com")]
+    [InlineData("evil.example.org")]
+    public async Task ListDatabasesAsync_WithNonAzureServerFQDN_ThrowsArgumentException(string maliciousServer)
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _postgresService.ListDatabasesAsync(
+                "test-sub", "test-rg", AuthTypes.MicrosoftEntra, "test-user", null,
+                maliciousServer,
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("not a valid Azure Database for PostgreSQL hostname", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("attacker.com")]
+    [InlineData("evil.example.org")]
+    public async Task ListTablesAsync_WithNonAzureServerFQDN_ThrowsArgumentException(string maliciousServer)
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _postgresService.ListTablesAsync(
+                "test-sub", "test-rg", AuthTypes.MicrosoftEntra, "test-user", null,
+                maliciousServer, "testdb",
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("not a valid Azure Database for PostgreSQL hostname", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("attacker.com")]
+    [InlineData("evil.example.org")]
+    public async Task GetTableSchemaAsync_WithNonAzureServerFQDN_ThrowsArgumentException(string maliciousServer)
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _postgresService.GetTableSchemaAsync(
+                "test-sub", "test-rg", AuthTypes.MicrosoftEntra, "test-user", null,
+                maliciousServer, "testdb", "test_table",
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("not a valid Azure Database for PostgreSQL hostname", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("myserver.postgres.database.azure.com")]
+    [InlineData("myserver.postgres.database.usgovcloudapi.net")]
+    [InlineData("myserver.postgres.database.chinacloudapi.cn")]
+    [InlineData("MyServer.Postgres.Database.Azure.Com")]
+    public async Task ExecuteQueryAsync_WithValidAzureServerFQDN_DoesNotThrow(string validServer)
+    {
+        // Should not throw - valid Azure PostgreSQL FQDNs are accepted
+        await _postgresService.ExecuteQueryAsync(
+            "test-sub", "test-rg", AuthTypes.MicrosoftEntra, "test-user", null,
+            validServer, "testdb", "SELECT 1",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(_capturedConnectionString);
+        var parsed = new NpgsqlConnectionStringBuilder(_capturedConnectionString!);
+        Assert.Equal(validServer, parsed.Host);
+    }
+
+    [Fact]
+    public async Task ExecuteQueryAsync_WithShortServerName_AppendsSuffix()
+    {
+        // Short names (no dot) get the suffix appended automatically
+        await _postgresService.ExecuteQueryAsync(
+            "test-sub", "test-rg", AuthTypes.MicrosoftEntra, "test-user", null,
+            "myserver", "testdb", "SELECT 1",
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(_capturedConnectionString);
+        var parsed = new NpgsqlConnectionStringBuilder(_capturedConnectionString!);
+        Assert.Equal("myserver.postgres.database.azure.com", parsed.Host);
+    }
+}


### PR DESCRIPTION
… allowed Azure domain suffixes when a fully qualified domain name is provided.

## What does this PR do?
`[Provide a clear, concise description of the changes]`

Fixed PostgreSQL and MySQL server name validation to strictly require allowed Azure domain suffixes when a fully qualified domain name is provided.

`[Add additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
