### PR TITLE
[Part 1] Migrate tool command unit tests to using CommandUnitTestsBase

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Group/UnitTests/ResourceGroupListCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Group/UnitTests/ResourceGroupListCommandTests.cs
@@ -38,12 +38,7 @@ public class ResourceGroupListCommandTests : CommandUnitTestsBase<GroupListComma
         var result = await ExecuteCommandAsync("--subscription", subscriptionId);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.OK, result.Status);
-        Assert.NotNull(result.Results);
-
-        var resultGroups = DeserializeResponse(result, GroupJsonContext.Default.Result);
-        Assert.NotNull(resultGroups);
+        var resultGroups = ValidateAndDeserializeResponse(result, GroupJsonContext.Default.Result);
         Assert.Equal(2, resultGroups.Groups.Count);
 
         var first = resultGroups.Groups[0];
@@ -111,12 +106,7 @@ public class ResourceGroupListCommandTests : CommandUnitTestsBase<GroupListComma
         var result = await ExecuteCommandAsync("--subscription", subscriptionId);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.OK, result.Status);
-        Assert.NotNull(result.Results);
-
-        var resultGroups = DeserializeResponse(result, GroupJsonContext.Default.Result);
-        Assert.NotNull(resultGroups);
+        var resultGroups = ValidateAndDeserializeResponse(result, GroupJsonContext.Default.Result);
         Assert.Empty(resultGroups.Groups);
     }
 

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Group/UnitTests/ResourceListCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Group/UnitTests/ResourceListCommandTests.cs
@@ -39,12 +39,7 @@ public class ResourceListCommandTests : CommandUnitTestsBase<ResourceListCommand
         var result = await ExecuteCommandAsync("--subscription", subscriptionId, "--resource-group", resourceGroup);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.OK, result.Status);
-        Assert.NotNull(result.Results);
-
-        var listResult = DeserializeResponse(result, GroupJsonContext.Default.ResourceListCommandResult);
-        Assert.NotNull(listResult);
+        var listResult = ValidateAndDeserializeResponse(result, GroupJsonContext.Default.ResourceListCommandResult);
         Assert.Equal(2, listResult.Resources.Count);
 
         Assert.Equal("storageAccount1", listResult.Resources[0].Name);
@@ -118,11 +113,7 @@ public class ResourceListCommandTests : CommandUnitTestsBase<ResourceListCommand
         var result = await ExecuteCommandAsync("--subscription", subscriptionId, "--resource-group", resourceGroup);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.OK, result.Status);
-
-        var listResult = DeserializeResponse(result, GroupJsonContext.Default.ResourceListCommandResult);
-        Assert.NotNull(listResult);
+        var listResult = ValidateAndDeserializeResponse(result, GroupJsonContext.Default.ResourceListCommandResult);
         Assert.Empty(listResult.Resources);
     }
 

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Subscription/SubscriptionListCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Subscription/SubscriptionListCommandTests.cs
@@ -35,12 +35,7 @@ public class SubscriptionListCommandTests : CommandUnitTestsBase<SubscriptionLis
         var result = await ExecuteCommandAsync();
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.OK, result.Status);
-        Assert.NotNull(result.Results);
-
-        var subscriptions = DeserializeResponse(result, SubscriptionJsonContext.Default.SubscriptionListCommandResult);
-        Assert.NotNull(subscriptions);
+        var subscriptions = ValidateAndDeserializeResponse(result, SubscriptionJsonContext.Default.SubscriptionListCommandResult);
         Assert.Equal(2, subscriptions.Subscriptions.Count);
 
         var first = subscriptions.Subscriptions[0];
@@ -190,12 +185,7 @@ public class SubscriptionListCommandTests : CommandUnitTestsBase<SubscriptionLis
         var result = await ExecuteCommandAsync();
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(HttpStatusCode.OK, result.Status);
-        Assert.NotNull(result.Results);
-
-        var subscriptions = DeserializeResponse(result, SubscriptionJsonContext.Default.SubscriptionListCommandResult);
-        Assert.NotNull(subscriptions);
+        var subscriptions = ValidateAndDeserializeResponse(result, SubscriptionJsonContext.Default.SubscriptionListCommandResult);
         Assert.Equal(2, subscriptions.Subscriptions.Count);
 
         // No subscription should be marked as default

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/CommandUnitTestsBase.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/CommandUnitTestsBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.CommandLine;
+using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.Extensions.DependencyInjection;
@@ -55,8 +56,32 @@ public abstract class CommandUnitTestsBase<TCommand, TService> : IDisposable
     protected Task<CommandResponse> ExecuteCommandAsync(string args)
         => Command.ExecuteAsync(Context, CommandDefinition.Parse(args), TestContext.Current.CancellationToken);
 
+    /// <summary>
+    /// Deserializes the command response results into the specified type using the provided JSON type information.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize the command response results into.</typeparam>
+    /// <param name="response">The command response containing the results to deserialize.</param>
+    /// <param name="jsonTypeInfo">The JSON type information.</param>
+    /// <returns>The deserialized command response results.</returns>
     protected T? DeserializeResponse<T>(CommandResponse response, JsonTypeInfo<T> jsonTypeInfo)
         => JsonSerializer.Deserialize(JsonSerializer.Serialize(response.Results), jsonTypeInfo);
+
+    /// <summary>
+    /// Validates that the command response indicates a successful execution and deserializes the results into the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize the command response results into.</typeparam>
+    /// <param name="response">The command response containing the results to deserialize.</param>
+    /// <param name="jsonTypeInfo">The JSON type information.</param>
+    /// <returns>The deserialized command response results.</returns>
+    protected T ValidateAndDeserializeResponse<T>(CommandResponse response, JsonTypeInfo<T> jsonTypeInfo)
+    {
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+        var result = DeserializeResponse(response, jsonTypeInfo);
+        Assert.NotNull(result);
+        return result;
+    }
 
     public void Dispose()
     {
@@ -68,7 +93,8 @@ public abstract class CommandUnitTestsBase<TCommand, TService> : IDisposable
     {
         if (_disposed)
             return;
-        ServiceProvider.Dispose();
+        if (disposing)
+            ServiceProvider.Dispose();
         _disposed = true;
     }
 }

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/CommandUnitTestsBase.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/CommandUnitTestsBase.cs
@@ -72,8 +72,12 @@ public abstract class CommandUnitTestsBase<TCommand, TService> : IDisposable
     /// <typeparam name="T">The type to deserialize the command response results into.</typeparam>
     /// <param name="response">The command response containing the results to deserialize.</param>
     /// <param name="jsonTypeInfo">The JSON type information.</param>
+    /// <param name="expectedStatus">The expected HTTP status code of the command response (default is OK).</param>
     /// <returns>The deserialized command response results.</returns>
-    protected T ValidateAndDeserializeResponse<T>(CommandResponse response, JsonTypeInfo<T> jsonTypeInfo)
+    protected T ValidateAndDeserializeResponse<T>(
+        CommandResponse response,
+        JsonTypeInfo<T> jsonTypeInfo,
+        HttpStatusCode expectedStatus = HttpStatusCode.OK)
     {
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/CommandUnitTestsBase.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/CommandUnitTestsBase.cs
@@ -80,7 +80,7 @@ public abstract class CommandUnitTestsBase<TCommand, TService> : IDisposable
         HttpStatusCode expectedStatus = HttpStatusCode.OK)
     {
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.Equal(expectedStatus, response.Status);
         Assert.NotNull(response.Results);
         var result = DeserializeResponse(response, jsonTypeInfo);
         Assert.NotNull(result);

--- a/tools/Azure.Mcp.Tools.Acr/tests/Azure.Mcp.Tools.Acr.UnitTests/Registry/RegistryListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Acr/tests/Azure.Mcp.Tools.Acr.UnitTests/Registry/RegistryListCommandTests.cs
@@ -115,12 +115,8 @@ public class RegistryListCommandTests : CommandUnitTestsBase<RegistryListCommand
         var response = await ExecuteCommandAsync("--subscription", "sub");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AcrJsonContext.Default.RegistryListCommandResult);
 
-        var result = DeserializeResponse(response, AcrJsonContext.Default.RegistryListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Registries);
     }
 

--- a/tools/Azure.Mcp.Tools.Acr/tests/Azure.Mcp.Tools.Acr.UnitTests/Registry/RegistryRepositoryListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Acr/tests/Azure.Mcp.Tools.Acr.UnitTests/Registry/RegistryRepositoryListCommandTests.cs
@@ -92,12 +92,8 @@ public class RegistryRepositoryListCommandTests : CommandUnitTestsBase<RegistryR
         var response = await ExecuteCommandAsync("--subscription", "sub");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AcrJsonContext.Default.RegistryRepositoryListCommandResult);
 
-        var result = DeserializeResponse(response, AcrJsonContext.Default.RegistryRepositoryListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.RepositoriesByRegistry);
     }
 }

--- a/tools/Azure.Mcp.Tools.Advisor/tests/Azure.Mcp.Tools.Advisor.UnitTests/Recommendation/RecommendationListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/tests/Azure.Mcp.Tools.Advisor.UnitTests/Recommendation/RecommendationListCommandTests.cs
@@ -79,8 +79,12 @@ public class RecommendationListCommandTests : CommandUnitTestsBase<Recommendatio
         var response = await ExecuteCommandAsync("--subscription", "sub123");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AdvisorJsonContext.Default.RecommendationListResult);
+
+        Assert.Equal(expectedRecommendations.Count, result.Recommendations.Count);
+        Assert.Equal(expectedRecommendations[0].ResourceId, result.Recommendations[0].ResourceId);
+        Assert.Equal(expectedRecommendations[0].RecommendationText, result.Recommendations[0].RecommendationText);
+        Assert.Equal(expectedRecommendations[0].Category, result.Recommendations[0].Category);
 
         // Verify the mock was called
         await Service.Received(1).ListRecommendationsAsync(
@@ -88,14 +92,6 @@ public class RecommendationListCommandTests : CommandUnitTestsBase<Recommendatio
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
-
-        var result = DeserializeResponse(response, AdvisorJsonContext.Default.RecommendationListResult);
-
-        Assert.NotNull(result);
-        Assert.Equal(expectedRecommendations.Count, result.Recommendations.Count);
-        Assert.Equal(expectedRecommendations[0].ResourceId, result.Recommendations[0].ResourceId);
-        Assert.Equal(expectedRecommendations[0].RecommendationText, result.Recommendations[0].RecommendationText);
-        Assert.Equal(expectedRecommendations[0].Category, result.Recommendations[0].Category);
     }
 
     [Fact]
@@ -113,12 +109,8 @@ public class RecommendationListCommandTests : CommandUnitTestsBase<Recommendatio
         var response = await ExecuteCommandAsync("--subscription", "sub123");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AdvisorJsonContext.Default.RecommendationListResult);
 
-        var result = DeserializeResponse(response, AdvisorJsonContext.Default.RecommendationListResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Recommendations);
     }
 

--- a/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.UnitTests/Cluster/ClusterGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.UnitTests/Cluster/ClusterGetCommandTests.cs
@@ -83,8 +83,12 @@ public class ClusterGetCommandTests : CommandUnitTestsBase<ClusterGetCommand, IA
         var response = await ExecuteCommandAsync("--subscription", "sub123");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AksJsonContext.Default.ClusterGetCommandResult);
+
+        Assert.Equal(expectedClusters.Count, result.Clusters.Count);
+        Assert.Equal(expectedClusters[0].Name, result.Clusters[0].Name);
+        Assert.Equal(expectedClusters[0].Location, result.Clusters[0].Location);
+        Assert.Equal(expectedClusters[0].KubernetesVersion, result.Clusters[0].KubernetesVersion);
 
         // Verify the mock was called
         await Service.Received(1).GetClusters(
@@ -94,14 +98,6 @@ public class ClusterGetCommandTests : CommandUnitTestsBase<ClusterGetCommand, IA
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
-
-        var result = DeserializeResponse(response, AksJsonContext.Default.ClusterGetCommandResult);
-
-        Assert.NotNull(result);
-        Assert.Equal(expectedClusters.Count, result.Clusters.Count);
-        Assert.Equal(expectedClusters[0].Name, result.Clusters[0].Name);
-        Assert.Equal(expectedClusters[0].Location, result.Clusters[0].Location);
-        Assert.Equal(expectedClusters[0].KubernetesVersion, result.Clusters[0].KubernetesVersion);
     }
 
     [Fact]
@@ -193,12 +189,8 @@ public class ClusterGetCommandTests : CommandUnitTestsBase<ClusterGetCommand, IA
         var response = await ExecuteCommandAsync("--subscription", "sub123");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AksJsonContext.Default.ClusterGetCommandResult);
 
-        var result = DeserializeResponse(response, AksJsonContext.Default.ClusterGetCommandResult);
-
-        Assert.NotNull(result);
         var c = result.Clusters[0];
         Assert.Equal(enriched.Id, c.Id);
         Assert.Equal(enriched.NetworkProfile?.NetworkPolicy, c.NetworkProfile?.NetworkPolicy);
@@ -228,12 +220,8 @@ public class ClusterGetCommandTests : CommandUnitTestsBase<ClusterGetCommand, IA
         var response = await ExecuteCommandAsync("--subscription", "sub123");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AksJsonContext.Default.ClusterGetCommandResult);
 
-        var result = DeserializeResponse(response, AksJsonContext.Default.ClusterGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Clusters);
     }
 

--- a/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.UnitTests/Nodepool/NodepoolGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.UnitTests/Nodepool/NodepoolGetCommandTests.cs
@@ -155,22 +155,8 @@ public sealed class NodepoolGetCommandTests : CommandUnitTestsBase<NodepoolGetCo
         var response = await ExecuteCommandAsync("--subscription sub123 --resource-group rg1 --cluster c1");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AksJsonContext.Default.NodepoolGetCommandResult);
 
-        // Verify the mock was called
-        await Service.Received(1).GetNodePools(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<CancellationToken>());
-
-        var result = DeserializeResponse(response, AksJsonContext.Default.NodepoolGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(expectedNodePools.Count, result.NodePools.Count);
 
         // Validate enriched fields for first pool
@@ -206,6 +192,16 @@ public sealed class NodepoolGetCommandTests : CommandUnitTestsBase<NodepoolGetCo
         Assert.Equal(1, result.NodePools[0].NetworkProfile?.AllowedHostPorts?.Count);
         Assert.Equal("/subscriptions/s/rg/r/providers/Microsoft.Network/virtualNetworks/vnet/subnets/podsubnet", result.NodePools[0].PodSubnetId);
         Assert.Equal("/subscriptions/s/rg/r/providers/Microsoft.Network/virtualNetworks/vnet/subnets/nodesubnet", result.NodePools[0].VnetSubnetId);
+
+        // Verify the mock was called
+        await Service.Received(1).GetNodePools(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -226,12 +222,8 @@ public sealed class NodepoolGetCommandTests : CommandUnitTestsBase<NodepoolGetCo
         var response = await ExecuteCommandAsync("--subscription sub123 --resource-group rg1 --cluster c1");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AksJsonContext.Default.NodepoolGetCommandResult);
 
-        var result = DeserializeResponse(response, AksJsonContext.Default.NodepoolGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.NodePools);
     }
 
@@ -312,14 +304,8 @@ public sealed class NodepoolGetCommandTests : CommandUnitTestsBase<NodepoolGetCo
         var response = await ExecuteCommandAsync("--subscription sub123 --resource-group rg1 --cluster c1 --nodepool userpool");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AksJsonContext.Default.NodepoolGetCommandResult);
 
-        await Service.Received(1).GetNodePools(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
-
-        var result = DeserializeResponse(response, AksJsonContext.Default.NodepoolGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Single(result.NodePools);
         Assert.Equal(expectedNodePool.Name, result.NodePools[0].Name);
         Assert.Equal(expectedNodePool.Count, result.NodePools[0].Count);
@@ -354,5 +340,7 @@ public sealed class NodepoolGetCommandTests : CommandUnitTestsBase<NodepoolGetCo
         Assert.Equal(1, result.NodePools[0].NetworkProfile?.AllowedHostPorts?.Count);
         Assert.Equal("/subscriptions/s/rg/r/providers/Microsoft.Network/virtualNetworks/vnet/subnets/podsubnet", result.NodePools[0].PodSubnetId);
         Assert.Equal("/subscriptions/s/rg/r/providers/Microsoft.Network/virtualNetworks/vnet/subnets/nodesubnet", result.NodePools[0].VnetSubnetId);
+
+        await Service.Received(1).GetNodePools(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/Account/AccountListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/Account/AccountListCommandTests.cs
@@ -35,13 +35,10 @@ public class AccountListCommandTests : CommandUnitTestsBase<AccountListCommand, 
 
         // Act
         var response = await ExecuteCommandAsync("--subscription", "sub123");
+
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.AccountListCommandResult);
 
-        var result = DeserializeResponse(response, AppConfigJsonContext.Default.AccountListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(2, result.Accounts.Count);
         Assert.Equal("account1", result.Accounts[0].Name);
         Assert.Equal("account2", result.Accounts[1].Name);
@@ -62,12 +59,8 @@ public class AccountListCommandTests : CommandUnitTestsBase<AccountListCommand, 
         var response = await ExecuteCommandAsync("--subscription", "sub123");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.AccountListCommandResult);
 
-        var result = DeserializeResponse(response, AppConfigJsonContext.Default.AccountListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Accounts);
     }
 

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueDeleteCommandTests.cs
@@ -25,7 +25,6 @@ public class KeyValueDeleteCommandTests : CommandUnitTestsBase<KeyValueDeleteCom
             "--key", "my-key");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
         await Service.Received(1).DeleteKeyValue(
             "account1",
             "my-key",
@@ -35,9 +34,8 @@ public class KeyValueDeleteCommandTests : CommandUnitTestsBase<KeyValueDeleteCom
             null,
             Arg.Any<CancellationToken>());
 
-        var result = DeserializeResponse(response, AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
 
-        Assert.NotNull(result);
         Assert.Equal("my-key", result.Key);
     }
 
@@ -52,7 +50,6 @@ public class KeyValueDeleteCommandTests : CommandUnitTestsBase<KeyValueDeleteCom
             "--label", "prod");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
         await Service.Received(1).DeleteKeyValue(
             "account1",
             "my-key",
@@ -61,9 +58,8 @@ public class KeyValueDeleteCommandTests : CommandUnitTestsBase<KeyValueDeleteCom
             "prod",
             Arg.Any<CancellationToken>());
 
-        var result = DeserializeResponse(response, AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
 
-        Assert.NotNull(result);
         Assert.Equal("my-key", result.Key);
         Assert.Equal("prod", result.Label);
     }

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueGetCommandTests.cs
@@ -41,12 +41,8 @@ public class KeyValueGetCommandTests : CommandUnitTestsBase<KeyValueGetCommand, 
         var response = await ExecuteCommandAsync("--subscription", "sub123", "--account", "account1");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueGetCommandResult);
 
-        var result = DeserializeResponse(response, AppConfigJsonContext.Default.KeyValueGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(2, result.Settings.Count);
         Assert.Equal("key1", result.Settings[0].Key);
         Assert.Equal("key2", result.Settings[1].Key);
@@ -77,13 +73,11 @@ public class KeyValueGetCommandTests : CommandUnitTestsBase<KeyValueGetCommand, 
             "--subscription", "sub123",
             "--account", "account1",
             "--key-filter", "key1");
+
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
 
-        var result = DeserializeResponse(response, AppConfigJsonContext.Default.KeyValueGetCommandResult);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueGetCommandResult);
 
-        Assert.NotNull(result);
         Assert.Single(result.Settings);
         Assert.Equal("key1", result.Settings[0].Key);
         Assert.Equal("value1", result.Settings[0].Value);
@@ -117,12 +111,8 @@ public class KeyValueGetCommandTests : CommandUnitTestsBase<KeyValueGetCommand, 
             "--label-filter", "prod");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueGetCommandResult);
 
-        var result = DeserializeResponse(response, AppConfigJsonContext.Default.KeyValueGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Single(result.Settings);
         Assert.Equal("key1", result.Settings[0].Key);
         Assert.Equal("value1", result.Settings[0].Value);
@@ -161,11 +151,8 @@ public class KeyValueGetCommandTests : CommandUnitTestsBase<KeyValueGetCommand, 
             "--label", "prod");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueGetCommandResult);
 
-        var result = DeserializeResponse(response, AppConfigJsonContext.Default.KeyValueGetCommandResult);
-        Assert.NotNull(result);
         Assert.Single(result.Settings);
         Assert.Equal("my-key", result.Settings[0].Key);
         Assert.Equal("my-value", result.Settings[0].Value);
@@ -203,12 +190,8 @@ public class KeyValueGetCommandTests : CommandUnitTestsBase<KeyValueGetCommand, 
             "--key", "my-key");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueGetCommandResult);
 
-        var result = DeserializeResponse(response, AppConfigJsonContext.Default.KeyValueGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Single(result.Settings);
         Assert.Equal("my-key", result.Settings[0].Key);
         Assert.Equal("my-value", result.Settings[0].Value);

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/KeyValueSetCommandTests.cs
@@ -26,7 +26,6 @@ public class KeyValueSetCommandTests : CommandUnitTestsBase<KeyValueSetCommand, 
             "--value", "my-value");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
         await Service.Received(1).SetKeyValue(
             "account1",
             "my-key",
@@ -39,9 +38,8 @@ public class KeyValueSetCommandTests : CommandUnitTestsBase<KeyValueSetCommand, 
             Arg.Any<string[]>(),
             Arg.Any<CancellationToken>());
 
-        var result = DeserializeResponse(response, AppConfigJsonContext.Default.KeyValueSetCommandResult);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueSetCommandResult);
 
-        Assert.NotNull(result);
         Assert.Equal("my-key", result.Key);
         Assert.Equal("my-value", result.Value);
     }
@@ -58,7 +56,6 @@ public class KeyValueSetCommandTests : CommandUnitTestsBase<KeyValueSetCommand, 
             "--label", "prod");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
         await Service.Received(1).SetKeyValue(
             "account1",
             "my-key",
@@ -71,9 +68,8 @@ public class KeyValueSetCommandTests : CommandUnitTestsBase<KeyValueSetCommand, 
             Arg.Any<string[]>(),
             Arg.Any<CancellationToken>());
 
-        var result = DeserializeResponse(response, AppConfigJsonContext.Default.KeyValueSetCommandResult);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueSetCommandResult);
 
-        Assert.NotNull(result);
         Assert.Equal("my-key", result.Key);
         Assert.Equal("my-value", result.Value);
         Assert.Equal("prod", result.Label);
@@ -92,7 +88,6 @@ public class KeyValueSetCommandTests : CommandUnitTestsBase<KeyValueSetCommand, 
             "--tags", "environment=prod", "team=backend");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
         await Service.Received(1).SetKeyValue(
             "account1",
             "my-key",
@@ -105,9 +100,8 @@ public class KeyValueSetCommandTests : CommandUnitTestsBase<KeyValueSetCommand, 
             Arg.Is<string[]>(tags => tags.Contains("environment=prod") && tags.Contains("team=backend")),
             Arg.Any<CancellationToken>());
 
-        var result = DeserializeResponse(response, AppConfigJsonContext.Default.KeyValueSetCommandResult);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueSetCommandResult);
 
-        Assert.NotNull(result);
         Assert.Equal("my-key", result.Key);
         Assert.Equal("my-value", result.Value);
         Assert.Equal("application/json", result.ContentType);

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
@@ -1,60 +1,33 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AppConfig.Commands;
 using Azure.Mcp.Tools.AppConfig.Commands.KeyValue.Lock;
 using Azure.Mcp.Tools.AppConfig.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AppConfig.UnitTests.KeyValue.Lock;
 
-public class KeyValueLockSetCommandTests
+public class KeyValueLockSetCommandTests : CommandUnitTestsBase<KeyValueLockSetCommand, IAppConfigService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAppConfigService _appConfigService;
-    private readonly ILogger<KeyValueLockSetCommand> _logger;
-    private readonly KeyValueLockSetCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public KeyValueLockSetCommandTests()
-    {
-        _appConfigService = Substitute.For<IAppConfigService>();
-        _logger = Substitute.For<ILogger<KeyValueLockSetCommand>>();
-
-        _command = new(_logger, _appConfigService);
-        _commandDefinition = _command.GetCommand();
-        _serviceProvider = new ServiceCollection()
-            .BuildServiceProvider();
-        _context = new(_serviceProvider);
-    }
-
     [Fact]
     public async Task ExecuteAsync_LocksKeyValue_WhenValidParametersProvided()
     {
-        // Arrange
-        var args = _commandDefinition.Parse([
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--account", "account1",
             "--key", "my-key",
-            "--lock"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--lock");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _appConfigService.Received(1).SetKeyValueLockState(
+        await Service.Received(1).SetKeyValueLockState(
             "account1",
             "my-key",
             true,
@@ -64,8 +37,7 @@ public class KeyValueLockSetCommandTests
             null,
             Arg.Any<CancellationToken>());
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
+        var result = ConvertResponse(response, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
 
         Assert.NotNull(result);
         Assert.Equal("my-key", result.Key);
@@ -75,21 +47,17 @@ public class KeyValueLockSetCommandTests
     [Fact]
     public async Task ExecuteAsync_LocksKeyValueWithLabel_WhenLabelProvided()
     {
-        // Arrange
-        var args = _commandDefinition.Parse([
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--account", "account1",
             "--key", "my-key",
             "--label", "prod",
-            "--lock"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--lock");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _appConfigService.Received(1).SetKeyValueLockState(
+        await Service.Received(1).SetKeyValueLockState(
             "account1",
             "my-key",
             true,
@@ -99,8 +67,7 @@ public class KeyValueLockSetCommandTests
             "prod",
             Arg.Any<CancellationToken>());
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
+        var result = ConvertResponse(response, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
 
         Assert.NotNull(result);
         Assert.Equal("my-key", result.Key);
@@ -111,19 +78,15 @@ public class KeyValueLockSetCommandTests
     [Fact]
     public async Task ExecuteAsync_UnlocksKeyValue_WhenValidParametersProvided()
     {
-        // Arrange
-        var args = _commandDefinition.Parse([
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--account", "account1",
-            "--key", "my-key"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--key", "my-key");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _appConfigService.Received(1).SetKeyValueLockState(
+        await Service.Received(1).SetKeyValueLockState(
             "account1",
             "my-key",
             false,
@@ -132,8 +95,8 @@ public class KeyValueLockSetCommandTests
             Arg.Any<RetryPolicyOptions>(),
             null,
             Arg.Any<CancellationToken>());
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
+
+        var result = ConvertResponse(response, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
 
         Assert.NotNull(result);
         Assert.Equal("my-key", result.Key);
@@ -143,20 +106,16 @@ public class KeyValueLockSetCommandTests
     [Fact]
     public async Task ExecuteAsync_UnlocksKeyValueWithLabel_WhenLabelProvided()
     {
-        // Arrange
-        var args = _commandDefinition.Parse([
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--account", "account1",
             "--key", "my-key",
-            "--label", "prod"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--label", "prod");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _appConfigService.Received(1).SetKeyValueLockState(
+        await Service.Received(1).SetKeyValueLockState(
             "account1",
             "my-key",
             false,
@@ -165,8 +124,8 @@ public class KeyValueLockSetCommandTests
             Arg.Any<RetryPolicyOptions>(),
             "prod",
             Arg.Any<CancellationToken>());
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
+
+        var result = ConvertResponse(response, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
 
         Assert.NotNull(result);
         Assert.Equal("my-key", result.Key);
@@ -179,7 +138,7 @@ public class KeyValueLockSetCommandTests
     public async Task ExecuteAsync_Returns500_WhenServiceThrowsException(bool locked)
     {
         // Arrange
-        _appConfigService.SetKeyValueLockState(
+        Service.SetKeyValueLockState(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<bool>(),
@@ -190,13 +149,12 @@ public class KeyValueLockSetCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Failed to lock key-value"));
 
-        var argsToParse = locked
-            ? new List<string> { "--subscription", "sub123", "--account", "account1", "--key", "my-key", "--lock" }
-            : new List<string> { "--subscription", "sub123", "--account", "account1", "--key", "my-key" };
-        var args = _commandDefinition.Parse(argsToParse);
+        string[] argsToParse = locked
+            ? ["--subscription", "sub123", "--account", "account1", "--key", "my-key", "--lock"]
+            : ["--subscription", "sub123", "--account", "account1", "--key", "my-key"];
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(argsToParse);
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -211,11 +169,8 @@ public class KeyValueLockSetCommandTests
     [InlineData("--subscription sub123 --key my-key")] // Missing account
     public async Task ExecuteAsync_Returns400_WhenRequiredParametersAreMissing(string args)
     {
-        // Arrange
-        var parsedArgs = _commandDefinition.Parse(args);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, parsedArgs, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
@@ -37,9 +37,7 @@ public class KeyValueLockSetCommandTests : CommandUnitTestsBase<KeyValueLockSetC
             null,
             Arg.Any<CancellationToken>());
 
-        var result = ConvertResponse(response, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
-
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
         Assert.Equal("my-key", result.Key);
         Assert.True(result.Locked);
     }
@@ -67,9 +65,7 @@ public class KeyValueLockSetCommandTests : CommandUnitTestsBase<KeyValueLockSetC
             "prod",
             Arg.Any<CancellationToken>());
 
-        var result = ConvertResponse(response, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
-
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
         Assert.Equal("my-key", result.Key);
         Assert.Equal("prod", result.Label);
         Assert.True(result.Locked);
@@ -96,9 +92,7 @@ public class KeyValueLockSetCommandTests : CommandUnitTestsBase<KeyValueLockSetC
             null,
             Arg.Any<CancellationToken>());
 
-        var result = ConvertResponse(response, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
-
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
         Assert.Equal("my-key", result.Key);
         Assert.False(result.Locked);
     }
@@ -125,9 +119,7 @@ public class KeyValueLockSetCommandTests : CommandUnitTestsBase<KeyValueLockSetC
             "prod",
             Arg.Any<CancellationToken>());
 
-        var result = ConvertResponse(response, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
-
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
         Assert.Equal("my-key", result.Key);
         Assert.Equal("prod", result.Label);
     }

--- a/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.UnitTests/Resource/ResourceDiagnoseCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.UnitTests/Resource/ResourceDiagnoseCommandTests.cs
@@ -2,50 +2,30 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AppLens.Commands.Resource;
 using Azure.Mcp.Tools.AppLens.Models;
 using Azure.Mcp.Tools.AppLens.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AppLens.UnitTests.Resource;
 
-public class ResourceDiagnoseCommandTests
+public class ResourceDiagnoseCommandTests : CommandUnitTestsBase<ResourceDiagnoseCommand, IAppLensService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAppLensService _appLensService;
-    private readonly ILogger<ResourceDiagnoseCommand> _logger;
-    private readonly ResourceDiagnoseCommand _command;
-    private readonly CommandContext _context;
-
-    public ResourceDiagnoseCommandTests()
-    {
-        _appLensService = Substitute.For<IAppLensService>();
-        _logger = Substitute.For<ILogger<ResourceDiagnoseCommand>>();
-
-        _command = new(_logger, _appLensService);
-        _serviceProvider = new ServiceCollection()
-            .BuildServiceProvider();
-        _context = new(_serviceProvider);
-    }
-
     [Fact]
     public async Task ExecuteAsync_ReturnsDiagnosticResult_WhenAllParametersProvided()
     {
         // Arrange
         var expectedResult = new DiagnosticResult(
-            new List<string> { "Insight 1", "Insight 2" },
-            new List<string> { "Solution 1", "Solution 2" },
+            ["Insight 1", "Insight 2"],
+            ["Solution 1", "Solution 2"],
             "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp",
-            "Microsoft.Web/sites"
-        );
+            "Microsoft.Web/sites");
 
-        _appLensService.DiagnoseResourceAsync(
+        Service.DiagnoseResourceAsync(
             "Why is my app slow?",
             "myapp",
             "sub123",
@@ -55,27 +35,20 @@ public class ResourceDiagnoseCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
-        var args = _command.GetCommand().Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--question", "Why is my app slow?",
             "--resource", "myapp",
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--resource-type", "Microsoft.Web/sites"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-type", "Microsoft.Web/sites");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.Equal("Success", response.Message);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<ResourceDiagnoseCommandResult>(json, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-        });
+        var result = ConvertResponse(response, AppLensJsonContext.Default.ResourceDiagnoseCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Result);
@@ -92,13 +65,12 @@ public class ResourceDiagnoseCommandTests
     {
         // Arrange - only question and resource are required now
         var expectedResult = new DiagnosticResult(
-            new List<string> { "Insight 1" },
-            new List<string> { "Solution 1" },
+            ["Insight 1"],
+            ["Solution 1"],
             "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp",
-            "Microsoft.Web/sites"
-        );
+            "Microsoft.Web/sites");
 
-        _appLensService.DiagnoseResourceAsync(
+        Service.DiagnoseResourceAsync(
             "Why is my app slow?",
             "myapp",
             Arg.Any<string?>(),
@@ -108,13 +80,10 @@ public class ResourceDiagnoseCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
-        var args = _command.GetCommand().Parse([
-            "--question", "Why is my app slow?",
-            "--resource", "myapp"
-        ]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--question", "Why is my app slow?",
+            "--resource", "myapp");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -125,12 +94,11 @@ public class ResourceDiagnoseCommandTests
     public async Task ExecuteAsync_Returns400_WhenQuestionIsMissing()
     {
         // Arrange && Act
-        var response = await _command.ExecuteAsync(_context, _command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--resource", "myapp",
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--resource-type", "Microsoft.Web/sites"
-        ]), TestContext.Current.CancellationToken);
+            "--resource-type", "Microsoft.Web/sites");
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -141,12 +109,11 @@ public class ResourceDiagnoseCommandTests
     public async Task ExecuteAsync_Returns400_WhenResourceIsMissing()
     {
         // Arrange && Act
-        var response = await _command.ExecuteAsync(_context, _command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--question", "Why is my app slow?",
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--resource-type", "Microsoft.Web/sites"
-        ]), TestContext.Current.CancellationToken);
+            "--resource-type", "Microsoft.Web/sites");
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -158,13 +125,12 @@ public class ResourceDiagnoseCommandTests
     {
         // Arrange - subscription is now optional
         var expectedResult = new DiagnosticResult(
-            new List<string> { "Insight 1" },
-            new List<string> { "Solution 1" },
+            ["Insight 1"],
+            ["Solution 1"],
             "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp",
-            "Microsoft.Web/sites"
-        );
+            "Microsoft.Web/sites");
 
-        _appLensService.DiagnoseResourceAsync(
+        Service.DiagnoseResourceAsync(
             "Why is my app slow?",
             "myapp",
             Arg.Any<string?>(),
@@ -174,15 +140,12 @@ public class ResourceDiagnoseCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
-        var args = _command.GetCommand().Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--question", "Why is my app slow?",
             "--resource", "myapp",
             "--resource-group", "rg1",
-            "--resource-type", "Microsoft.Web/sites"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-type", "Microsoft.Web/sites");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -193,13 +156,12 @@ public class ResourceDiagnoseCommandTests
     {
         // Arrange - resource group is now optional
         var expectedResult = new DiagnosticResult(
-            new List<string> { "Insight 1" },
-            new List<string> { "Solution 1" },
+            ["Insight 1"],
+            ["Solution 1"],
             "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp",
-            "Microsoft.Web/sites"
-        );
+            "Microsoft.Web/sites");
 
-        _appLensService.DiagnoseResourceAsync(
+        Service.DiagnoseResourceAsync(
             "Why is my app slow?",
             "myapp",
             "sub123",
@@ -209,15 +171,12 @@ public class ResourceDiagnoseCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
-        var args = _command.GetCommand().Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--question", "Why is my app slow?",
             "--resource", "myapp",
             "--subscription", "sub123",
-            "--resource-type", "Microsoft.Web/sites"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-type", "Microsoft.Web/sites");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -228,13 +187,12 @@ public class ResourceDiagnoseCommandTests
     {
         // Arrange - resource type is now optional
         var expectedResult = new DiagnosticResult(
-            new List<string> { "Insight 1" },
-            new List<string> { "Solution 1" },
+            ["Insight 1"],
+            ["Solution 1"],
             "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp",
-            "Microsoft.Web/sites"
-        );
+            "Microsoft.Web/sites");
 
-        _appLensService.DiagnoseResourceAsync(
+        Service.DiagnoseResourceAsync(
             "Why is my app slow?",
             "myapp",
             "sub123",
@@ -244,15 +202,12 @@ public class ResourceDiagnoseCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
-        var args = _command.GetCommand().Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--question", "Why is my app slow?",
             "--resource", "myapp",
             "--subscription", "sub123",
-            "--resource-group", "rg1"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-group", "rg1");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -262,7 +217,7 @@ public class ResourceDiagnoseCommandTests
     public async Task ExecuteAsync_Returns500_WhenServiceThrowsGenericException()
     {
         // Arrange
-        _appLensService.DiagnoseResourceAsync(
+        Service.DiagnoseResourceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
@@ -272,16 +227,13 @@ public class ResourceDiagnoseCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Service error"));
 
-        var args = _command.GetCommand().Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--question", "Why is my app slow?",
             "--resource", "myapp",
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--resource-type", "Microsoft.Web/sites"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-type", "Microsoft.Web/sites");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -292,7 +244,7 @@ public class ResourceDiagnoseCommandTests
     public async Task ExecuteAsync_Returns400_WhenServiceThrowsInvalidOperationException()
     {
         // Arrange
-        _appLensService.DiagnoseResourceAsync(
+        Service.DiagnoseResourceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
@@ -302,16 +254,13 @@ public class ResourceDiagnoseCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Resource not found"));
 
-        var args = _command.GetCommand().Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--question", "Why is my app slow?",
             "--resource", "myapp",
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--resource-type", "Microsoft.Web/sites"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-type", "Microsoft.Web/sites");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -322,7 +271,7 @@ public class ResourceDiagnoseCommandTests
     public async Task ExecuteAsync_Returns503_WhenServiceIsUnavailable()
     {
         // Arrange
-        _appLensService.DiagnoseResourceAsync(
+        Service.DiagnoseResourceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
@@ -330,18 +279,15 @@ public class ResourceDiagnoseCommandTests
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
-            .ThrowsAsync(new HttpRequestException("Service Unavailable", null, System.Net.HttpStatusCode.ServiceUnavailable));
+            .ThrowsAsync(new HttpRequestException("Service Unavailable", null, HttpStatusCode.ServiceUnavailable));
 
-        var args = _command.GetCommand().Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--question", "Why is my app slow?",
             "--resource", "myapp",
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--resource-type", "Microsoft.Web/sites"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-type", "Microsoft.Web/sites");
 
         // Assert
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.Status);
@@ -353,13 +299,12 @@ public class ResourceDiagnoseCommandTests
     {
         // Arrange
         var expectedResult = new DiagnosticResult(
-            new List<string>(),
-            new List<string>(),
+            [],
+            [],
             "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp",
-            "Microsoft.Web/sites"
-        );
+            "Microsoft.Web/sites");
 
-        _appLensService.DiagnoseResourceAsync(
+        Service.DiagnoseResourceAsync(
             "Why is my app slow?",
             "myapp",
             "sub123",
@@ -369,26 +314,19 @@ public class ResourceDiagnoseCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
-        var args = _command.GetCommand().Parse([
-            "--subscription", "sub123",
-            "--resource-group", "rg1",
+        // Act
+        var response = await ExecuteCommandAsync(
             "--question", "Why is my app slow?",
             "--resource", "myapp",
-            "--resource-type", "Microsoft.Web/sites"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", "sub123",
+            "--resource-group", "rg1",
+            "--resource-type", "Microsoft.Web/sites");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<ResourceDiagnoseCommandResult>(json, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-        });
+        var result = ConvertResponse(response, AppLensJsonContext.Default.ResourceDiagnoseCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Result);
@@ -408,10 +346,8 @@ public class ResourceDiagnoseCommandTests
         if (!string.IsNullOrEmpty(resource))
         { args.AddRange(["--resource", resource]); }
 
-        var parseResult = _command.GetCommand().Parse(args.ToArray());
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args.ToArray());
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -423,13 +359,12 @@ public class ResourceDiagnoseCommandTests
     {
         // Arrange
         var expectedResult = new DiagnosticResult(
-            new List<string> { "Insight 1" },
-            new List<string> { "Solution 1" },
+            ["Insight 1"],
+            ["Solution 1"],
             "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Web/sites/myapp",
-            "Microsoft.Web/sites"
-        );
+            "Microsoft.Web/sites");
 
-        _appLensService.DiagnoseResourceAsync(
+        Service.DiagnoseResourceAsync(
             "Why is my app slow?",
             "myapp",
             "sub123",
@@ -439,19 +374,16 @@ public class ResourceDiagnoseCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
-        var args = _command.GetCommand().Parse([
+        // Act
+        await ExecuteCommandAsync(
             "--question", "Why is my app slow?",
             "--resource", "myapp",
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--resource-type", "Microsoft.Web/sites"
-        ]);
-
-        // Act
-        await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-type", "Microsoft.Web/sites");
 
         // Assert
-        _logger.Received(1).Log(
+        Logger.Received(1).Log(
             LogLevel.Information,
             Arg.Any<EventId>(),
             Arg.Is<object>(o => o.ToString()!.Contains("Diagnosing resource")),
@@ -463,7 +395,7 @@ public class ResourceDiagnoseCommandTests
     public async Task ExecuteAsync_LogsErrorOnException()
     {
         // Arrange
-        _appLensService.DiagnoseResourceAsync(
+        Service.DiagnoseResourceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
@@ -473,19 +405,16 @@ public class ResourceDiagnoseCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _command.GetCommand().Parse([
+        // Act
+        await ExecuteCommandAsync(
             "--question", "Why is my app slow?",
             "--resource", "myapp",
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--resource-type", "Microsoft.Web/sites"
-        ]);
-
-        // Act
-        await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-type", "Microsoft.Web/sites");
 
         // Assert
-        _logger.Received(1).Log(
+        Logger.Received(1).Log(
             LogLevel.Error,
             Arg.Any<EventId>(),
             Arg.Is<object>(o => o.ToString()!.Contains("Error in diagnose")),

--- a/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.UnitTests/Resource/ResourceDiagnoseCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.UnitTests/Resource/ResourceDiagnoseCommandTests.cs
@@ -44,13 +44,8 @@ public class ResourceDiagnoseCommandTests : CommandUnitTestsBase<ResourceDiagnos
             "--resource-type", "Microsoft.Web/sites");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.Equal("Success", response.Message);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AppLensJsonContext.Default.ResourceDiagnoseCommandResult);
 
-        var result = ConvertResponse(response, AppLensJsonContext.Default.ResourceDiagnoseCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Result);
         Assert.Equal(2, result.Result.Insights.Count);
         Assert.Equal(2, result.Result.Solutions.Count);
@@ -323,12 +318,8 @@ public class ResourceDiagnoseCommandTests : CommandUnitTestsBase<ResourceDiagnos
             "--resource-type", "Microsoft.Web/sites");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AppLensJsonContext.Default.ResourceDiagnoseCommandResult);
 
-        var result = ConvertResponse(response, AppLensJsonContext.Default.ResourceDiagnoseCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Result);
         Assert.Empty(result.Result.Insights);
         Assert.Empty(result.Result.Solutions);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Database/DatabaseAddCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Database/DatabaseAddCommandTests.cs
@@ -5,10 +5,8 @@ using System.Net;
 using Azure.Mcp.Tools.AppService.Commands.Database;
 using Azure.Mcp.Tools.AppService.Models;
 using Azure.Mcp.Tools.AppService.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -16,21 +14,8 @@ using Xunit;
 namespace Azure.Mcp.Tools.AppService.UnitTests.Commands.Database;
 
 [Trait("Command", "DatabaseAdd")]
-public class DatabaseAddCommandTests
+public class DatabaseAddCommandTests : CommandUnitTestsBase<DatabaseAddCommand, IAppServiceService>
 {
-    private readonly IAppServiceService _appServiceService;
-    private readonly ILogger<DatabaseAddCommand> _logger;
-    private readonly DatabaseAddCommand _command;
-    private readonly CommandContext _context;
-
-    public DatabaseAddCommandTests()
-    {
-        _appServiceService = Substitute.For<IAppServiceService>();
-        _logger = Substitute.For<ILogger<DatabaseAddCommand>>();
-        _command = new(_logger, _appServiceService);
-        _context = new(new ServiceCollection().BuildServiceProvider());
-    }
-
     [Theory]
     [InlineData("SqlServer", "test-server.database.windows.net", "test-db", null, null)]
     [InlineData("MySQL", "mysql-server.mysql.database.azure.com", "mysql-db", "Server=custom-server;Database=custom-db;", null)]
@@ -60,22 +45,21 @@ public class DatabaseAddCommandTests
         };
 
         // Set up the mock to return success for any arguments
-        _appServiceService
-            .AddDatabaseAsync(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.AddDatabaseAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedConnection);
 
         // Test the service directly
-        var connectionInfo = await _appServiceService.AddDatabaseAsync(
+        var connectionInfo = await Service.AddDatabaseAsync(
             appName,
             resourceGroup,
             databaseType,
@@ -94,14 +78,14 @@ public class DatabaseAddCommandTests
         Assert.Equal(databaseName, connectionInfo.DatabaseName);
 
         // Verify that the mock was called with the expected parameters
-        await _appServiceService.Received(1).AddDatabaseAsync(
-            Arg.Is<string>(x => x == appName),
-            Arg.Is<string>(x => x == resourceGroup),
-            Arg.Is<string>(x => x == databaseType),
-            Arg.Is<string>(x => x == databaseServer),
-            Arg.Is<string>(x => x == databaseName),
+        await Service.Received(1).AddDatabaseAsync(
+            Arg.Is(appName),
+            Arg.Is(resourceGroup),
+            Arg.Is(databaseType),
+            Arg.Is(databaseServer),
+            Arg.Is(databaseName),
             Arg.Any<string>(),
-            Arg.Is<string>(x => x == subscription),
+            Arg.Is(subscription),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
@@ -115,17 +99,14 @@ public class DatabaseAddCommandTests
     [InlineData("--resource-group", "rg1", "--app", "test-app", "--database-type", "SqlServer", "--database-server", "test-server", "--database", "test-db")] // Missing subscription
     public async Task ExecuteAsync_MissingRequiredParameter_ReturnsErrorResponse(params string[] commandArgs)
     {
-        // Arrange
-        var args = _command.GetCommand().Parse(commandArgs);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(commandArgs);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
 
-        await _appServiceService.DidNotReceive().AddDatabaseAsync(
+        await Service.DidNotReceive().AddDatabaseAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -176,8 +157,7 @@ public class DatabaseAddCommandTests
 
         // Execute the command directly in unit tests rather than via the tool runner helper
         var argList = parameters.SelectMany(kvp => new[] { $"--{kvp.Key}", kvp.Value?.ToString() ?? string.Empty }).ToArray();
-        var parseResult = _command.GetCommand().Parse(argList);
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(argList);
 
         // Test actual command execution and proper error handling
         Assert.NotNull(response);
@@ -222,7 +202,7 @@ public class DatabaseAddCommandTests
         var databaseServer = "test-server.database.windows.net";
         var databaseName = "test-db";
 
-        _appServiceService.AddDatabaseAsync(
+        Service.AddDatabaseAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -235,17 +215,15 @@ public class DatabaseAddCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Service error"));
 
-        var args = _command.GetCommand().Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--app", appName,
             "--database-type", databaseType,
             "--database-server", databaseServer,
-            "--database", databaseName
-        ]);
+            "--database", databaseName);
 
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Deployment/DeploymentGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Deployment/DeploymentGetCommandTests.cs
@@ -47,10 +47,7 @@ public class DeploymentGetCommandTests : CommandUnitTestsBase<DeploymentGetComma
         await Service.Received(1).GetDeploymentsAsync("sub123", "rg1", "test-app", deploymentId,
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
 
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
-
-        var result = ConvertResponse(response, AppServiceJsonContext.Default.DeploymentGetResult);
+        var result = ValidateAndDeserializeResponse(response, AppServiceJsonContext.Default.DeploymentGetResult);
 
         Assert.NotNull(result);
         Assert.Equal(JsonSerializer.Serialize(expectedDeployments), JsonSerializer.Serialize(result.Deployments));

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Deployment/DeploymentGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Deployment/DeploymentGetCommandTests.cs
@@ -1,17 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using System.Text.Json;
 using Azure.Mcp.Tools.AppService.Commands;
 using Azure.Mcp.Tools.AppService.Commands.Webapp.Deployment;
 using Azure.Mcp.Tools.AppService.Models;
 using Azure.Mcp.Tools.AppService.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -19,28 +16,8 @@ using Xunit;
 namespace Azure.Mcp.Tools.AppService.UnitTests.Commands.Webapp.Deployment;
 
 [Trait("Command", "DeploymentGet")]
-public class DeploymentGetCommandTests
+public class DeploymentGetCommandTests : CommandUnitTestsBase<DeploymentGetCommand, IAppServiceService>
 {
-    private readonly IAppServiceService _appServiceService;
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<DeploymentGetCommand> _logger;
-    private readonly DeploymentGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public DeploymentGetCommandTests()
-    {
-        _appServiceService = Substitute.For<IAppServiceService>();
-        _logger = Substitute.For<ILogger<DeploymentGetCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_appServiceService);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Theory]
     [InlineData(null)]
     [InlineData("deployment123")]
@@ -52,7 +29,7 @@ public class DeploymentGetCommandTests
         ];
 
         // Set up the mock to return success for any arguments
-        _appServiceService.GetDeploymentsAsync("sub123", "rg1", "test-app", deploymentId, Arg.Any<string?>(),
+        Service.GetDeploymentsAsync("sub123", "rg1", "test-app", deploymentId, Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedDeployments);
 
@@ -62,21 +39,18 @@ public class DeploymentGetCommandTests
             unparsedArgs.AddRange(["--deployment-id", deploymentId]);
         }
 
-        var args = _commandDefinition.Parse(unparsedArgs);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(unparsedArgs.ToArray());
 
         // Assert
         // Verify that the mock was called with the expected parameters
-        await _appServiceService.Received(1).GetDeploymentsAsync("sub123", "rg1", "test-app", deploymentId,
+        await Service.Received(1).GetDeploymentsAsync("sub123", "rg1", "test-app", deploymentId,
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
 
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AppServiceJsonContext.Default.DeploymentGetResult);
+        var result = ConvertResponse(response, AppServiceJsonContext.Default.DeploymentGetResult);
 
         Assert.NotNull(result);
         Assert.Equal(JsonSerializer.Serialize(expectedDeployments), JsonSerializer.Serialize(result.Deployments));
@@ -91,17 +65,14 @@ public class DeploymentGetCommandTests
     [InlineData("--resource-group", "rg1", "--app", "test-app")] // Missing subscription
     public async Task ExecuteAsync_MissingRequiredParameter_ReturnsErrorResponse(params string[] commandArgs)
     {
-        // Arrange
-        var args = _commandDefinition.Parse(commandArgs);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(commandArgs);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
 
-        await _appServiceService.DidNotReceive().GetDeploymentsAsync(
+        await Service.DidNotReceive().GetDeploymentsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -117,7 +88,7 @@ public class DeploymentGetCommandTests
     public async Task ExecuteAsync_ServiceThrowsException_ReturnsErrorResponse(string? deploymentId)
     {
         // Arrange
-        _appServiceService.GetDeploymentsAsync("sub123", "rg1", "test-app", deploymentId, Arg.Any<string?>(),
+        Service.GetDeploymentsAsync("sub123", "rg1", "test-app", deploymentId, Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Service error"));
 
@@ -127,16 +98,14 @@ public class DeploymentGetCommandTests
             unparsedArgs.AddRange(["--deployment-id", deploymentId]);
         }
 
-        var args = _commandDefinition.Parse(unparsedArgs);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(unparsedArgs.ToArray());
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
 
-        await _appServiceService.Received(1).GetDeploymentsAsync("sub123", "rg1", "test-app", deploymentId,
+        await Service.Received(1).GetDeploymentsAsync("sub123", "rg1", "test-app", deploymentId,
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Diagnostic/DetectorDiagnoseCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Diagnostic/DetectorDiagnoseCommandTests.cs
@@ -71,10 +71,7 @@ public class DetectorDiagnoseCommandTests : CommandUnitTestsBase<DetectorDiagnos
             startTime, endTime, interval, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
 
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
-
-        var result = ConvertResponse(response, AppServiceJsonContext.Default.DetectorDiagnoseResult);
+        var result = ValidateAndDeserializeResponse(response, AppServiceJsonContext.Default.DetectorDiagnoseResult);
 
         Assert.NotNull(result);
         Assert.Single(result.Diagnoses.Datasets);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Diagnostic/DetectorDiagnoseCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Diagnostic/DetectorDiagnoseCommandTests.cs
@@ -1,18 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AppService.Commands;
 using Azure.Mcp.Tools.AppService.Commands.Webapp.Diagnostic;
 using Azure.Mcp.Tools.AppService.Models;
 using Azure.Mcp.Tools.AppService.Services;
 using Azure.ResourceManager.AppService.Models;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -20,28 +16,8 @@ using Xunit;
 namespace Azure.Mcp.Tools.AppService.UnitTests.Commands.Webapp.Diagnostic;
 
 [Trait("Command", "DetectorDiagnose")]
-public class DetectorDiagnoseCommandTests
+public class DetectorDiagnoseCommandTests : CommandUnitTestsBase<DetectorDiagnoseCommand, IAppServiceService>
 {
-    private readonly IAppServiceService _appServiceService;
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<DetectorDiagnoseCommand> _logger;
-    private readonly DetectorDiagnoseCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public DetectorDiagnoseCommandTests()
-    {
-        _appServiceService = Substitute.For<IAppServiceService>();
-        _logger = Substitute.For<ILogger<DetectorDiagnoseCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_appServiceService);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Theory]
     [InlineData(null, null, null)]
     [InlineData(null, null, "PT1H")]
@@ -63,7 +39,7 @@ public class DetectorDiagnoseCommandTests
 
         // Arrange
         // Set up the mock to return success for any arguments
-        _appServiceService.DiagnoseDetectorAsync("sub123", "rg1", "test-app", "detector-name", startTime, endTime,
+        Service.DiagnoseDetectorAsync("sub123", "rg1", "test-app", "detector-name", startTime, endTime,
             interval, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedValue);
 
@@ -85,22 +61,20 @@ public class DetectorDiagnoseCommandTests
         {
             unparsedArgs.AddRange(["--interval", interval]);
         }
-        var args = _commandDefinition.Parse(unparsedArgs);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(unparsedArgs.ToArray());
 
         // Assert
         // Verify that the mock was called with the expected parameters
-        await _appServiceService.Received(1).DiagnoseDetectorAsync("sub123", "rg1", "test-app", "detector-name",
+        await Service.Received(1).DiagnoseDetectorAsync("sub123", "rg1", "test-app", "detector-name",
             startTime, endTime, interval, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
 
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AppServiceJsonContext.Default.DetectorDiagnoseResult);
+        var result = ConvertResponse(response, AppServiceJsonContext.Default.DetectorDiagnoseResult);
 
         Assert.NotNull(result);
         Assert.Single(result.Diagnoses.Datasets);
@@ -130,17 +104,14 @@ public class DetectorDiagnoseCommandTests
     [InlineData("--resource-group", "rg1", "--app", "test-app", "--detector-name", "detector-name")] // Missing subscription
     public async Task ExecuteAsync_MissingRequiredParameter_ReturnsErrorResponse(params string[] commandArgs)
     {
-        // Arrange
-        var args = _commandDefinition.Parse(commandArgs);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(commandArgs);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
 
-        await _appServiceService.DidNotReceive().DiagnoseDetectorAsync(
+        await Service.DidNotReceive().DiagnoseDetectorAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -167,7 +138,7 @@ public class DetectorDiagnoseCommandTests
 
         // Arrange
         // Set up the mock to return success for any arguments
-        _appServiceService.DiagnoseDetectorAsync("sub123", "rg1", "test-app", "detector-name", startTime, endTime,
+        Service.DiagnoseDetectorAsync("sub123", "rg1", "test-app", "detector-name", startTime, endTime,
             interval, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Service error"));
 
@@ -189,16 +160,15 @@ public class DetectorDiagnoseCommandTests
         {
             unparsedArgs.AddRange(["--interval", interval]);
         }
-        var args = _commandDefinition.Parse(unparsedArgs);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(unparsedArgs.ToArray());
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
 
-        await _appServiceService.Received(1).DiagnoseDetectorAsync("sub123", "rg1", "test-app", "detector-name",
+        await Service.Received(1).DiagnoseDetectorAsync("sub123", "rg1", "test-app", "detector-name",
             startTime, endTime, interval, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Diagnostic/DetectorListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Diagnostic/DetectorListCommandTests.cs
@@ -1,17 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AppService.Commands;
 using Azure.Mcp.Tools.AppService.Commands.Webapp.Diagnostic;
 using Azure.Mcp.Tools.AppService.Models;
 using Azure.Mcp.Tools.AppService.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -19,53 +15,30 @@ using Xunit;
 namespace Azure.Mcp.Tools.AppService.UnitTests.Commands.Webapp.Diagnostic;
 
 [Trait("Command", "DetectorList")]
-public class DetectorListCommandTests
+public class DetectorListCommandTests : CommandUnitTestsBase<DetectorListCommand, IAppServiceService>
 {
-    private readonly IAppServiceService _appServiceService;
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<DetectorListCommand> _logger;
-    private readonly DetectorListCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public DetectorListCommandTests()
-    {
-        _appServiceService = Substitute.For<IAppServiceService>();
-        _logger = Substitute.For<ILogger<DetectorListCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_appServiceService);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public async Task ExecuteAsync_WithValidParameters_CallsServiceWithCorrectArguments()
     {
-        List<DetectorDetails> expectedValue = [new DetectorDetails("name", "type", "description", "category", ["analysisType1", "analysisType2"])];
+        List<DetectorDetails> expectedValue = [new("name", "type", "description", "category", ["analysisType1", "analysisType2"])];
         // Arrange
         // Set up the mock to return success for any arguments
-        _appServiceService.ListDetectorsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
+        Service.ListDetectorsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedValue);
 
-        var args = _commandDefinition.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--app", "test-app"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123", "--resource-group", "rg1", "--app", "test-app");
 
         // Assert
         // Verify that the mock was called with the expected parameters
-        await _appServiceService.Received(1).ListDetectorsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
+        await Service.Received(1).ListDetectorsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
 
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AppServiceJsonContext.Default.DetectorListResult);
+        var result = ConvertResponse(response, AppServiceJsonContext.Default.DetectorListResult);
 
         Assert.NotNull(result);
         Assert.Single(result.Detectors);
@@ -86,17 +59,14 @@ public class DetectorListCommandTests
     [InlineData("--resource-group", "rg1", "--app", "test-app")] // Missing subscription
     public async Task ExecuteAsync_MissingRequiredParameter_ReturnsErrorResponse(params string[] commandArgs)
     {
-        // Arrange
-        var args = _commandDefinition.Parse(commandArgs);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(commandArgs);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
 
-        await _appServiceService.DidNotReceive().ListDetectorsAsync(
+        await Service.DidNotReceive().ListDetectorsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -110,20 +80,18 @@ public class DetectorListCommandTests
     {
         // Arrange
         // Set up the mock to return success for any arguments
-        _appServiceService.ListDetectorsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
+        Service.ListDetectorsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Service error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--app", "test-app"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123", "--resource-group", "rg1", "--app", "test-app");
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
 
-        await _appServiceService.Received(1).ListDetectorsAsync("sub123", "rg1", "test-app",
+        await Service.Received(1).ListDetectorsAsync("sub123", "rg1", "test-app",
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Diagnostic/DetectorListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Diagnostic/DetectorListCommandTests.cs
@@ -35,12 +35,8 @@ public class DetectorListCommandTests : CommandUnitTestsBase<DetectorListCommand
         await Service.Received(1).ListDetectorsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
 
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AppServiceJsonContext.Default.DetectorListResult);
 
-        var result = ConvertResponse(response, AppServiceJsonContext.Default.DetectorListResult);
-
-        Assert.NotNull(result);
         Assert.Single(result.Detectors);
         Assert.Equal(expectedValue[0].Name, result.Detectors[0].Name);
         Assert.Equal(expectedValue[0].Type, result.Detectors[0].Type);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Settings/AppSettingsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Settings/AppSettingsGetCommandTests.cs
@@ -40,12 +40,8 @@ public class AppSettingsGetCommandTests : CommandUnitTestsBase<AppSettingsGetCom
         await Service.Received(1).GetAppSettingsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
 
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AppServiceJsonContext.Default.AppSettingsGetResult);
 
-        var result = ConvertResponse(response, AppServiceJsonContext.Default.AppSettingsGetResult);
-
-        Assert.NotNull(result);
         Assert.Equal(JsonSerializer.Serialize(expectedSettings), JsonSerializer.Serialize(result.AppSettings));
     }
 

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Settings/AppSettingsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Settings/AppSettingsGetCommandTests.cs
@@ -1,16 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using System.Text.Json;
 using Azure.Mcp.Tools.AppService.Commands;
 using Azure.Mcp.Tools.AppService.Commands.Webapp.Settings;
 using Azure.Mcp.Tools.AppService.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -18,24 +15,8 @@ using Xunit;
 namespace Azure.Mcp.Tools.AppService.UnitTests.Commands.Webapp.Settings;
 
 [Trait("Command", "AppSettingsGet")]
-public class AppSettingsGetCommandTests
+public class AppSettingsGetCommandTests : CommandUnitTestsBase<AppSettingsGetCommand, IAppServiceService>
 {
-    private readonly IAppServiceService _appServiceService;
-    private readonly ILogger<AppSettingsGetCommand> _logger;
-    private readonly AppSettingsGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public AppSettingsGetCommandTests()
-    {
-        _appServiceService = Substitute.For<IAppServiceService>();
-        _logger = Substitute.For<ILogger<AppSettingsGetCommand>>();
-
-        _command = new(_logger, _appServiceService);
-        _context = new(new ServiceCollection().BuildServiceProvider());
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public async Task ExecuteAsync_WithValidParameters_CallsServiceWithCorrectArguments()
     {
@@ -47,25 +28,22 @@ public class AppSettingsGetCommandTests
         };
 
         // Set up the mock to return success for any arguments
-        _appServiceService.GetAppSettingsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
+        Service.GetAppSettingsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedSettings);
 
-        var args = _commandDefinition.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--app", "test-app"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123", "--resource-group", "rg1", "--app", "test-app");
 
         // Assert
         // Verify that the mock was called with the expected parameters
-        await _appServiceService.Received(1).GetAppSettingsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
+        await Service.Received(1).GetAppSettingsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
 
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AppServiceJsonContext.Default.AppSettingsGetResult);
+        var result = ConvertResponse(response, AppServiceJsonContext.Default.AppSettingsGetResult);
 
         Assert.NotNull(result);
         Assert.Equal(JsonSerializer.Serialize(expectedSettings), JsonSerializer.Serialize(result.AppSettings));
@@ -81,17 +59,14 @@ public class AppSettingsGetCommandTests
     [InlineData("--resource-group", "rg1", "--app", "test-app")] // Missing subscription
     public async Task ExecuteAsync_MissingRequiredParameter_ReturnsErrorResponse(params string[] commandArgs)
     {
-        // Arrange
-        var args = _commandDefinition.Parse(commandArgs);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(commandArgs);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
 
-        await _appServiceService.DidNotReceive().GetAppSettingsAsync(
+        await Service.DidNotReceive().GetAppSettingsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -104,20 +79,18 @@ public class AppSettingsGetCommandTests
     public async Task ExecuteAsync_ServiceThrowsException_ReturnsErrorResponse()
     {
         // Arrange
-        _appServiceService.GetAppSettingsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
+        Service.GetAppSettingsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Service error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--app", "test-app"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123", "--resource-group", "rg1", "--app", "test-app");
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
 
-        await _appServiceService.Received(1).GetAppSettingsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
+        await Service.Received(1).GetAppSettingsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Settings/AppSettingsUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Settings/AppSettingsUpdateCommandTests.cs
@@ -1,16 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AppService.Commands;
 using Azure.Mcp.Tools.AppService.Commands.Webapp.Settings;
 using Azure.Mcp.Tools.AppService.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -18,24 +14,8 @@ using Xunit;
 namespace Azure.Mcp.Tools.AppService.UnitTests.Commands.Webapp.Settings;
 
 [Trait("Command", "AppSettingsUpdate")]
-public class AppSettingsUpdateCommandTests
+public class AppSettingsUpdateCommandTests : CommandUnitTestsBase<AppSettingsUpdateCommand, IAppServiceService>
 {
-    private readonly IAppServiceService _appServiceService;
-    private readonly ILogger<AppSettingsUpdateCommand> _logger;
-    private readonly AppSettingsUpdateCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public AppSettingsUpdateCommandTests()
-    {
-        _appServiceService = Substitute.For<IAppServiceService>();
-        _logger = Substitute.For<ILogger<AppSettingsUpdateCommand>>();
-
-        _command = new(_logger, _appServiceService);
-        _context = new(new ServiceCollection().BuildServiceProvider());
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Theory]
     [InlineData("add", "Setting1", "Value1", "Application setting 'Setting1' added successfully.")]
     [InlineData("add", "Setting1", "Value1", "Failed to add application setting 'Setting1' because it already exists.")]
@@ -50,7 +30,7 @@ public class AppSettingsUpdateCommandTests
     {
         // Arrange
         // Set up the mock to return success for any arguments
-        _appServiceService.UpdateAppSettingsAsync("sub123", "rg1", "test-app", settingName, settingUpdateType,
+        Service.UpdateAppSettingsAsync("sub123", "rg1", "test-app", settingName, settingUpdateType,
             settingValue, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedValue);
 
@@ -65,22 +45,20 @@ public class AppSettingsUpdateCommandTests
         {
             unparsedArgs.AddRange(["--setting-value", settingValue]);
         }
-        var args = _commandDefinition.Parse(unparsedArgs);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(unparsedArgs.ToArray());
 
         // Assert
         // Verify that the mock was called with the expected parameters
-        await _appServiceService.Received(1).UpdateAppSettingsAsync("sub123", "rg1", "test-app", settingName,
+        await Service.Received(1).UpdateAppSettingsAsync("sub123", "rg1", "test-app", settingName,
             settingUpdateType, settingValue, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
 
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AppServiceJsonContext.Default.AppSettingsUpdateResult);
+        var result = ConvertResponse(response, AppServiceJsonContext.Default.AppSettingsUpdateResult);
 
         Assert.NotNull(result);
         Assert.Equal(expectedValue, result.UpdateStatus);
@@ -103,17 +81,14 @@ public class AppSettingsUpdateCommandTests
     [InlineData("--subscription", "sub123", "--resource-group", "rg1", "--app", "test-app", "--setting-update-type", "set", "--setting-name", "setting-name")] // Missing setting value
     public async Task ExecuteAsync_MissingRequiredParameter_ReturnsErrorResponse(params string[] commandArgs)
     {
-        // Arrange
-        var args = _commandDefinition.Parse(commandArgs);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(commandArgs);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
 
-        await _appServiceService.DidNotReceive().UpdateAppSettingsAsync(
+        await Service.DidNotReceive().UpdateAppSettingsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -132,7 +107,7 @@ public class AppSettingsUpdateCommandTests
     public async Task ExecuteAsync_ServiceThrowsException_ReturnsErrorResponse(string settingUpdateType, string settingName, string? settingValue)
     {
         // Arrange
-        _appServiceService.UpdateAppSettingsAsync("sub123", "rg1", "test-app", settingName, settingUpdateType,
+        Service.UpdateAppSettingsAsync("sub123", "rg1", "test-app", settingName, settingUpdateType,
             settingValue, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Service error"));
 
@@ -147,16 +122,15 @@ public class AppSettingsUpdateCommandTests
         {
             unparsedArgs.AddRange(["--setting-value", settingValue]);
         }
-        var args = _commandDefinition.Parse(unparsedArgs);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(unparsedArgs.ToArray());
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
 
-        await _appServiceService.Received(1).UpdateAppSettingsAsync("sub123", "rg1", "test-app", settingName,
+        await Service.Received(1).UpdateAppSettingsAsync("sub123", "rg1", "test-app", settingName,
             settingUpdateType, settingValue, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Settings/AppSettingsUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Settings/AppSettingsUpdateCommandTests.cs
@@ -55,12 +55,8 @@ public class AppSettingsUpdateCommandTests : CommandUnitTestsBase<AppSettingsUpd
             settingUpdateType, settingValue, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
 
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AppServiceJsonContext.Default.AppSettingsUpdateResult);
 
-        var result = ConvertResponse(response, AppServiceJsonContext.Default.AppSettingsUpdateResult);
-
-        Assert.NotNull(result);
         Assert.Equal(expectedValue, result.UpdateStatus);
     }
 

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/WebappGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/WebappGetCommandTests.cs
@@ -1,17 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using System.Text.Json;
 using Azure.Mcp.Tools.AppService.Commands;
 using Azure.Mcp.Tools.AppService.Commands.Webapp;
 using Azure.Mcp.Tools.AppService.Models;
 using Azure.Mcp.Tools.AppService.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -19,24 +16,8 @@ using Xunit;
 namespace Azure.Mcp.Tools.AppService.UnitTests.Commands.Webapp;
 
 [Trait("Command", "WebappGet")]
-public class WebappGetCommandTests
+public class WebappGetCommandTests : CommandUnitTestsBase<WebappGetCommand, IAppServiceService>
 {
-    private readonly IAppServiceService _appServiceService;
-    private readonly ILogger<WebappGetCommand> _logger;
-    private readonly WebappGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public WebappGetCommandTests()
-    {
-        _appServiceService = Substitute.For<IAppServiceService>();
-        _logger = Substitute.For<ILogger<WebappGetCommand>>();
-
-        _command = new(_logger, _appServiceService);
-        _context = new(new ServiceCollection().BuildServiceProvider());
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Theory]
     [InlineData("sub123", null, null)]
     [InlineData("sub123", "rg1", null)]
@@ -49,7 +30,7 @@ public class WebappGetCommandTests
         ];
 
         // Set up the mock to return success for any arguments
-        _appServiceService.GetWebAppsAsync(subscription, resourceGroup, appName, Arg.Any<string?>(),
+        Service.GetWebAppsAsync(subscription, resourceGroup, appName, Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedWebappDetails);
 
@@ -63,21 +44,18 @@ public class WebappGetCommandTests
             unparsedArgs.AddRange(["--app", appName]);
         }
 
-        var args = _commandDefinition.Parse(unparsedArgs);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(unparsedArgs.ToArray());
 
         // Assert
         // Verify that the mock was called with the expected parameters
-        await _appServiceService.Received(1).GetWebAppsAsync(subscription, resourceGroup, appName, Arg.Any<string?>(),
+        await Service.Received(1).GetWebAppsAsync(subscription, resourceGroup, appName, Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
 
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AppServiceJsonContext.Default.WebappGetResult);
+        var result = ConvertResponse(response, AppServiceJsonContext.Default.WebappGetResult);
 
         Assert.NotNull(result);
         Assert.Equal(JsonSerializer.Serialize(expectedWebappDetails), JsonSerializer.Serialize(result.Webapps));
@@ -88,17 +66,14 @@ public class WebappGetCommandTests
     [InlineData("--subscription", "sub123", "--app", "test-app")] // Missing resource group
     public async Task ExecuteAsync_MissingRequiredParameter_ReturnsErrorResponse(params string[] commandArgs)
     {
-        // Arrange
-        var args = _commandDefinition.Parse(commandArgs);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(commandArgs);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
 
-        await _appServiceService.DidNotReceive().GetWebAppsAsync(
+        await Service.DidNotReceive().GetWebAppsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -111,21 +86,18 @@ public class WebappGetCommandTests
     public async Task ExecuteAsync_ServiceThrowsException_ReturnsErrorResponse()
     {
         // Arrange
-
-        _appServiceService.GetWebAppsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
+        Service.GetWebAppsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Service error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--app", "test-app"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123", "--resource-group", "rg1", "--app", "test-app");
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
 
-        await _appServiceService.Received(1).GetWebAppsAsync("sub123", "rg1", "test-app",
+        await Service.Received(1).GetWebAppsAsync("sub123", "rg1", "test-app",
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/WebappGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/WebappGetCommandTests.cs
@@ -52,12 +52,8 @@ public class WebappGetCommandTests : CommandUnitTestsBase<WebappGetCommand, IApp
         await Service.Received(1).GetWebAppsAsync(subscription, resourceGroup, appName, Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
 
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AppServiceJsonContext.Default.WebappGetResult);
 
-        var result = ConvertResponse(response, AppServiceJsonContext.Default.WebappGetResult);
-
-        Assert.NotNull(result);
         Assert.Equal(JsonSerializer.Serialize(expectedWebappDetails), JsonSerializer.Serialize(result.Webapps));
     }
 

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/src/AssemblyInfo.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/src/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Azure.Mcp.Tools.ApplicationInsights.UnitTests")]

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/tests/Azure.Mcp.Tools.ApplicationInsights.UnitTests/RecommendationListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/tests/Azure.Mcp.Tools.ApplicationInsights.UnitTests/RecommendationListCommandTests.cs
@@ -32,10 +32,8 @@ public class RecommendationListCommandTests : CommandUnitTestsBase<Recommendatio
 
         var response = await ExecuteCommandAsync("--subscription", "sub1");
 
-        Assert.NotNull(response.Results);
-
-        var node = ConvertResponse(response, ApplicationInsightsJsonContext.Default.RecommendationListCommandResult);
-        var recs = node?.Recommendations;
+        var node = ValidateAndDeserializeResponse(response, ApplicationInsightsJsonContext.Default.RecommendationListCommandResult);
+        var recs = node.Recommendations;
         Assert.NotNull(recs);
         Assert.Equal(2, recs.Count());
     }

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/tests/Azure.Mcp.Tools.ApplicationInsights.UnitTests/RecommendationListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/tests/Azure.Mcp.Tools.ApplicationInsights.UnitTests/RecommendationListCommandTests.cs
@@ -1,74 +1,57 @@
-using System.CommandLine;
-using System.Text.Json;
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Text.Json.Nodes;
+using Azure.Mcp.Tools.ApplicationInsights.Commands;
 using Azure.Mcp.Tools.ApplicationInsights.Commands.Recommendation;
 using Azure.Mcp.Tools.ApplicationInsights.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using Xunit;
 
 namespace Azure.Mcp.Tools.ApplicationInsights.UnitTests;
 
-public class RecommendationListCommandTests
+public class RecommendationListCommandTests : CommandUnitTestsBase<RecommendationListCommand, IApplicationInsightsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IApplicationInsightsService _applicationInsightsService;
-    private readonly ILogger<RecommendationListCommand> _logger;
-    private readonly RecommendationListCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public RecommendationListCommandTests()
-    {
-        _applicationInsightsService = Substitute.For<IApplicationInsightsService>();
-        _logger = Substitute.For<ILogger<RecommendationListCommand>>();
-        _command = new(_logger, _applicationInsightsService);
-        _commandDefinition = _command.GetCommand();
-        _serviceProvider = new ServiceCollection()
-            .BuildServiceProvider();
-        _context = new(_serviceProvider);
-    }
-
     [Fact]
     public async Task ExecuteAsync_WhenServiceReturnsInsights_SetsResults()
     {
-        var insights = new List<JsonNode?>
+        var insights = new List<JsonNode>
         {
-            JsonNode.Parse("{ \"id\": \"rec1\", \"type\": \"cpu\" }")!,
-            JsonNode.Parse("{ \"id\": \"rec2\", \"type\": \"memory\" }")!
+            new JsonObject([new("id", "rec1"), new("type", "cpu")]),
+            new JsonObject([new("id", "rec2"), new("type", "memory")])
         };
-        _applicationInsightsService.GetProfilerInsightsAsync(
+        Service.GetProfilerInsightsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IEnumerable<JsonNode>>(insights!));
-        var args = _commandDefinition.Parse(["--subscription", "sub1"]);
-        await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
-        Assert.NotNull(_context.Response.Results);
-        var json = JsonSerializer.Serialize(_context.Response.Results);
-        var node = JsonNode.Parse(json);
-        var recs = node?["recommendations"]?.AsArray();
+            .Returns(insights);
+
+        var response = await ExecuteCommandAsync("--subscription", "sub1");
+
+        Assert.NotNull(response.Results);
+
+        var node = ConvertResponse(response, ApplicationInsightsJsonContext.Default.RecommendationListCommandResult);
+        var recs = node?.Recommendations;
         Assert.NotNull(recs);
-        Assert.Equal(2, recs!.Count);
+        Assert.Equal(2, recs.Count());
     }
 
     [Fact]
     public async Task ExecuteAsync_WhenServiceReturnsNoInsights_NoResults()
     {
-        _applicationInsightsService.GetProfilerInsightsAsync(
+        Service.GetProfilerInsightsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IEnumerable<JsonNode>>(Array.Empty<JsonNode>()));
-        var args = _commandDefinition.Parse(["--subscription", "sub1"]);
-        await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
-        Assert.Null(_context.Response.Results);
+            .Returns([]);
+
+        var response = await ExecuteCommandAsync("--subscription", "sub1");
+        Assert.Null(response.Results);
     }
 }

--- a/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.UnitTests/RoleAssignmentListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.UnitTests/RoleAssignmentListCommandTests.cs
@@ -1,46 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.Authorization.Commands;
 using Azure.Mcp.Tools.Authorization.Models;
 using Azure.Mcp.Tools.Authorization.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Authorization.UnitTests;
 
-public class RoleAssignmentListCommandTests
+public class RoleAssignmentListCommandTests : CommandUnitTestsBase<RoleAssignmentListCommand, IAuthorizationService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAuthorizationService _authorizationService;
-    private readonly ILogger<RoleAssignmentListCommand> _logger;
-    private readonly RoleAssignmentListCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public RoleAssignmentListCommandTests()
-    {
-        _authorizationService = Substitute.For<IAuthorizationService>();
-        _logger = Substitute.For<ILogger<RoleAssignmentListCommand>>();
-
-        _command = new(_logger, _authorizationService);
-        _commandDefinition = _command.GetCommand();
-        // CommandContext requires an IServiceProvider, but these tests do not resolve any services,
-        // so an empty ServiceProvider is sufficient and intentionally used here.
-        _serviceProvider = new ServiceCollection()
-            .BuildServiceProvider();
-        _context = new(_serviceProvider);
-    }
-
     [Fact]
     public async Task ExecuteAsync_ReturnsRoleAssignments_WhenRoleAssignmentsExist()
     {
@@ -74,27 +49,22 @@ public class RoleAssignmentListCommandTests
                 Condition = "ActionMatches{'Microsoft.Authorization/roleAssignments/write'}"
             }
         ], false);
-        _authorizationService.ListRoleAssignmentsAsync(
-                Arg.Is(subscriptionId),
-                Arg.Is(scope),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ListRoleAssignmentsAsync(
+            Arg.Is(subscriptionId),
+            Arg.Is(scope),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedRoleAssignments);
-        var args = _commandDefinition.Parse([
-            "--subscription", subscriptionId,
-            "--scope", scope,
-        ]);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId, "--scope", scope);
 
         // Assert
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);
+        var result = ConvertResponse(response, AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);
 
         Assert.NotNull(result);
         Assert.Equal(expectedRoleAssignments.Results, result.Assignments);
@@ -106,23 +76,17 @@ public class RoleAssignmentListCommandTests
         // Arrange
         var subscriptionId = "00000000-0000-0000-0000-000000000001";
         var scope = $"/subscriptions/{subscriptionId}/resourceGroups/rg1";
-        _authorizationService.ListRoleAssignmentsAsync(subscriptionId, scope, null, null, TestContext.Current.CancellationToken)
+        Service.ListRoleAssignmentsAsync(subscriptionId, scope, null, null, TestContext.Current.CancellationToken)
             .Returns(new ResourceQueryResults<RoleAssignment>([], false));
 
-        var args = _commandDefinition.Parse([
-            "--subscription", subscriptionId,
-            "--scope", scope
-        ]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId, "--scope", scope);
 
         // Assert
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);
+        var result = ConvertResponse(response, AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);
 
         Assert.NotNull(result);
         Assert.Empty(result.Assignments);
@@ -136,16 +100,11 @@ public class RoleAssignmentListCommandTests
         var subscriptionId = "00000000-0000-0000-0000-000000000001";
         var scope = $"/subscriptions/{subscriptionId}/resourceGroups/rg1";
 
-        _authorizationService.ListRoleAssignmentsAsync(subscriptionId, scope, null, null, TestContext.Current.CancellationToken)
+        Service.ListRoleAssignmentsAsync(subscriptionId, scope, null, null, TestContext.Current.CancellationToken)
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse([
-            "--subscription", subscriptionId,
-            "--scope", scope
-        ]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId, "--scope", scope);
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.UnitTests/RoleAssignmentListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.UnitTests/RoleAssignmentListCommandTests.cs
@@ -61,12 +61,8 @@ public class RoleAssignmentListCommandTests : CommandUnitTestsBase<RoleAssignmen
         var response = await ExecuteCommandAsync("--subscription", subscriptionId, "--scope", scope);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);
 
-        var result = ConvertResponse(response, AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(expectedRoleAssignments.Results, result.Assignments);
     }
 
@@ -83,12 +79,8 @@ public class RoleAssignmentListCommandTests : CommandUnitTestsBase<RoleAssignmen
         var response = await ExecuteCommandAsync("--subscription", subscriptionId, "--scope", scope);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);
 
-        var result = ConvertResponse(response, AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Assignments);
     }
 

--- a/tools/Azure.Mcp.Tools.AzureIsv/tests/Azure.Mcp.Tools.AzureIsv.UnitTests/Datadog/MonitoredResourcesListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureIsv/tests/Azure.Mcp.Tools.AzureIsv.UnitTests/Datadog/MonitoredResourcesListCommandTests.cs
@@ -4,31 +4,15 @@
 using System.Net;
 using Azure.Mcp.Tools.AzureIsv.Commands.Datadog;
 using Azure.Mcp.Tools.AzureIsv.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureIsv.UnitTests.Datadog;
 
-public class MonitoredResourcesListCommandTests
+public class MonitoredResourcesListCommandTests : CommandUnitTestsBase<MonitoredResourcesListCommand, IDatadogService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IDatadogService _datadogService;
-    private readonly ILogger<MonitoredResourcesListCommand> _logger;
-
-    public MonitoredResourcesListCommandTests()
-    {
-        _datadogService = Substitute.For<IDatadogService>();
-        _logger = Substitute.For<ILogger<MonitoredResourcesListCommand>>();
-
-        var collection = new ServiceCollection();
-
-        _serviceProvider = collection.BuildServiceProvider();
-    }
-
     [Fact]
     public async Task ExecuteAsync_ReturnsResources_WhenResourcesExist()
     {
@@ -37,15 +21,14 @@ public class MonitoredResourcesListCommandTests
             "/subscriptions/1234/resourceGroups/rg-demo/providers/Microsoft.Datadog/monitors/app-demo-1",
             "/subscriptions/1234/resourceGroups/rg-demo/providers/Microsoft.Datadog/monitors/vm-demo-2"
         };
-        _datadogService.ListMonitoredResources(Arg.Is("rg1"), Arg.Is("sub123"), Arg.Is("datadog1"), Arg.Any<CancellationToken>())
+        Service.ListMonitoredResources(Arg.Is("rg1"), Arg.Is("sub123"), Arg.Is("datadog1"), Arg.Any<CancellationToken>())
             .Returns(expectedResources);
 
-        var command = new MonitoredResourcesListCommand(_logger, _datadogService);
-        var args = command.GetCommand().Parse($"--subscription sub123 --resource-group rg1 --datadog-resource datadog1");
-        var context = new CommandContext(_serviceProvider);
-
         // Act
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub123",
+            "--resource-group", "rg1",
+            "--datadog-resource", "datadog1");
 
         // Assert
         Assert.NotNull(response);
@@ -56,15 +39,14 @@ public class MonitoredResourcesListCommandTests
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoResources()
     {
         // Arrange
-        _datadogService.ListMonitoredResources("rg1", "sub123", "datadog1", Arg.Any<CancellationToken>())
+        Service.ListMonitoredResources("rg1", "sub123", "datadog1", Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var command = new MonitoredResourcesListCommand(_logger, _datadogService);
-        var args = command.GetCommand().Parse($"--subscription sub123 --resource-group rg1 --datadog-resource datadog1");
-        var context = new CommandContext(_serviceProvider);
-
         // Act
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub123",
+            "--resource-group", "rg1",
+            "--datadog-resource", "datadog1");
 
         // Assert
         Assert.NotNull(response);
@@ -75,15 +57,14 @@ public class MonitoredResourcesListCommandTests
     {
         // Arrange
         var expectedError = "Missing required arguments: datadog-resource";
-        _datadogService.ListMonitoredResources("rg1", "sub123", "datadog1", Arg.Any<CancellationToken>())
+        Service.ListMonitoredResources("rg1", "sub123", "datadog1", Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var command = new MonitoredResourcesListCommand(_logger, _datadogService);
-        var args = command.GetCommand().Parse($"--subscription sub123 --resource-group rg1 --datadog-resource datadog1");
-        var context = new CommandContext(_serviceProvider);
-
         // Act
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub123",
+            "--resource-group", "rg1",
+            "--datadog-resource", "datadog1");
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.UnitTests/PlatformLandingZone/GetGuidanceCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.UnitTests/PlatformLandingZone/GetGuidanceCommandTests.cs
@@ -53,12 +53,8 @@ public class GetGuidanceCommandTests : CommandUnitTestsBase<GetGuidanceCommand, 
         var response = await ExecuteCommandAsync("--scenario", "bastion");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
 
-        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
-
-        Assert.NotNull(result);
         Assert.Contains("Bastion guidance", result.Guidance);
     }
 
@@ -73,12 +69,8 @@ public class GetGuidanceCommandTests : CommandUnitTestsBase<GetGuidanceCommand, 
         var response = await ExecuteCommandAsync("--scenario", "ddos");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
 
-        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotEmpty(result.Guidance);
     }
 
@@ -96,11 +88,8 @@ public class GetGuidanceCommandTests : CommandUnitTestsBase<GetGuidanceCommand, 
         var response = await ExecuteCommandAsync("--scenario", "policy-enforcement", "--policy-name", "ddos");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
 
-        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
-
-        Assert.NotNull(result);
         Assert.Contains("Enable-DDoS-VNET", result.Guidance);
         Assert.Contains("corp", result.Guidance);
         Assert.Contains("connectivity", result.Guidance);
@@ -124,11 +113,8 @@ public class GetGuidanceCommandTests : CommandUnitTestsBase<GetGuidanceCommand, 
         var response = await ExecuteCommandAsync("--scenario", "policy-assignment", "--list-policies", "true");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
 
-        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
-
-        Assert.NotNull(result);
         Assert.Contains("All Policies by Archetype", result.Guidance);
         Assert.Contains("Enable-DDoS-VNET", result.Guidance);
         Assert.Contains("Deny-Public-IP", result.Guidance);
@@ -149,11 +135,8 @@ public class GetGuidanceCommandTests : CommandUnitTestsBase<GetGuidanceCommand, 
         var response = await ExecuteCommandAsync("--scenario", "policy-enforcement", "--policy-name", "nonexistent");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
 
-        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
-
-        Assert.NotNull(result);
         Assert.Contains("No policies matching 'nonexistent' found", result.Guidance);
         Assert.Contains("list-policies", result.Guidance);
     }

--- a/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.UnitTests/PlatformLandingZone/GetGuidanceCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.UnitTests/PlatformLandingZone/GetGuidanceCommandTests.cs
@@ -1,44 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
+using Azure.Mcp.Tools.AzureMigrate.Commands;
 using Azure.Mcp.Tools.AzureMigrate.Commands.PlatformLandingZone;
 using Azure.Mcp.Tools.AzureMigrate.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
-using static Azure.Mcp.Tools.AzureMigrate.Services.PlatformLandingZoneGuidanceService;
+using Microsoft.Mcp.Tests.Client;
+using NSubstitute.ExceptionExtensions;
 
 namespace Azure.Mcp.Tools.AzureMigrate.UnitTests.PlatformLandingZone;
 
-public class GetGuidanceCommandTests
+public class GetGuidanceCommandTests : CommandUnitTestsBase<GetGuidanceCommand, IPlatformLandingZoneGuidanceService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<GetGuidanceCommand> _logger;
-    private readonly IPlatformLandingZoneGuidanceService _guidanceService;
-    private readonly GetGuidanceCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public GetGuidanceCommandTests()
-    {
-        _logger = Substitute.For<ILogger<GetGuidanceCommand>>();
-        _guidanceService = Substitute.For<IPlatformLandingZoneGuidanceService>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_guidanceService);
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _guidanceService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
+        var command = Command.GetCommand();
         Assert.Equal("getguidance", command.Name);
         Assert.NotNull(command.Description);
         Assert.NotEmpty(command.Description);
@@ -52,12 +30,11 @@ public class GetGuidanceCommandTests
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args)
     {
         // Arrange
-        _guidanceService.GetGuidanceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        Service.GetGuidanceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns("Sample guidance response");
 
         // Act
-        var parseResult = _commandDefinition.Parse(args);
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -69,20 +46,17 @@ public class GetGuidanceCommandTests
     public async Task ExecuteAsync_ReturnsGuidance_ForValidScenario()
     {
         // Arrange
-        _guidanceService.GetGuidanceAsync("bastion", Arg.Any<CancellationToken>())
+        Service.GetGuidanceAsync("bastion", Arg.Any<CancellationToken>())
             .Returns("Bastion guidance: To enable Bastion, configure...");
 
-        var parseResult = _commandDefinition.Parse(["--scenario", "bastion"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--scenario", "bastion");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, Commands.AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
+        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
 
         Assert.NotNull(result);
         Assert.Contains("Bastion guidance", result.Guidance);
@@ -92,20 +66,17 @@ public class GetGuidanceCommandTests
     public async Task ExecuteAsync_DeserializationValidation()
     {
         // Arrange
-        _guidanceService.GetGuidanceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        Service.GetGuidanceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns("DDoS guidance: To enable DDoS protection...");
 
-        var parseResult = _commandDefinition.Parse(["--scenario", "ddos"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--scenario", "ddos");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, Commands.AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
+        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
 
         Assert.NotNull(result);
         Assert.NotEmpty(result.Guidance);
@@ -115,27 +86,19 @@ public class GetGuidanceCommandTests
     public async Task ExecuteAsync_WithPolicyName_SearchesForPolicies()
     {
         // Arrange
-        _guidanceService.GetGuidanceAsync("policy-enforcement", Arg.Any<CancellationToken>())
+        Service.GetGuidanceAsync("policy-enforcement", Arg.Any<CancellationToken>())
             .Returns("Policy enforcement guidance...");
 
-        _guidanceService.SearchPoliciesAsync("ddos", Arg.Any<CancellationToken>())
-            .Returns([
-                new PolicyLocationResult("Enable-DDoS-VNET", ["corp", "connectivity"])
-            ]);
-
-        var parseResult = _commandDefinition.Parse([
-            "--scenario", "policy-enforcement",
-            "--policy-name", "ddos"
-        ]);
+        Service.SearchPoliciesAsync("ddos", Arg.Any<CancellationToken>())
+            .Returns([new("Enable-DDoS-VNET", ["corp", "connectivity"])]);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--scenario", "policy-enforcement", "--policy-name", "ddos");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, Commands.AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
+        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
 
         Assert.NotNull(result);
         Assert.Contains("Enable-DDoS-VNET", result.Guidance);
@@ -147,29 +110,23 @@ public class GetGuidanceCommandTests
     public async Task ExecuteAsync_WithListPolicies_ReturnsAllPolicies()
     {
         // Arrange
-        _guidanceService.GetGuidanceAsync("policy-assignment", Arg.Any<CancellationToken>())
+        Service.GetGuidanceAsync("policy-assignment", Arg.Any<CancellationToken>())
             .Returns("Policy assignment guidance...");
 
-        _guidanceService.GetAllPoliciesAsync(Arg.Any<CancellationToken>())
+        Service.GetAllPoliciesAsync(Arg.Any<CancellationToken>())
             .Returns(new Dictionary<string, List<string>>
             {
                 ["corp"] = ["Enable-DDoS-VNET", "Deny-Public-IP"],
                 ["connectivity"] = ["Deploy-ASC-Monitoring"]
             });
 
-        var parseResult = _commandDefinition.Parse([
-            "--scenario", "policy-assignment",
-            "--list-policies", "true"
-        ]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--scenario", "policy-assignment", "--list-policies", "true");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, Commands.AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
+        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
 
         Assert.NotNull(result);
         Assert.Contains("All Policies by Archetype", result.Guidance);
@@ -182,25 +139,19 @@ public class GetGuidanceCommandTests
     public async Task ExecuteAsync_PolicyNotFound_SuggestsListPolicies()
     {
         // Arrange
-        _guidanceService.GetGuidanceAsync("policy-enforcement", Arg.Any<CancellationToken>())
+        Service.GetGuidanceAsync("policy-enforcement", Arg.Any<CancellationToken>())
             .Returns("Policy enforcement guidance...");
 
-        _guidanceService.SearchPoliciesAsync("nonexistent", Arg.Any<CancellationToken>())
+        Service.SearchPoliciesAsync("nonexistent", Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var parseResult = _commandDefinition.Parse([
-            "--scenario", "policy-enforcement",
-            "--policy-name", "nonexistent"
-        ]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--scenario", "policy-enforcement", "--policy-name", "nonexistent");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, Commands.AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
+        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.GetGuidanceCommandResult);
 
         Assert.NotNull(result);
         Assert.Contains("No policies matching 'nonexistent' found", result.Guidance);
@@ -212,20 +163,18 @@ public class GetGuidanceCommandTests
     {
         // Arrange
         var expectedException = new InvalidOperationException("Service error occurred");
-        _guidanceService.GetGuidanceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<string>(expectedException));
-
-        var parseResult = _commandDefinition.Parse(["--scenario", "bastion"]);
+        Service.GetGuidanceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(expectedException);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--scenario", "bastion");
 
         // Assert
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
         Assert.Contains("error", response.Message, StringComparison.OrdinalIgnoreCase);
 
         // Verify logging
-        _logger.Received(1).Log(
+        Logger.Received(1).Log(
             LogLevel.Error,
             Arg.Any<EventId>(),
             Arg.Is<object>(o => o.ToString()!.Contains("Error fetching guidance for scenario")),
@@ -238,20 +187,18 @@ public class GetGuidanceCommandTests
     {
         // Arrange
         var httpException = new HttpRequestException("Network error", null, HttpStatusCode.ServiceUnavailable);
-        _guidanceService.GetGuidanceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<string>(httpException));
-
-        var parseResult = _commandDefinition.Parse(["--scenario", "ddos"]);
+        Service.GetGuidanceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(httpException);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--scenario", "ddos");
 
         // Assert
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Message);
 
         // Verify the exception was logged
-        _logger.Received(1).Log(
+        Logger.Received(1).Log(
             LogLevel.Error,
             Arg.Any<EventId>(),
             Arg.Any<object>(),
@@ -264,19 +211,17 @@ public class GetGuidanceCommandTests
     {
         // Arrange
         var argumentException = new ArgumentException("Invalid scenario", "scenario");
-        _guidanceService.GetGuidanceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<string>(argumentException));
-
-        var parseResult = _commandDefinition.Parse(["--scenario", "invalid-scenario"]);
+        Service.GetGuidanceAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(argumentException);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--scenario", "invalid-scenario");
 
         // Assert
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
 
         // Verify error was logged
-        _logger.Received(1).Log(
+        Logger.Received(1).Log(
             LogLevel.Error,
             Arg.Any<EventId>(),
             Arg.Any<object>(),

--- a/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.UnitTests/PlatformLandingZone/RequestCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.UnitTests/PlatformLandingZone/RequestCommandTests.cs
@@ -1,53 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using System.Text.Json;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.AzureMigrate.Commands;
 using Azure.Mcp.Tools.AzureMigrate.Commands.PlatformLandingZone;
-using Azure.Mcp.Tools.AzureMigrate.Helpers;
 using Azure.Mcp.Tools.AzureMigrate.Models;
 using Azure.Mcp.Tools.AzureMigrate.Services;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute.ExceptionExtensions;
 
 namespace Azure.Mcp.Tools.AzureMigrate.UnitTests.PlatformLandingZone;
 
-public class RequestCommandTests
+public class RequestCommandTests : CommandUnitTestsBase<RequestCommand, IPlatformLandingZoneService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IPlatformLandingZoneService _platformLandingZoneService;
-    private readonly ILogger<RequestCommand> _logger;
-    private readonly RequestCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public RequestCommandTests()
+    public RequestCommandTests() : base(serviceCollection =>
     {
-        _platformLandingZoneService = Substitute.For<IPlatformLandingZoneService>();
-        _logger = Substitute.For<ILogger<RequestCommand>>();
-
-        var subscriptionService = Substitute.For<ISubscriptionService>();
-        var tenantService = Substitute.For<ITenantService>();
-        var azureMigrateProjectHelper = new AzureMigrateProjectHelper(subscriptionService, tenantService);
-
-        var collection = new ServiceCollection().AddSingleton(_platformLandingZoneService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _platformLandingZoneService, azureMigrateProjectHelper);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
+        serviceCollection.AddSingleton(Substitute.For<ISubscriptionService>());
+        serviceCollection.AddSingleton(Substitute.For<ITenantService>());
+    })
+    {
     }
 
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
+        var command = Command.GetCommand();
         Assert.Equal("request", command.Name);
         Assert.NotNull(command.Description);
         Assert.NotEmpty(command.Description);
@@ -85,7 +66,7 @@ public class RequestCommandTests
                 CachedAt = DateTime.UtcNow
             };
 
-            _platformLandingZoneService.UpdateParametersAsync(
+            Service.UpdateParametersAsync(
                 Arg.Any<PlatformLandingZoneContext>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -98,30 +79,28 @@ public class RequestCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(parameters));
+                .Returns(parameters);
 
-            _platformLandingZoneService.DownloadAsync(
+            Service.DownloadAsync(
                 Arg.Any<PlatformLandingZoneContext>(),
                 Arg.Any<string>(),
                 Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult("/path/to/downloaded/file.zip"));
+                .Returns("/path/to/downloaded/file.zip");
 
-            _platformLandingZoneService.GenerateAsync(
+            Service.GenerateAsync(
                 Arg.Any<PlatformLandingZoneContext>(),
                 Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult<string?>("https://download.url/file.zip"));
+                .Returns("https://download.url/file.zip");
 
-            _platformLandingZoneService.GetParameterStatus(Arg.Any<PlatformLandingZoneContext>())
+            Service.GetParameterStatus(Arg.Any<PlatformLandingZoneContext>())
                 .Returns("Status message");
 
-            _platformLandingZoneService.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
+            Service.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
                 .Returns(new List<string>());
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -161,7 +140,7 @@ public class RequestCommandTests
             CachedAt = DateTime.UtcNow
         };
 
-        _platformLandingZoneService.UpdateParametersAsync(
+        Service.UpdateParametersAsync(
             Arg.Is<PlatformLandingZoneContext>(ctx =>
                 ctx.SubscriptionId == subscription &&
                 ctx.ResourceGroupName == resourceGroup &&
@@ -177,30 +156,26 @@ public class RequestCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(updatedParameters));
+            .Returns(updatedParameters);
 
-        _platformLandingZoneService.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
-            .Returns(new List<string>());
+        Service.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
+            .Returns([]);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--action", "update",
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--migrate-project-name", projectName,
             "--region-type", regionType,
-            "--firewall-type", fireWallType
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--firewall-type", fireWallType);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureMigrateJsonContext.Default.RequestCommandResult);
+        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
 
         Assert.NotNull(result);
         Assert.Contains("Parameters updated successfully", result.Message);
@@ -216,24 +191,21 @@ public class RequestCommandTests
         var projectName = "project1";
         var downloadedPath = "/path/to/downloaded/file.zip";
 
-        _platformLandingZoneService.DownloadAsync(
+        Service.DownloadAsync(
             Arg.Is<PlatformLandingZoneContext>(ctx =>
                 ctx.SubscriptionId == subscription &&
                 ctx.ResourceGroupName == resourceGroup &&
                 ctx.MigrateProjectName == projectName),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(downloadedPath));
+            .Returns(downloadedPath);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--action", "download",
             "--subscription", subscription,
             "--resource-group", resourceGroup,
-            "--migrate-project-name", projectName
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--migrate-project-name", projectName);
 
         // Assert
         Assert.NotNull(response);
@@ -257,34 +229,30 @@ public class RequestCommandTests
         var downloadUrl = "https://download.url/landingzone.zip";
 
         // Mock that all parameters are provided
-        _platformLandingZoneService.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
-            .Returns(new List<string>());
+        Service.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
+            .Returns([]);
 
-        _platformLandingZoneService.GenerateAsync(
+        Service.GenerateAsync(
             Arg.Is<PlatformLandingZoneContext>(ctx =>
                 ctx.SubscriptionId == subscription &&
                 ctx.ResourceGroupName == resourceGroup &&
                 ctx.MigrateProjectName == projectName),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<string?>(downloadUrl));
+            .Returns(downloadUrl);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--action", "generate",
             "--subscription", subscription,
             "--resource-group", resourceGroup,
-            "--migrate-project-name", projectName
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--migrate-project-name", projectName);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureMigrateJsonContext.Default.RequestCommandResult);
+        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
 
         Assert.NotNull(result);
         Assert.Contains("Platform Landing zone generated successfully", result.Message);
@@ -300,37 +268,33 @@ public class RequestCommandTests
         var projectName = "project1";
 
         // Mock that defaults are applied (no missing parameters)
-        _platformLandingZoneService.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
-            .Returns(new List<string>());
+        Service.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
+            .Returns([]);
 
-        _platformLandingZoneService.GenerateAsync(
+        Service.GenerateAsync(
             Arg.Any<PlatformLandingZoneContext>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<string?>("https://download.url/landingzone.zip"));
+            .Returns("https://download.url/landingzone.zip");
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--action", "generate",
             "--subscription", subscription,
             "--resource-group", resourceGroup,
-            "--migrate-project-name", projectName
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--migrate-project-name", projectName);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureMigrateJsonContext.Default.RequestCommandResult);
+        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
 
         Assert.NotNull(result);
         Assert.Contains("Platform Landing zone generated successfully", result.Message);
 
         // Verify GenerateAsync was called
-        await _platformLandingZoneService.Received(1).GenerateAsync(
+        await Service.Received(1).GenerateAsync(
             Arg.Any<PlatformLandingZoneContext>(),
             Arg.Any<CancellationToken>());
     }
@@ -344,30 +308,26 @@ public class RequestCommandTests
         var projectName = "project1";
 
         // Mock that all parameters are provided
-        _platformLandingZoneService.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
-            .Returns(new List<string>());
+        Service.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
+            .Returns([]);
 
-        _platformLandingZoneService.GenerateAsync(
+        Service.GenerateAsync(
             Arg.Any<PlatformLandingZoneContext>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<string?>(null));
+            .Returns((string?)null);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--action", "generate",
             "--subscription", subscription,
             "--resource-group", resourceGroup,
-            "--migrate-project-name", projectName
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--migrate-project-name", projectName);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureMigrateJsonContext.Default.RequestCommandResult);
+        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
 
         Assert.NotNull(result);
         Assert.Contains("in progress", result.Message, StringComparison.OrdinalIgnoreCase);
@@ -382,29 +342,25 @@ public class RequestCommandTests
         var projectName = "project1";
         var statusMessage = "Parameters for sub123:rg1:project1:\n  Cached at: 2025-12-10\n  Complete: True";
 
-        _platformLandingZoneService.GetParameterStatus(
+        Service.GetParameterStatus(
             Arg.Is<PlatformLandingZoneContext>(ctx =>
                 ctx.SubscriptionId == subscription &&
                 ctx.ResourceGroupName == resourceGroup &&
                 ctx.MigrateProjectName == projectName))
             .Returns(statusMessage);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--action", "status",
             "--subscription", subscription,
             "--resource-group", resourceGroup,
-            "--migrate-project-name", projectName
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--migrate-project-name", projectName);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureMigrateJsonContext.Default.RequestCommandResult);
+        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
 
         Assert.NotNull(result);
         Assert.Equal(statusMessage, result.Message);
@@ -418,15 +374,12 @@ public class RequestCommandTests
         var resourceGroup = "rg1";
         var projectName = "project1";
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--action", "invalid-action",
             "--subscription", subscription,
             "--resource-group", resourceGroup,
-            "--migrate-project-name", projectName
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--migrate-project-name", projectName);
 
         // Assert
         Assert.NotNull(response);
@@ -442,21 +395,18 @@ public class RequestCommandTests
         var resourceGroup = "rg1";
         var projectName = "project1";
 
-        _platformLandingZoneService.DownloadAsync(
+        Service.DownloadAsync(
             Arg.Any<PlatformLandingZoneContext>(),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Service error"));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--action", "download",
             "--subscription", subscription,
             "--resource-group", resourceGroup,
-            "--migrate-project-name", projectName
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--migrate-project-name", projectName);
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -471,23 +421,20 @@ public class RequestCommandTests
         var resourceGroup = "rg1";
         var projectName = "project1";
 
-        _platformLandingZoneService.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
-            .Returns(new List<string>());
+        Service.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
+            .Returns([]);
 
-        _platformLandingZoneService.GenerateAsync(
+        Service.GenerateAsync(
             Arg.Any<PlatformLandingZoneContext>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("HTTP request failed"));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--action", "generate",
             "--subscription", subscription,
             "--resource-group", resourceGroup,
-            "--migrate-project-name", projectName
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--migrate-project-name", projectName);
 
         // Assert
         Assert.True(response.Status == HttpStatusCode.BadGateway || response.Status == HttpStatusCode.ServiceUnavailable);
@@ -502,23 +449,20 @@ public class RequestCommandTests
         var resourceGroup = "rg1";
         var projectName = "project1";
 
-        _platformLandingZoneService.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
-            .Returns(new List<string>());
+        Service.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
+            .Returns([]);
 
-        _platformLandingZoneService.GenerateAsync(
+        Service.GenerateAsync(
             Arg.Any<PlatformLandingZoneContext>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Missing required parameters"));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--action", "generate",
             "--subscription", subscription,
             "--resource-group", resourceGroup,
-            "--migrate-project-name", projectName
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--migrate-project-name", projectName);
 
         // Assert
         Assert.True(response.Status == HttpStatusCode.BadRequest || response.Status == HttpStatusCode.InternalServerError);
@@ -533,7 +477,7 @@ public class RequestCommandTests
         var resourceGroup = "rg1";
         var projectName = "project1";
 
-        _platformLandingZoneService.UpdateParametersAsync(
+        Service.UpdateParametersAsync(
             Arg.Any<PlatformLandingZoneContext>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -548,16 +492,13 @@ public class RequestCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException("regionType must be 'single' or 'multi'"));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--action", "update",
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--migrate-project-name", projectName,
-            "--region-type", "invalid"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--region-type", "invalid");
 
         // Assert
         Assert.True(response.Status == HttpStatusCode.BadRequest || response.Status == HttpStatusCode.InternalServerError);
@@ -587,7 +528,7 @@ public class RequestCommandTests
             CachedAt = DateTime.UtcNow
         };
 
-        _platformLandingZoneService.UpdateParametersAsync(
+        Service.UpdateParametersAsync(
             Arg.Any<PlatformLandingZoneContext>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -600,12 +541,13 @@ public class RequestCommandTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(completeParameters));
+            .Returns(completeParameters);
 
-        _platformLandingZoneService.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
-            .Returns(new List<string>());
+        Service.GetMissingParameters(Arg.Any<PlatformLandingZoneContext>())
+            .Returns([]);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--action", "update",
             "--subscription", subscription,
             "--resource-group", resourceGroup,
@@ -619,18 +561,13 @@ public class RequestCommandTests
             "--regions", "eastus,westus",
             "--environment-name", "prod",
             "--version-control-system", "github",
-            "--organization-name", "myorg"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--organization-name", "myorg");
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureMigrateJsonContext.Default.RequestCommandResult);
+        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
 
         Assert.NotNull(result);
         Assert.Contains("Complete: True", result.Message);
@@ -640,7 +577,7 @@ public class RequestCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var args = _commandDefinition.Parse([
+        var args = CommandDefinition.Parse([
             "--action", "update",
             "--subscription", "sub123",
             "--resource-group", "rg1",

--- a/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.UnitTests/PlatformLandingZone/RequestCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.UnitTests/PlatformLandingZone/RequestCommandTests.cs
@@ -7,6 +7,7 @@ using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.AzureMigrate.Commands;
 using Azure.Mcp.Tools.AzureMigrate.Commands.PlatformLandingZone;
+using Azure.Mcp.Tools.AzureMigrate.Helpers;
 using Azure.Mcp.Tools.AzureMigrate.Models;
 using Azure.Mcp.Tools.AzureMigrate.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,6 +22,7 @@ public class RequestCommandTests : CommandUnitTestsBase<RequestCommand, IPlatfor
     {
         serviceCollection.AddSingleton(Substitute.For<ISubscriptionService>());
         serviceCollection.AddSingleton(Substitute.For<ITenantService>());
+        serviceCollection.AddSingleton<AzureMigrateProjectHelper>();
     })
     {
     }

--- a/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.UnitTests/PlatformLandingZone/RequestCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.UnitTests/PlatformLandingZone/RequestCommandTests.cs
@@ -171,13 +171,8 @@ public class RequestCommandTests : CommandUnitTestsBase<RequestCommand, IPlatfor
             "--firewall-type", fireWallType);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
 
-        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
-
-        Assert.NotNull(result);
         Assert.Contains("Parameters updated successfully", result.Message);
         Assert.Contains("Complete: True", result.Message);
     }
@@ -248,13 +243,8 @@ public class RequestCommandTests : CommandUnitTestsBase<RequestCommand, IPlatfor
             "--migrate-project-name", projectName);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
 
-        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
-
-        Assert.NotNull(result);
         Assert.Contains("Platform Landing zone generated successfully", result.Message);
         Assert.Contains(downloadUrl, result.Message);
     }
@@ -284,13 +274,8 @@ public class RequestCommandTests : CommandUnitTestsBase<RequestCommand, IPlatfor
             "--migrate-project-name", projectName);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
 
-        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
-
-        Assert.NotNull(result);
         Assert.Contains("Platform Landing zone generated successfully", result.Message);
 
         // Verify GenerateAsync was called
@@ -324,12 +309,8 @@ public class RequestCommandTests : CommandUnitTestsBase<RequestCommand, IPlatfor
             "--migrate-project-name", projectName);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
 
-        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
-
-        Assert.NotNull(result);
         Assert.Contains("in progress", result.Message, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -357,12 +338,8 @@ public class RequestCommandTests : CommandUnitTestsBase<RequestCommand, IPlatfor
             "--migrate-project-name", projectName);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
 
-        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(statusMessage, result.Message);
     }
 
@@ -564,12 +541,8 @@ public class RequestCommandTests : CommandUnitTestsBase<RequestCommand, IPlatfor
             "--organization-name", "myorg");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
 
-        var result = ConvertResponse(response, AzureMigrateJsonContext.Default.RequestCommandResult);
-
-        Assert.NotNull(result);
         Assert.Contains("Complete: True", result.Message);
     }
 

--- a/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.UnitTests/BicepSchemaGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.UnitTests/BicepSchemaGetCommandTests.cs
@@ -14,11 +14,9 @@ public class BicepSchemaGetCommandTests : CommandUnitTestsBase<BicepSchemaGetCom
     public async Task ExecuteAsync_ReturnsSchema_WhenResourceTypeExists()
     {
         var response = await ExecuteCommandAsync("--resource-type", "Microsoft.Sql/servers/databases/schemas");
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
 
-        var result = ConvertResponse(response, BicepSchemaJsonContext.Default.BicepSchemaGetCommandResult);
-        var name = result?.BicepSchemaResult.FirstOrDefault()?.Name;
+        var result = ValidateAndDeserializeResponse(response, BicepSchemaJsonContext.Default.BicepSchemaGetCommandResult);
+        var name = result.BicepSchemaResult.FirstOrDefault()?.Name;
 
         Assert.Contains("Microsoft.Sql/servers/databases/schemas@2023-08-01", name);
     }

--- a/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.UnitTests/BicepSchemaGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.UnitTests/BicepSchemaGetCommandTests.cs
@@ -1,53 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
-using System.Text.Json;
 using Azure.Mcp.Tools.BicepSchema.Commands;
 using Azure.Mcp.Tools.BicepSchema.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
-using NSubstitute;
+using Microsoft.Mcp.Tests.Client;
 using Xunit;
 
 namespace Azure.Mcp.Tools.BicepSchema.UnitTests;
 
-public class BicepSchemaGetCommandTests
+public class BicepSchemaGetCommandTests : CommandUnitTestsBase<BicepSchemaGetCommand, IBicepSchemaService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IBicepSchemaService _bicepSchemaService;
-    private readonly ILogger<BicepSchemaGetCommand> _logger;
-    private readonly CommandContext _context;
-    private readonly BicepSchemaGetCommand _command;
-    private readonly Command _commandDefinition;
-
-    public BicepSchemaGetCommandTests()
-    {
-        _bicepSchemaService = Substitute.For<IBicepSchemaService>();
-        _logger = Substitute.For<ILogger<BicepSchemaGetCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_bicepSchemaService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _context = new(_serviceProvider);
-        _command = new(_logger);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public async Task ExecuteAsync_ReturnsSchema_WhenResourceTypeExists()
     {
-        var args = _commandDefinition.Parse("--resource-type Microsoft.Sql/servers/databases/schemas");
-
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-type", "Microsoft.Sql/servers/databases/schemas");
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, BicepSchemaJsonContext.Default.BicepSchemaGetCommandResult);
+        var result = ConvertResponse(response, BicepSchemaJsonContext.Default.BicepSchemaGetCommandResult);
         var name = result?.BicepSchemaResult.FirstOrDefault()?.Name;
 
         Assert.Contains("Microsoft.Sql/servers/databases/schemas@2023-08-01", name);
@@ -56,10 +26,7 @@ public class BicepSchemaGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenResourceTypeDoesNotExist()
     {
-
-        var args = _commandDefinition.Parse("--resource-type Microsoft.Unknown/virtualRandom");
-
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-type", "Microsoft.Unknown/virtualRandom");
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 

--- a/tools/Azure.Mcp.Tools.Communication/src/AssemblyInfo.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Azure.Mcp.Tools.Communication.UnitTests")]
+[assembly: InternalsVisibleTo("Azure.Mcp.Tools.Communication.LiveTests")]

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.UnitTests/Email/EmailSendCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.UnitTests/Email/EmailSendCommandTests.cs
@@ -1,43 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using System.Text.Json;
 using Azure.Mcp.Tools.Communication.Commands.Email;
 using Azure.Mcp.Tools.Communication.Models;
 using Azure.Mcp.Tools.Communication.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Communication.UnitTests.Email;
 
-public class EmailSendCommandTests
+public class EmailSendCommandTests : CommandUnitTestsBase<EmailSendCommand, ICommunicationService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ICommunicationService _mockCommunicationService;
-    private readonly ILogger<EmailSendCommand> _logger;
-    private readonly EmailSendCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public EmailSendCommandTests()
-    {
-        _mockCommunicationService = Substitute.For<ICommunicationService>();
-        _logger = Substitute.For<ILogger<EmailSendCommand>>();
-
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-
-        _command = new(_logger, _mockCommunicationService);
-        _context = new CommandContext(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Theory]
     [InlineData(null, "sender@example.com", "recipient@example.com", "Subject", "Message", false, "Missing endpoint")]
     [InlineData("", "sender@example.com", "recipient@example.com", "Subject", "Message", false, "Empty endpoint")]
@@ -66,8 +44,6 @@ public class EmailSendCommandTests
         if (message != null)
         { args.AddRange(["--message", message]); }
 
-        var parseResult = _commandDefinition.Parse(args.ToArray());
-
         if (shouldSucceed)
         {
             // Setup mock for success case
@@ -77,61 +53,41 @@ public class EmailSendCommandTests
                 Status = "Queued"
             };
 
-            _mockCommunicationService
-                .SendEmailAsync(
-                    Arg.Any<string>(),
-                    Arg.Any<string>(),
-                    Arg.Any<string>(),
-                    Arg.Any<string[]>(),
-                    Arg.Any<string>(),
-                    Arg.Any<string>(),
-                    Arg.Any<bool>(),
-                    Arg.Any<string[]>(),
-                    Arg.Any<string[]>(),
-                    Arg.Any<string[]>(),
-                    Arg.Any<string>(),
-                    Arg.Any<RetryPolicyOptions>(),
-                    Arg.Any<CancellationToken>())
+            Service.SendEmailAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string[]>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<bool>(),
+                Arg.Any<string[]>(),
+                Arg.Any<string[]>(),
+                Arg.Any<string[]>(),
+                Arg.Any<string>(),
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
                 .Returns(expectedResult);
+        }
 
-            // Act
-            var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        // Act
+        var response = await ExecuteCommandAsync(args.ToArray());
 
-            // Assert
+        // Assert
+        if (shouldSucceed)
+        {
             Assert.Equal(HttpStatusCode.OK, response.Status);
         }
         else
         {
-            // Act & Assert
-            if (parseResult.Errors.Count > 0)
+            if (response.Status == HttpStatusCode.BadRequest)
             {
-                // Parse-time validation errors (missing required options)
-                Assert.True(parseResult.Errors.Count > 0, $"Expected parse errors for scenario: {scenario}");
+                // This is expected for validation failures
+                Assert.Equal(HttpStatusCode.BadRequest, response.Status);
             }
             else
             {
-                // Runtime validation errors (empty values or command validation)
-                try
-                {
-                    var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
-
-                    // If we reach here without exception, check if it's a validation error response
-                    if (response.Status == HttpStatusCode.BadRequest)
-                    {
-                        // This is expected for validation failures
-                        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
-                    }
-                    else
-                    {
-                        Assert.Fail($"Expected validation failure for scenario: {scenario}, but got status: {response.Status}");
-                    }
-                }
-                catch (ArgumentException ex)
-                {
-                    // This is expected for service-level validation failures
-                    Assert.NotNull(ex.Message);
-                    Assert.NotEmpty(ex.Message);
-                }
+                Assert.Fail($"Expected validation failure for scenario: {scenario}, but got status: {response.Status}");
             }
         }
     }
@@ -148,41 +104,36 @@ public class EmailSendCommandTests
             "--message", "Test Message"
         ];
 
-        var parseResult = _commandDefinition.Parse(args);
-
         var expectedResult = new EmailSendResult
         {
             MessageId = "test-message-id",
             Status = "Queued"
         };
 
-        _mockCommunicationService
-            .SendEmailAsync(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string[]>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<bool>(),
-                Arg.Any<string[]>(),
-                Arg.Any<string[]>(),
-                Arg.Any<string[]>(),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.SendEmailAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string[]>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<bool>(),
+            Arg.Any<string[]>(),
+            Arg.Any<string[]>(),
+            Arg.Any<string[]>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
-        Console.WriteLine($"Response: {JsonSerializer.Serialize(response)}");
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.Equal(HttpStatusCode.OK, _context.Response.Status);
 
         // Verify service was called with correct parameters
-        await _mockCommunicationService.Received(1).SendEmailAsync(
+        await Service.Received(1).SendEmailAsync(
             "https://example.communication.azure.com",
             "sender@example.com",
             null,
@@ -195,18 +146,18 @@ public class EmailSendCommandTests
             null,
             null,
             null,
-            Arg.Any<CancellationToken>()
-        );
+            Arg.Any<CancellationToken>());
 
         // Verify the response contains the expected result
-        Assert.NotNull(_context.Response.Results);
-        var responseJson = JsonSerializer.Serialize(_context.Response.Results);
-        Assert.Contains(expectedResult.MessageId, responseJson);
-        Assert.Contains(expectedResult.Status, responseJson);
+        Assert.NotNull(response.Results);
+        var result = ConvertResponse(response, CommunicationJsonContext.Default.EmailSendCommandResult);
 
+        Assert.NotNull(result);
+        Assert.NotNull(result.Result);
+        
         // Verify the JSON can be properly deserialized (contains expected values)
-        Assert.Contains("test-message-id", responseJson);
-        Assert.Contains("Queued", responseJson);
+        Assert.Contains("test-message-id", result.Result.MessageId);
+        Assert.Contains("Queued", result.Result.Status);
     }
 
     [Fact]
@@ -221,10 +172,8 @@ public class EmailSendCommandTests
             "--message", "Test Message"
         ];
 
-        var parseResult = _commandDefinition.Parse(args);
-
         var expectedException = new RequestFailedException("Test error message");
-        _mockCommunicationService.SendEmailAsync(
+        Service.SendEmailAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -241,13 +190,12 @@ public class EmailSendCommandTests
             .ThrowsAsync(expectedException);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
-        Console.WriteLine($"Response: {JsonSerializer.Serialize(response)}");
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(_context.Response.Results);
-        var responseJson = JsonSerializer.Serialize(_context.Response.Results);
+        Assert.NotNull(response.Results);
+        var responseJson = JsonSerializer.Serialize(response.Results);
         Assert.Contains("Test error message", responseJson);
     }
 }

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.UnitTests/Email/EmailSendCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.UnitTests/Email/EmailSendCommandTests.cs
@@ -149,12 +149,10 @@ public class EmailSendCommandTests : CommandUnitTestsBase<EmailSendCommand, ICom
             Arg.Any<CancellationToken>());
 
         // Verify the response contains the expected result
-        Assert.NotNull(response.Results);
-        var result = ConvertResponse(response, CommunicationJsonContext.Default.EmailSendCommandResult);
+        var result = ValidateAndDeserializeResponse(response, CommunicationJsonContext.Default.EmailSendCommandResult);
 
-        Assert.NotNull(result);
         Assert.NotNull(result.Result);
-        
+
         // Verify the JSON can be properly deserialized (contains expected values)
         Assert.Contains("test-message-id", result.Result.MessageId);
         Assert.Contains("Queued", result.Result.Status);

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.UnitTests/Sms/SmsSendCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.UnitTests/Sms/SmsSendCommandTests.cs
@@ -1,73 +1,50 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using Azure.Mcp.Tools.Communication.Commands.Sms;
 using Azure.Mcp.Tools.Communication.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Communication.UnitTests.Sms;
 
-public class SmsSendCommandTests
+public class SmsSendCommandTests : CommandUnitTestsBase<SmsSendCommand, ICommunicationService>
 {
-    private readonly ICommunicationService _communicationService;
-    private readonly ILogger<SmsSendCommand> _logger;
-    private readonly SmsSendCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public SmsSendCommandTests()
-    {
-        _communicationService = Substitute.For<ICommunicationService>();
-        _logger = Substitute.For<ILogger<SmsSendCommand>>();
-
-        _command = new(_logger, _communicationService);
-        _context = new CommandContext(new ServiceCollection().BuildServiceProvider());
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_ShouldInitializeCorrectly()
     {
         // Assert
-        Assert.NotNull(_command);
-        Assert.Equal("send", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.NotEmpty(_command.Title);
+        Assert.NotNull(Command);
+        Assert.Equal("send", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.NotEmpty(Command.Title);
     }
 
     [Fact]
     public void Command_ShouldHaveRequiredOptions()
     {
         // Assert
-        Assert.NotNull(_commandDefinition);
-        Assert.Contains(_commandDefinition.Options, o => o.Name == "--endpoint");
-        Assert.Contains(_commandDefinition.Options, o => o.Name == "--from");
-        Assert.Contains(_commandDefinition.Options, o => o.Name == "--to");
-        Assert.Contains(_commandDefinition.Options, o => o.Name == "--message");
+        Assert.NotNull(CommandDefinition);
+        Assert.Contains(CommandDefinition.Options, o => o.Name == "--endpoint");
+        Assert.Contains(CommandDefinition.Options, o => o.Name == "--from");
+        Assert.Contains(CommandDefinition.Options, o => o.Name == "--to");
+        Assert.Contains(CommandDefinition.Options, o => o.Name == "--message");
     }
 
-    public static IEnumerable<object[]> ValidParameters => new List<object[]>
-    {
-        new object[] { "https://mycomm.communication.azure.com", "+1234567890", new string[] { "+1234567891" }, "Hello", true, "test" },
-        new object[] { "https://mycomm.communication.azure.com", "+1234567899", new string[] { "+1234567892", "+1234567893" }, "Hi", false, "" }
-    };
-
     [Theory]
-    [MemberData(nameof(ValidParameters))]
+    [InlineData("https://mycomm.communication.azure.com", "+1234567890", new[] { "+1234567891" }, "Hello", true, "test")]
+    [InlineData("https://mycomm.communication.azure.com", "+1234567899", new[] { "+1234567892", "+1234567893" }, "Hi", false, "")]
     public async Task ExecuteAsync_WithValidParameters_CallsServiceAndReturnsResults(string endpoint, string from, string[] to, string message, bool enableDeliveryReport, string? tag)
     {
         var results = new List<Models.SmsResult> {
-            new Models.SmsResult { MessageId = "msg1", To = to.First(), Successful = true, HttpStatusCode = 202 }
+            new() { MessageId = "msg1", To = to.First(), Successful = true, HttpStatusCode = 202 }
         };
-        _communicationService.SendSmsAsync(
+        Service.SendSmsAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(results));
+            .Returns(results);
 
         var args = new List<string>
         {
@@ -80,28 +57,24 @@ public class SmsSendCommandTests
             args.Add("--enable-delivery-report");
         if (!string.IsNullOrEmpty(tag))
         { args.Add("--tag"); args.Add(tag!); }
-        var parseResult = _commandDefinition.Parse(args.ToArray());
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args.ToArray());
 
         // Assert
         Assert.NotNull(response);
-        Assert.NotNull(_context.Response.Results);
+        Assert.NotNull(response.Results);
     }
 
     [Fact]
     public async Task ExecuteAsync_ServiceThrowsException_HandlesError()
     {
-        _communicationService.SendSmsAsync(
+        Service.SendSmsAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<Models.SmsResult>>(new InvalidOperationException("fail")));
-
-        var args = new[] { "--endpoint", "https://mycomm.communication.azure.com", "--from", "+1", "--to", "+2", "--message", "fail" };
-        var parseResult = _commandDefinition.Parse(args);
+            .ThrowsAsync(new InvalidOperationException("fail"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--endpoint", "https://mycomm.communication.azure.com", "--from", "+1", "--to", "+2", "--message", "fail");
 
         // Assert
         Assert.NotNull(response);
@@ -109,16 +82,11 @@ public class SmsSendCommandTests
         Assert.NotNull(response.Message);
     }
 
-    public static IEnumerable<object?[]> InvalidParameters => new List<object?[]>
-    {
-        new object?[] { null, "+1234567890", new string[] { "+1234567891" }, "Hello" },
-        new object?[] { "https://mycomm.communication.azure.com", null, new string[] { "+1234567891" }, "Hello" },
-        new object?[] { "https://mycomm.communication.azure.com", "+1234567890", null, "Hello" },
-        new object?[] { "https://mycomm.communication.azure.com", "+1234567890", new string[] { "+1234567891" }, null }
-    };
-
     [Theory]
-    [MemberData(nameof(InvalidParameters))]
+    [InlineData(null, "+1234567890", new[] { "+1234567891" }, "Hello")]
+    [InlineData("https://mycomm.communication.azure.com", null, new[] { "+1234567891" }, "Hello")]
+    [InlineData("https://mycomm.communication.azure.com", "+1234567890", null, "Hello")]
+    [InlineData("https://mycomm.communication.azure.com", "+1234567890", new[] { "+1234567891" }, null)]
     public async Task ExecuteAsync_MissingRequiredParameters_ReturnsError(string? endpoint, string? from, string[]? to, string? message)
     {
         var args = new List<string>();
@@ -130,10 +98,9 @@ public class SmsSendCommandTests
         { args.Add("--to"); args.Add(string.Join(",", to)); }
         if (message != null)
         { args.Add("--message"); args.Add(message); }
-        var parseResult = _commandDefinition.Parse(args.ToArray());
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args.ToArray());
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskCreateCommandTests.cs
@@ -106,13 +106,8 @@ public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IC
             "--size-gb", sizeGb.ToString());
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(diskName, result.Disk.Name);
         Assert.Equal(resourceGroup, result.Disk.ResourceGroup);
@@ -191,13 +186,8 @@ public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IC
             "--hyper-v-generation", hyperVGeneration);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(diskName, result.Disk.Name);
         Assert.Equal(sku, result.Disk.SkuName);
@@ -266,12 +256,8 @@ public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IC
             "--size-gb", "64");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(mockDisk.Name, result.Disk.Name);
         Assert.Equal(mockDisk.Location, result.Disk.Location);
@@ -339,13 +325,8 @@ public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IC
             "--size-gb", "128");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(diskName, result.Disk.Name);
     }
@@ -509,13 +490,8 @@ public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IC
             "--source", source);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(diskName, result.Disk.Name);
     }
@@ -580,13 +556,8 @@ public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IC
             "--source", source);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(diskName, result.Disk.Name);
     }
@@ -663,13 +634,8 @@ public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IC
             "--tier", tier);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(diskName, result.Disk.Name);
         Assert.Equal(sizeGb, result.Disk.DiskSizeGB);
@@ -772,13 +738,8 @@ public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IC
             "--enable-bursting", "true");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(diskName, result.Disk.Name);
         Assert.Equal(sku, result.Disk.SkuName);
@@ -859,13 +820,8 @@ public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IC
             "--upload-size-bytes", uploadSizeBytes.ToString());
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(diskName, result.Disk.Name);
         Assert.Equal("ReadyToUpload", result.Disk.DiskState);
@@ -949,13 +905,8 @@ public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IC
             "--hyper-v-generation", "V2");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(diskName, result.Disk.Name);
         Assert.Equal("ReadyToUpload", result.Disk.DiskState);
@@ -1021,13 +972,8 @@ public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IC
             "--gallery-image-reference", galleryImageRef);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(diskName, result.Disk.Name);
     }
@@ -1094,13 +1040,8 @@ public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IC
             "--gallery-image-reference-lun", lun.ToString());
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(diskName, result.Disk.Name);
 

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskCreateCommandTests.cs
@@ -1,21 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using System.Security;
-using System.Text.Json;
-using Azure.Mcp.Tests;
 using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Disk;
 using Azure.Mcp.Tools.Compute.Models;
 using Azure.Mcp.Tools.Compute.Services;
 using Azure.ResourceManager;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Helpers;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -25,41 +20,21 @@ namespace Azure.Mcp.Tools.Compute.UnitTests.Disk;
 /// <summary>
 /// Unit tests for the DiskCreateCommand.
 /// </summary>
-public class DiskCreateCommandTests
+public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IComputeService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IComputeService _computeService;
-    private readonly ILogger<DiskCreateCommand> _logger;
-    private readonly DiskCreateCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public DiskCreateCommandTests()
-    {
-        _computeService = Substitute.For<IComputeService>();
-        _logger = Substitute.For<ILogger<DiskCreateCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_computeService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.NotNull(_command);
-        Assert.Equal("create", _command.Name);
-        Assert.Contains("managed disk", _command.Description, StringComparison.OrdinalIgnoreCase);
-        Assert.NotEqual(Guid.Empty.ToString(), _command.Id);
+        Assert.NotNull(Command);
+        Assert.Equal("create", Command.Name);
+        Assert.Contains("managed disk", Command.Description, StringComparison.OrdinalIgnoreCase);
+        Assert.NotEqual(Guid.Empty.ToString(), Command.Id);
     }
 
     [Fact]
     public void Metadata_HasCorrectProperties()
     {
-        var metadata = _command.Metadata;
+        var metadata = Command.Metadata;
 
         Assert.False(metadata.OpenWorld);
         Assert.True(metadata.Destructive);
@@ -91,7 +66,7 @@ public class DiskCreateCommandTests
             ProvisioningState = "Succeeded"
         };
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             diskName,
             resourceGroup,
             subscription,
@@ -122,24 +97,20 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--disk-name", diskName,
             "--location", location,
-            "--size-gb", sizeGb.ToString()
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--size-gb", sizeGb.ToString());
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskCreateCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disk);
@@ -176,7 +147,7 @@ public class DiskCreateCommandTests
             ProvisioningState = "Succeeded"
         };
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             diskName,
             resourceGroup,
             subscription,
@@ -207,7 +178,8 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--disk-name", diskName,
@@ -216,19 +188,14 @@ public class DiskCreateCommandTests
             "--sku", sku,
             "--os-type", osType,
             "--zone", zone,
-            "--hyper-v-generation", hyperVGeneration
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--hyper-v-generation", hyperVGeneration);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskCreateCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disk);
@@ -259,7 +226,7 @@ public class DiskCreateCommandTests
             TimeCreated = DateTimeOffset.UtcNow
         };
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -290,23 +257,19 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--disk-name", diskName,
             "--location", location,
-            "--size-gb", "64"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--size-gb", "64");
 
         // Assert
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskCreateCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disk);
@@ -337,7 +300,7 @@ public class DiskCreateCommandTests
             ProvisioningState = "Succeeded"
         };
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -368,23 +331,19 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--disk-name", diskName,
-            "--size-gb", "128"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--size-gb", "128");
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskCreateCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disk);
@@ -394,16 +353,12 @@ public class DiskCreateCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingResourceGroup_ReturnsBadRequest()
     {
-        // Arrange - no resource-group specified
-        var args = _commandDefinition.Parse([
+        // Arrange & Act - no resource-group specified
+        var response = await ExecuteCommandAsync(
             "--subscription", "test-sub",
             "--disk-name", "testdisk",
             "--location", "eastus",
-            "--size-gb", "128"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--size-gb", "128");
 
         // Assert
         Assert.NotNull(response);
@@ -414,7 +369,7 @@ public class DiskCreateCommandTests
     public async Task ExecuteAsync_HandlesServiceError()
     {
         // Arrange
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -445,16 +400,13 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Service unavailable"));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", "test-sub",
             "--resource-group", "testrg",
             "--disk-name", "testdisk",
             "--location", "eastus",
-            "--size-gb", "128"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--size-gb", "128");
 
         // Assert
         Assert.NotNull(response);
@@ -465,7 +417,7 @@ public class DiskCreateCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange
-        var args = _commandDefinition.Parse([
+        var args = CommandDefinition.Parse([
             "--subscription", "test-sub",
             "--resource-group", "testrg",
             "--disk-name", "testdisk",
@@ -518,7 +470,7 @@ public class DiskCreateCommandTests
             ProvisioningState = "Succeeded"
         };
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -549,23 +501,19 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--disk-name", diskName,
-            "--source", source
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--source", source);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskCreateCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disk);
@@ -593,7 +541,7 @@ public class DiskCreateCommandTests
             ProvisioningState = "Succeeded"
         };
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -624,23 +572,19 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--disk-name", diskName,
-            "--source", source
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--source", source);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskCreateCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disk);
@@ -674,7 +618,7 @@ public class DiskCreateCommandTests
             ProvisioningState = "Succeeded"
         };
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             diskName,
             resourceGroup,
             subscription,
@@ -705,7 +649,8 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--disk-name", diskName,
@@ -715,26 +660,21 @@ public class DiskCreateCommandTests
             "--disk-encryption-set", diskEncryptionSet,
             "--encryption-type", encryptionType,
             "--disk-access", diskAccess,
-            "--tier", tier
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--tier", tier);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskCreateCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(diskName, result.Disk.Name);
         Assert.Equal(sizeGb, result.Disk.DiskSizeGB);
 
-        await _computeService.Received(1).CreateDiskAsync(
+        await Service.Received(1).CreateDiskAsync(
             diskName,
             resourceGroup,
             subscription,
@@ -788,7 +728,7 @@ public class DiskCreateCommandTests
             ProvisioningState = "Succeeded"
         };
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -819,7 +759,8 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--disk-name", diskName,
@@ -828,19 +769,14 @@ public class DiskCreateCommandTests
             "--sku", sku,
             "--max-shares", "3",
             "--network-access-policy", "AllowPrivate",
-            "--enable-bursting", "true"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--enable-bursting", "true");
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskCreateCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disk);
@@ -851,15 +787,11 @@ public class DiskCreateCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingSourceAndSizeGbAndGalleryRefAndUpload_ReturnsBadRequest()
     {
-        // Arrange - neither --source, --size-gb, --gallery-image-reference, nor --upload-type specified
-        var args = _commandDefinition.Parse([
+        // Arrange & Act - neither --source, --size-gb, --gallery-image-reference, nor --upload-type specified
+        var response = await ExecuteCommandAsync(
             "--subscription", "test-sub",
             "--resource-group", "testrg",
-            "--disk-name", "testdisk"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--disk-name", "testdisk");
 
         // Assert
         Assert.NotNull(response);
@@ -887,7 +819,7 @@ public class DiskCreateCommandTests
             ProvisioningState = "Succeeded"
         };
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -918,24 +850,20 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--disk-name", diskName,
             "--upload-type", "Upload",
-            "--upload-size-bytes", uploadSizeBytes.ToString()
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--upload-size-bytes", uploadSizeBytes.ToString());
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskCreateCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disk);
@@ -946,16 +874,12 @@ public class DiskCreateCommandTests
     [Fact]
     public async Task ExecuteAsync_UploadTypeMissingUploadSizeBytes_ReturnsBadRequest()
     {
-        // Arrange - --upload-type specified but --upload-size-bytes missing
-        var args = _commandDefinition.Parse([
+        // Arrange & Act - --upload-type specified but --upload-size-bytes missing
+        var response = await ExecuteCommandAsync(
             "--subscription", "test-sub",
             "--resource-group", "testrg",
             "--disk-name", "testdisk",
-            "--upload-type", "Upload"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--upload-type", "Upload");
 
         // Assert
         Assert.NotNull(response);
@@ -983,7 +907,7 @@ public class DiskCreateCommandTests
             ProvisioningState = "Succeeded"
         };
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -1014,26 +938,22 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--disk-name", diskName,
             "--upload-type", "UploadWithSecurityData",
             "--upload-size-bytes", uploadSizeBytes.ToString(),
             "--security-type", "TrustedLaunch",
-            "--hyper-v-generation", "V2"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--hyper-v-generation", "V2");
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskCreateCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disk);
@@ -1062,7 +982,7 @@ public class DiskCreateCommandTests
             ProvisioningState = "Succeeded"
         };
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -1093,23 +1013,19 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--disk-name", diskName,
-            "--gallery-image-reference", galleryImageRef
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--gallery-image-reference", galleryImageRef);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskCreateCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disk);
@@ -1138,7 +1054,7 @@ public class DiskCreateCommandTests
             ProvisioningState = "Succeeded"
         };
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -1169,30 +1085,26 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscription,
             "--resource-group", resourceGroup,
             "--disk-name", diskName,
             "--gallery-image-reference", galleryImageRef,
-            "--gallery-image-reference-lun", lun.ToString()
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--gallery-image-reference-lun", lun.ToString());
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskCreateCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskCreateCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disk);
         Assert.Equal(diskName, result.Disk.Name);
 
-        await _computeService.Received(1).CreateDiskAsync(
+        await Service.Received(1).CreateDiskAsync(
             diskName,
             resourceGroup,
             subscription,
@@ -1300,7 +1212,7 @@ public class DiskCreateCommandTests
         // Arrange - service throws ArgumentException for HTTP source
         var source = "http://mystorageaccount.blob.core.windows.net/vhds/mydisk.vhd";
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -1331,15 +1243,12 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new SecurityException("Endpoint must use HTTPS protocol. Got: http"));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", "test-sub",
             "--resource-group", "testrg",
             "--disk-name", "testdisk",
-            "--source", source
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--source", source);
 
         // Assert
         Assert.NotNull(response);
@@ -1353,7 +1262,7 @@ public class DiskCreateCommandTests
         // Arrange - service throws ArgumentException for non-Azure blob URI
         var source = "https://evil-server.com/vhds/mydisk.vhd";
 
-        _computeService.CreateDiskAsync(
+        Service.CreateDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -1384,15 +1293,12 @@ public class DiskCreateCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new SecurityException("Endpoint host 'evil-server.com' is not a valid storage-blob domain for Azure Public Cloud."));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", "test-sub",
             "--resource-group", "testrg",
             "--disk-name", "testdisk",
-            "--source", source
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--source", source);
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskDeleteCommandTests.cs
@@ -1,16 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Disk;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -20,39 +16,15 @@ namespace Azure.Mcp.Tools.Compute.UnitTests.Disk;
 /// <summary>
 /// Unit tests for the DiskDeleteCommand.
 /// </summary>
-public class DiskDeleteCommandTests
+public class DiskDeleteCommandTests : CommandUnitTestsBase<DiskDeleteCommand, IComputeService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IComputeService _computeService;
-    private readonly ILogger<DiskDeleteCommand> _logger;
-    private readonly DiskDeleteCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public DiskDeleteCommandTests()
-    {
-        _computeService = Substitute.For<IComputeService>();
-        _logger = Substitute.For<ILogger<DiskDeleteCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_computeService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        // Arrange & Act
-        // Command already created in constructor
-
-        // Assert
-        Assert.NotNull(_command);
-        Assert.Equal("delete", _command.Name);
-        Assert.Contains("disk", _command.Description, StringComparison.OrdinalIgnoreCase);
-        Assert.NotEqual(Guid.Empty.ToString(), _command.Id.ToString());
+        Assert.NotNull(Command);
+        Assert.Equal("delete", Command.Name);
+        Assert.Contains("disk", Command.Description, StringComparison.OrdinalIgnoreCase);
+        Assert.NotEqual(Guid.Empty.ToString(), Command.Id.ToString());
     }
 
     [Fact]
@@ -63,7 +35,7 @@ public class DiskDeleteCommandTests
         var resourceGroup = "testrg";
         var diskName = "testdisk";
 
-        _computeService.DeleteDiskAsync(
+        Service.DeleteDiskAsync(
             diskName,
             resourceGroup,
             subscription,
@@ -72,18 +44,18 @@ public class DiskDeleteCommandTests
             Arg.Any<CancellationToken>())
             .Returns(true);
 
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--resource-group", resourceGroup, "--disk-name", diskName]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--resource-group", resourceGroup,
+            "--disk-name", diskName);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskDeleteCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskDeleteCommandResult);
 
         Assert.NotNull(result);
         Assert.True(result.Deleted);
@@ -98,7 +70,7 @@ public class DiskDeleteCommandTests
         var resourceGroup = "testrg";
         var diskName = "nonexistent";
 
-        _computeService.DeleteDiskAsync(
+        Service.DeleteDiskAsync(
             diskName,
             resourceGroup,
             subscription,
@@ -107,18 +79,18 @@ public class DiskDeleteCommandTests
             Arg.Any<CancellationToken>())
             .Returns(false);
 
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--resource-group", resourceGroup, "--disk-name", diskName]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--resource-group", resourceGroup,
+            "--disk-name", diskName);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskDeleteCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskDeleteCommandResult);
 
         Assert.NotNull(result);
         Assert.False(result.Deleted);
@@ -133,7 +105,7 @@ public class DiskDeleteCommandTests
         var resourceGroup = "testrg";
         var diskName = "testdisk";
 
-        _computeService.DeleteDiskAsync(
+        Service.DeleteDiskAsync(
             diskName,
             resourceGroup,
             subscription,
@@ -142,17 +114,17 @@ public class DiskDeleteCommandTests
             Arg.Any<CancellationToken>())
             .Returns(true);
 
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--resource-group", resourceGroup, "--disk-name", diskName]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--resource-group", resourceGroup,
+            "--disk-name", diskName);
 
         // Assert
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskDeleteCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskDeleteCommandResult);
 
         Assert.NotNull(result);
         Assert.True(result.Deleted);
@@ -162,11 +134,10 @@ public class DiskDeleteCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingRequiredDiskName_ReturnsError()
     {
-        // Arrange - missing --disk-name
-        var args = _commandDefinition.Parse(["--subscription", "test-sub", "--resource-group", "testrg"]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act - missing --disk-name
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "testrg");
 
         // Assert
         Assert.NotNull(response);
@@ -176,11 +147,10 @@ public class DiskDeleteCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingRequiredResourceGroup_ReturnsError()
     {
-        // Arrange - missing --resource-group
-        var args = _commandDefinition.Parse(["--subscription", "test-sub", "--disk-name", "testdisk"]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act - missing --resource-group
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--disk-name", "testdisk");
 
         // Assert
         Assert.NotNull(response);
@@ -195,19 +165,20 @@ public class DiskDeleteCommandTests
         var resourceGroup = "testrg";
         var diskName = "testdisk";
 
-        _computeService.DeleteDiskAsync(
+        Service.DeleteDiskAsync(
             diskName,
             resourceGroup,
             subscription,
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Azure.RequestFailedException("Conflict"));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--resource-group", resourceGroup, "--disk-name", diskName]);
+            .ThrowsAsync(new RequestFailedException("Conflict"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--resource-group", resourceGroup,
+            "--disk-name", diskName);
 
         // Assert
         Assert.NotNull(response);
@@ -222,13 +193,14 @@ public class DiskDeleteCommandTests
         var resourceGroup = "testrg";
         var diskName = "testdisk";
 
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--resource-group", resourceGroup, "--disk-name", diskName]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--resource-group", resourceGroup,
+            "--disk-name", diskName);
 
         // Assert - if the command reached the service call, options were bound correctly
-        await _computeService.Received().DeleteDiskAsync(
+        await Service.Received().DeleteDiskAsync(
             diskName,
             resourceGroup,
             subscription,

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskDeleteCommandTests.cs
@@ -51,13 +51,8 @@ public class DiskDeleteCommandTests : CommandUnitTestsBase<DiskDeleteCommand, IC
             "--disk-name", diskName);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskDeleteCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskDeleteCommandResult);
-
-        Assert.NotNull(result);
         Assert.True(result.Deleted);
         Assert.Equal(diskName, result.DiskName);
     }
@@ -86,13 +81,8 @@ public class DiskDeleteCommandTests : CommandUnitTestsBase<DiskDeleteCommand, IC
             "--disk-name", diskName);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskDeleteCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskDeleteCommandResult);
-
-        Assert.NotNull(result);
         Assert.False(result.Deleted);
         Assert.Equal(diskName, result.DiskName);
     }
@@ -121,12 +111,8 @@ public class DiskDeleteCommandTests : CommandUnitTestsBase<DiskDeleteCommand, IC
             "--disk-name", diskName);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskDeleteCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskDeleteCommandResult);
-
-        Assert.NotNull(result);
         Assert.True(result.Deleted);
         Assert.Equal(diskName, result.DiskName);
     }

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskGetCommandTests.cs
@@ -1,16 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Disk;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using Xunit;
 
@@ -19,48 +15,15 @@ namespace Azure.Mcp.Tools.Compute.UnitTests.Disk;
 /// <summary>
 /// Unit tests for the DiskGetCommand.
 /// </summary>
-public class DiskGetCommandTests
+public class DiskGetCommandTests : CommandUnitTestsBase<DiskGetCommand, IComputeService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IComputeService _computeService;
-    private readonly ILogger<DiskGetCommand> _logger;
-    private readonly DiskGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public DiskGetCommandTests()
-    {
-        _computeService = Substitute.For<IComputeService>();
-        _logger = Substitute.For<ILogger<DiskGetCommand>>();
-
-        // Set up default empty returns to avoid null reference issues
-        _computeService.ListDisksAsync(
-            Arg.Any<string>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<CancellationToken>())
-            .ReturnsForAnyArgs(new List<Models.DiskInfo>());
-
-        var collection = new ServiceCollection().AddSingleton(_computeService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        // Arrange & Act
-        // Command already created in constructor
-
-        // Assert
-        Assert.NotNull(_command);
-        Assert.Equal("get", _command.Name);
-        Assert.Contains("disk", _command.Description, StringComparison.OrdinalIgnoreCase);
-        Assert.NotEqual(Guid.Empty.ToString(), _command.Id.ToString());
+        Assert.NotNull(Command);
+        Assert.Equal("get", Command.Name);
+        Assert.Contains("disk", Command.Description, StringComparison.OrdinalIgnoreCase);
+        Assert.NotEqual(Guid.Empty.ToString(), Command.Id.ToString());
     }
 
     [Fact]
@@ -93,26 +56,23 @@ public class DiskGetCommandTests
             }
         };
 
-        _computeService.ListDisksAsync(
+        Service.ListDisksAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .ReturnsForAnyArgs(mockDisks);
-
-        var args = _commandDefinition.Parse(["--subscription", subscription]);
+            .Returns(mockDisks);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskGetCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disks);
@@ -142,26 +102,23 @@ public class DiskGetCommandTests
             }
         };
 
-        _computeService.ListDisksAsync(
+        Service.ListDisksAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .ReturnsForAnyArgs(mockDisks);
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--resource-group", resourceGroup]);
+            .Returns(mockDisks);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription, "--resource-group", resourceGroup);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskGetCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disks);
@@ -190,27 +147,27 @@ public class DiskGetCommandTests
             TimeCreated = DateTimeOffset.UtcNow
         };
 
-        _computeService.GetDiskAsync(
+        Service.GetDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .ReturnsForAnyArgs(mockDisk);
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--disk-name", diskName, "--resource-group", resourceGroup]);
+            .Returns(mockDisk);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--disk-name", diskName,
+            "--resource-group", resourceGroup);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskGetCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disks);
@@ -218,8 +175,6 @@ public class DiskGetCommandTests
         Assert.Equal(diskName, result.Disks[0].Name);
         Assert.Equal(resourceGroup, result.Disks[0].ResourceGroup);
     }
-
-
 
     [Fact]
     public async Task ExecuteAsync_DeserializationValidation()
@@ -239,26 +194,26 @@ public class DiskGetCommandTests
             DiskSizeGB = 64
         };
 
-        _computeService.GetDiskAsync(
+        Service.GetDiskAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .ReturnsForAnyArgs(mockDisk);
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--disk-name", diskName, "--resource-group", resourceGroup]);
+            .Returns(mockDisk);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--disk-name", diskName,
+            "--resource-group", resourceGroup);
 
         // Assert
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskGetCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disks);
@@ -307,26 +262,23 @@ public class DiskGetCommandTests
             }
         };
 
-        _computeService.ListDisksAsync(
+        Service.ListDisksAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .ReturnsForAnyArgs(mockDisks);
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--disk-name", diskPattern]);
+            .Returns(mockDisks);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription, "--disk-name", diskPattern);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskGetCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disks);
@@ -375,26 +327,26 @@ public class DiskGetCommandTests
             }
         };
 
-        _computeService.ListDisksAsync(
+        Service.ListDisksAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .ReturnsForAnyArgs(mockDisks);
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--disk-name", diskPattern, "--resource-group", resourceGroup]);
+            .Returns(mockDisks);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--disk-name", diskPattern,
+            "--resource-group", resourceGroup);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskGetCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disks);
@@ -433,26 +385,23 @@ public class DiskGetCommandTests
             }
         };
 
-        _computeService.ListDisksAsync(
+        Service.ListDisksAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .ReturnsForAnyArgs(mockDisks);
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--disk-name", diskName]);
+            .Returns(mockDisks);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription, "--disk-name", diskName);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ComputeJsonContext.Default.DiskGetCommandResult);
+        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
         Assert.NotNull(result);
         Assert.NotNull(result.Disks);

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskGetCommandTests.cs
@@ -68,13 +68,8 @@ public class DiskGetCommandTests : CommandUnitTestsBase<DiskGetCommand, ICompute
         var response = await ExecuteCommandAsync("--subscription", subscription);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disks);
         Assert.Equal(2, result.Disks.Count);
         Assert.Contains(result.Disks, d => d.Name == "disk1");
@@ -114,13 +109,8 @@ public class DiskGetCommandTests : CommandUnitTestsBase<DiskGetCommand, ICompute
         var response = await ExecuteCommandAsync("--subscription", subscription, "--resource-group", resourceGroup);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disks);
         Assert.Single(result.Disks);
         Assert.Equal("disk1", result.Disks[0].Name);
@@ -163,13 +153,8 @@ public class DiskGetCommandTests : CommandUnitTestsBase<DiskGetCommand, ICompute
             "--resource-group", resourceGroup);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disks);
         Assert.Single(result.Disks);
         Assert.Equal(diskName, result.Disks[0].Name);
@@ -210,12 +195,8 @@ public class DiskGetCommandTests : CommandUnitTestsBase<DiskGetCommand, ICompute
             "--resource-group", resourceGroup);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disks);
         Assert.Single(result.Disks);
         Assert.Equal(mockDisk.Name, result.Disks[0].Name);
@@ -274,13 +255,8 @@ public class DiskGetCommandTests : CommandUnitTestsBase<DiskGetCommand, ICompute
         var response = await ExecuteCommandAsync("--subscription", subscription, "--disk-name", diskPattern);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disks);
         Assert.Equal(2, result.Disks.Count);
         Assert.Contains(result.Disks, d => d.Name == "win_OsDisk1");
@@ -342,13 +318,8 @@ public class DiskGetCommandTests : CommandUnitTestsBase<DiskGetCommand, ICompute
             "--resource-group", resourceGroup);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disks);
         Assert.Equal(2, result.Disks.Count);
         Assert.Contains(result.Disks, d => d.Name == "datadisk1");
@@ -397,13 +368,8 @@ public class DiskGetCommandTests : CommandUnitTestsBase<DiskGetCommand, ICompute
         var response = await ExecuteCommandAsync("--subscription", subscription, "--disk-name", diskName);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
 
-        var result = ConvertResponse(response, ComputeJsonContext.Default.DiskGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Disks);
         Assert.Single(result.Disks);
         Assert.Equal("exactdisk", result.Disks[0].Name);

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.UnitTests/Account/AccountCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.UnitTests/Account/AccountCreateCommandTests.cs
@@ -78,12 +78,8 @@ public class AccountCreateCommandTests : CommandUnitTestsBase<AccountCreateComma
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
         if (shouldSucceed)
         {
-            Assert.NotNull(response.Results);
-            Assert.Equal("Success", response.Message);
-
-            var result = DeserializeResponse(response, StorageJsonContext.Default.AccountCreateCommandResult);
-            Assert.NotNull(result);
-            Assert.NotNull(result!.Account);
+            var result = ValidateAndDeserializeResponse(response, StorageJsonContext.Default.AccountCreateCommandResult);
+            Assert.NotNull(result.Account);
             Assert.Equal("testaccount", result.Account.Name);
         }
         else

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.UnitTests/Account/AccountGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.UnitTests/Account/AccountGetCommandTests.cs
@@ -40,12 +40,8 @@ public class AccountGetCommandTests : CommandUnitTestsBase<AccountGetCommand, IS
         var response = await ExecuteCommandAsync("--subscription", subscription);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, StorageJsonContext.Default.AccountGetCommandResult);
 
-        var result = DeserializeResponse(response, StorageJsonContext.Default.AccountGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Accounts);
         Assert.Equal(expectedAccounts.Results.Count, result.Accounts.Count);
         Assert.Equal(expectedAccounts.Results.Select(a => a.Name), result.Accounts.Select(a => a.Name));
@@ -69,12 +65,8 @@ public class AccountGetCommandTests : CommandUnitTestsBase<AccountGetCommand, IS
         var response = await ExecuteCommandAsync("--subscription", subscription);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, StorageJsonContext.Default.AccountGetCommandResult);
 
-        var result = DeserializeResponse(response, StorageJsonContext.Default.AccountGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Accounts);
     }
 
@@ -171,15 +163,9 @@ public class AccountGetCommandTests : CommandUnitTestsBase<AccountGetCommand, IS
         var response = await ExecuteCommandAsync("--account", account, "--subscription", subscription);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, StorageJsonContext.Default.AccountGetCommandResult);
 
-        var result = DeserializeResponse(response, StorageJsonContext.Default.AccountGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Single(result.Accounts);
-
         Assert.Equal(expectedAccount.Results[0].Name, result.Accounts[0].Name);
         Assert.Equal(expectedAccount.Results[0].Location, result.Accounts[0].Location);
         Assert.Equal(expectedAccount.Results[0].Kind, result.Accounts[0].Kind);

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.UnitTests/Table/TableListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.UnitTests/Table/TableListCommandTests.cs
@@ -38,12 +38,8 @@ public class TableListCommandTests : CommandUnitTestsBase<TableListCommand, ISto
             "--subscription", _knownSubscription);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, StorageJsonContext.Default.TableListCommandResult);
 
-        var result = DeserializeResponse(response, StorageJsonContext.Default.TableListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(expectedTables, result.Tables);
     }
 
@@ -65,12 +61,8 @@ public class TableListCommandTests : CommandUnitTestsBase<TableListCommand, ISto
             "--subscription", _knownSubscription);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, StorageJsonContext.Default.TableListCommandResult);
 
-        var result = DeserializeResponse(response, StorageJsonContext.Default.TableListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Tables);
     }
 


### PR DESCRIPTION
## What does this PR do?

Migrates Command unit tests to use `CommandUnitTestBase`. Adds new helper method to `CommandUnitTestBase` that performs common validation when a tool call was expected to succeed with a response value.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
