### PR TITLE
Add default sanitizer for resource group name in URI

### DIFF
--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/RecordedCommandTestsBase.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/RecordedCommandTestsBase.cs
@@ -57,13 +57,14 @@ public abstract class RecordedCommandTestsBase(ITestOutputHelper output, TestPro
     /// </summary>
     public virtual List<UriRegexSanitizer> UriRegexSanitizers { get; } = [
         // Sanitize Resource Group name from the URI. This is needed as there is another default GeneralRegexSanitizer for
-        // Settings.ResourceBaseName. But there is two issues we hit with that:
+        // Settings.ResourceBaseName. But there are two issues we hit with that:
         // 1. Resource group names often have other characters added to it, like prepending or appending for uniqueness.
-        // 2. In playback, Settings.ResourceBaseName is configured to be 'Sanitized', so it won't find the right string.
+        // 2. In playback, Settings.ResourceBaseName and Settings.ResourceGroupName are both configured to be 'Sanitized',
+        //    so it won't find the right string.
         new UriRegexSanitizer(new()
         {
             Value = "Sanitized",
-            Regex = "/resource[gG]roups/(?<rgname>[\\w\\-.()]{1,90})/",
+            Regex = "/resource[gG]roups/(?<rgname>[\\w\\-.()]{1,90})(?=/|\\?|$)",
             GroupForReplace = "rgname"
         })
     ];

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/RecordedCommandTestsBase.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/RecordedCommandTestsBase.cs
@@ -55,7 +55,18 @@ public abstract class RecordedCommandTestsBase(ITestOutputHelper output, TestPro
     /// <summary>
     /// Sanitizers that apply a regex replacement to URIs. This sanitization is applied to to recorded data at rest and during recording, and against test requests during playback.
     /// </summary>
-    public virtual List<UriRegexSanitizer> UriRegexSanitizers { get; } = [];
+    public virtual List<UriRegexSanitizer> UriRegexSanitizers { get; } = [
+        // Sanitize Resource Group name from the URI. This is needed as there is another default GeneralRegexSanitizer for
+        // Settings.ResourceBaseName. But there is two issues we hit with that:
+        // 1. Resource group names often have other characters added to it, like prepending or appending for uniqueness.
+        // 2. In playback, Settings.ResourceBaseName is configured to be 'Sanitized', so it won't find the right string.
+        new UriRegexSanitizer(new()
+        {
+            Value = "Sanitized",
+            Regex = "/resource[gG]roups/(?<rgname>[\\w\\-.()]{1,90})/",
+            GroupForReplace = "rgname"
+        })
+    ];
 
     /// <summary>
     /// Sanitizers that will apply a regex replacement to a specific json body key. This sanitization is applied to to recorded data at rest and during recording, and against test requests during playback.

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/RecordedCommandTestsBase.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/RecordedCommandTestsBase.cs
@@ -55,19 +55,7 @@ public abstract class RecordedCommandTestsBase(ITestOutputHelper output, TestPro
     /// <summary>
     /// Sanitizers that apply a regex replacement to URIs. This sanitization is applied to to recorded data at rest and during recording, and against test requests during playback.
     /// </summary>
-    public virtual List<UriRegexSanitizer> UriRegexSanitizers { get; } = [
-        // Sanitize Resource Group name from the URI. This is needed as there is another default GeneralRegexSanitizer for
-        // Settings.ResourceBaseName. But there are two issues we hit with that:
-        // 1. Resource group names often have other characters added to it, like prepending or appending for uniqueness.
-        // 2. In playback, Settings.ResourceBaseName and Settings.ResourceGroupName are both configured to be 'Sanitized',
-        //    so it won't find the right string.
-        new UriRegexSanitizer(new()
-        {
-            Value = "Sanitized",
-            Regex = "/resource[gG]roups/(?<rgname>[\\w\\-.()]{1,90})(?=/|\\?|$)",
-            GroupForReplace = "rgname"
-        })
-    ];
+    public virtual List<UriRegexSanitizer> UriRegexSanitizers { get; } = [];
 
     /// <summary>
     /// Sanitizers that will apply a regex replacement to a specific json body key. This sanitization is applied to to recorded data at rest and during recording, and against test requests during playback.
@@ -315,15 +303,26 @@ public abstract class RecordedCommandTestsBase(ITestOutputHelper output, TestPro
         // Registering a few common sanitizers for values that we know will be universally present and cleaned up
         if (EnableDefaultSanitizerAdditions)
         {
-            GeneralRegexSanitizers.Add(new GeneralRegexSanitizer(new GeneralRegexSanitizerBody()
+            GeneralRegexSanitizers.Add(new(new()
             {
                 Regex = Settings.ResourceBaseName,
                 Value = "Sanitized",
             }));
-            GeneralRegexSanitizers.Add(new GeneralRegexSanitizer(new GeneralRegexSanitizerBody()
+            GeneralRegexSanitizers.Add(new(new()
             {
                 Regex = Settings.SubscriptionId,
                 Value = EmptyGuid,
+            }));
+            // Sanitize Resource Group name from the URI. This is needed as there is another default GeneralRegexSanitizer for
+            // Settings.ResourceBaseName. But there are two issues we hit with that:
+            // 1. Resource group names often have other characters added to it, like prepending or appending for uniqueness.
+            // 2. In playback, Settings.ResourceBaseName and Settings.ResourceGroupName are both configured to be 'Sanitized',
+            //    so it won't find the right string.
+            UriRegexSanitizers.Add(new(new()
+            {
+                Value = "Sanitized",
+                Regex = "/resource[gG]roups/(?<rgname>[\\w\\-.()]{1,90})(?=/|\\?|$)",
+                GroupForReplace = "rgname"
             }));
         }
     }

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.LiveTests/AppConfigCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.LiveTests/AppConfigCommandTests.cs
@@ -49,14 +49,14 @@ public class AppConfigCommandTests : RecordedCommandTestsBase
         _appConfigService = new AppConfigService(subscriptionService, tenantService, _logger, httpClientFactory);
     }
 
-    public override List<BodyRegexSanitizer> BodyRegexSanitizers => new()
-    {
+    public override List<BodyRegexSanitizer> BodyRegexSanitizers =>
+    [
         new BodyRegexSanitizer(new BodyRegexSanitizerBody() {
           Regex = "\"domains\"\\s*:\\s*\\[(?s)(?<domains>.*?)\\]",
           GroupForReplace = "domains",
           Value = "\"contoso.com\""
         })
-    };
+    ];
 
     public override async ValueTask DisposeAsync()
     {

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.LiveTests/assets.json
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.LiveTests/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "",
   "TagPrefix": "Azure.Mcp.Tools.AppConfig.LiveTests",
-  "Tag": "Azure.Mcp.Tools.AppConfig.LiveTests_db8ee56198"
+  "Tag": "Azure.Mcp.Tools.AppConfig.LiveTests_d4554e504e"
 }


### PR DESCRIPTION
## What does this PR do?

Adds a default `UriRegexSanitizer` to `RecordedCommandTestsBase` that handles sanitizing resource group name in URIs in a way that won't have issues in playback after recording.

The previous sanitization was done using a `GeneralRegexSanitizer` looking for the resource base name. This might not be the same as the resource group name, which is the first issue, but generally the resource group name does contain the base name. The second issue is only the base name specifically was being sanitized, so only part of the resource group name may be sanitized, which would be fine if the third issue wasn't present. The third problem is that the base name is defaulted to `Santized` in playback, which would fail to match the resource group name if it was capture.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
