### PR TITLE
Fix local runs of Core unit test

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Subscription/SubscriptionCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Subscription/SubscriptionCommandTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace Azure.Mcp.Core.UnitTests.Areas.Subscription;
 
-public class SubscriptionCommandTests
+public class SubscriptionCommandTests : IDisposable
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly IStorageService _storageService;
@@ -24,9 +24,14 @@ public class SubscriptionCommandTests
     private readonly AccountGetCommand _command;
     private readonly CommandContext _context;
     private readonly Command _commandDefinition;
+    private readonly string? _originalSubscriptionId;
 
     public SubscriptionCommandTests()
     {
+        _originalSubscriptionId = Environment.GetEnvironmentVariable("AZURE_SUBSCRIPTION_ID");
+        EnvironmentHelpers.SetAzureSubscriptionId(null);
+        CommandHelper.ResetProfileCacheForTesting();
+
         _storageService = Substitute.For<IStorageService>();
         _logger = Substitute.For<ILogger<AccountGetCommand>>();
 
@@ -36,6 +41,12 @@ public class SubscriptionCommandTests
         _command = new(_logger, _storageService);
         _context = new(_serviceProvider);
         _commandDefinition = _command.GetCommand();
+    }
+
+    public void Dispose()
+    {
+        EnvironmentHelpers.SetAzureSubscriptionId(_originalSubscriptionId);
+        CommandHelper.ResetProfileCacheForTesting();
     }
 
     [Fact]

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Helpers/CommandHelperTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Helpers/CommandHelperTests.cs
@@ -7,8 +7,23 @@ using Xunit;
 
 namespace Azure.Mcp.Core.UnitTests.Helpers;
 
-public class CommandHelperTests
+public class CommandHelperTests : IDisposable
 {
+    private readonly string? _originalSubscriptionId;
+
+    public CommandHelperTests()
+    {
+        _originalSubscriptionId = Environment.GetEnvironmentVariable("AZURE_SUBSCRIPTION_ID");
+        EnvironmentHelpers.SetAzureSubscriptionId(null);
+        CommandHelper.ResetProfileCacheForTesting();
+    }
+
+    public void Dispose()
+    {
+        EnvironmentHelpers.SetAzureSubscriptionId(_originalSubscriptionId);
+        CommandHelper.ResetProfileCacheForTesting();
+    }
+
     [Fact]
     public void GetSubscription_EmptySubscriptionParameter_ReturnsEnvironmentValue()
     {
@@ -83,6 +98,8 @@ public class CommandHelperTests
     public void GetSubscription_NoEnvironmentVariableParameterValueContainingDefault_ReturnsParameterValue()
     {
         // Arrange
+        EnvironmentHelpers.SetAzureSubscriptionId(null);
+        CommandHelper.ResetProfileCacheForTesting(() => null);
         var parseResult = GetParseResult(["--subscription", "Some default name"]);
 
         // Act
@@ -96,6 +113,8 @@ public class CommandHelperTests
     public void GetSubscription_NoEnvironmentVariableParameterValueContainingSubscription_ReturnsParameterValue()
     {
         // Arrange
+        EnvironmentHelpers.SetAzureSubscriptionId(null);
+        CommandHelper.ResetProfileCacheForTesting(() => null);
         var parseResult = GetParseResult(["--subscription", "Azure subscription 1"]);
 
         // Act

--- a/core/Microsoft.Mcp.Core/src/Helpers/CommandHelper.cs
+++ b/core/Microsoft.Mcp.Core/src/Helpers/CommandHelper.cs
@@ -11,7 +11,7 @@ namespace Azure.Mcp.Core.Helpers
     {
         // Cache the Azure CLI profile read to avoid redundant file I/O.
         // The profile is read at most once per process invocation.
-        private static readonly Lazy<string?> s_profileDefault = new(AzureCliProfileHelper.GetDefaultSubscriptionId);
+        private static Lazy<string?> s_profileDefault = new(AzureCliProfileHelper.GetDefaultSubscriptionId);
 
         /// <summary>
         /// Checks if a subscription is available from the command option, Azure CLI profile, or AZURE_SUBSCRIPTION_ID environment variable.
@@ -45,21 +45,29 @@ namespace Azure.Mcp.Core.Helpers
         }
 
         /// <summary>
-        /// Gets the default subscription from the Azure CLI profile (~/.azure/azureProfile.json),
-        /// falling back to the AZURE_SUBSCRIPTION_ID environment variable.
+        /// Gets the default subscription from the AZURE_SUBSCRIPTION_ID environment variable,
+        /// falling back to the Azure CLI profile (~/.azure/azureProfile.json).
         /// The CLI profile read is cached for the lifetime of the process to avoid redundant file I/O.
         /// </summary>
         public static string? GetDefaultSubscription()
         {
-            // Primary: Azure CLI profile (set via 'az account set') - cached to avoid repeated file I/O
-            var profileDefault = s_profileDefault.Value;
-            if (!string.IsNullOrEmpty(profileDefault))
+            // Primary: AZURE_SUBSCRIPTION_ID environment variable (cheap, not cached)
+            var envSubscription = EnvironmentHelpers.GetAzureSubscriptionId();
+            if (!string.IsNullOrEmpty(envSubscription))
             {
-                return profileDefault;
+                return envSubscription;
             }
 
-            // Fallback: AZURE_SUBSCRIPTION_ID environment variable (cheap, not cached)
-            return EnvironmentHelpers.GetAzureSubscriptionId();
+            // Fallback: Azure CLI profile (set via 'az account set') - cached to avoid repeated file I/O
+            return s_profileDefault.Value;
+        }
+
+        /// <summary>
+        /// Resets the cached Azure CLI profile subscription for testing purposes.
+        /// </summary>
+        internal static void ResetProfileCacheForTesting(Func<string?>? factory = null)
+        {
+            s_profileDefault = new Lazy<string?>(factory ?? AzureCliProfileHelper.GetDefaultSubscriptionId);
         }
 
         private static bool IsPlaceholder(string value) => value.Contains("subscription") || value.Contains("default");

--- a/servers/Azure.Mcp.Server/changelog-entries/1774543138326.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1774543138326.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed default subscription resolution to prioritize AZURE_SUBSCRIPTION_ID environment variable over Azure CLI profile, matching standard Azure SDK conventions"


### PR DESCRIPTION
This PR fixes an issue where locally the unit tests will fail due to pulling the default subscription from Azure CLI instead of using the environment variable value set in the test.

**This PR contains a behavioral breaking change**, as it changes the order in which `CommandHelper` will try to resolve the subscription, giving priority to the environment variable over Azure CLI.