### PR TITLE
Update VSIX-DESIGN.md

### DIFF
--- a/servers/Template.Mcp.Server/vscode/VSIX-DESIGN.md
+++ b/servers/Template.Mcp.Server/vscode/VSIX-DESIGN.md
@@ -125,6 +125,7 @@ const serverPath = path.join(context.extensionPath, 'server', binary);
 - As an optimization, the extension could download the latest platform-specific server binary from a public URL at runtime.
 - This reduces VSIX size but requires HTTP(S) download logic.
 - Not currently implemented in the default design for maximum compatibility and offline support.
+- Note: Platform specific .zip files are hosted on GitHub in each release.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?
[Pipelines - Run 20260323.2 logs](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6051701&view=logs&j=36df4387-3551-57fa-098c-b43a23930261&t=9a6b6ada-f8a7-57e5-51fa-391e0b5b8f0b&s=ff05ad62-bb9a-53b6-ce9f-72f329a63e7c) - The release pipeline is currently failing at the Link Verification stage. 
 
The releases/tags for the Template.Mcp.Server are not present in our GitHub releases section ([https://github.com/microsoft/mcp/activity?activity_type=release](https://github.com/microsoft/mcp/activity?ref=refs/tags/Template.Mcp.Server-0.0.12-alpha.5425605)) , while `servers\Template.Mcp.Server\vscode\VSIX-DESIGN.md` still references zip download links for them. ([VSIX-DESIGN.md](https://github.com/microsoft/mcp/blob/6e09982de7f52520366543e361c7a54389dc5b2d/servers/Template.Mcp.Server/vscode/VSIX-DESIGN.md?plain=1#L129)). 
These links are broken and is causing the build failure.

Removing these links as they no longer exist.

    
