### PR TITLE
Bump @azure/msal-browser to 5.2.0+ to comply with Comp Gov  (#2207)

### DIFF
--- a/eng/vsix-tools/package-lock.json
+++ b/eng/vsix-tools/package-lock.json
@@ -157,14 +157,22 @@
             }
         },
         "node_modules/@azure/msal-browser": {
-            "version": "4.27.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.27.0.tgz",
-            "integrity": "sha512-bZ8Pta6YAbdd0o0PEaL1/geBsPrLEnyY/RDWqvF1PP9RUH8EMLvUMGoZFYS6jSlUan6KZ9IMTLCnwpWWpQRK/w==",
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.6.1.tgz",
+            "integrity": "sha512-Ylmp8yngH7YRLV5mA1aF4CNS6WsJTPbVXaA0Tb1x1Gv/J3BM3hE4Q7nDaf7dRfU00FcxDBBudTjqlpH74ZSsgw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "15.13.3"
+                "@azure/msal-common": "16.4.0"
             },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.4.0.tgz",
+            "integrity": "sha512-twXt09PYtj1PffNNIAzQlrBd0DS91cdA6i1gAfzJ6BnPM4xNk5k9q/5xna7jLIjU3Jnp0slKYtucshGM8OGNAw==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }

--- a/eng/vsix-tools/package.json
+++ b/eng/vsix-tools/package.json
@@ -4,12 +4,14 @@
     },
     "_overrideComments": {
         "yauzl": "GHSA-gmq8-994r-jv83: off-by-one error in yauzl < 3.2.1 (via @vscode/vsce)",
-        "undici": "CVE-2026-1527, CVE-2026-1528, and CVE-2026-2229 in undici < 7.24.0 (via @vscode/vsce)"
+        "undici": "CVE-2026-1527, CVE-2026-1528, and CVE-2026-2229 in undici < 7.24.0 (via @vscode/vsce)",
+        "@azure/msal-browser": "MVS-2026-vmmw-f85q: auth code theft and COOP vulnerability in @azure/msal-browser < 5.2.0 (via @vscode/vsce > @azure/identity)"
     },
     "overrides": {
         "@vscode/vsce": {
             "yauzl": "^3.2.1",
             "undici": "^7.24.4"
-        }
+        },
+        "@azure/msal-browser": "^5.2.0"
     }
 }

--- a/servers/Azure.Mcp.Server/vscode/package-lock.json
+++ b/servers/Azure.Mcp.Server/vscode/package-lock.json
@@ -202,14 +202,22 @@
             "peer": true
         },
         "node_modules/@azure/msal-browser": {
-            "version": "4.26.2",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.26.2.tgz",
-            "integrity": "sha512-F2U1mEAFsYGC5xzo1KuWc/Sy3CRglU9Ql46cDUx8x/Y3KnAIr1QAq96cIKCk/ZfnVxlvprXWRjNKoEpgLJXLhg==",
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.6.1.tgz",
+            "integrity": "sha512-Ylmp8yngH7YRLV5mA1aF4CNS6WsJTPbVXaA0Tb1x1Gv/J3BM3hE4Q7nDaf7dRfU00FcxDBBudTjqlpH74ZSsgw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "15.13.2"
+                "@azure/msal-common": "16.4.0"
             },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.4.0.tgz",
+            "integrity": "sha512-twXt09PYtj1PffNNIAzQlrBd0DS91cdA6i1gAfzJ6BnPM4xNk5k9q/5xna7jLIjU3Jnp0slKYtucshGM8OGNAw==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }

--- a/servers/Azure.Mcp.Server/vscode/package.json
+++ b/servers/Azure.Mcp.Server/vscode/package.json
@@ -205,7 +205,8 @@
         "serialize-javascript": "Prototype pollution in serialize-javascript < 7.0.0 (via mocha)",
         "diff": "GHSA-73rr-hh4g-fpgx: DoS in jsdiff 6.0.0-8.0.2 (via mocha)",
         "yauzl": "GHSA-gmq8-994r-jv83: off-by-one error in yauzl < 3.2.1 (via @vscode/vsce)",
-        "flatted": "Prototype pollution in flatted < 3.4.2 (via eslint)"
+        "flatted": "Prototype pollution in flatted < 3.4.2 (via eslint)",
+        "@azure/msal-browser": "MVS-2026-vmmw-f85q: auth code theft and COOP vulnerability in @azure/msal-browser < 5.2.0 (via @azure/identity)"
     },
     "overrides": {
         "mocha": {
@@ -215,6 +216,7 @@
         "@vscode/vsce": {
             "yauzl": "^3.2.1"
         },
-        "flatted": "^3.4.2"
+        "flatted": "^3.4.2",
+        "@azure/msal-browser": "^5.2.0"
     }
 }

--- a/servers/Fabric.Mcp.Server/vscode/package-lock.json
+++ b/servers/Fabric.Mcp.Server/vscode/package-lock.json
@@ -202,14 +202,22 @@
             "peer": true
         },
         "node_modules/@azure/msal-browser": {
-            "version": "4.26.2",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.26.2.tgz",
-            "integrity": "sha512-F2U1mEAFsYGC5xzo1KuWc/Sy3CRglU9Ql46cDUx8x/Y3KnAIr1QAq96cIKCk/ZfnVxlvprXWRjNKoEpgLJXLhg==",
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.6.1.tgz",
+            "integrity": "sha512-Ylmp8yngH7YRLV5mA1aF4CNS6WsJTPbVXaA0Tb1x1Gv/J3BM3hE4Q7nDaf7dRfU00FcxDBBudTjqlpH74ZSsgw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "15.13.2"
+                "@azure/msal-common": "16.4.0"
             },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.4.0.tgz",
+            "integrity": "sha512-twXt09PYtj1PffNNIAzQlrBd0DS91cdA6i1gAfzJ6BnPM4xNk5k9q/5xna7jLIjU3Jnp0slKYtucshGM8OGNAw==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }

--- a/servers/Fabric.Mcp.Server/vscode/package.json
+++ b/servers/Fabric.Mcp.Server/vscode/package.json
@@ -127,7 +127,8 @@
         "serialize-javascript": "Prototype pollution in serialize-javascript < 7.0.0 (via mocha)",
         "diff": "GHSA-73rr-hh4g-fpgx: DoS in jsdiff 6.0.0-8.0.2 (via mocha)",
         "yauzl": "GHSA-gmq8-994r-jv83: off-by-one error in yauzl < 3.2.1 (via @vscode/vsce)",
-        "flatted": "Prototype pollution in flatted < 3.4.2 (via eslint)"
+        "flatted": "Prototype pollution in flatted < 3.4.2 (via eslint)",
+        "@azure/msal-browser": "MVS-2026-vmmw-f85q: auth code theft and COOP vulnerability in @azure/msal-browser < 5.2.0 (via @azure/identity)"
     },
     "overrides": {
         "mocha": {
@@ -137,6 +138,7 @@
         "@vscode/vsce": {
             "yauzl": "^3.2.1"
         },
-        "flatted": "^3.4.2"
+        "flatted": "^3.4.2",
+        "@azure/msal-browser": "^5.2.0"
     }
 }

--- a/servers/Template.Mcp.Server/vscode/package-lock.json
+++ b/servers/Template.Mcp.Server/vscode/package-lock.json
@@ -202,14 +202,22 @@
             "peer": true
         },
         "node_modules/@azure/msal-browser": {
-            "version": "4.26.2",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.26.2.tgz",
-            "integrity": "sha512-F2U1mEAFsYGC5xzo1KuWc/Sy3CRglU9Ql46cDUx8x/Y3KnAIr1QAq96cIKCk/ZfnVxlvprXWRjNKoEpgLJXLhg==",
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.6.1.tgz",
+            "integrity": "sha512-Ylmp8yngH7YRLV5mA1aF4CNS6WsJTPbVXaA0Tb1x1Gv/J3BM3hE4Q7nDaf7dRfU00FcxDBBudTjqlpH74ZSsgw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "15.13.2"
+                "@azure/msal-common": "16.4.0"
             },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.4.0.tgz",
+            "integrity": "sha512-twXt09PYtj1PffNNIAzQlrBd0DS91cdA6i1gAfzJ6BnPM4xNk5k9q/5xna7jLIjU3Jnp0slKYtucshGM8OGNAw==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }

--- a/servers/Template.Mcp.Server/vscode/package.json
+++ b/servers/Template.Mcp.Server/vscode/package.json
@@ -128,7 +128,8 @@
         "serialize-javascript": "Prototype pollution in serialize-javascript < 7.0.0 (via mocha)",
         "diff": "GHSA-73rr-hh4g-fpgx: DoS in jsdiff 6.0.0-8.0.2 (via mocha)",
         "yauzl": "GHSA-gmq8-994r-jv83: off-by-one error in yauzl < 3.2.1 (via @vscode/vsce)",
-        "flatted": "Prototype pollution in flatted < 3.4.2 (via eslint)"
+        "flatted": "Prototype pollution in flatted < 3.4.2 (via eslint)",
+        "@azure/msal-browser": "MVS-2026-vmmw-f85q: auth code theft and COOP vulnerability in @azure/msal-browser < 5.2.0 (via @azure/identity)"
     },
     "overrides": {
         "mocha": {
@@ -138,6 +139,7 @@
         "@vscode/vsce": {
             "yauzl": "^3.2.1"
         },
-        "flatted": "^3.4.2"
+        "flatted": "^3.4.2",
+        "@azure/msal-browser": "^5.2.0"
     }
 }


### PR DESCRIPTION
Cherry Picks the change to release branch.