### PR TITLE
Refactor plugin telemetry allowlists and validate tool name before emitting

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/PluginTelemetryCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/PluginTelemetryCommandTests.cs
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Commands;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Mcp.Core.Areas;
+using Microsoft.Mcp.Core.Areas.Server;
+using Microsoft.Mcp.Core.Areas.Server.Commands;
+using Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
+using Microsoft.Mcp.Core.Configuration;
+using Microsoft.Mcp.Core.Services.Telemetry;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Mcp.Core.UnitTests.Areas.Server.Commands.ToolLoading;
+
+public class PluginTelemetryCommandTests
+{
+    private readonly IPluginFileReferenceAllowlistProvider _fileReferenceProvider;
+    private readonly IPluginSkillNameAllowlistProvider _skillNameProvider;
+    private readonly ICommandFactory _commandFactory;
+    private readonly PluginTelemetryCommand _command;
+
+    public PluginTelemetryCommandTests()
+    {
+        var serverAssembly = typeof(Azure.Mcp.Server.Program).Assembly;
+
+        _fileReferenceProvider = new ResourcePluginFileReferenceAllowlistProvider(
+            NullLogger<ResourcePluginFileReferenceAllowlistProvider>.Instance,
+            serverAssembly,
+            "allowed-plugin-file-references.json");
+
+        _skillNameProvider = new ResourcePluginSkillNameAllowlistProvider(
+            NullLogger<ResourcePluginSkillNameAllowlistProvider>.Instance,
+            serverAssembly,
+            "allowed-skill-names.json");
+
+        // Build a real CommandFactory with ServerSetup to get actual registered commands
+        var services = new ServiceCollection();
+        services.AddSingleton<IAreaSetup>(new ServerSetup());
+        services.AddSingleton(Microsoft.Extensions.Options.Options.Create(new McpServerConfiguration
+        {
+            RootCommandGroupName = "azmcp",
+            Name = "Azure.Mcp.Server.Test",
+            DisplayName = "Azure MCP Server (Test)",
+            Version = "1.0.0-test"
+        }));
+        services.AddSingleton<ITelemetryService>(Substitute.For<ITelemetryService>());
+        services.AddSingleton<ILogger<CommandFactory>>(NullLogger<CommandFactory>.Instance);
+        services.AddSingleton<ILogger<ServiceInfoCommand>>(NullLogger<ServiceInfoCommand>.Instance);
+        services.AddSingleton(_fileReferenceProvider);
+        services.AddSingleton(_skillNameProvider);
+
+        // Register area services (ServerSetup registers its commands here)
+        new ServerSetup().ConfigureServices(services);
+
+        services.AddSingleton<ICommandFactory, CommandFactory>();
+
+        var serviceProvider = services.BuildServiceProvider();
+        _commandFactory = serviceProvider.GetRequiredService<ICommandFactory>();
+
+        _command = new PluginTelemetryCommand(
+            _fileReferenceProvider,
+            _skillNameProvider,
+            serviceProvider);
+    }
+
+    [Theory]
+    [InlineData("azure-storage", true)]
+    [InlineData("azure-ai", true)]
+    [InlineData("microsoft-foundry", true)]
+    [InlineData("custom-skill", false)]
+    [InlineData("azure-mcp-skill", false)]
+    public void SkillNameProvider_ValidatesSkillNamesCorrectly(string skillName, bool shouldBeAllowed)
+    {
+        var result = _skillNameProvider.IsSkillNameAllowed(skillName);
+        Assert.Equal(shouldBeAllowed, result);
+    }
+
+    [Theory]
+    [InlineData("azure-ai\\references\\auth-best-practices.md", true)]
+    [InlineData("custom/file/path.ts", false)]
+    public void FileReferenceProvider_ValidatesFileReferencesCorrectly(string fileReference, bool shouldBeAllowed)
+    {
+        var result = _fileReferenceProvider.IsPathAllowed(fileReference);
+        Assert.Equal(shouldBeAllowed, result);
+    }
+
+    [Theory]
+    [InlineData("server_start", true)]
+    [InlineData("server_info", true)]
+    [InlineData("server_plugin-telemetry", true)]
+    [InlineData("invalid-tool-name", false)]
+    [InlineData("storage_account-create", false)] // not registered in ServerSetup-only factory
+    public void CommandFactory_ValidatesToolNamesCorrectly(string toolName, bool shouldBeAllowed)
+    {
+        var result = _commandFactory.FindCommandByName(toolName);
+
+        if (shouldBeAllowed)
+        {
+            Assert.NotNull(result);
+        }
+        else
+        {
+            Assert.Null(result);
+        }
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    public void SkillNameProvider_RejectsNullOrEmptySkillNames(string? skillName, bool expected)
+    {
+        var result = _skillNameProvider.IsSkillNameAllowed(skillName!);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    public void FileReferenceProvider_RejectsNullOrEmptyPaths(string? filePath, bool expected)
+    {
+        var result = _fileReferenceProvider.IsPathAllowed(filePath!);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("AZURE-STORAGE", false)]
+    [InlineData("Azure-Storage", false)]
+    [InlineData("azure-storage", true)]
+    public void SkillNameProvider_IsCaseSensitive(string skillName, bool expected)
+    {
+        var result = _skillNameProvider.IsSkillNameAllowed(skillName);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Command_ConstructorSucceeds_WithProviders()
+    {
+        Assert.NotNull(_command);
+        Assert.Equal("plugin-telemetry", _command.Name);
+        Assert.Equal("Plugin Telemetry", _command.Title);
+    }
+
+    [Fact]
+    public void CommandFactory_RegistersExpectedServerCommands()
+    {
+        var allCommands = _commandFactory.AllCommands;
+        Assert.Contains("server_start", allCommands.Keys);
+        Assert.Contains("server_info", allCommands.Keys);
+        Assert.Contains("server_plugin-telemetry", allCommands.Keys);
+        Assert.True(allCommands.Count >= 3);
+    }
+
+    [Theory]
+    // Claude Code prefix
+    [InlineData("mcp__plugin_azure_azure__pricing", "pricing")]
+    [InlineData("mcp__plugin_azure_azure__group_resource_list", "group_resource_list")]
+    // VS Code prefix
+    [InlineData("mcp_azure_mcp_monitor", "monitor")]
+    [InlineData("mcp_azure_mcp_subscription_list", "subscription_list")]
+    // Copilot CLI prefix
+    [InlineData("azure-documentation", "documentation")]
+    [InlineData("azure-group_resource_list", "group_resource_list")]
+    [InlineData("azure-monitor_workspace_list", "monitor_workspace_list")]
+    // No prefix - returned as-is
+    [InlineData("pricing", "pricing")]
+    [InlineData("server_start", "server_start")]
+    // Unknown prefix - returned as-is (validation catches these later)
+    [InlineData("unknown_tool", "unknown_tool")]
+    [InlineData("mcp_azure_documentation", "mcp_azure_documentation")]
+    public void StripClientPrefix_RemovesKnownPrefixes(string rawToolName, string expected)
+    {
+        var result = PluginTelemetryCommand.StripClientPrefix(rawToolName);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    // Area-level matches (server area exists in our test factory)
+    [InlineData("mcp__plugin_azure_azure__server", "server")]
+    [InlineData("mcp_azure_mcp_server", "server")]
+    [InlineData("azure-server", "server")]
+    // Exact command matches
+    [InlineData("server_start", "server_start")]
+    [InlineData("mcp__plugin_azure_azure__server_info", "server_info")]
+    // Full command path with prefix — proves exact match after stripping (same path monitor_workspace_list takes)
+    [InlineData("azure-server_start", "server_start")]
+    [InlineData("mcp_azure_mcp_server_start", "server_start")]
+    [InlineData("mcp__plugin_azure_azure__server_plugin-telemetry", "server_plugin-telemetry")]
+    // Allowlisted Azure extension tools (pass through as-is)
+    [InlineData("azure_auth-set_auth_context", "azure_auth-set_auth_context")]
+    [InlineData("azure_get_auth_context", "azure_get_auth_context")]
+    [InlineData("azure_query_azure_resource_graph", "azure_query_azure_resource_graph")]
+    [InlineData("azure_recommend_custom_modes", "azure_recommend_custom_modes")]
+    [InlineData("azure_get_dotnet_template_tags", "azure_get_dotnet_template_tags")]
+    [InlineData("azure_get_dotnet_templates_for_tag", "azure_get_dotnet_templates_for_tag")]
+    // Invalid - no matching command or area
+    [InlineData("mcp__plugin_azure_azure__nonexistent", null)]
+    [InlineData("azure-fakeTool", null)]
+    [InlineData("completely_unknown", null)]
+    // Non-standard VS Code prefixes are rejected (not stripped)
+    [InlineData("mcp_azure_documentation", null)]
+    public void ValidateAndNormalizeToolName_ValidatesAndNormalizes(string rawToolName, string? expected)
+    {
+        var result = PluginTelemetryCommand.ValidateAndNormalizeToolName(rawToolName, _commandFactory);
+        Assert.Equal(expected, result);
+    }
+}

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/IPluginFileReferenceAllowlistProvider.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/IPluginFileReferenceAllowlistProvider.cs
@@ -2,26 +2,36 @@
 // Licensed under the MIT License.
 
 using System.Reflection;
+using System.Text.Json;
 using Azure.Mcp.Core.Helpers;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
 
 /// <summary>
-/// Provides access to the allowlist of plugin file references permitted for telemetry.
+/// Provides validation for plugin file references permitted for telemetry.
 /// </summary>
 public interface IPluginFileReferenceAllowlistProvider
 {
     /// <summary>
-    /// Gets the set of allowed plugin-relative file references.
-    /// Only telemetry events with file paths in this set will be logged (with PII stripped).
+    /// Checks if a plugin-relative file reference is allowed for telemetry logging.
     /// </summary>
-    /// <returns>A HashSet of allowed plugin-relative file references (case-insensitive).</returns>
-    HashSet<string> GetAllowedPaths();
+    /// <param name="pluginRelativePath">The plugin-relative file path to validate.</param>
+    /// <returns>True if the file reference is allowed, false otherwise.</returns>
+    bool IsPathAllowed(string pluginRelativePath);
 }
 
 /// <summary>
-/// Provides plugin file reference allowlist loaded from an embedded JSON resource.
+/// No-op implementation that rejects all file references.
+/// Used by servers that don't support plugin telemetry (e.g., Fabric).
+/// </summary>
+public class NullPluginFileReferenceAllowlistProvider : IPluginFileReferenceAllowlistProvider
+{
+    public bool IsPathAllowed(string pluginRelativePath) => false;
+}
+
+/// <summary>
+/// Provides file reference validation using an embedded JSON resource allowlist.
 /// The resource should contain a JSON array of plugin-relative file references.
 /// </summary>
 public sealed class ResourcePluginFileReferenceAllowlistProvider : IPluginFileReferenceAllowlistProvider
@@ -49,7 +59,15 @@ public sealed class ResourcePluginFileReferenceAllowlistProvider : IPluginFileRe
     }
 
     /// <inheritdoc/>
-    public HashSet<string> GetAllowedPaths() => _allowedPaths.Value;
+    public bool IsPathAllowed(string pluginRelativePath)
+    {
+        if (string.IsNullOrWhiteSpace(pluginRelativePath))
+        {
+            return false;
+        }
+
+        return _allowedPaths.Value.Contains(pluginRelativePath);
+    }
 
     private HashSet<string> LoadAllowedPaths()
     {
@@ -69,7 +87,7 @@ public sealed class ResourcePluginFileReferenceAllowlistProvider : IPluginFileRe
             }
 
             _logger.LogInformation("Loaded {Count} allowed plugin file references from {ResourceName}", paths.Count, resourceName);
-            return new HashSet<string>(paths, StringComparer.OrdinalIgnoreCase);
+            return new HashSet<string>(paths, StringComparer.Ordinal);
         }
         catch (Exception ex)
         {
@@ -78,9 +96,7 @@ public sealed class ResourcePluginFileReferenceAllowlistProvider : IPluginFileRe
             // no telemetry will be logged rather than allowing all paths
             var errorMessage = "Failed to load allowed plugin file references from JSON resource. Returning empty allowlist for security.";
             _logger.LogError(ex, errorMessage);
-            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            return new HashSet<string>(StringComparer.Ordinal);
         }
     }
 }
-
-

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/IPluginSkillNameAllowlistProvider.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/IPluginSkillNameAllowlistProvider.cs
@@ -2,26 +2,36 @@
 // Licensed under the MIT License.
 
 using System.Reflection;
+using System.Text.Json;
 using Azure.Mcp.Core.Helpers;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
 
 /// <summary>
-/// Provides access to the allowlist of skill names permitted for telemetry.
+/// Provides validation for skill names permitted for telemetry.
 /// </summary>
 public interface IPluginSkillNameAllowlistProvider
 {
     /// <summary>
-    /// Gets the set of allowed skill names.
-    /// Only telemetry events with skill names in this set will be logged.
+    /// Checks if a skill name is allowed for telemetry logging.
     /// </summary>
-    /// <returns>A HashSet of allowed skill names (case-insensitive).</returns>
-    HashSet<string> GetAllowedSkillNames();
+    /// <param name="skillName">The skill name to validate.</param>
+    /// <returns>True if the skill name is allowed, false otherwise.</returns>
+    bool IsSkillNameAllowed(string skillName);
 }
 
 /// <summary>
-/// Provides skill name allowlist loaded from an embedded JSON resource.
+/// No-op implementation that rejects all skill names.
+/// Used by servers that don't support plugin telemetry (e.g., Fabric).
+/// </summary>
+public class NullPluginSkillNameAllowlistProvider : IPluginSkillNameAllowlistProvider
+{
+    public bool IsSkillNameAllowed(string skillName) => false;
+}
+
+/// <summary>
+/// Provides skill name validation using an embedded JSON resource allowlist.
 /// The resource should contain a JSON array of skill names.
 /// </summary>
 public sealed class ResourcePluginSkillNameAllowlistProvider : IPluginSkillNameAllowlistProvider
@@ -49,7 +59,15 @@ public sealed class ResourcePluginSkillNameAllowlistProvider : IPluginSkillNameA
     }
 
     /// <inheritdoc/>
-    public HashSet<string> GetAllowedSkillNames() => _allowedSkillNames.Value;
+    public bool IsSkillNameAllowed(string skillName)
+    {
+        if (string.IsNullOrWhiteSpace(skillName))
+        {
+            return false;
+        }
+
+        return _allowedSkillNames.Value.Contains(skillName);
+    }
 
     private HashSet<string> LoadAllowedSkillNames()
     {
@@ -69,7 +87,7 @@ public sealed class ResourcePluginSkillNameAllowlistProvider : IPluginSkillNameA
             }
 
             _logger.LogInformation("Loaded {Count} allowed skill names from {ResourceName}", skillNames.Count, resourceName);
-            return new HashSet<string>(skillNames, StringComparer.OrdinalIgnoreCase);
+            return new HashSet<string>(skillNames, StringComparer.Ordinal);
         }
         catch (Exception ex)
         {
@@ -78,7 +96,7 @@ public sealed class ResourcePluginSkillNameAllowlistProvider : IPluginSkillNameA
             // no telemetry will be logged rather than allowing all skill names
             var errorMessage = "Failed to load allowed skill names from JSON resource. Returning empty allowlist for security.";
             _logger.LogError(ex, errorMessage);
-            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            return new HashSet<string>(StringComparer.Ordinal);
         }
     }
 }

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/PluginTelemetryCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/PluginTelemetryCommand.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Net;
+using Azure.Mcp.Core.Commands;
 using Azure.Mcp.Core.Logging;
 using Azure.Mcp.Core.Services.Azure.Authentication;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,9 +23,15 @@ namespace Microsoft.Mcp.Core.Areas.Server.Commands;
 /// This command is hidden from the main tool list and intended for programmatic use only.
 /// </summary>
 [HiddenCommand]
-public sealed class PluginTelemetryCommand : BaseCommand<PluginTelemetryOptions>
+public sealed class PluginTelemetryCommand(
+    IPluginFileReferenceAllowlistProvider fileReferenceAllowlistProvider,
+    IPluginSkillNameAllowlistProvider skillNameAllowlistProvider,
+    IServiceProvider serviceProvider) : BaseCommand<PluginTelemetryOptions>
 {
     private const string CommandTitle = "Plugin Telemetry";
+    private readonly IPluginFileReferenceAllowlistProvider _fileReferenceAllowlistProvider = fileReferenceAllowlistProvider;
+    private readonly IPluginSkillNameAllowlistProvider _skillNameAllowlistProvider = skillNameAllowlistProvider;
+    private readonly IServiceProvider _serviceProvider = serviceProvider;
 
     public override string Id => "b3e7c1a2-4f85-4d9e-a6c3-8f2b1e0d7a94";
 
@@ -66,24 +73,108 @@ public sealed class PluginTelemetryCommand : BaseCommand<PluginTelemetryOptions>
     /// Checks if a plugin-relative path is allowed based on the exact path allowlist.
     /// </summary>
     /// <param name="pluginRelativePath">The plugin-relative path to check.</param>
-    /// <param name="allowlistProvider">The provider that supplies the allowed file references.</param>
+    /// <param name="allowlistProvider">The provider that validates allowed file references.</param>
     /// <returns>True if the path is in the allowlist, false otherwise.</returns>
     private static bool IsPathAllowed(string pluginRelativePath, IPluginFileReferenceAllowlistProvider allowlistProvider)
     {
-        var allowedPaths = allowlistProvider.GetAllowedPaths();
-        return allowedPaths.Contains(pluginRelativePath);
+        return allowlistProvider.IsPathAllowed(pluginRelativePath);
     }
 
     /// <summary>
     /// Checks if a skill name is allowed based on the exact skill name allowlist.
     /// </summary>
     /// <param name="skillName">The skill name to check.</param>
-    /// <param name="allowlistProvider">The provider that supplies the allowed skill names.</param>
+    /// <param name="allowlistProvider">The provider that validates allowed skill names.</param>
     /// <returns>True if the skill name is in the allowlist, false otherwise.</returns>
     private static bool IsSkillNameAllowed(string skillName, IPluginSkillNameAllowlistProvider allowlistProvider)
     {
-        var allowedSkillNames = allowlistProvider.GetAllowedSkillNames();
-        return allowedSkillNames.Contains(skillName);
+        return allowlistProvider.IsSkillNameAllowed(skillName);
+    }
+
+    /// <summary>
+    /// Known client-specific prefixes for tool names, ordered most specific first.
+    /// Each client wraps the azmcp command name with a different prefix:
+    /// - Claude Code: mcp__plugin_azure_azure__
+    /// - VS Code: mcp_azure_mcp_
+    /// - Copilot CLI: azure-
+    /// </summary>
+    private static readonly string[] KnownToolNamePrefixes =
+    [
+        "mcp__plugin_azure_azure__",
+        "mcp_azure_mcp_",
+        "azure-"
+    ];
+
+    /// <summary>
+    /// Strips known client-specific prefixes from a tool name to extract the azmcp command name.
+    /// For example, "mcp__plugin_azure_azure__pricing" becomes "pricing".
+    /// Returns the original name if no known prefix is found.
+    /// </summary>
+    internal static string StripClientPrefix(string toolName)
+    {
+        foreach (var prefix in KnownToolNamePrefixes)
+        {
+            if (toolName.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return toolName[prefix.Length..];
+            }
+        }
+
+        return toolName;
+    }
+
+    /// <summary>
+    /// Azure extension tool names that are not azmcp commands but should still be tracked.
+    /// These are tools from the @azure VS Code extension (e.g., auth, resource graph, templates).
+    /// </summary>
+    private static readonly HashSet<string> AllowlistedExtensionTools = new(StringComparer.Ordinal)
+    {
+        "azure_auth-set_auth_context",
+        "azure_get_auth_context",
+        "azure_get_dotnet_template_tags",
+        "azure_get_dotnet_templates_for_tag",
+        "azure_query_azure_resource_graph",
+        "azure_recommend_custom_modes"
+    };
+
+    /// <summary>
+    /// Validates a tool name against registered commands by stripping client prefixes
+    /// and checking if the result is a known command name or area name.
+    /// Also allows explicitly allowlisted Azure extension tools to pass through as-is.
+    /// Returns the normalized azmcp tool name if valid, or null if not recognized.
+    /// </summary>
+    internal static string? ValidateAndNormalizeToolName(string toolName, ICommandFactory commandFactory)
+    {
+        // Check allowlisted Azure extension tools first (pass through without normalization)
+        if (AllowlistedExtensionTools.Contains(toolName))
+        {
+            return toolName;
+        }
+
+        var normalizedName = StripClientPrefix(toolName);
+
+        if (string.IsNullOrEmpty(normalizedName))
+        {
+            return null;
+        }
+
+        // Check for exact command match (e.g., "group_resource_list", "subscription_list")
+        if (commandFactory.FindCommandByName(normalizedName) != null)
+        {
+            return normalizedName;
+        }
+
+        // Check for area-level match (e.g., "pricing" matches area with commands like "pricing_get")
+        // Case-sensitive: area names must be lowercase as registered
+        foreach (var subGroup in commandFactory.RootGroup.SubGroup)
+        {
+            if (string.Equals(subGroup.Name, normalizedName, StringComparison.Ordinal))
+            {
+                return normalizedName;
+            }
+        }
+
+        return null;
     }
 
     protected override void RegisterOptions(Command command)
@@ -119,8 +210,9 @@ public sealed class PluginTelemetryCommand : BaseCommand<PluginTelemetryOptions>
 
     /// <summary>
     /// Executes the plugin telemetry command by validating and logging telemetry.
-    /// This method validates required options, checks paths against the allowlist,
-    /// creates a host with telemetry services, and logs the telemetry event.
+    /// This method validates required options, checks paths and skill names against allowlists,
+    /// validates tool names against registered commands, creates a host with telemetry services,
+    /// and logs the telemetry event.
     /// </summary>
     /// <param name="context">The command execution context containing the response object.</param>
     /// <param name="parseResult">The parsed command-line arguments containing telemetry event data.</param>
@@ -137,16 +229,11 @@ public sealed class PluginTelemetryCommand : BaseCommand<PluginTelemetryOptions>
 
         try
         {
-            // Create host early so we can access services for validation
-            using var host = CreateStdioHost(options);
-            await InitializeServicesAsync(host.Services);
-
             // Validate file reference if provided
             if (!string.IsNullOrWhiteSpace(options.FileReference))
             {
                 // Validate against allowlist
-                var allowlistProvider = host.Services.GetRequiredService<IPluginFileReferenceAllowlistProvider>();
-                if (!IsPathAllowed(options.FileReference, allowlistProvider))
+                if (!IsPathAllowed(options.FileReference, _fileReferenceAllowlistProvider))
                 {
                     context.Response.Status = HttpStatusCode.Forbidden;
                     context.Response.Message = $"Plugin file reference '{options.FileReference}' is not in the allowlist and will not be logged.";
@@ -158,8 +245,7 @@ public sealed class PluginTelemetryCommand : BaseCommand<PluginTelemetryOptions>
             if (!string.IsNullOrWhiteSpace(options.SkillName))
             {
                 // Validate against allowlist
-                var skillNameAllowlistProvider = host.Services.GetRequiredService<IPluginSkillNameAllowlistProvider>();
-                if (!IsSkillNameAllowed(options.SkillName, skillNameAllowlistProvider))
+                if (!IsSkillNameAllowed(options.SkillName, _skillNameAllowlistProvider))
                 {
                     context.Response.Status = HttpStatusCode.Forbidden;
                     context.Response.Message = $"Skill name '{options.SkillName}' is not in the allowlist and will not be logged.";
@@ -167,7 +253,27 @@ public sealed class PluginTelemetryCommand : BaseCommand<PluginTelemetryOptions>
                 }
             }
 
-            // Start host and log telemetry
+            // Validate tool name if provided: strip client-specific prefixes and check against registered commands/areas
+            if (!string.IsNullOrWhiteSpace(options.ToolName))
+            {
+                // Resolve ICommandFactory lazily to avoid circular dependency during construction
+                var commandFactory = _serviceProvider.GetRequiredService<ICommandFactory>();
+
+                var normalizedToolName = ValidateAndNormalizeToolName(options.ToolName, commandFactory);
+                if (normalizedToolName == null)
+                {
+                    context.Response.Status = HttpStatusCode.Forbidden;
+                    context.Response.Message = $"Tool name '{options.ToolName}' is not a recognized azmcp command and will not be logged.";
+                    return context.Response;
+                }
+
+                // Replace with normalized name for clean telemetry data
+                options.ToolName = normalizedToolName;
+            }
+
+            // Create host and log telemetry
+            using var host = CreateStdioHost(options);
+            await InitializeServicesAsync(host.Services);
             await host.StartAsync(cancellationToken);
 
             var telemetryService = host.Services.GetRequiredService<ITelemetryService>();
@@ -188,8 +294,9 @@ public sealed class PluginTelemetryCommand : BaseCommand<PluginTelemetryOptions>
 
     /// <summary>
     /// Logs plugin telemetry by creating an activity and adding relevant tags.
-    /// Only non-empty fields are added as tags. File references should be validated
-    /// against the allowlist before calling this method.
+    /// Only non-empty fields are added as tags. File references and skill names
+    /// should be validated against their respective allowlists, and tool names
+    /// should be validated as registered commands, before calling this method.
     /// </summary>
     /// <param name="telemetryService">The telemetry service used to create and track activities.</param>
     /// <param name="options">The plugin telemetry options containing event data (timestamp, event type, session ID, etc.).</param>

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -112,7 +112,9 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 ### Other Changes
 
-- Improved tool descriptions to enhance LLM selection accuracy for the following tools: [[#2131](https://github.com/microsoft/mcp/pull/2131)]
+- Added skill name and tool name validation to the plugin-telemetry tool. Skill names are validated against an allowlist to prevent logging of customer-defined custom skill names. Tool names are validated by stripping known client prefixes (Claude Code, VS Code, Copilot CLI) and matching against registered commands or area names, with normalized names logged for consistent telemetry. Added an allowlist for Azure extension tools that are not azmcp commands but still tracked. Expanded the plugin file-reference allowlist with additional azure-enterprise-infra-planner reference paths. [[#2149](https://github.com/microsoft/mcp/pull/2149)]
+- Refactored PluginTelemetryCommand to use constructor injection for allowlist providers and lazy resolution of ICommandFactory via IServiceProvider to avoid circular dependency during startup.
+- Improved tool descriptions to enahnce LLM selection accuracy for the following tools: [[#2131](https://github.com/microsoft/mcp/pull/2131)]
   - `extension_azqr`
   - `extension_cli_generate`
   - `extension_cli_install`

--- a/servers/Fabric.Mcp.Server/src/Program.cs
+++ b/servers/Fabric.Mcp.Server/src/Program.cs
@@ -17,6 +17,7 @@ using Microsoft.Mcp.Core.Areas;
 using Microsoft.Mcp.Core.Areas.Server;
 using Microsoft.Mcp.Core.Areas.Server.Commands;
 using Microsoft.Mcp.Core.Areas.Server.Commands.Discovery;
+using Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
 using Microsoft.Mcp.Core.Areas.Server.Models;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Command;
@@ -169,6 +170,10 @@ internal class Program
 
         // Until there is a consolidated tool list, just use an empty provider
         services.AddSingleton<IConsolidatedToolDefinitionProvider>(new NullConsolidatedToolDefinitionProvider());
+
+        // Plugin telemetry is not supported in Fabric - register no-op providers
+        services.AddSingleton<IPluginFileReferenceAllowlistProvider>(new NullPluginFileReferenceAllowlistProvider());
+        services.AddSingleton<IPluginSkillNameAllowlistProvider>(new NullPluginSkillNameAllowlistProvider());
     }
 
     internal static async Task InitializeServicesAsync(IServiceProvider serviceProvider)

--- a/servers/Template.Mcp.Server/src/Program.cs
+++ b/servers/Template.Mcp.Server/src/Program.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Areas;
 using Microsoft.Mcp.Core.Areas.Server.Commands;
 using Microsoft.Mcp.Core.Areas.Server.Commands.Discovery;
+using Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
 using Microsoft.Mcp.Core.Areas.Server.Models;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Command;
@@ -163,6 +164,10 @@ internal class Program
 
         // Until there is a consolidated tool list, just use an empty provider
         services.AddSingleton<IConsolidatedToolDefinitionProvider>(new NullConsolidatedToolDefinitionProvider());
+
+        // Plugin telemetry is not supported in Template - register no-op providers
+        services.AddSingleton<IPluginFileReferenceAllowlistProvider>(new NullPluginFileReferenceAllowlistProvider());
+        services.AddSingleton<IPluginSkillNameAllowlistProvider>(new NullPluginSkillNameAllowlistProvider());
     }
 
     internal static async Task InitializeServicesAsync(IServiceProvider serviceProvider)


### PR DESCRIPTION
…itting telemetry (#2282)

* Refactor PluginTelemetryCommand to use constructor injection

- Inject IPluginFileReferenceAllowlistProvider and IPluginSkillNameAllowlistProvider via constructor
- Remove service resolution from ExecuteAsync method
- Move validation before host creation for better performance
- Improves testability by allowing easy dependency mocking

* Add tool name validation to plugin telemetry using CommandFactory

- Validate tool names directly using ICommandFactory.FindCommandByName() in PluginTelemetryCommand
- Remove IPluginToolNameAllowlistProvider abstraction (too thin, CommandFactory is already mockable)
- Tool name validation automatically stays in sync with registered commands
- Update CHANGELOG with cleaner validation approach

* Refactor allowlist providers to use simpler interface design

- Change IPluginFileReferenceAllowlistProvider from GetAllowedPaths() to IsPathAllowed(string)
- Change IPluginSkillNameAllowlistProvider from GetAllowedSkillNames() to IsSkillNameAllowed(string)
- Providers now encapsulate the check logic instead of exposing collections
- Simplifies caller code - single method call instead of get + contains
- Better encapsulation - implementation details (HashSet) hidden from callers
- Tests now directly test behavior (true/false) like testing a HashSet
- All three validation mechanisms now follow consistent patterns
- Add comprehensive unit tests for all three validation providers

* remove circular dependency, added toolname validation by stripping the prefix

* updated unit tests and changelog

* Make plugin telemetry no-op for fabric and template

* update the test and make checks case sensitive

## What does this PR do?
`[Provide a clear, concise description of the changes]`

`[Add additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
