### PR TITLE
docs: update --subscription global option to document CLI profile default resolution

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -9,7 +9,7 @@ The following options are available for all commands:
 
 | Option | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `--subscription` | No | Environment variable `AZURE_SUBSCRIPTION_ID` | Azure subscription ID for target resources |
+| `--subscription` | No | Azure CLI profile, then `AZURE_SUBSCRIPTION_ID` env var | Azure subscription ID or display name. If not specified, uses the default subscription from `az account set` or `AZURE_SUBSCRIPTION_ID`. |
 | `--tenant-id` | No | - | Azure tenant ID for authentication |
 | `--auth-method` | No | 'credential' | Authentication method ('credential', 'key', 'connectionString') |
 | `--retry-max-retries` | No | 3 | Maximum retry attempts for failed operations |


### PR DESCRIPTION
## Summary

Updates the `--subscription` global option documentation in `azmcp-commands.md` to reflect the default subscription resolution behavior added in #1974.

## What changed

The Global Options table previously only mentioned `AZURE_SUBSCRIPTION_ID` as the default for `--subscription`. Since #1974, the resolution order is:

1. Explicit `--subscription` value from the command
2. Azure CLI profile (`~/.azure/azureProfile.json`, set via `az account set`)
3. `AZURE_SUBSCRIPTION_ID` environment variable

The updated description also notes that both subscription ID (GUID) and display name are accepted.

## Why

The subscription list tool section (lines 3454-3456) was already updated by #1974 to document `isDefault` and the CLI profile behavior. However, the Global Options table still showed the old default. This creates an inconsistency - users reading the global options would not know about CLI profile resolution.

## Related

- #1974 (engineering PR that added the behavior)
- MicrosoftDocs/azure-dev-docs-pr#8774 (content docs PR for the same change)
