### PR TITLE
Fix endpoint validation to pass ArmEnvironment always

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Helpers/EndpointValidator.cs
+++ b/core/Microsoft.Mcp.Core/src/Helpers/EndpointValidator.cs
@@ -97,17 +97,6 @@ public static class EndpointValidator
     }
 
     /// <summary>
-    /// Validates that an endpoint belongs to an allowed Azure service domain.
-    /// Uses Azure Public Cloud domains by default.
-    /// </summary>
-    /// <param name="endpoint">The endpoint URL to validate.</param>
-    /// <param name="serviceType">The type of Azure service (e.g., "storage-blob", "keyvault").</param>
-    public static void ValidateAzureServiceEndpoint(string endpoint, string serviceType)
-    {
-        ValidateAzureServiceEndpoint(endpoint, serviceType, ArmEnvironment.AzurePublicCloud);
-    }
-
-    /// <summary>
     /// Validates that an endpoint belongs to an allowed Azure service domain for the specified cloud environment.
     /// </summary>
     /// <param name="endpoint">The endpoint URL to validate.</param>

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.UnitTests/Helpers/EndpointValidatorTests.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.UnitTests/Helpers/EndpointValidatorTests.cs
@@ -25,7 +25,7 @@ public class EndpointValidatorTests
     public void ValidateAzureServiceEndpoint_ValidEndpoints_DoesNotThrow(string endpoint, string serviceType)
     {
         // Act & Assert
-        var exception = Record.Exception(() => EndpointValidator.ValidateAzureServiceEndpoint(endpoint, serviceType));
+        var exception = Record.Exception(() => EndpointValidator.ValidateAzureServiceEndpoint(endpoint, serviceType, ArmEnvironment.AzurePublicCloud));
         Assert.Null(exception);
     }
 
@@ -47,7 +47,7 @@ public class EndpointValidatorTests
     {
         // Act & Assert
         var exception = Assert.Throws<SecurityException>(
-            () => EndpointValidator.ValidateAzureServiceEndpoint(endpoint, serviceType));
+            () => EndpointValidator.ValidateAzureServiceEndpoint(endpoint, serviceType, ArmEnvironment.AzurePublicCloud));
         Assert.Contains(expectedMessagePart, exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -60,7 +60,7 @@ public class EndpointValidatorTests
     {
         // Act & Assert
         Assert.Throws<ArgumentException>(
-            () => EndpointValidator.ValidateAzureServiceEndpoint(endpoint, serviceType));
+            () => EndpointValidator.ValidateAzureServiceEndpoint(endpoint, serviceType, ArmEnvironment.AzurePublicCloud));
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class EndpointValidatorTests
     {
         // Act & Assert
         Assert.Throws<ArgumentException>(
-            () => EndpointValidator.ValidateAzureServiceEndpoint(null!, "communication"));
+            () => EndpointValidator.ValidateAzureServiceEndpoint(null!, "communication", ArmEnvironment.AzurePublicCloud));
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class EndpointValidatorTests
 
         // Act & Assert
         var exception = Assert.Throws<SecurityException>(
-            () => EndpointValidator.ValidateAzureServiceEndpoint(invalidEndpoint, "communication"));
+            () => EndpointValidator.ValidateAzureServiceEndpoint(invalidEndpoint, "communication", ArmEnvironment.AzurePublicCloud));
         Assert.Contains("Invalid endpoint format", exception.Message);
     }
 
@@ -92,7 +92,7 @@ public class EndpointValidatorTests
 
         // Act & Assert
         var exception = Assert.Throws<ArgumentException>(
-            () => EndpointValidator.ValidateAzureServiceEndpoint(endpoint, unknownServiceType));
+            () => EndpointValidator.ValidateAzureServiceEndpoint(endpoint, unknownServiceType, ArmEnvironment.AzurePublicCloud));
         Assert.Contains("Unknown service type", exception.Message);
     }
 
@@ -213,8 +213,7 @@ public class EndpointValidatorTests
     public void ValidateExternalUrl_NullUrl_ThrowsArgumentException()
     {
         // Act & Assert
-        Assert.Throws<ArgumentException>(
-            () => EndpointValidator.ValidateExternalUrl(null!, new[] { "github.com" }));
+        Assert.Throws<ArgumentException>(() => EndpointValidator.ValidateExternalUrl(null!, ["github.com"]));
     }
 
     #endregion
@@ -403,7 +402,7 @@ public class EndpointValidatorTests
     {
         // Act & Assert
         var exception = Record.Exception(
-            () => EndpointValidator.ValidateAzureServiceEndpoint(endpoint, serviceType));
+            () => EndpointValidator.ValidateAzureServiceEndpoint(endpoint, serviceType, ArmEnvironment.AzurePublicCloud));
         Assert.Null(exception);
     }
 
@@ -417,7 +416,7 @@ public class EndpointValidatorTests
     {
         // Act & Assert
         Assert.Throws<SecurityException>(
-            () => EndpointValidator.ValidateAzureServiceEndpoint(endpoint, serviceType));
+            () => EndpointValidator.ValidateAzureServiceEndpoint(endpoint, serviceType, ArmEnvironment.AzurePublicCloud));
     }
 
     [Fact]

--- a/servers/Azure.Mcp.Server/changelog-entries/1775052619914.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1775052619914.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fix endpoint validation on non-Public cloud environments"

--- a/tools/Azure.Mcp.Tools.Acr/src/Services/AcrService.cs
+++ b/tools/Azure.Mcp.Tools.Acr/src/Services/AcrService.cs
@@ -72,7 +72,7 @@ public sealed class AcrService(ISubscriptionService subscriptionService, ITenant
         if (!string.IsNullOrEmpty(reg.LoginServer))
         {
             var acrEndpointString = $"https://{reg.LoginServer}";
-            EndpointValidator.ValidateAzureServiceEndpoint(acrEndpointString, "acr");
+            EndpointValidator.ValidateAzureServiceEndpoint(acrEndpointString, "acr", TenantService.CloudConfiguration.ArmEnvironment);
         }
 
         // Build data-plane client for this login server

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
@@ -176,7 +176,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
             throw new InvalidOperationException($"The App Configuration store '{accountName}' does not have a valid endpoint.");
         }
 
-        EndpointValidator.ValidateAzureServiceEndpoint(endpoint, "appconfig");
+        EndpointValidator.ValidateAzureServiceEndpoint(endpoint, "appconfig", TenantService.CloudConfiguration.ArmEnvironment);
 
         var credential = await GetCredential(tenant, cancellationToken);
         var options = new ConfigurationClientOptions();

--- a/tools/Azure.Mcp.Tools.Communication/src/Services/CommunicationService.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Services/CommunicationService.cs
@@ -35,7 +35,7 @@ public class CommunicationService(ITenantService tenantService, ILogger<Communic
             (nameof(from), from),
             (nameof(message), message));
 
-        EndpointValidator.ValidateAzureServiceEndpoint(endpoint, "communication");
+        EndpointValidator.ValidateAzureServiceEndpoint(endpoint, "communication", TenantService.CloudConfiguration.ArmEnvironment);
 
         // Validate to array separately since it has special requirements
         if (to == null || to.Length == 0)
@@ -116,7 +116,7 @@ public class CommunicationService(ITenantService tenantService, ILogger<Communic
             (nameof(subject), subject),
             (nameof(message), message));
 
-        EndpointValidator.ValidateAzureServiceEndpoint(endpoint, "communication");
+        EndpointValidator.ValidateAzureServiceEndpoint(endpoint, "communication", TenantService.CloudConfiguration.ArmEnvironment);
 
         // Validate to array separately since it has special requirements
         if (to == null || to.Length == 0)


### PR DESCRIPTION
## What does this PR do?

Updates `EndpointValidator` to remove overload of `ValidateAzureServiceEndpoint` that doesn't take `ArmEnvironment` and update all calling locations to use the variant that does and to pass the `ArmEnvironment` configured in the `TenantService`.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
