### PR TITLE
Fix subscription ID tests when logged in with Azure CLI

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Subscription/SubscriptionCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Subscription/SubscriptionCommandTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Helpers;
 using NSubstitute;
 using Xunit;
 
@@ -42,7 +43,7 @@ public class SubscriptionCommandTests
     public void Validate_WithEnvironmentVariableOnly_PassesValidation()
     {
         // Arrange
-        EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        TestEnvironment.SetAzureSubscriptionId("env-subs");
 
         // Act
         var parseResult = _commandDefinition.Parse([]);
@@ -55,7 +56,8 @@ public class SubscriptionCommandTests
     public async Task ExecuteAsync_WithEnvironmentVariableOnly_CallsServiceWithCorrectSubscription()
     {
         // Arrange
-        var subscription = EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        TestEnvironment.SetAzureSubscriptionId("env-subs");
+        var subscription = CommandHelper.GetDefaultSubscription()!;
 
         var expectedAccounts = new ResourceQueryResults<StorageAccountInfo>(
         [
@@ -92,7 +94,8 @@ public class SubscriptionCommandTests
     public async Task ExecuteAsync_WithBothOptionAndEnvironmentVariable_PrefersOption()
     {
         // Arrange
-        var ignoredSubscription = EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        TestEnvironment.SetAzureSubscriptionId("env-subs");
+        var ignoredSubscription = CommandHelper.GetDefaultSubscription()!;
         var expectedSubscription = "option-subs";
 
         var expectedAccounts = new ResourceQueryResults<StorageAccountInfo>(

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Subscription/SubscriptionCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Subscription/SubscriptionCommandTests.cs
@@ -55,7 +55,7 @@ public class SubscriptionCommandTests
     public async Task ExecuteAsync_WithEnvironmentVariableOnly_CallsServiceWithCorrectSubscription()
     {
         // Arrange
-        EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        var subscription = EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
 
         var expectedAccounts = new ResourceQueryResults<StorageAccountInfo>(
         [
@@ -65,7 +65,7 @@ public class SubscriptionCommandTests
 
         _storageService.GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            Arg.Is("env-subs"),
+            Arg.Is(subscription),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
@@ -82,7 +82,7 @@ public class SubscriptionCommandTests
         // Verify the service was called with the environment variable subscription
         _ = _storageService.Received(1).GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            "env-subs",
+            subscription,
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
@@ -92,7 +92,8 @@ public class SubscriptionCommandTests
     public async Task ExecuteAsync_WithBothOptionAndEnvironmentVariable_PrefersOption()
     {
         // Arrange
-        EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        var ignoredSubscription = EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        var expectedSubscription = "option-subs";
 
         var expectedAccounts = new ResourceQueryResults<StorageAccountInfo>(
         [
@@ -102,13 +103,13 @@ public class SubscriptionCommandTests
 
         _storageService.GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            Arg.Is("option-subs"),
+            Arg.Is(expectedSubscription),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(expectedAccounts));
 
-        var parseResult = _commandDefinition.Parse(["--subscription", "option-subs"]);
+        var parseResult = _commandDefinition.Parse(["--subscription", expectedSubscription]);
 
         // Act
         var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
@@ -119,13 +120,13 @@ public class SubscriptionCommandTests
         // Verify the service was called with the option subscription, not the environment variable
         _ = _storageService.Received(1).GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            "option-subs",
+            expectedSubscription,
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
         _ = _storageService.DidNotReceive().GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            "env-subs",
+            ignoredSubscription,
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Helpers/CommandHelperTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Helpers/CommandHelperTests.cs
@@ -13,28 +13,28 @@ public class CommandHelperTests
     public void GetSubscription_EmptySubscriptionParameter_ReturnsEnvironmentValue()
     {
         // Arrange
-        EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        var subscription = EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
         var parseResult = GetParseResult(["--subscription", ""]);
 
         // Act
         var actual = CommandHelper.GetSubscription(parseResult);
 
         // Assert
-        Assert.Equal("env-subs", actual);
+        Assert.Equal(subscription, actual);
     }
 
     [Fact]
     public void GetSubscription_MissingSubscriptionParameter_ReturnsEnvironmentValue()
     {
         // Arrange
-        EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        var subscription = EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
         var parseResult = GetParseResult([]);
 
         // Act
         var actual = CommandHelper.GetSubscription(parseResult);
 
         // Assert
-        Assert.Equal("env-subs", actual);
+        Assert.Equal(subscription, actual);
     }
 
     [Fact]
@@ -55,54 +55,56 @@ public class CommandHelperTests
     public void GetSubscription_ParameterValueContainingSubscription_ReturnsEnvironmentValue()
     {
         // Arrange
-        EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        var subscription = EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
         var parseResult = GetParseResult(["--subscription", "Azure subscription 1"]);
 
         // Act
         var actual = CommandHelper.GetSubscription(parseResult);
 
         // Assert
-        Assert.Equal("env-subs", actual);
+        Assert.Equal(subscription, actual);
     }
 
     [Fact]
     public void GetSubscription_ParameterValueContainingDefault_ReturnsEnvironmentValue()
     {
         // Arrange
-        EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        var subscription = EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
         var parseResult = GetParseResult(["--subscription", "Some default name"]);
 
         // Act
         var actual = CommandHelper.GetSubscription(parseResult);
 
         // Assert
-        Assert.Equal("env-subs", actual);
+        Assert.Equal(subscription, actual);
     }
 
     [Fact]
     public void GetSubscription_NoEnvironmentVariableParameterValueContainingDefault_ReturnsParameterValue()
     {
         // Arrange
+        var subscription = CommandHelper.GetProfileSubscription();
         var parseResult = GetParseResult(["--subscription", "Some default name"]);
 
         // Act
         var actual = CommandHelper.GetSubscription(parseResult);
 
         // Assert
-        Assert.Equal("Some default name", actual);
+        Assert.Equal(subscription ?? "Some default name", actual);
     }
 
     [Fact]
     public void GetSubscription_NoEnvironmentVariableParameterValueContainingSubscription_ReturnsParameterValue()
     {
         // Arrange
+        var subscription = CommandHelper.GetProfileSubscription();
         var parseResult = GetParseResult(["--subscription", "Azure subscription 1"]);
 
         // Act
         var actual = CommandHelper.GetSubscription(parseResult);
 
         // Assert
-        Assert.Equal("Azure subscription 1", actual);
+        Assert.Equal(subscription ?? "Azure subscription 1", actual);
     }
 
     private static ParseResult GetParseResult(params string[] args)

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Helpers/CommandHelperTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Helpers/CommandHelperTests.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using Azure.Mcp.Core.Areas.Group.Commands;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Helpers;
+using Microsoft.Mcp.Tests.Helpers;
 using NSubstitute;
 using Xunit;
 
@@ -13,7 +14,8 @@ public class CommandHelperTests
     public void GetSubscription_EmptySubscriptionParameter_ReturnsEnvironmentValue()
     {
         // Arrange
-        var subscription = EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        TestEnvironment.SetAzureSubscriptionId("env-subs");
+        var subscription = CommandHelper.GetDefaultSubscription();
         var parseResult = GetParseResult(["--subscription", ""]);
 
         // Act
@@ -27,7 +29,8 @@ public class CommandHelperTests
     public void GetSubscription_MissingSubscriptionParameter_ReturnsEnvironmentValue()
     {
         // Arrange
-        var subscription = EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        TestEnvironment.SetAzureSubscriptionId("env-subs");
+        var subscription = CommandHelper.GetDefaultSubscription();
         var parseResult = GetParseResult([]);
 
         // Act
@@ -41,7 +44,7 @@ public class CommandHelperTests
     public void GetSubscription_ValidSubscriptionParameter_ReturnsParameterValue()
     {
         // Arrange
-        EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        TestEnvironment.SetAzureSubscriptionId("env-subs");
         var parseResult = GetParseResult(["--subscription", "param-subs"]);
 
         // Act
@@ -55,7 +58,8 @@ public class CommandHelperTests
     public void GetSubscription_ParameterValueContainingSubscription_ReturnsEnvironmentValue()
     {
         // Arrange
-        var subscription = EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        TestEnvironment.SetAzureSubscriptionId("env-subs");
+        var subscription = CommandHelper.GetDefaultSubscription();
         var parseResult = GetParseResult(["--subscription", "Azure subscription 1"]);
 
         // Act
@@ -69,7 +73,8 @@ public class CommandHelperTests
     public void GetSubscription_ParameterValueContainingDefault_ReturnsEnvironmentValue()
     {
         // Arrange
-        var subscription = EnvironmentHelpers.SetAzureSubscriptionId("env-subs");
+        TestEnvironment.SetAzureSubscriptionId("env-subs");
+        var subscription = CommandHelper.GetDefaultSubscription();
         var parseResult = GetParseResult(["--subscription", "Some default name"]);
 
         // Act
@@ -83,6 +88,7 @@ public class CommandHelperTests
     public void GetSubscription_NoEnvironmentVariableParameterValueContainingDefault_ReturnsParameterValue()
     {
         // Arrange
+        TestEnvironment.ClearAzureSubscriptionId();
         var subscription = CommandHelper.GetProfileSubscription();
         var parseResult = GetParseResult(["--subscription", "Some default name"]);
 
@@ -90,13 +96,23 @@ public class CommandHelperTests
         var actual = CommandHelper.GetSubscription(parseResult);
 
         // Assert
-        Assert.Equal(subscription ?? "Some default name", actual);
+        // If-else this test as being logged in with Azure CLI cannot be mocked out at this time.
+        // So, if the running environment is logged in the subscription will be defaulted to the Azure CLI subscription.
+        if (subscription != null)
+        {
+            Assert.Equal(subscription, actual);
+        }
+        else
+        {
+            Assert.Equal("Some default name", actual);
+        }
     }
 
     [Fact]
     public void GetSubscription_NoEnvironmentVariableParameterValueContainingSubscription_ReturnsParameterValue()
     {
         // Arrange
+        TestEnvironment.ClearAzureSubscriptionId();
         var subscription = CommandHelper.GetProfileSubscription();
         var parseResult = GetParseResult(["--subscription", "Azure subscription 1"]);
 
@@ -104,7 +120,16 @@ public class CommandHelperTests
         var actual = CommandHelper.GetSubscription(parseResult);
 
         // Assert
-        Assert.Equal(subscription ?? "Azure subscription 1", actual);
+        // If-else this test as being logged in with Azure CLI cannot be mocked out at this time.
+        // So, if the running environment is logged in the subscription will be defaulted to the Azure CLI subscription.
+        if (subscription != null)
+        {
+            Assert.Equal(subscription, actual);
+        }
+        else
+        {
+            Assert.Equal("Azure subscription 1", actual);
+        }
     }
 
     private static ParseResult GetParseResult(params string[] args)

--- a/core/Microsoft.Mcp.Core/src/Helpers/CommandHelper.cs
+++ b/core/Microsoft.Mcp.Core/src/Helpers/CommandHelper.cs
@@ -52,7 +52,7 @@ public static class CommandHelper
     public static string? GetDefaultSubscription()
     {
         // Primary: Azure CLI profile (set via 'az account set') - cached to avoid repeated file I/O
-        var profileDefault = s_profileDefault.Value;
+        var profileDefault = GetProfileSubscription();
         if (!string.IsNullOrEmpty(profileDefault))
         {
             return profileDefault;
@@ -61,6 +61,8 @@ public static class CommandHelper
         // Fallback: AZURE_SUBSCRIPTION_ID environment variable (cheap, not cached)
         return EnvironmentHelpers.GetAzureSubscriptionId();
     }
+
+    internal static string? GetProfileSubscription() => s_profileDefault.Value;
 
     private static bool IsPlaceholder(string value) => value.Contains("subscription") || value.Contains("default");
 }

--- a/core/Microsoft.Mcp.Core/src/Helpers/EnvironmentHelpers.cs
+++ b/core/Microsoft.Mcp.Core/src/Helpers/EnvironmentHelpers.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Mcp.Core.Helpers;
 
 public static class EnvironmentHelpers
 {
-    private const string AzureSubscriptionIdEnvironmentVariable = "AZURE_SUBSCRIPTION_ID";
+    internal const string AzureSubscriptionIdEnvironmentVariable = "AZURE_SUBSCRIPTION_ID";
 
     public static bool GetEnvironmentVariableAsBool(string envVarName)
         => Environment.GetEnvironmentVariable(envVarName) switch
@@ -23,31 +23,6 @@ public static class EnvironmentHelpers
     /// <returns>The subscription ID if available, null otherwise.</returns>
     public static string? GetAzureSubscriptionId()
         => Environment.GetEnvironmentVariable(AzureSubscriptionIdEnvironmentVariable);
-
-    /// <summary>
-    /// Sets the AZURE_SUBSCRIPTION_ID environment variable. 
-    /// This method is primarily intended for testing scenarios.
-    /// </summary>
-    /// <param name="subscriptionId">The subscription ID to set, or null to clear the variable.</param>
-    /// <returns>Either the AZURE_SUBSCRIPTION_ID environment variable value that was set or the logged into Azure CLI subscription.</returns>
-    public static string SetAzureSubscriptionId(string subscriptionId)
-    {
-        var currentSubscription = CommandHelper.GetProfileSubscription();
-        if (!string.IsNullOrEmpty(currentSubscription))
-        {
-            return currentSubscription;
-        }
-
-        Environment.SetEnvironmentVariable(AzureSubscriptionIdEnvironmentVariable, subscriptionId);
-        return subscriptionId;
-    }
-
-    /// <summary>
-    /// Clears the AZURE_SUBSCRIPTION_ID environment variable.
-    /// This is primarily intended for testing scenarios to ensure a clean environment state between tests.
-    /// </summary>
-    public static void ClearAzureSubscriptionId()
-        => Environment.SetEnvironmentVariable(AzureSubscriptionIdEnvironmentVariable, null);
 
     public static bool IsPlaybackTesting()
     {

--- a/core/Microsoft.Mcp.Core/src/Helpers/EnvironmentVariableHelpers.cs
+++ b/core/Microsoft.Mcp.Core/src/Helpers/EnvironmentVariableHelpers.cs
@@ -8,8 +8,7 @@ public static class EnvironmentHelpers
     private const string AzureSubscriptionIdEnvironmentVariable = "AZURE_SUBSCRIPTION_ID";
 
     public static bool GetEnvironmentVariableAsBool(string envVarName)
-    {
-        return Environment.GetEnvironmentVariable(envVarName) switch
+        => Environment.GetEnvironmentVariable(envVarName) switch
         {
             "true" => true,
             "True" => true,
@@ -17,26 +16,38 @@ public static class EnvironmentHelpers
             "1" => true,
             _ => false
         };
-    }
 
     /// <summary>
     /// Gets the Azure subscription ID from the AZURE_SUBSCRIPTION_ID environment variable.
     /// </summary>
     /// <returns>The subscription ID if available, null otherwise.</returns>
     public static string? GetAzureSubscriptionId()
-    {
-        return Environment.GetEnvironmentVariable(AzureSubscriptionIdEnvironmentVariable);
-    }
+        => Environment.GetEnvironmentVariable(AzureSubscriptionIdEnvironmentVariable);
 
     /// <summary>
     /// Sets the AZURE_SUBSCRIPTION_ID environment variable. 
     /// This method is primarily intended for testing scenarios.
     /// </summary>
     /// <param name="subscriptionId">The subscription ID to set, or null to clear the variable.</param>
-    public static void SetAzureSubscriptionId(string? subscriptionId)
+    /// <returns>Either the AZURE_SUBSCRIPTION_ID environment variable value that was set or the logged into Azure CLI subscription.</returns>
+    public static string SetAzureSubscriptionId(string subscriptionId)
     {
+        var currentSubscription = CommandHelper.GetProfileSubscription();
+        if (!string.IsNullOrEmpty(currentSubscription))
+        {
+            return currentSubscription;
+        }
+
         Environment.SetEnvironmentVariable(AzureSubscriptionIdEnvironmentVariable, subscriptionId);
+        return subscriptionId;
     }
+
+    /// <summary>
+    /// Clears the AZURE_SUBSCRIPTION_ID environment variable.
+    /// This is primarily intended for testing scenarios to ensure a clean environment state between tests.
+    /// </summary>
+    public static void ClearAzureSubscriptionId()
+        => Environment.SetEnvironmentVariable(AzureSubscriptionIdEnvironmentVariable, null);
 
     public static bool IsPlaybackTesting()
     {

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Helpers/TestEnvironment.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Helpers/TestEnvironment.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Mcp.Core.Helpers;
+
 namespace Microsoft.Mcp.Tests.Helpers;
 
 /// <summary>
@@ -16,5 +18,20 @@ public enum TestMode
 public static class TestEnvironment
 {
     public static bool IsRunningInCi =>
-        string.Equals(Environment.GetEnvironmentVariable("CI"), "true", StringComparison.OrdinalIgnoreCase) || !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TF_BUILD"));
+        string.Equals(Environment.GetEnvironmentVariable("CI"), "true", StringComparison.OrdinalIgnoreCase) ||
+        !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TF_BUILD"));
+
+    /// <summary>
+    /// Sets the AZURE_SUBSCRIPTION_ID environment variable.
+    /// </summary>
+    /// <param name="subscriptionId">The subscription ID to set, or null to clear the variable.</param>
+    /// <returns>Either the AZURE_SUBSCRIPTION_ID environment variable value that was set or the logged into Azure CLI subscription.</returns>
+    public static void SetAzureSubscriptionId(string subscriptionId)
+        => Environment.SetEnvironmentVariable(EnvironmentHelpers.AzureSubscriptionIdEnvironmentVariable, subscriptionId);
+
+    /// <summary>
+    /// Clears the AZURE_SUBSCRIPTION_ID environment variable.
+    /// </summary>
+    public static void ClearAzureSubscriptionId()
+        => Environment.SetEnvironmentVariable(EnvironmentHelpers.AzureSubscriptionIdEnvironmentVariable, null);
 }

--- a/tools/Azure.Mcp.Tools.Acr/tests/Azure.Mcp.Tools.Acr.UnitTests/Registry/RegistryListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Acr/tests/Azure.Mcp.Tools.Acr.UnitTests/Registry/RegistryListCommandTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Helpers;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -54,7 +55,7 @@ public class RegistryListCommandTests
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
     {
         // Ensure environment variable fallback does not interfere with validation tests
-        EnvironmentHelpers.SetAzureSubscriptionId(null);
+        TestEnvironment.ClearAzureSubscriptionId();
         // Arrange
         if (shouldSucceed)
         {

--- a/tools/Azure.Mcp.Tools.ContainerApps/tests/Azure.Mcp.Tools.ContainerApps.UnitTests/ContainerApp/ContainerAppListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ContainerApps/tests/Azure.Mcp.Tools.ContainerApps.UnitTests/ContainerApp/ContainerAppListCommandTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Helpers;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -53,11 +54,11 @@ public class ContainerAppListCommandTests
     [InlineData("", false)]
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
     {
-        var originalSubscriptionId = Environment.GetEnvironmentVariable("AZURE_SUBSCRIPTION_ID");
+        var originalSubscriptionId = EnvironmentHelpers.GetAzureSubscriptionId();
         try
         {
             // Ensure environment variable fallback does not interfere with validation tests
-            EnvironmentHelpers.ClearAzureSubscriptionId();
+            TestEnvironment.ClearAzureSubscriptionId();
             // Arrange
             if (shouldSucceed)
             {
@@ -89,7 +90,7 @@ public class ContainerAppListCommandTests
         {
             if (originalSubscriptionId != null)
             {
-                EnvironmentHelpers.SetAzureSubscriptionId(originalSubscriptionId);
+                TestEnvironment.SetAzureSubscriptionId(originalSubscriptionId);
             }
         }
     }

--- a/tools/Azure.Mcp.Tools.ContainerApps/tests/Azure.Mcp.Tools.ContainerApps.UnitTests/ContainerApp/ContainerAppListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ContainerApps/tests/Azure.Mcp.Tools.ContainerApps.UnitTests/ContainerApp/ContainerAppListCommandTests.cs
@@ -57,7 +57,7 @@ public class ContainerAppListCommandTests
         try
         {
             // Ensure environment variable fallback does not interfere with validation tests
-            EnvironmentHelpers.SetAzureSubscriptionId(null);
+            EnvironmentHelpers.ClearAzureSubscriptionId();
             // Arrange
             if (shouldSucceed)
             {
@@ -87,7 +87,10 @@ public class ContainerAppListCommandTests
         }
         finally
         {
-            EnvironmentHelpers.SetAzureSubscriptionId(originalSubscriptionId);
+            if (originalSubscriptionId != null)
+            {
+                EnvironmentHelpers.SetAzureSubscriptionId(originalSubscriptionId);
+            }
         }
     }
 

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Admin/AdminSettingsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Admin/AdminSettingsGetCommandTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Helpers;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -107,7 +108,7 @@ public class AdminSettingsGetCommandTests
         if (args.Contains("--vault") && !args.Contains("--subscription") && shouldSucceed)
         {
             // Provide subscription via environment variable
-            EnvironmentHelpers.SetAzureSubscriptionId(KnownSubscriptionId);
+            TestEnvironment.SetAzureSubscriptionId(KnownSubscriptionId);
         }
         else if (!args.Contains("--subscription"))
         {

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Database/DatabaseRenameCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Database/DatabaseRenameCommandTests.cs
@@ -8,9 +8,9 @@ using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Helpers;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -307,7 +307,7 @@ public class DatabaseRenameCommandTests
     public async Task ExecuteAsync_WithSubscriptionFromEnvironment_Succeeds()
     {
         // Arrange - Test when subscription comes from environment variable
-        EnvironmentHelpers.SetAzureSubscriptionId("env-sub-id");
+        TestEnvironment.SetAzureSubscriptionId("env-sub-id");
 
         var mockDatabase = new SqlDatabase(
             Name: "newdb",

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Database/DatabaseUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Database/DatabaseUpdateCommandTests.cs
@@ -8,9 +8,9 @@ using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Helpers;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -432,7 +432,7 @@ public class DatabaseUpdateCommandTests
     public async Task ExecuteAsync_WithSubscriptionFromEnvironment_Succeeds()
     {
         // Arrange - Test minimum scope when subscription comes from environment variable
-        EnvironmentHelpers.SetAzureSubscriptionId("env-sub-id");
+        TestEnvironment.SetAzureSubscriptionId("env-sub-id");
 
         var mockDatabase = new SqlDatabase(
             Name: "testdb",


### PR DESCRIPTION
## What does this PR do?

Fixes testing pain point where some tests fail if you're signed into Azure CLI due to `subscription` falling back to the logged in Azure CLI subscription if it's available.

Tests targeting `subscription` testing now use the Azure CLI subscription if it's set, otherwise fallback to previous handling with using the injected / omitted `AZURE_SUBSCRIPTION_ID` environment variable.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
