### PR TITLE
Enforce read-only and http mode in runtime (#2175)

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
@@ -964,4 +964,162 @@ public class CommandFactoryToolLoaderTests
     }
 
     #endregion
+
+    #region Execution-Time Mode Enforcement Tests
+
+    [Fact]
+    public async Task CallToolHandler_WithReadOnlyMode_RejectsNonReadOnlyTool()
+    {
+        // Arrange - create a tool loader with read-only mode enabled
+        var readOnlyOptions = new ToolLoaderOptions(ReadOnly: true);
+        var (toolLoader, commandFactory) = CreateToolLoader(readOnlyOptions);
+
+        // Add a fake non-read-only command
+        var fakeCommand = Substitute.For<IBaseCommand>();
+        var fakeSystemCommand = new Command("fake-write-tool", "A fake write tool for testing");
+        fakeCommand.GetCommand().Returns(fakeSystemCommand);
+        fakeCommand.Title.Returns("Fake Write Tool");
+        fakeCommand.Metadata.Returns(new ToolMetadata { ReadOnly = false });
+
+        var commandMapField = typeof(CommandFactory).GetField("_commandMap", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var commandMap = (Dictionary<string, IBaseCommand>)commandMapField!.GetValue(commandFactory)!;
+        commandMap["fake-write-tool"] = fakeCommand;
+
+        var mockServer = Substitute.For<ModelContextProtocol.Server.McpServer>();
+        var request = new ModelContextProtocol.Server.RequestContext<CallToolRequestParams>(mockServer, new() { Method = RequestMethods.ToolsCall })
+        {
+            Params = new CallToolRequestParams
+            {
+                Name = "fake-write-tool",
+                Arguments = new Dictionary<string, JsonElement>()
+            }
+        };
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - Should reject the tool call due to read-only mode
+        Assert.NotNull(result);
+        Assert.True(result.IsError);
+        var errorText = ((TextContentBlock)result.Content.First()).Text;
+        Assert.Contains("read-only mode", errorText);
+        Assert.Contains("fake-write-tool", errorText);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithReadOnlyMode_AllowsReadOnlyTool()
+    {
+        // Arrange - create a tool loader with read-only mode enabled
+        var readOnlyOptions = new ToolLoaderOptions(ReadOnly: true);
+        var (toolLoader, commandFactory) = CreateToolLoader(readOnlyOptions);
+
+        // Add a fake read-only command
+        var fakeCommand = Substitute.For<IBaseCommand>();
+        var fakeSystemCommand = new Command("fake-readonly-tool", "A fake read-only tool for testing");
+        fakeCommand.GetCommand().Returns(fakeSystemCommand);
+        fakeCommand.Title.Returns("Fake ReadOnly Tool");
+        fakeCommand.Metadata.Returns(new ToolMetadata { ReadOnly = true, Destructive = false });
+        fakeCommand.ExecuteAsync(Arg.Any<CommandContext>(), Arg.Any<ParseResult>(), Arg.Any<CancellationToken>())
+                   .Returns(new CommandResponse { Status = HttpStatusCode.OK, Message = "Read-only test response" });
+
+        var commandMapField = typeof(CommandFactory).GetField("_commandMap", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var commandMap = (Dictionary<string, IBaseCommand>)commandMapField!.GetValue(commandFactory)!;
+        commandMap["fake-readonly-tool"] = fakeCommand;
+
+        var mockServer = Substitute.For<ModelContextProtocol.Server.McpServer>();
+        var request = new ModelContextProtocol.Server.RequestContext<CallToolRequestParams>(mockServer, new() { Method = RequestMethods.ToolsCall })
+        {
+            Params = new CallToolRequestParams
+            {
+                Name = "fake-readonly-tool",
+                Arguments = new Dictionary<string, JsonElement>()
+            }
+        };
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - Should allow execution of read-only tool
+        Assert.NotNull(result);
+        Assert.False(result.IsError);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithHttpMode_RejectsLocalRequiredTool()
+    {
+        // Arrange - create a tool loader with HTTP mode enabled
+        var httpOptions = new ToolLoaderOptions(IsHttpMode: true);
+        var (toolLoader, commandFactory) = CreateToolLoader(httpOptions);
+
+        // Add a fake local-required command
+        var fakeCommand = Substitute.For<IBaseCommand>();
+        var fakeSystemCommand = new Command("fake-local-tool", "A fake local tool for testing");
+        fakeCommand.GetCommand().Returns(fakeSystemCommand);
+        fakeCommand.Title.Returns("Fake Local Tool");
+        fakeCommand.Metadata.Returns(new ToolMetadata { LocalRequired = true });
+
+        var commandMapField = typeof(CommandFactory).GetField("_commandMap", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var commandMap = (Dictionary<string, IBaseCommand>)commandMapField!.GetValue(commandFactory)!;
+        commandMap["fake-local-tool"] = fakeCommand;
+
+        var mockServer = Substitute.For<ModelContextProtocol.Server.McpServer>();
+        var request = new ModelContextProtocol.Server.RequestContext<CallToolRequestParams>(mockServer, new() { Method = RequestMethods.ToolsCall })
+        {
+            Params = new CallToolRequestParams
+            {
+                Name = "fake-local-tool",
+                Arguments = new Dictionary<string, JsonElement>()
+            }
+        };
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - Should reject the tool call due to HTTP mode
+        Assert.NotNull(result);
+        Assert.True(result.IsError);
+        var errorText = ((TextContentBlock)result.Content.First()).Text;
+        Assert.Contains("HTTP mode", errorText);
+        Assert.Contains("fake-local-tool", errorText);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithoutReadOnlyMode_AllowsNonReadOnlyTool()
+    {
+        // Arrange - create a tool loader WITHOUT read-only mode
+        var defaultOptions = new ToolLoaderOptions(ReadOnly: false);
+        var (toolLoader, commandFactory) = CreateToolLoader(defaultOptions);
+
+        // Add a fake non-read-only command
+        var fakeCommand = Substitute.For<IBaseCommand>();
+        var fakeSystemCommand = new Command("fake-write-tool-2", "A fake write tool for testing");
+        fakeCommand.GetCommand().Returns(fakeSystemCommand);
+        fakeCommand.Title.Returns("Fake Write Tool 2");
+        fakeCommand.Metadata.Returns(new ToolMetadata { ReadOnly = false, Destructive = false });
+        fakeCommand.ExecuteAsync(Arg.Any<CommandContext>(), Arg.Any<ParseResult>(), Arg.Any<CancellationToken>())
+                   .Returns(new CommandResponse { Status = HttpStatusCode.OK, Message = "Write test response" });
+
+        var commandMapField = typeof(CommandFactory).GetField("_commandMap", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var commandMap = (Dictionary<string, IBaseCommand>)commandMapField!.GetValue(commandFactory)!;
+        commandMap["fake-write-tool-2"] = fakeCommand;
+
+        var mockServer = Substitute.For<ModelContextProtocol.Server.McpServer>();
+        var request = new ModelContextProtocol.Server.RequestContext<CallToolRequestParams>(mockServer, new() { Method = RequestMethods.ToolsCall })
+        {
+            Params = new CallToolRequestParams
+            {
+                Name = "fake-write-tool-2",
+                Arguments = new Dictionary<string, JsonElement>()
+            }
+        };
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - Should allow execution when read-only mode is not enabled
+        Assert.NotNull(result);
+        Assert.False(result.IsError);
+    }
+
+    #endregion
 }

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
@@ -659,6 +659,174 @@ public sealed class NamespaceToolLoaderTests : IDisposable
     }
 
     [Fact]
+    public async Task CallToolHandler_ReadOnlyMode_RejectsNonReadOnlyCommand()
+    {
+        // Arrange
+        var commandFactory = Substitute.For<ICommandFactory>();
+        var rootGroup = new CommandGroup("root", "Root command group");
+        var storageGroup = new CommandGroup("storage", "Storage commands");
+
+        var executed = false;
+        var writeCmd = Substitute.For<IBaseCommand>();
+        writeCmd.Metadata.Returns(new ToolMetadata { ReadOnly = false });
+        writeCmd.GetCommand().Returns(new System.CommandLine.Command("write-cmd", "A write command"));
+        writeCmd.ExecuteAsync(default!, default!, default!).ReturnsForAnyArgs(call =>
+        {
+            executed = true;
+            return new Microsoft.Mcp.Core.Models.Command.CommandResponse { Status = System.Net.HttpStatusCode.OK };
+        });
+        storageGroup.AddCommand("write-cmd", writeCmd);
+
+        rootGroup.SubGroup.Add(storageGroup);
+        commandFactory.RootGroup.Returns(rootGroup);
+        commandFactory.GroupCommands(Arg.Any<string[]>())
+            .Returns(new Dictionary<string, IBaseCommand> { ["write-cmd"] = writeCmd });
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions { ReadOnly = true });
+        var logger = Substitute.For<ILogger<NamespaceToolLoader>>();
+
+        var loader = new NamespaceToolLoader(commandFactory, options, serviceProvider, logger);
+        var request = CreateCallToolRequest("storage", new Dictionary<string, object?>
+        {
+            ["command"] = "write-cmd",
+            ["parameters"] = new Dictionary<string, object?>()
+        });
+
+        // Act
+        await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - non-read-only command should not have been executed
+        Assert.False(executed, "Non-read-only command should not be executed in read-only mode");
+    }
+
+    [Fact]
+    public async Task CallToolHandler_ReadOnlyMode_AllowsReadOnlyCommand()
+    {
+        // Arrange
+        var commandFactory = Substitute.For<ICommandFactory>();
+        var rootGroup = new CommandGroup("root", "Root command group");
+        var storageGroup = new CommandGroup("storage", "Storage commands");
+
+        var executed = false;
+        var readCmd = Substitute.For<IBaseCommand>();
+        readCmd.Metadata.Returns(new ToolMetadata { ReadOnly = true, Destructive = false });
+        readCmd.GetCommand().Returns(new System.CommandLine.Command("read-cmd", "A read command"));
+        readCmd.ExecuteAsync(default!, default!, default!).ReturnsForAnyArgs(call =>
+        {
+            executed = true;
+            return new Microsoft.Mcp.Core.Models.Command.CommandResponse { Status = System.Net.HttpStatusCode.OK };
+        });
+        storageGroup.AddCommand("read-cmd", readCmd);
+
+        rootGroup.SubGroup.Add(storageGroup);
+        commandFactory.RootGroup.Returns(rootGroup);
+        commandFactory.GroupCommands(Arg.Any<string[]>())
+            .Returns(new Dictionary<string, IBaseCommand> { ["read-cmd"] = readCmd });
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions { ReadOnly = true });
+        var logger = Substitute.For<ILogger<NamespaceToolLoader>>();
+
+        var loader = new NamespaceToolLoader(commandFactory, options, serviceProvider, logger);
+        var request = CreateCallToolRequest("storage", new Dictionary<string, object?>
+        {
+            ["command"] = "read-cmd",
+            ["parameters"] = new Dictionary<string, object?>()
+        });
+
+        // Act
+        await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - read-only command should have been executed
+        Assert.True(executed, "Read-only command should be executed in read-only mode");
+    }
+
+    [Fact]
+    public async Task CallToolHandler_HttpMode_RejectsLocalRequiredCommand()
+    {
+        // Arrange
+        var commandFactory = Substitute.For<ICommandFactory>();
+        var rootGroup = new CommandGroup("root", "Root command group");
+        var storageGroup = new CommandGroup("storage", "Storage commands");
+
+        var executed = false;
+        var localCmd = Substitute.For<IBaseCommand>();
+        localCmd.Metadata.Returns(new ToolMetadata { LocalRequired = true });
+        localCmd.GetCommand().Returns(new System.CommandLine.Command("local-cmd", "A local command"));
+        localCmd.ExecuteAsync(default!, default!, default!).ReturnsForAnyArgs(call =>
+        {
+            executed = true;
+            return new Microsoft.Mcp.Core.Models.Command.CommandResponse { Status = System.Net.HttpStatusCode.OK };
+        });
+        storageGroup.AddCommand("local-cmd", localCmd);
+
+        rootGroup.SubGroup.Add(storageGroup);
+        commandFactory.RootGroup.Returns(rootGroup);
+        commandFactory.GroupCommands(Arg.Any<string[]>())
+            .Returns(new Dictionary<string, IBaseCommand> { ["local-cmd"] = localCmd });
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions { Transport = TransportTypes.Http });
+        var logger = Substitute.For<ILogger<NamespaceToolLoader>>();
+
+        var loader = new NamespaceToolLoader(commandFactory, options, serviceProvider, logger);
+        var request = CreateCallToolRequest("storage", new Dictionary<string, object?>
+        {
+            ["command"] = "local-cmd",
+            ["parameters"] = new Dictionary<string, object?>()
+        });
+
+        // Act
+        await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - local-required command should not have been executed in HTTP mode
+        Assert.False(executed, "Local-required command should not be executed in HTTP mode");
+    }
+
+    [Fact]
+    public async Task CallToolHandler_HttpMode_AllowsNonLocalRequiredCommand()
+    {
+        // Arrange
+        var commandFactory = Substitute.For<ICommandFactory>();
+        var rootGroup = new CommandGroup("root", "Root command group");
+        var storageGroup = new CommandGroup("storage", "Storage commands");
+
+        var executed = false;
+        var remoteCmd = Substitute.For<IBaseCommand>();
+        remoteCmd.Metadata.Returns(new ToolMetadata { LocalRequired = false, Destructive = false });
+        remoteCmd.GetCommand().Returns(new System.CommandLine.Command("remote-cmd", "A remote command"));
+        remoteCmd.ExecuteAsync(default!, default!, default!).ReturnsForAnyArgs(call =>
+        {
+            executed = true;
+            return new Microsoft.Mcp.Core.Models.Command.CommandResponse { Status = System.Net.HttpStatusCode.OK };
+        });
+        storageGroup.AddCommand("remote-cmd", remoteCmd);
+
+        rootGroup.SubGroup.Add(storageGroup);
+        commandFactory.RootGroup.Returns(rootGroup);
+        commandFactory.GroupCommands(Arg.Any<string[]>())
+            .Returns(new Dictionary<string, IBaseCommand> { ["remote-cmd"] = remoteCmd });
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions { Transport = TransportTypes.Http });
+        var logger = Substitute.For<ILogger<NamespaceToolLoader>>();
+
+        var loader = new NamespaceToolLoader(commandFactory, options, serviceProvider, logger);
+        var request = CreateCallToolRequest("storage", new Dictionary<string, object?>
+        {
+            ["command"] = "remote-cmd",
+            ["parameters"] = new Dictionary<string, object?>()
+        });
+
+        // Act
+        await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - non-local-required command should have been executed in HTTP mode
+        Assert.True(executed, "Non-local-required command should be executed in HTTP mode");
+    }
+
+    [Fact]
     public async Task GetChildToolList_WithReadOnlyOption_ReturnsOnlyReadOnlyTools()
     {
         // Arrange

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/RegistryToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/RegistryToolLoaderTests.cs
@@ -861,4 +861,189 @@ public class RegistryToolLoaderTests
         Assert.Single(result.Tools);
         Assert.Equal("search_docs", result.Tools[0].Name);
     }
+
+    [Fact]
+    public async Task CallToolHandler_WithReadOnlyMode_RejectsNonReadOnlyTool()
+    {
+        // Arrange
+        var readOnlyTool = new Tool
+        {
+            Name = "readonly-tool",
+            Description = "Read-only tool",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = true }
+        };
+
+        var writeTool = new Tool
+        {
+            Name = "write-tool",
+            Description = "Write tool",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = false }
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(readOnlyTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Read-only result" }], IsError = false })
+            .AddTool(writeTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Write result" }], IsError = false });
+
+        var discoveryStrategy = new MockMcpDiscoveryStrategyBuilder()
+            .AddServer("test-server", "test-server", "Test Server Description", clientBuilder)
+            .Build();
+
+        var readOnlyOptions = new ToolLoaderOptions(ReadOnly: true);
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger<RegistryToolLoader>();
+        var serviceOptions = Microsoft.Extensions.Options.Options.Create(readOnlyOptions);
+
+        var toolLoader = new RegistryToolLoader(discoveryStrategy, serviceOptions, logger);
+
+        // Act - Try to call the non-read-only tool directly
+        var request = CreateCallToolRequest("write-tool");
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - Should reject the tool call due to read-only mode
+        Assert.NotNull(result);
+        Assert.True(result.IsError);
+        var errorText = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(errorText);
+        Assert.Contains("read-only mode", errorText.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithReadOnlyMode_AllowsReadOnlyTool()
+    {
+        // Arrange
+        var readOnlyTool = new Tool
+        {
+            Name = "readonly-tool",
+            Description = "Read-only tool",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = true }
+        };
+
+        var writeTool = new Tool
+        {
+            Name = "write-tool",
+            Description = "Write tool",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = false }
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(readOnlyTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Read-only result" }], IsError = false })
+            .AddTool(writeTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Write result" }], IsError = false });
+
+        var discoveryStrategy = new MockMcpDiscoveryStrategyBuilder()
+            .AddServer("test-server", "test-server", "Test Server Description", clientBuilder)
+            .Build();
+
+        var readOnlyOptions = new ToolLoaderOptions(ReadOnly: true);
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger<RegistryToolLoader>();
+        var serviceOptions = Microsoft.Extensions.Options.Options.Create(readOnlyOptions);
+
+        var toolLoader = new RegistryToolLoader(discoveryStrategy, serviceOptions, logger);
+
+        // Act - Call the read-only tool
+        var request = CreateCallToolRequest("readonly-tool");
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - Should allow execution of read-only tool
+        Assert.NotNull(result);
+        Assert.False(result.IsError);
+        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(textContent);
+        Assert.Equal("Read-only result", textContent.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithHttpMode_RejectsLocalRequiredTool()
+    {
+        // Arrange
+        var localRequiredTool = new Tool
+        {
+            Name = "local-tool",
+            Description = "Local required tool",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new(),
+            Meta = new JsonObject { ["LocalRequiredHint"] = true }
+        };
+
+        var remoteTool = new Tool
+        {
+            Name = "remote-tool",
+            Description = "Remote tool",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new(),
+            Meta = new JsonObject { ["LocalRequiredHint"] = false }
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(localRequiredTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Local result" }], IsError = false })
+            .AddTool(remoteTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Remote result" }], IsError = false });
+
+        var discoveryStrategy = new MockMcpDiscoveryStrategyBuilder()
+            .AddServer("test-server", "test-server", "Test Server Description", clientBuilder)
+            .Build();
+
+        var httpOptions = new ToolLoaderOptions(IsHttpMode: true);
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger<RegistryToolLoader>();
+        var serviceOptions = Microsoft.Extensions.Options.Options.Create(httpOptions);
+
+        var toolLoader = new RegistryToolLoader(discoveryStrategy, serviceOptions, logger);
+
+        // Act - Try to call the local-required tool in HTTP mode
+        var request = CreateCallToolRequest("local-tool");
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - Should reject the tool call due to HTTP mode
+        Assert.NotNull(result);
+        Assert.True(result.IsError);
+        var errorText = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(errorText);
+        Assert.Contains("HTTP mode", errorText.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithReadOnlyToolWithNullAnnotations_RejectsInReadOnlyMode()
+    {
+        // Arrange - tool with null annotations should be rejected in read-only mode
+        var toolWithoutAnnotations = new Tool
+        {
+            Name = "no-annotations-tool",
+            Description = "Tool without annotations",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = null
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(toolWithoutAnnotations, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Result" }], IsError = false });
+
+        var discoveryStrategy = new MockMcpDiscoveryStrategyBuilder()
+            .AddServer("test-server", "test-server", "Test Server Description", clientBuilder)
+            .Build();
+
+        var readOnlyOptions = new ToolLoaderOptions(ReadOnly: true);
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger<RegistryToolLoader>();
+        var serviceOptions = Microsoft.Extensions.Options.Options.Create(readOnlyOptions);
+
+        var toolLoader = new RegistryToolLoader(discoveryStrategy, serviceOptions, logger);
+
+        // Act - Try to call a tool with null annotations in read-only mode
+        var request = CreateCallToolRequest("no-annotations-tool");
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - Should reject since null annotations means ReadOnlyHint is not true
+        Assert.NotNull(result);
+        Assert.True(result.IsError);
+        var errorText = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(errorText);
+        Assert.Contains("read-only mode", errorText.Text);
+    }
 }

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/ServerToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/ServerToolLoaderTests.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Azure.Mcp.Core.UnitTests.Areas.Server.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Areas.Server.Commands.Discovery;
@@ -242,4 +243,341 @@ public class ServerToolLoaderTests
             }
         });
     }
+
+    #region Execution-Time Mode Enforcement Tests
+
+    private static (ServerToolLoader toolLoader, IMcpDiscoveryStrategy discoveryStrategy) CreateToolLoaderWithMockClient(
+        ToolLoaderOptions options, MockMcpClientBuilder clientBuilder, string serverName = "test-server")
+    {
+        var discoveryStrategy = new MockMcpDiscoveryStrategyBuilder()
+            .AddServer(serverName, serverName, $"{serverName} description", clientBuilder)
+            .Build();
+
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<ServerToolLoader>();
+        var toolLoaderOptions = Microsoft.Extensions.Options.Options.Create(options);
+
+        return (new ServerToolLoader(discoveryStrategy, toolLoaderOptions, logger), discoveryStrategy);
+    }
+
+    private static RequestContext<CallToolRequestParams> CreateCallToolRequestWithCommand(
+        string serverName, string command, Dictionary<string, JsonElement>? extraParams = null)
+    {
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            { "intent", JsonDocument.Parse($"\"Execute {command}\"").RootElement },
+            { "command", JsonDocument.Parse($"\"{command}\"").RootElement },
+        };
+
+        if (extraParams != null)
+        {
+            foreach (var kvp in extraParams)
+            {
+                arguments[kvp.Key] = kvp.Value;
+            }
+        }
+
+        var mockServer = Substitute.For<McpServer>();
+        return new(mockServer, new() { Method = RequestMethods.ToolsCall })
+        {
+            Params = new()
+            {
+                Name = serverName,
+                Arguments = arguments
+            }
+        };
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithReadOnlyMode_RejectsNonReadOnlyCommand()
+    {
+        // Arrange
+        var readOnlyTool = new Tool
+        {
+            Name = "account_list",
+            Description = "List storage accounts",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = true }
+        };
+
+        var writeTool = new Tool
+        {
+            Name = "account_create",
+            Description = "Create storage account",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = false }
+        };
+
+        var writeToolExecuted = false;
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(readOnlyTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Listed accounts" }], IsError = false })
+            .AddTool(writeTool, _ =>
+            {
+                writeToolExecuted = true;
+                return new CallToolResult { Content = [new TextContentBlock { Text = "Created account" }], IsError = false };
+            });
+
+        var (toolLoader, _) = CreateToolLoaderWithMockClient(
+            new ToolLoaderOptions(ReadOnly: true), clientBuilder, "storage");
+
+        var request = CreateCallToolRequestWithCommand("storage", "account_create");
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - The non-read-only tool must NOT be executed
+        Assert.False(writeToolExecuted, "Non-read-only tool should not be executed in read-only mode");
+        Assert.NotNull(result);
+        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(textContent);
+        // Should not contain the write tool's success response
+        Assert.DoesNotContain("Created account", textContent.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithReadOnlyMode_AllowsReadOnlyCommand()
+    {
+        // Arrange
+        var readOnlyTool = new Tool
+        {
+            Name = "account_list",
+            Description = "List storage accounts",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = true }
+        };
+
+        var writeTool = new Tool
+        {
+            Name = "account_create",
+            Description = "Create storage account",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = false }
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(readOnlyTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Listed accounts" }], IsError = false })
+            .AddTool(writeTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Created account" }], IsError = false });
+
+        var (toolLoader, _) = CreateToolLoaderWithMockClient(
+            new ToolLoaderOptions(ReadOnly: true), clientBuilder, "storage");
+
+        var request = CreateCallToolRequestWithCommand("storage", "account_list");
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - Should allow the read-only tool call
+        Assert.NotNull(result);
+        Assert.False(result.IsError);
+        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(textContent);
+        Assert.Equal("Listed accounts", textContent.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithIsHttpMode_RejectsLocalRequiredCommand()
+    {
+        // Arrange
+        var localRequiredTool = new Tool
+        {
+            Name = "local_command",
+            Description = "Local-only command",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations(),
+            Meta = new JsonObject { ["LocalRequiredHint"] = true }
+        };
+
+        var remoteTool = new Tool
+        {
+            Name = "remote_command",
+            Description = "Remote-safe command",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations(),
+            Meta = new JsonObject { ["LocalRequiredHint"] = false }
+        };
+
+        var localToolExecuted = false;
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(localRequiredTool, _ =>
+            {
+                localToolExecuted = true;
+                return new CallToolResult { Content = [new TextContentBlock { Text = "Local result" }], IsError = false };
+            })
+            .AddTool(remoteTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Remote result" }], IsError = false });
+
+        var (toolLoader, _) = CreateToolLoaderWithMockClient(
+            new ToolLoaderOptions(IsHttpMode: true), clientBuilder, "storage");
+
+        var request = CreateCallToolRequestWithCommand("storage", "local_command");
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - The local-required tool must NOT be executed in HTTP mode
+        Assert.False(localToolExecuted, "Local-required tool should not be executed in HTTP mode");
+        Assert.NotNull(result);
+        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(textContent);
+        // Should not contain the local tool's success response
+        Assert.DoesNotContain("Local result", textContent.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithIsHttpMode_AllowsNonLocalRequiredCommand()
+    {
+        // Arrange
+        var localRequiredTool = new Tool
+        {
+            Name = "local_command",
+            Description = "Local-only command",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations(),
+            Meta = new JsonObject { ["LocalRequiredHint"] = true }
+        };
+
+        var remoteTool = new Tool
+        {
+            Name = "remote_command",
+            Description = "Remote-safe command",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations(),
+            Meta = new JsonObject { ["LocalRequiredHint"] = false }
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(localRequiredTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Local result" }], IsError = false })
+            .AddTool(remoteTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Remote result" }], IsError = false });
+
+        var (toolLoader, _) = CreateToolLoaderWithMockClient(
+            new ToolLoaderOptions(IsHttpMode: true), clientBuilder, "storage");
+
+        var request = CreateCallToolRequestWithCommand("storage", "remote_command");
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - Should allow the non-local-required tool call
+        Assert.NotNull(result);
+        Assert.False(result.IsError);
+        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(textContent);
+        Assert.Equal("Remote result", textContent.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithReadOnlyMode_RejectsCommandWithNullAnnotations()
+    {
+        // Arrange - tool with null annotations should be rejected in read-only mode
+        var toolWithoutAnnotations = new Tool
+        {
+            Name = "unknown_command",
+            Description = "Tool without annotations",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = null
+        };
+
+        var toolExecuted = false;
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(toolWithoutAnnotations, _ =>
+            {
+                toolExecuted = true;
+                return new CallToolResult { Content = [new TextContentBlock { Text = "Result" }], IsError = false };
+            });
+
+        var (toolLoader, _) = CreateToolLoaderWithMockClient(
+            new ToolLoaderOptions(ReadOnly: true), clientBuilder, "storage");
+
+        var request = CreateCallToolRequestWithCommand("storage", "unknown_command");
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - Tool without read-only annotation must NOT be executed in read-only mode
+        Assert.False(toolExecuted, "Tool without ReadOnlyHint should not be executed in read-only mode");
+        Assert.NotNull(result);
+        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(textContent);
+        // Should not contain the tool's success response
+        Assert.DoesNotContain("Result", textContent.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithoutReadOnlyMode_AllowsNonReadOnlyCommand()
+    {
+        // Arrange
+        var writeTool = new Tool
+        {
+            Name = "account_create",
+            Description = "Create storage account",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = false }
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(writeTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Created account" }], IsError = false });
+
+        var (toolLoader, _) = CreateToolLoaderWithMockClient(
+            new ToolLoaderOptions(ReadOnly: false), clientBuilder, "storage");
+
+        var request = CreateCallToolRequestWithCommand("storage", "account_create");
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - Should allow execution when read-only mode is not enabled
+        Assert.NotNull(result);
+        Assert.False(result.IsError);
+        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(textContent);
+        Assert.Equal("Created account", textContent.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithReadOnlyAndSamplingFallback_RejectsNonReadOnlyResolvedCommand()
+    {
+        // Arrange - Set up a server where the direct command name doesn't match,
+        // forcing the code path through sampling. With no sampling support on the mock server,
+        // this should fall back to learn mode or reject.
+        var readOnlyTool = new Tool
+        {
+            Name = "account_list",
+            Description = "List storage accounts",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = true }
+        };
+
+        var writeTool = new Tool
+        {
+            Name = "account_create",
+            Description = "Create storage account",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = false }
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(readOnlyTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Listed accounts" }], IsError = false })
+            .AddTool(writeTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Created account" }], IsError = false });
+
+        var (toolLoader, _) = CreateToolLoaderWithMockClient(
+            new ToolLoaderOptions(ReadOnly: true), clientBuilder, "storage");
+
+        // Use a command name that doesn't exist in the filtered available tools list.
+        // "account_create" exists in the backend but is filtered out by ReadOnly.
+        // The non-existent command "bad_command" will fail the availableTools check
+        // and without sampling support, it should fall back to learn mode.
+        var request = CreateCallToolRequestWithCommand("storage", "bad_command");
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert - Should NOT succeed with a write operation.
+        // The command doesn't match any filtered tool, so it should trigger learn mode or rejection.
+        Assert.NotNull(result);
+        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(textContent);
+        // Should not contain the write tool's response
+        Assert.DoesNotContain("Created account", textContent.Text);
+    }
+
+    #endregion
 }

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/SingleProxyToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/SingleProxyToolLoaderTests.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Azure.Mcp.Core.Helpers;
+using Azure.Mcp.Core.UnitTests.Areas.Server.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Areas.Server.Commands.Discovery;
@@ -399,4 +400,253 @@ public class SingleProxyToolLoaderTests
         Assert.Throws<ArgumentNullException>(() => new SingleProxyToolLoader(discoveryStrategy, null!, toolLoaderOptions));
         Assert.Throws<ArgumentNullException>(() => new SingleProxyToolLoader(discoveryStrategy, logger, null!));
     }
+
+    #region Execution-Time Mode Enforcement Tests
+
+    private static SingleProxyToolLoader CreateToolLoaderWithMockClient(
+        ToolLoaderOptions toolLoaderOptions, MockMcpClientBuilder clientBuilder, string serverName = "storage")
+    {
+        var discoveryStrategy = new MockMcpDiscoveryStrategyBuilder()
+            .AddServer(serverName, serverName, $"{serverName} description", clientBuilder)
+            .Build();
+
+        var logger = Substitute.For<ILogger<SingleProxyToolLoader>>();
+        var options = Microsoft.Extensions.Options.Options.Create(toolLoaderOptions);
+
+        return new SingleProxyToolLoader(discoveryStrategy, logger, options);
+    }
+
+    private static ModelContextProtocol.Server.RequestContext<CallToolRequestParams> CreateCallToolRequestWithToolAndCommand(
+        string tool, string command)
+    {
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["intent"] = JsonDocument.Parse($"\"Execute {command}\"").RootElement,
+            ["tool"] = JsonDocument.Parse($"\"{tool}\"").RootElement,
+            ["command"] = JsonDocument.Parse($"\"{command}\"").RootElement,
+        };
+
+        var mockServer = Substitute.For<ModelContextProtocol.Server.McpServer>();
+        return new(mockServer, new() { Method = RequestMethods.ToolsCall })
+        {
+            Params = new CallToolRequestParams
+            {
+                Name = "azure",
+                Arguments = arguments
+            }
+        };
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithReadOnlyMode_RejectsNonReadOnlyCommand()
+    {
+        // Arrange
+        var readOnlyTool = new Tool
+        {
+            Name = "account_list",
+            Description = "List storage accounts",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = true }
+        };
+
+        var writeTool = new Tool
+        {
+            Name = "account_create",
+            Description = "Create storage account",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = false }
+        };
+
+        var writeToolExecuted = false;
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(readOnlyTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Listed accounts" }] })
+            .AddTool(writeTool, _ =>
+            {
+                writeToolExecuted = true;
+                return new CallToolResult { Content = [new TextContentBlock { Text = "Created account" }] };
+            });
+
+        var toolLoader = CreateToolLoaderWithMockClient(
+            new ToolLoaderOptions(ReadOnly: true), clientBuilder);
+
+        var request = CreateCallToolRequestWithToolAndCommand("storage", "account_create");
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(writeToolExecuted, "Non-read-only tool should not be executed in read-only mode");
+        Assert.True(result.IsError);
+        var textContent = result.Content.OfType<TextContentBlock>().First();
+        Assert.Contains("read-only mode", textContent.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithReadOnlyMode_AllowsReadOnlyCommand()
+    {
+        // Arrange
+        var readOnlyTool = new Tool
+        {
+            Name = "account_list",
+            Description = "List storage accounts",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = true }
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(readOnlyTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Listed accounts" }] });
+
+        var toolLoader = CreateToolLoaderWithMockClient(
+            new ToolLoaderOptions(ReadOnly: true), clientBuilder);
+
+        var request = CreateCallToolRequestWithToolAndCommand("storage", "account_list");
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsError ?? false);
+        var textContent = result.Content.OfType<TextContentBlock>().First();
+        Assert.Equal("Listed accounts", textContent.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithHttpMode_RejectsLocalRequiredCommand()
+    {
+        // Arrange
+        var localTool = new Tool
+        {
+            Name = "local_command",
+            Description = "Local-only command",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations(),
+            Meta = new JsonObject { ["LocalRequiredHint"] = true }
+        };
+
+        var remoteTool = new Tool
+        {
+            Name = "remote_command",
+            Description = "Remote-safe command",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations()
+        };
+
+        var localToolExecuted = false;
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(localTool, _ =>
+            {
+                localToolExecuted = true;
+                return new CallToolResult { Content = [new TextContentBlock { Text = "Local result" }] };
+            })
+            .AddTool(remoteTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Remote result" }] });
+
+        var toolLoader = CreateToolLoaderWithMockClient(
+            new ToolLoaderOptions(IsHttpMode: true), clientBuilder);
+
+        var request = CreateCallToolRequestWithToolAndCommand("storage", "local_command");
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(localToolExecuted, "Local-required tool should not be executed in HTTP mode");
+        Assert.True(result.IsError);
+        var textContent = result.Content.OfType<TextContentBlock>().First();
+        Assert.Contains("HTTP mode", textContent.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithHttpMode_AllowsNonLocalRequiredCommand()
+    {
+        // Arrange
+        var remoteTool = new Tool
+        {
+            Name = "remote_command",
+            Description = "Remote-safe command",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations()
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(remoteTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Remote result" }] });
+
+        var toolLoader = CreateToolLoaderWithMockClient(
+            new ToolLoaderOptions(IsHttpMode: true), clientBuilder);
+
+        var request = CreateCallToolRequestWithToolAndCommand("storage", "remote_command");
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsError ?? false);
+        var textContent = result.Content.OfType<TextContentBlock>().First();
+        Assert.Equal("Remote result", textContent.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithReadOnlyMode_RejectsCommandWithNullAnnotations()
+    {
+        // Arrange — tool without annotations should be rejected in read-only mode
+        var toolWithoutAnnotations = new Tool
+        {
+            Name = "unknown_command",
+            Description = "Tool without annotations",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = null
+        };
+
+        var toolExecuted = false;
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(toolWithoutAnnotations, _ =>
+            {
+                toolExecuted = true;
+                return new CallToolResult { Content = [new TextContentBlock { Text = "Result" }] };
+            });
+
+        var toolLoader = CreateToolLoaderWithMockClient(
+            new ToolLoaderOptions(ReadOnly: true), clientBuilder);
+
+        var request = CreateCallToolRequestWithToolAndCommand("storage", "unknown_command");
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(toolExecuted, "Tool without ReadOnlyHint should not be executed in read-only mode");
+        Assert.True(result.IsError);
+        var textContent = result.Content.OfType<TextContentBlock>().First();
+        Assert.Contains("read-only mode", textContent.Text);
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithoutModeRestrictions_AllowsNonReadOnlyCommand()
+    {
+        // Arrange
+        var writeTool = new Tool
+        {
+            Name = "account_create",
+            Description = "Create storage account",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = false }
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(writeTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Created account" }] });
+
+        var toolLoader = CreateToolLoaderWithMockClient(
+            new ToolLoaderOptions(), clientBuilder);
+
+        var request = CreateCallToolRequestWithToolAndCommand("storage", "account_create");
+
+        // Act
+        var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert — should execute without restrictions
+        Assert.False(result.IsError ?? false);
+        var textContent = result.Content.OfType<TextContentBlock>().First();
+        Assert.Equal("Created account", textContent.Text);
+    }
+
+    #endregion
 }

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -146,6 +146,37 @@ public sealed class CommandFactoryToolLoader(
             };
         }
         activity?.SetTag(TagName.ToolId, command.Id);
+
+        // Enforce read-only mode at execution time
+        if (_options.Value.ReadOnly && !command.Metadata.ReadOnly)
+        {
+            var content = new TextContentBlock
+            {
+                Text = $"Tool '{toolName}' is not available. This server is configured in read-only mode and this tool is not a read-only tool.",
+            };
+
+            return new CallToolResult
+            {
+                Content = [content],
+                IsError = true,
+            };
+        }
+
+        // Enforce HTTP mode restrictions at execution time
+        if (_options.Value.IsHttpMode && command.Metadata.LocalRequired)
+        {
+            var content = new TextContentBlock
+            {
+                Text = $"Tool '{toolName}' is not available. This server is running in HTTP mode and this tool requires local execution.",
+            };
+
+            return new CallToolResult
+            {
+                Content = [content],
+                IsError = true,
+            };
+        }
+
         var commandContext = new CommandContext(_serviceProvider, activity);
 
         // Check if this tool requires elicitation for sensitive or destructive operations

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
@@ -366,6 +366,38 @@ public sealed class NamespaceToolLoader(
                 return await InvokeToolLearn(request, intent, namespaceName, cancellationToken);
             }
 
+            // Enforce read-only mode at execution time
+            if ((_options.Value.ReadOnly ?? false) && !cmd.Metadata.ReadOnly)
+            {
+                return new CallToolResult
+                {
+                    Content =
+                    [
+                        new TextContentBlock
+                        {
+                            Text = $"Tool '{namespaceName} {command}' is not available. This server is configured in read-only mode and this tool is not a read-only tool.",
+                        }
+                    ],
+                    IsError = true,
+                };
+            }
+
+            // Enforce HTTP mode restrictions at execution time
+            if (_options.Value.IsHttpMode && cmd.Metadata.LocalRequired)
+            {
+                return new CallToolResult
+                {
+                    Content =
+                    [
+                        new TextContentBlock
+                        {
+                            Text = $"Tool '{namespaceName} {command}' is not available. This server is running in HTTP mode and this tool requires local execution.",
+                        }
+                    ],
+                    IsError = true,
+                };
+            }
+
             // Check if this tool requires elicitation for sensitive or destructive operations
             var metadata = cmd.Metadata;
             var elicitationResult = await HandleElicitationAsync(

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/RegistryToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/RegistryToolLoader.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Mcp.Core.Areas.Server.Commands.Discovery;
@@ -23,7 +24,7 @@ public sealed class RegistryToolLoader(
 {
     private readonly IMcpDiscoveryStrategy _serverDiscoveryStrategy = discoveryStrategy;
     private readonly IOptions<ToolLoaderOptions> _options = options;
-    private Dictionary<string, (string ServerName, string OriginalToolName, McpClient Client)> _toolClientMap = [];
+    private Dictionary<string, (string ServerName, string OriginalToolName, McpClient Client, Tool Tool)> _toolClientMap = [];
     private List<McpClient> _discoveredClients = [];
     private Dictionary<McpClient, string?> _clientPrefixMap = [];
     private readonly SemaphoreSlim _initializationSemaphore = new(1, 1);
@@ -56,7 +57,7 @@ public sealed class RegistryToolLoader(
             var filteredTools = toolsResponse
                 .Select(t => t.ProtocolTool)
                 .Where(t => !_options.Value.ReadOnly || (t.Annotations?.ReadOnlyHint == true))
-                .Where(t => !_options.Value.IsHttpMode || !HasLocalRequiredHint(t));
+                .Where(t => !_options.Value.IsHttpMode || !HasLocalRequiredHint(t.Meta));
 
             // Filter by specific tools if provided
             if (_options.Value.Tool != null && _options.Value.Tool.Length > 0)
@@ -93,8 +94,6 @@ public sealed class RegistryToolLoader(
                 Text = "Cannot call tools with null parameters.",
             };
 
-            _logger.LogWarning(content.Text);
-
             return new CallToolResult
             {
                 Content = [content],
@@ -115,8 +114,6 @@ public sealed class RegistryToolLoader(
                     Text = $"Tool '{request.Params.Name}' is not available. This server is configured to only expose the tools: {string.Join(", ", _options.Value.Tool.Select(t => $"'{t}'"))}",
                 };
 
-                _logger.LogWarning(content.Text);
-
                 return new CallToolResult
                 {
                     Content = [content],
@@ -132,7 +129,35 @@ public sealed class RegistryToolLoader(
                 Text = $"The tool {request.Params.Name} was not found in the tool registry.",
             };
 
-            _logger.LogWarning(content.Text);
+            return new CallToolResult
+            {
+                Content = [content],
+                IsError = true,
+            };
+        }
+
+        // Enforce read-only mode at execution time
+        if (_options.Value.ReadOnly && kvp.Tool.Annotations?.ReadOnlyHint != true)
+        {
+            var content = new TextContentBlock
+            {
+                Text = $"Tool '{request.Params.Name}' is not available. This server is configured in read-only mode and this tool is not a read-only tool.",
+            };
+
+            return new CallToolResult
+            {
+                Content = [content],
+                IsError = true,
+            };
+        }
+
+        // Enforce HTTP mode restrictions at execution time
+        if (_options.Value.IsHttpMode && HasLocalRequiredHint(kvp.Tool.Meta))
+        {
+            var content = new TextContentBlock
+            {
+                Text = $"Tool '{request.Params.Name}' is not available. This server is running in HTTP mode and this tool requires local execution.",
+            };
 
             return new CallToolResult
             {
@@ -243,13 +268,11 @@ public sealed class RegistryToolLoader(
                     try
                     {
                         var toolsResponse = await mcpClient.ListToolsAsync(cancellationToken: cancellationToken);
-                        var filteredTools = toolsResponse
+                        var allTools = toolsResponse
                             .Select(t => t.ProtocolTool)
-                            .Where(t => !_options.Value.ReadOnly || (t.Annotations?.ReadOnlyHint == true))
-                            .Where(t => !_options.Value.IsHttpMode || !HasLocalRequiredHint(t))
                             .ToArray();
 
-                        return (serverMetadata.Name, serverMetadata.ToolPrefix, mcpClient, (IEnumerable<Tool>?)filteredTools);
+                        return (serverMetadata.Name, serverMetadata.ToolPrefix, mcpClient, (IEnumerable<Tool>?)allTools);
                     }
                     catch (OperationCanceledException)
                     {
@@ -285,7 +308,7 @@ public sealed class RegistryToolLoader(
                     foreach (var tool in tools)
                     {
                         var exposedName = string.IsNullOrEmpty(toolPrefix) ? tool.Name : toolPrefix + tool.Name;
-                        _toolClientMap[exposedName] = (serverName, tool.Name, mcpClient);
+                        _toolClientMap[exposedName] = (serverName, tool.Name, mcpClient, tool);
                         toolCount++;
                     }
                     successCount++;
@@ -305,9 +328,9 @@ public sealed class RegistryToolLoader(
         }
     }
 
-    private static bool HasLocalRequiredHint(Tool tool)
+    private static bool HasLocalRequiredHint(JsonObject? meta)
     {
-        if (tool.Meta != null && tool.Meta.TryGetPropertyValue("LocalRequiredHint", out var localRequired))
+        if (meta != null && meta.TryGetPropertyValue("LocalRequiredHint", out var localRequired))
         {
             return localRequired?.GetValueKind() == JsonValueKind.True;
         }

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -15,7 +16,7 @@ namespace Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
 public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrategy, IOptions<ToolLoaderOptions> options, ILogger<ServerToolLoader> logger) : BaseToolLoader(logger)
 {
     private readonly IMcpDiscoveryStrategy _serverDiscoveryStrategy = serverDiscoveryStrategy ?? throw new ArgumentNullException(nameof(serverDiscoveryStrategy));
-    private readonly Dictionary<string, List<Tool>> _cachedToolLists = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, List<Tool>> _cachedAllToolLists = new(StringComparer.OrdinalIgnoreCase);
 
     private const string ToolCallProxySchema = """
         {
@@ -253,6 +254,47 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
                 parameters = samplingResult.parameters;
             }
 
+            // Verify the resolved command (which may have been updated by sampling)
+            // exists and is permitted under current mode restrictions.
+            var allTools = await GetAllChildToolsAsync(request, tool, cancellationToken);
+            var resolvedTool = allTools.FirstOrDefault(t => string.Equals(t.Name, command, StringComparison.OrdinalIgnoreCase));
+
+            if (resolvedTool == null)
+            {
+                // Sampling resolved to a command that doesn't exist at all.
+                return await InvokeToolLearn(request, intent, tool, cancellationToken);
+            }
+
+            if ((options?.Value?.ReadOnly ?? false) && resolvedTool.Annotations?.ReadOnlyHint != true)
+            {
+                return new CallToolResult
+                {
+                    Content =
+                    [
+                        new TextContentBlock
+                        {
+                            Text = $"Tool '{tool} {command}' is not available. This server is configured in read-only mode and this tool is not a read-only tool.",
+                        }
+                    ],
+                    IsError = true,
+                };
+            }
+
+            if ((options?.Value?.IsHttpMode ?? false) && HasLocalRequiredHint(resolvedTool))
+            {
+                return new CallToolResult
+                {
+                    Content =
+                    [
+                        new TextContentBlock
+                        {
+                            Text = $"Tool '{tool} {command}' is not available. This server is running in HTTP mode and this tool requires local execution.",
+                        }
+                    ],
+                    IsError = true,
+                };
+            }
+
             // At this point we should always have a valid command (child tool) call to invoke.
             Activity.Current?.SetTag(TagName.IsServerCommandInvoked, true)
                 .SetTag(TagName.ToolName, command);
@@ -369,20 +411,15 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
     /// <param name="request"></param>
     /// <param name="tool"></param>
     /// <returns></returns>
-    internal async Task<List<Tool>> GetChildToolListAsync(RequestContext<CallToolRequestParams> request, string tool, CancellationToken cancellationToken)
+    internal async Task<List<Tool>> GetAllChildToolsAsync(RequestContext<CallToolRequestParams> request, string tool, CancellationToken cancellationToken)
     {
-        if (_cachedToolLists.TryGetValue(tool, out var cachedList))
+        if (_cachedAllToolLists.TryGetValue(tool, out var cachedList))
         {
             return cachedList;
         }
 
-        if (string.IsNullOrWhiteSpace(request.Params?.Name))
-        {
-            throw new ArgumentNullException(nameof(request.Params.Name), "Tool name cannot be null or empty.");
-        }
-
         var clientOptions = CreateClientOptions(request.Server);
-        var client = await _serverDiscoveryStrategy.GetOrCreateClientAsync(request.Params.Name, clientOptions, cancellationToken);
+        var client = await _serverDiscoveryStrategy.GetOrCreateClientAsync(tool, clientOptions, cancellationToken);
         if (client == null)
         {
             return [];
@@ -397,12 +434,19 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
 
         var list = listTools
             .Select(t => t.ProtocolTool)
+            .ToList();
+
+        _cachedAllToolLists[tool] = list;
+        return list;
+    }
+
+    internal async Task<List<Tool>> GetChildToolListAsync(RequestContext<CallToolRequestParams> request, string tool, CancellationToken cancellationToken)
+    {
+        var allTools = await GetAllChildToolsAsync(request, tool, cancellationToken);
+        return allTools
             .Where(t => !(options?.Value?.ReadOnly ?? false) || (t.Annotations?.ReadOnlyHint == true))
             .Where(t => !(options?.Value?.IsHttpMode ?? false) || !HasLocalRequiredHint(t))
             .ToList();
-
-        _cachedToolLists[tool] = list;
-        return list;
     }
 
     private static bool HasLocalRequiredHint(Tool tool)
@@ -539,7 +583,7 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
     /// </summary>
     protected override async ValueTask DisposeAsyncCore()
     {
-        _cachedToolLists.Clear();
+        _cachedAllToolLists.Clear();
         await ValueTask.CompletedTask;
     }
 }

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/SingleProxyToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/SingleProxyToolLoader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -19,7 +20,8 @@ public sealed class SingleProxyToolLoader(
 {
     private readonly IMcpDiscoveryStrategy _discoveryStrategy = discoveryStrategy ?? throw new ArgumentNullException(nameof(discoveryStrategy));
     private string? _cachedRootToolsJson;
-    private readonly Dictionary<string, string> _cachedToolListsJson = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, string> _cachedToolListsJson = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, IList<McpClientTool>> _cachedAllToolLists = new(StringComparer.OrdinalIgnoreCase);
     private readonly IOptions<ToolLoaderOptions> _options = options ?? throw new ArgumentNullException(nameof(options));
 
     private const string ToolCallProxySchema = """
@@ -217,16 +219,29 @@ public sealed class SingleProxyToolLoader(
         return toolsJson;
     }
 
-    internal async Task<IList<McpClientTool>> GetToolListAsync(RequestContext<CallToolRequestParams> request, string tool, CancellationToken cancellationToken)
+    internal async Task<IList<McpClientTool>> GetAllToolsAsync(RequestContext<CallToolRequestParams> request, string tool, CancellationToken cancellationToken)
     {
+        if (_cachedAllToolLists.TryGetValue(tool, out var cachedList))
+        {
+            return cachedList;
+        }
+
         var clientOptions = CreateClientOptions(request.Server);
         var client = await _discoveryStrategy.GetOrCreateClientAsync(tool, clientOptions, cancellationToken);
         var listTools = await client.ListToolsAsync(cancellationToken: cancellationToken);
-        listTools = listTools.Where(t => !_options.Value.ReadOnly || (t.ProtocolTool.Annotations?.ReadOnlyHint == true))
+        var all = listTools.ToArray();
+
+        _cachedAllToolLists[tool] = all;
+        return all;
+    }
+
+    internal async Task<IList<McpClientTool>> GetToolListAsync(RequestContext<CallToolRequestParams> request, string tool, CancellationToken cancellationToken)
+    {
+        var allTools = await GetAllToolsAsync(request, tool, cancellationToken);
+        return allTools
+            .Where(t => !_options.Value.ReadOnly || (t.ProtocolTool.Annotations?.ReadOnlyHint == true))
             .Where(t => !_options.Value.IsHttpMode || !HasLocalRequiredHint(t.ProtocolTool))
             .ToArray();
-
-        return listTools;
     }
 
     private static bool HasLocalRequiredHint(Tool tool)
@@ -331,6 +346,46 @@ public sealed class SingleProxyToolLoader(
         Activity.Current?.SetTag(TagName.IsServerCommandInvoked, true)
             .SetTag(TagName.ToolArea, tool)
             .SetTag(TagName.ToolName, command);
+
+        // Enforce mode restrictions at execution time: look up the actual tool and check its properties.
+        if (_options.Value.ReadOnly || _options.Value.IsHttpMode)
+        {
+            var allTools = await GetAllToolsAsync(request, tool, cancellationToken);
+            var resolvedTool = allTools.FirstOrDefault(t => string.Equals(t.ProtocolTool.Name, command, StringComparison.OrdinalIgnoreCase));
+
+            if (resolvedTool != null)
+            {
+                if (_options.Value.ReadOnly && resolvedTool.ProtocolTool.Annotations?.ReadOnlyHint != true)
+                {
+                    return new CallToolResult
+                    {
+                        Content =
+                        [
+                            new TextContentBlock
+                            {
+                                Text = $"Tool '{tool} {command}' is not available. This server is configured in read-only mode and this tool is not a read-only tool.",
+                            }
+                        ],
+                        IsError = true,
+                    };
+                }
+
+                if (_options.Value.IsHttpMode && HasLocalRequiredHint(resolvedTool.ProtocolTool))
+                {
+                    return new CallToolResult
+                    {
+                        Content =
+                        [
+                            new TextContentBlock
+                            {
+                                Text = $"Tool '{tool} {command}' is not available. This server is running in HTTP mode and this tool requires local execution.",
+                            }
+                        ],
+                        IsError = true,
+                    };
+                }
+            }
+        }
 
         try
         {
@@ -515,6 +570,7 @@ public sealed class SingleProxyToolLoader(
     protected override async ValueTask DisposeAsyncCore()
     {
         // Clear caching collections
+        _cachedAllToolLists.Clear();
         _cachedToolListsJson.Clear();
         _cachedRootToolsJson = null;
 

--- a/servers/Azure.Mcp.Server/changelog-entries/1774310978413.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1774310978413.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Enforce read-only and HTTP mode restrictions at tool execution time, not just at list time"


### PR DESCRIPTION
* Enforce read-only and http mode in runtime

* update

* updates

* updates

* address feedback

* fix tests

* update

## What does this PR do?
`[Provide a clear, concise description of the changes]`

`[Add additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
