### PR TITLE
Set AppConfigurationAudience based on Cloud configuration when creating App Configuration SDK clients

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1774886640626.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1774886640626.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Configure AppConfigurationAudience when creating AppConfiguration SDK clients"

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
@@ -7,6 +7,7 @@ using Azure.Data.AppConfiguration;
 using Azure.Mcp.Core.Models.Identity;
 using Azure.Mcp.Core.Options;
 using Azure.Mcp.Core.Services.Azure;
+using Azure.Mcp.Core.Services.Azure.Authentication;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.AppConfig.Models;
@@ -168,7 +169,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
 
     private async Task<ConfigurationClient> GetConfigurationClient(string accountName, string subscription, string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
     {
-        var configStore = await FindAppConfigStore(subscription, accountName, subscription, retryPolicy, cancellationToken);
+        var configStore = await FindAppConfigStore(subscription, tenant, accountName, subscription, retryPolicy, cancellationToken);
         var endpoint = configStore.Endpoint;
         if (string.IsNullOrEmpty(endpoint))
         {
@@ -177,8 +178,9 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
 
         EndpointValidator.ValidateAzureServiceEndpoint(endpoint, "appconfig");
 
-        var credential = await GetCredential(cancellationToken);
+        var credential = await GetCredential(tenant, cancellationToken);
         var options = new ConfigurationClientOptions();
+        options.Audience = GetAppConfigurationAudience();
         AddDefaultPolicies(options);
 
         var endpointUri = new Uri(endpoint);
@@ -191,25 +193,22 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
 
     private async Task<AppConfigurationAccount> FindAppConfigStore(
         string subscription,
+        string? tenant,
         string accountName,
         string subscriptionIdentifier,
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken)
     {
-        var account = await ExecuteSingleResourceQueryAsync(
+        return await ExecuteSingleResourceQueryAsync(
             "Microsoft.AppConfiguration/configurationStores",
             resourceGroup: null, // all resource groups
             subscription: subscription,
             retryPolicy: retryPolicy,
             converter: ConvertToAppConfigurationAccountModel,
             additionalFilter: $"name =~ '{EscapeKqlString(accountName)}'",
-            cancellationToken: cancellationToken);
-
-        if (account == null)
-        {
-            throw new KeyNotFoundException($"App Configuration store '{accountName}' not found for subscription '{subscriptionIdentifier}'.");
-        }
-        return account;
+            tenant: tenant,
+            cancellationToken: cancellationToken)
+            ?? throw new KeyNotFoundException($"App Configuration store '{accountName}' not found for subscription '{subscriptionIdentifier}'.");
     }
 
     /// <summary>
@@ -264,6 +263,17 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
                 KeyIdentifier = appConfigAccount.Properties?.Encryption?.KeyVaultProperties?.KeyIdentifier,
                 IdentityClientId = appConfigAccount.Properties?.Encryption?.KeyVaultProperties?.IdentityClientId,
             }
+        };
+    }
+
+    private AppConfigurationAudience GetAppConfigurationAudience()
+    {
+        return TenantService.CloudConfiguration.CloudType switch
+        {
+            AzureCloudConfiguration.AzureCloud.AzurePublicCloud => AppConfigurationAudience.AzurePublicCloud,
+            AzureCloudConfiguration.AzureCloud.AzureChinaCloud => AppConfigurationAudience.AzureChina,
+            AzureCloudConfiguration.AzureCloud.AzureUSGovernmentCloud => AppConfigurationAudience.AzureGovernment,
+            _ => AppConfigurationAudience.AzurePublicCloud
         };
     }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes authentication issues with App Configuration tools where they weren't setting `AppConfigurationAudience` based on the cloud configuration of Azure MCP, resulting in a mismatch audience issue.

Now all App Configuration SDKs have `AppConfigurationAudience` configured based on which cloud is being interacted with.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
