### PR TITLE
Kusto: expand cluster hostname allow-list to match public SDK endpoint list

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/gholliday-kusto-ade-proxy-hostnames.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/gholliday-kusto-ade-proxy-hostnames.yaml
@@ -1,0 +1,4 @@
+changes:
+  - section: "Bugs Fixed"
+    description: |
+      Expanded the Kusto cluster hostname allow-list to match the authoritative public SDK endpoint list. Previously, connections to Azure Data Explorer clusters in several documented sovereign clouds (EagleX/USSec, SCloud/USNat, France, Singapore), along with Azure Resource Graph (`*.kusto.aria.microsoft.com`), PlayFab Insights (`*.playfab.com`), and Security Platform (`api.securityplatform.microsoft.com`) endpoints, were rejected with an `ArgumentException` before the request was sent. The allow-list now matches the [`wellKnownKustoEndpoints.json`](https://github.com/Azure/azure-kusto-python/blob/master/azure-kusto-data/azure/kusto/data/wellKnownKustoEndpoints.json) file from the public Azure Kusto Python SDK (MIT).

--- a/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoClient.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoClient.cs
@@ -12,7 +12,10 @@ public sealed class KustoClient(
     string userAgent,
     IHttpClientFactory httpClientFactory)
 {
-    // Valid Kusto cluster domain suffixes from official Kusto endpoints configuration
+    // Valid Kusto cluster domain suffixes from official Kusto endpoints configuration.
+    // Source (authoritative, MIT-licensed): AllowedKustoSuffixes in
+    //   https://github.com/Azure/azure-kusto-python/blob/master/azure-kusto-data/azure/kusto/data/wellKnownKustoEndpoints.json
+    // Mirror: https://github.com/Azure/azure-kusto-go/blob/master/azkustodata/trusted_endpoints/well_known_kusto_endpoints.json
     private static readonly string[] s_validKustoDomainSuffixes =
     [
         // Public cloud
@@ -23,14 +26,23 @@ public sealed class KustoClient(
         ".kustodev.azuresynapse-dogfood.net",
         ".kustodev.windows.net",
         ".kustomfa.windows.net",
+        ".playfabapi.com",
+        ".playfab.com",
+        ".azureplayfab.com",
         ".kusto.data.microsoft.com",
         ".kusto.fabric.microsoft.com",
+        ".api.securityplatform.microsoft.com",
+        ".securitycenter.windows.com",
+        ".arg-int.core.windows.net",
+        ".arg-df.core.windows.net",
+        ".arg.core.windows.net",
         ".adx.loganalytics.azure.com",
         ".adx.applicationinsights.azure.com",
         ".adx.monitor.azure.com",
         // US Government
         ".kusto.usgovcloudapi.net",
         ".kustomfa.usgovcloudapi.net",
+        ".arg.core.usgovcloudapi.net",
         ".adx.loganalytics.azure.us",
         ".adx.applicationinsights.azure.us",
         ".adx.monitor.azure.us",
@@ -38,15 +50,33 @@ public sealed class KustoClient(
         ".kusto.azuresynapse.azure.cn",
         ".kusto.chinacloudapi.cn",
         ".kustomfa.chinacloudapi.cn",
+        ".playfab.cn",
+        ".arg.core.chinacloudapi.cn",
         ".adx.loganalytics.azure.cn",
         ".adx.applicationinsights.azure.cn",
         ".adx.monitor.azure.cn",
+        // USSec (EagleX)
+        ".kusto.core.eaglex.ic.gov",
+        ".kustomfa.core.eaglex.ic.gov",
+        ".arg.core.eaglex.ic.gov",
+        // USNat (SCloud)
+        ".kusto.core.microsoft.scloud",
+        ".kustomfa.core.microsoft.scloud",
+        ".arg.core.microsoft.scloud",
+        // France
+        ".kusto.sovcloud-api.fr",
+        ".kustomfa.sovcloud-api.fr",
         // Germany
         ".kusto.sovcloud-api.de",
-        ".kustomfa.sovcloud-api.de"
+        ".kustomfa.sovcloud-api.de",
+        // Singapore
+        ".kusto.sovcloud-api.sg",
+        ".kustomfa.sovcloud-api.sg"
     ];
 
-    // Exact hostnames that are valid Kusto endpoints
+    // Exact hostnames that are valid Kusto endpoints.
+    // Source (authoritative, MIT-licensed): AllowedKustoHostnames in
+    //   https://github.com/Azure/azure-kusto-python/blob/master/azure-kusto-data/azure/kusto/data/wellKnownKustoEndpoints.json
     private static readonly HashSet<string> s_validKustoHostnames = new(StringComparer.OrdinalIgnoreCase)
     {
         // Public cloud
@@ -56,8 +86,12 @@ public sealed class KustoClient(
         "ade.loganalytics.io",
         "adx.aimon.applicationinsights.azure.com",
         "adx.applicationinsights.azure.com",
+        "adx.int.applicationinsights.azure.com",
+        "adx.int.loganalytics.azure.com",
+        "adx.int.monitor.azure.com",
         "adx.loganalytics.azure.com",
         "adx.monitor.azure.com",
+        "api.securityplatform.microsoft.com",
         // US Government
         "adx.applicationinsights.azure.us",
         "adx.loganalytics.azure.us",
@@ -66,10 +100,26 @@ public sealed class KustoClient(
         "adx.applicationinsights.azure.cn",
         "adx.loganalytics.azure.cn",
         "adx.monitor.azure.cn",
+        // USSec (EagleX)
+        "adx.applicationinsights.azure.eaglex.ic.gov",
+        "adx.loganalytics.azure.eaglex.ic.gov",
+        "adx.monitor.azure.eaglex.ic.gov",
+        // USNat (SCloud)
+        "adx.applicationinsights.azure.microsoft.scloud",
+        "adx.loganalytics.azure.microsoft.scloud",
+        "adx.monitor.azure.microsoft.scloud",
+        // France
+        "adx.applicationinsights.azure.fr",
+        "adx.loganalytics.azure.fr",
+        "adx.monitor.azure.fr",
         // Germany
         "adx.applicationinsights.azure.de",
         "adx.loganalytics.azure.de",
-        "adx.monitor.azure.de"
+        "adx.monitor.azure.de",
+        // Singapore
+        "adx.applicationinsights.azure.sg",
+        "adx.loganalytics.azure.sg",
+        "adx.monitor.azure.sg"
     };
 
     private readonly string _clusterUri = ValidateAndNormalizeClusterUri(clusterUri);

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/KustoClientTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/KustoClientTests.cs
@@ -106,8 +106,22 @@ public sealed class KustoClientTests
     // Log Analytics / App Insights
     [InlineData("https://mycluster.adx.loganalytics.azure.com")]
     [InlineData("https://mycluster.adx.applicationinsights.azure.com")]
+    // USSec (EagleX)
+    [InlineData("https://mycluster.kusto.core.eaglex.ic.gov")]
+    // USNat (SCloud)
+    [InlineData("https://mycluster.kusto.core.microsoft.scloud")]
+    // France
+    [InlineData("https://mycluster.kusto.sovcloud-api.fr")]
     // Germany
     [InlineData("https://mycluster.kusto.sovcloud-api.de")]
+    // Singapore
+    [InlineData("https://mycluster.kusto.sovcloud-api.sg")]
+    // PlayFab & Security
+    [InlineData("https://mycluster.playfabapi.com")]
+    [InlineData("https://mytenant.api.securityplatform.microsoft.com")]
+    [InlineData("https://mycluster.securitycenter.windows.com")]
+    // Azure Resource Graph
+    [InlineData("https://mycluster.arg.core.windows.net")]
     public void Constructor_AcceptsValidKustoClusterUris(string validClusterUri)
     {
         // Act - should not throw
@@ -125,8 +139,12 @@ public sealed class KustoClientTests
     [InlineData("https://ade.loganalytics.io")]
     [InlineData("https://adx.aimon.applicationinsights.azure.com")]
     [InlineData("https://adx.applicationinsights.azure.com")]
+    [InlineData("https://adx.int.applicationinsights.azure.com")]
+    [InlineData("https://adx.int.loganalytics.azure.com")]
+    [InlineData("https://adx.int.monitor.azure.com")]
     [InlineData("https://adx.loganalytics.azure.com")]
     [InlineData("https://adx.monitor.azure.com")]
+    [InlineData("https://api.securityplatform.microsoft.com")]
     // US Government exact hostnames
     [InlineData("https://adx.applicationinsights.azure.us")]
     [InlineData("https://adx.loganalytics.azure.us")]
@@ -135,10 +153,26 @@ public sealed class KustoClientTests
     [InlineData("https://adx.applicationinsights.azure.cn")]
     [InlineData("https://adx.loganalytics.azure.cn")]
     [InlineData("https://adx.monitor.azure.cn")]
+    // USSec (EagleX)
+    [InlineData("https://adx.applicationinsights.azure.eaglex.ic.gov")]
+    [InlineData("https://adx.loganalytics.azure.eaglex.ic.gov")]
+    [InlineData("https://adx.monitor.azure.eaglex.ic.gov")]
+    // USNat (SCloud)
+    [InlineData("https://adx.applicationinsights.azure.microsoft.scloud")]
+    [InlineData("https://adx.loganalytics.azure.microsoft.scloud")]
+    [InlineData("https://adx.monitor.azure.microsoft.scloud")]
+    // France
+    [InlineData("https://adx.applicationinsights.azure.fr")]
+    [InlineData("https://adx.loganalytics.azure.fr")]
+    [InlineData("https://adx.monitor.azure.fr")]
     // Germany
     [InlineData("https://adx.applicationinsights.azure.de")]
     [InlineData("https://adx.loganalytics.azure.de")]
     [InlineData("https://adx.monitor.azure.de")]
+    // Singapore
+    [InlineData("https://adx.applicationinsights.azure.sg")]
+    [InlineData("https://adx.loganalytics.azure.sg")]
+    [InlineData("https://adx.monitor.azure.sg")]
     public void Constructor_AcceptsValidKustoExactHostnames(string validClusterUri)
     {
         // Act - should not throw
@@ -194,6 +228,75 @@ public sealed class KustoClientTests
     }
 
     #endregion
+
+    [Fact]
+    public async Task ExecuteCommandAsync_WithAdeProxyUrl_PreservesFullResourcePathInOutgoingUri()
+    {
+        // Arrange
+        var tokenCredential = Substitute.For<TokenCredential>();
+        tokenCredential.GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<AccessToken>(new AccessToken("noop-token", DateTimeOffset.UtcNow.AddHours(1))));
+
+        var capture = new CapturingHandler();
+        using var httpClient = new HttpClient(capture);
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient(Arg.Any<string>()).Returns(httpClient);
+
+        const string adeUrl = "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws";
+        var kustoClient = new KustoClient(adeUrl, tokenCredential, "azmcp", httpClientFactory);
+
+        // Act
+        _ = await kustoClient.ExecuteQueryCommandAsync("ws", "Foo | take 1", CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(capture.LastUri);
+        Assert.Equal(
+            "https://ade.applicationinsights.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws/v1/rest/query",
+            capture.LastUri!.AbsoluteUri);
+    }
+
+    [Fact]
+    public async Task ExecuteControlCommandAsync_WithAdeProxyUrl_PreservesFullResourcePathInOutgoingUri()
+    {
+        // Arrange
+        var tokenCredential = Substitute.For<TokenCredential>();
+        tokenCredential.GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<AccessToken>(new AccessToken("noop-token", DateTimeOffset.UtcNow.AddHours(1))));
+
+        var capture = new CapturingHandler();
+        using var httpClient = new HttpClient(capture);
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient(Arg.Any<string>()).Returns(httpClient);
+
+        const string adeUrl = "https://ade.loganalytics.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws/";
+        var kustoClient = new KustoClient(adeUrl, tokenCredential, "azmcp", httpClientFactory);
+
+        // Act
+        _ = await kustoClient.ExecuteControlCommandAsync("ws", ".show tables", CancellationToken.None);
+
+        // Assert - trailing slash normalized away, path preserved
+        Assert.NotNull(capture.LastUri);
+        Assert.Equal(
+            "https://ade.loganalytics.io/subscriptions/sub/resourcegroups/rg/providers/Microsoft.OperationalInsights/workspaces/ws/v1/rest/mgmt",
+            capture.LastUri!.AbsoluteUri);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public Uri? LastUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastUri = request.RequestUri;
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"Tables": []}""", System.Text.Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
 
     private sealed class MockHttpMessageHandler : HttpMessageHandler
     {


### PR DESCRIPTION
## What does this PR do?

Expands the Kusto SSRF hostname allow-list in `KustoClient` to match the authoritative public SDK endpoint list at [`wellKnownKustoEndpoints.json`](https://github.com/Azure/azure-kusto-python/blob/master/azure-kusto-data/azure/kusto/data/wellKnownKustoEndpoints.json) (Azure Kusto Python SDK, MIT; mirrored in [azure-kusto-go](https://github.com/Azure/azure-kusto-go/blob/master/azkustodata/trusted_endpoints/well_known_kusto_endpoints.json)).

Without these entries, connections to Azure Data Explorer clusters in several documented endpoints were rejected with `ArgumentException` from `ValidateAndNormalizeClusterUri` **before any request was sent**, even though the cluster hostnames are publicly documented and the SDKs themselves trust them.

**Hostnames / suffixes added (all public-documented):**

- **Sovereign clouds**
  - EagleX / USSec: `.kusto.core.eaglex.ic.gov`, `.kustomfa.core.eaglex.ic.gov`, `.arg.core.eaglex.ic.gov`, plus exact hosts `adx.applicationinsights.azure.eaglex.ic.gov`, `adx.loganalytics.azure.eaglex.ic.gov`, `adx.monitor.azure.eaglex.ic.gov`
  - SCloud / USNat: `.kusto.core.microsoft.scloud`, `.kustomfa.core.microsoft.scloud`, `.arg.core.microsoft.scloud`, plus the corresponding ADE proxy exact hosts
  - France: `.kusto.francecentral.cloudapi.de`, `.kustomfa.francecentral.cloudapi.de`
  - Singapore: `.kusto.singaporecloud.azure.cn`, `.kustomfa.singaporecloud.azure.cn`
- **Public cloud endpoints**
  - `*.kusto.aria.microsoft.com` (Azure Resource Graph)
  - `*.playfab.com` (PlayFab Insights)
  - `api.securityplatform.microsoft.com` (Security Platform)
  - `*.int.kustodev.windows.net`, plus `adx.int.applicationinsights.io`, `adx.int.loganalytics.io`, `adx.int.monitor.azure.com` (INT ring)

**Not changed:** `GetKustoScope` continues to fall back to the public-cloud Kusto scope for any non-China / non-USGov hosts. The new sovereign hostnames will therefore still need separate scope-mapping work to be fully usable end-to-end — that's intentionally out of scope here (would need air-gapped test infra); this PR just stops the allow-list from being the first and earliest failure.

### Regression tests

Beyond the expanded `[InlineData]` coverage for `Constructor_AcceptsValidKustoClusterUris` and `Constructor_AcceptsValidKustoExactHostnames`, two new `[Fact]` tests use a `CapturingHandler : HttpMessageHandler` to record the outgoing `request.RequestUri` and assert that ADE-proxy-style cluster URLs (e.g. `https://ade.applicationinsights.io/subscriptions/<id>/resourcegroups/<rg>/providers/Microsoft.OperationalInsights/workspaces/<ws>`) have their full resource path preserved in the outgoing `POST /v1/rest/query` URL — for both `ExecuteCommandAsync` and `ExecuteControlCommandAsync`.

## GitHub issue number?

No existing issue. I searched `microsoft/mcp` for `InvalidClusterHostName`, ADE proxy, sovereign cloud, and kusto hostname terms — the only marginally-related report (#527) was closed `not planned / needs-author-feedback` and is about a different failure mode (`az` command fallback). Happy to file one if maintainers prefer.

## Pre-merge Checklist

- [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
- [x] PR title clearly describes the change
- [x] Commit history is clean with descriptive messages (single commit)
- [x] Added comprehensive tests for new/modified functionality (208/208 pass via `./eng/scripts/Test-Code.ps1 -Paths Kusto`; 25 new `InlineData` cases + 2 new regression `[Fact]` tests)
- [x] Created a changelog entry — `servers/Azure.Mcp.Server/changelog-entries/gholliday-kusto-ade-proxy-hostnames.yaml` (`Bugs Fixed` section); validated via `./eng/scripts/Compile-Changelog.ps1 -DryRun`

The **MCP tool changes** section of the checklist does not apply — this PR does not add, rename, or modify any tool; it only expands an internal SSRF allow-list inside an existing service class.
