### PR TITLE
Update HttpRequestException handling to check for StatusCode (#2172)

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Commands/BaseCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/BaseCommand.cs
@@ -110,6 +110,7 @@ public abstract class BaseCommand<TOptions> : IBaseCommand where TOptions : clas
     {
         ArgumentException => HttpStatusCode.BadRequest,  // Bad Request for invalid arguments
         InvalidOperationException => HttpStatusCode.UnprocessableEntity,  // Unprocessable Entity for configuration errors
+        HttpRequestException httpEx => httpEx.StatusCode ?? HttpStatusCode.ServiceUnavailable,
         _ => HttpStatusCode.InternalServerError  // Internal Server Error for unexpected errors
     };
 

--- a/core/Microsoft.Mcp.Core/src/Commands/GlobalCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/GlobalCommand.cs
@@ -121,7 +121,7 @@ public abstract class GlobalCommand<
         KeyNotFoundException => HttpStatusCode.NotFound,
         AuthenticationFailedException => HttpStatusCode.Unauthorized,
         RequestFailedException rfEx => (HttpStatusCode)rfEx.Status,
-        HttpRequestException => HttpStatusCode.ServiceUnavailable,
+        HttpRequestException httpEx => httpEx.StatusCode ?? HttpStatusCode.ServiceUnavailable,
         _ => HttpStatusCode.InternalServerError
     };
 

--- a/servers/Azure.Mcp.Server/changelog-entries/1774379055021.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1774379055021.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Other Changes"
+    description: "Update HttpRequestException to attempt to return a more specific status code for better troubleshooting"

--- a/servers/Fabric.Mcp.Server/changelog-entries/1774379067978.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1774379067978.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Other Changes"
+    description: "Update HttpRequestException to attempt to return a more specific status code for better troubleshooting"


### PR DESCRIPTION
## What does this PR do?

PR #2172 porting to 2.x branch.

Updates handling of `HttpRequestException` to check for `StatusCode` being non-null and using it before falling back to default of `HttpStatusCode.ServiceUnavailable`. Also adds handling for `HttpRequestException` to `BaseCommand`.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
