### PR TITLE
Rename IlcOptimizationPreference to OptimizationPreference

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -55,7 +55,7 @@
     <!-- AOT native build flags -->
     <IsAotCompatible>true</IsAotCompatible>
     <PublishAot>true</PublishAot>
-    <IlcOptimizationPreference>Size</IlcOptimizationPreference>
+    <OptimizationPreference>Size</OptimizationPreference>
     <IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>
   </PropertyGroup>
 


### PR DESCRIPTION
IlcOptimizationPreference is not used anywhere in the nativeaot msbuild files. OptimizationPreference is the correct property to set.