### PR TITLE
Fix Az Compute Tools Update issue.

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1776357848029.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1776357848029.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed compute_vmss_update tool returning HTTP 400 when only --capacity, --overprovision, or --enable-auto-os-upgrade is provided by correcting option type definitions to use nullable types"

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/ComputeOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/ComputeOptionDefinitions.cs
@@ -307,7 +307,7 @@ public static class ComputeOptionDefinitions
 
     public const string CapacityName = "capacity";
 
-    public static readonly Option<int> Capacity = new($"--{CapacityName}")
+    public static readonly Option<int?> Capacity = new($"--{CapacityName}")
     {
         Description = "Number of VM instances (capacity) in the scale set",
         Required = false
@@ -317,13 +317,13 @@ public static class ComputeOptionDefinitions
     public const string OverprovisionName = "overprovision";
     public const string EnableAutoOsUpgradeName = "enable-auto-os-upgrade";
     public const string ScaleInPolicyName = "scale-in-policy";
-    public static readonly Option<bool> Overprovision = new($"--{OverprovisionName}")
+    public static readonly Option<bool?> Overprovision = new($"--{OverprovisionName}")
     {
         Description = "Enable or disable overprovisioning. When enabled, Azure provisions more VMs than requested and deletes extra VMs after deployment",
         Required = false
     };
 
-    public static readonly Option<bool> EnableAutoOsUpgrade = new($"--{EnableAutoOsUpgradeName}")
+    public static readonly Option<bool?> EnableAutoOsUpgrade = new($"--{EnableAutoOsUpgradeName}")
     {
         Description = "Enable automatic OS image upgrades. Requires health probes or Application Health extension",
         Required = false

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Vmss/VmssUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Vmss/VmssUpdateCommandTests.cs
@@ -56,6 +56,9 @@ public class VmssUpdateCommandTests
     [InlineData("--vmss-name test-vmss --resource-group test-rg --subscription sub123 --upgrade-policy Automatic", true)]
     [InlineData("--vmss-name test-vmss --resource-group test-rg --subscription sub123 --tags env=test", true)]
     [InlineData("--vmss-name test-vmss --resource-group test-rg --subscription sub123 --scale-in-policy OldestVM", true)]
+    [InlineData("--vmss-name test-vmss --resource-group test-rg --subscription sub123 --capacity 10", true)] // Capacity only
+    [InlineData("--vmss-name test-vmss --resource-group test-rg --subscription sub123 --overprovision true", true)] // Overprovision only
+    [InlineData("--vmss-name test-vmss --resource-group test-rg --subscription sub123 --enable-auto-os-upgrade true", true)] // EnableAutoOsUpgrade only
     [InlineData("--vmss-name test-vmss --resource-group test-rg --subscription sub123", false)] // No update property
     [InlineData("--resource-group test-rg --subscription sub123 --tags env=test", false)] // Missing vmss-name
     [InlineData("--vmss-name test-vmss --subscription sub123 --tags env=test", false)] // Missing resource-group


### PR DESCRIPTION
The `azmcp compute vmss update` command returned an HTTP 400 error when invoked with only `--capacity`, `--overprovision`, or `--enable-auto-os-upgrade` as the sole update parameter. This happened because the three option definitions were typed as non-nullable (`Option<int>`, `Option<bool>`) instead of nullable (`Option<int?>`, `Option<bool?>`).

When a non-nullable option is not supplied, the System.CommandLine parser resolves it to its default value (`0` for `int`, `false` for `bool`) rather than `null`. The command's "at least one update property required" validation then evaluated these default values as if the user had passed them, but the downstream service call sent `0` or `false` to ARM — causing a 400 from the API in some cases, and silently no-op'ing the update in others.

*Fix**
Changed the three affected option definitions in `ComputeOptionDefinitions.cs` to use nullable types: