### PR TITLE
Bump Azure.Core, Azure.ResourceManager, System.ClientModel for Azure Backup SDK compatibility

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,18 +22,6 @@
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 
-  <!--
-    Suppress known vulnerability advisories for System.Security.Cryptography.Xml where no patched
-    version is available for net10.0. All 10.x versions are affected. Remove these suppressions
-    once a patched version is released.
-    See: https://github.com/advisories/GHSA-37gx-xxp4-5rgx
-    See: https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
-  -->
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-37gx-xxp4-5rgx" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-w3x6-4m5h-cxqf" />
-  </ItemGroup>
-
   <PropertyGroup Condition="'$(BuildNative)' == 'true'">
     <DefineConstants>$(DefineConstants);BUILD_NATIVE</DefineConstants>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,18 @@
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 
+  <!--
+    Suppress known vulnerability advisories for System.Security.Cryptography.Xml where no patched
+    version is available for net10.0. All 10.x versions are affected. Remove these suppressions
+    once a patched version is released.
+    See: https://github.com/advisories/GHSA-37gx-xxp4-5rgx
+    See: https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
+  -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-37gx-xxp4-5rgx" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-w3x6-4m5h-cxqf" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(BuildNative)' == 'true'">
     <DefineConstants>$(DefineConstants);BUILD_NATIVE</DefineConstants>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Azure.AI.Agents.Persistent" Version="1.2.0-beta.4" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
     <PackageVersion Include="Azure.Bicep.Types" Version="0.6.50" />
-    <PackageVersion Include="Azure.Core" Version="1.50.0" />
+    <PackageVersion Include="Azure.Core" Version="1.51.1" />
     <PackageVersion Include="Azure.Data.AppConfiguration" Version="1.6.1" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
@@ -20,7 +20,7 @@
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Azure.Monitor.Ingestion" Version="1.2.0" />
     <PackageVersion Include="Azure.Monitor.Query.Logs" Version="1.0.0" />
-    <PackageVersion Include="Azure.ResourceManager" Version="1.13.2" />
+    <PackageVersion Include="Azure.ResourceManager" Version="1.14.0" />
     <PackageVersion Include="Azure.ResourceManager.ApplicationInsights" Version="1.1.0-beta.1" />
     <PackageVersion Include="Azure.ResourceManager.AppContainers" Version="1.4.1" />
     <PackageVersion Include="Azure.ResourceManager.AppService" Version="1.4.1" />
@@ -87,7 +87,7 @@
     <PackageVersion Include="Npgsql" Version="10.0.1" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
-    <PackageVersion Include="System.ClientModel" Version="1.8.0" />
+    <PackageVersion Include="System.ClientModel" Version="1.9.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.2" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />


### PR DESCRIPTION
## Summary

Bumps three centrally-managed packages that are **required transitive dependencies** for the Azure Backup SDK packages used in #2116:

| Package | Old Version | New Version | Reason |
|---------|-------------|-------------|--------|
| Azure.Core | 1.50.0 | 1.51.1 | Required by RecoveryServicesBackup 1.3.1, RecoveryServices 1.2.0, DataProtectionBackup 1.7.1 |
| Azure.ResourceManager | 1.13.2 | 1.14.0 | Required by RecoveryServicesBackup 1.3.1, RecoveryServices 1.2.0, DataProtectionBackup 1.7.1 |
| System.ClientModel | 1.8.0 | 1.9.0 | Transitive dependency of the above |

All three are **stable GA minor/patch bumps** with backward compatibility guarantees.

## Why a separate PR?

Per review feedback on #2116, these core package bumps affect all toolsets in the repo, not just Azure Backup. Splitting them out allows independent validation across all toolsets before the Azure Backup toolset lands.

## Validation

- Full server build (\dotnet build servers/Azure.Mcp.Server/src\) passes with 0 warnings, 0 errors.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with \write\ access to the repo need to validate the contents of this PR before leaving a comment with the text \/azp run mcp - pullrequest - live\. This will trigger the necessary livetest workflows to complete required validation.