### PR TITLE
Fix Docker image failure by creating home directory for non-root mcp user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY ${PUBLISH_DIR}/${EXECUTABLE_NAME} server-binary
 RUN chmod +x server-binary && test -x server-binary
 
 # Run as non-root user for security hardening
-RUN adduser -D -H -s /sbin/nologin mcp && \
+RUN adduser -D -s /sbin/nologin mcp && \
     chown -R mcp:mcp /mcp-server
 USER mcp
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes container startup failure caused by missing `/home/mcp` directory.
The `-H` flag prevented creation of the home directory for the `mcp` user, causing .NET bundle extraction to fail during Docker execution.

**Pipeline Failure:** https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6071092&view=logs&j=8d4890d7-5c47-5db3-e49b-98be0c3ec191&t=67b49b0a-fe6f-5b7c-b637-ff9232fab8e2&s=c371a22f-0f89-5b34-7677-e9ec3332410e

**Error:** `Default extraction directory [/home/mcp] either doesn't exist or is not accessible for read/write. Failure processing application bundle. Failed to determine location for extracting embedded files. DOTNET_BUNDLE_EXTRACT_BASE_DIR is not set, and a read-write cache directory couldn't be created.`

### Changes

- Removed `-H` from `adduser` so `/home/mcp` is created.

I validated this change by running the pipeline from a release branch- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6071535&view=results