### PR TITLE
Add protecteditem undelete command to Azure Backup toolset

### DIFF
--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -964,6 +964,7 @@ For full configuration options, see the [Sovereign Clouds documentation](https:/
 * "Find unprotected resources in my subscription"
 * "Configure soft delete to 'AlwaysOn' and immutability to 'Locked' on my vault"
 * "Enable cross-region restore on my vault"
+* "Restore a soft-deleted backup item in vault 'myvault' for datasource '/subscriptions/.../virtualMachines/myvm'"
 
 ### 🖥️ Azure CLI Generate
 

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -815,6 +815,15 @@ azmcp azurebackup protecteditem protect --subscription <subscription> \
                                         [--vault-type <vault-type>] \
                                         [--container <container>] \
                                         [--datasource-type <datasource-type>]
+
+# Restores a soft-deleted backup item to an active protection state. For RSV vaults, pass the datasource ARM resource ID as --datasource-id. For DPP vaults, pass the datasource ARM resource ID to find and restore the soft-deleted backup instance.
+# ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
+azmcp azurebackup protecteditem undelete --subscription <subscription> \
+                                         --resource-group <resource-group> \
+                                         --vault <vault> \
+                                         --datasource-id <datasource-id> \
+                                         [--vault-type <vault-type>] \
+                                         [--container <container>]
 ```
 
 #### Protectable Item

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -153,7 +153,9 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | azurebackup_protecteditem_get | Get protected item details for <item_name> in vault <vault_name> and resource group <resource_group> |
 | azurebackup_protecteditem_get | Show backup status of protected item <item_name> in vault <vault_name> under resource group <resource_group> |
 | azurebackup_protecteditem_protect | Enable backup protection for <item_name> using policy <policy_name> in vault <vault_name> and resource group <resource_group> |
-| azurebackup_protecteditem_protect | Protect item <item_name> with backup policy <policy_name> in vault <vault_name> under resource group <resource_group> |
+| azurebackup_protecteditem_protect | Start protecting my Azure VM by enabling backup on <item_name> in vault <vault_name> under resource group <resource_group> |
+| azurebackup_protecteditem_undelete | Restore a soft-deleted backup item for datasource <datasource_id> in vault <vault_name> and resource group <resource_group> |
+| azurebackup_protecteditem_undelete | Undelete the accidentally deleted backup for VM <datasource_id> in vault <vault_name> under resource group <resource_group> |
 | azurebackup_recoverypoint_get | Get recovery points for protected item <item_name> in vault <vault_name> and resource group <resource_group> |
 | azurebackup_recoverypoint_get | List available recovery points for <item_name> in vault <vault_name> under resource group <resource_group> |
 | azurebackup_vault_create | Create a Recovery Services vault named <vault_name> in resource group <resource_group> in region <location> with vault-type 'rsv' |

--- a/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json
+++ b/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json
@@ -3771,7 +3771,8 @@
         "azurebackup_vault_update",
         "azurebackup_governance_immutability",
         "azurebackup_governance_soft-delete",
-        "azurebackup_disasterrecovery_enable-crr"
+        "azurebackup_disasterrecovery_enable-crr",
+        "azurebackup_protecteditem_undelete"
       ]
     }
   ]

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/AzureBackupSetup.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/AzureBackupSetup.cs
@@ -38,6 +38,7 @@ public sealed class AzureBackupSetup : IAreaSetup
 
         services.AddSingleton<ProtectedItemGetCommand>();
         services.AddSingleton<ProtectedItemProtectCommand>();
+        services.AddSingleton<ProtectedItemUndeleteCommand>();
 
         services.AddSingleton<ProtectableItemListCommand>();
 
@@ -76,10 +77,11 @@ public sealed class AzureBackupSetup : IAreaSetup
         RegisterCommand<PolicyGetCommand>(serviceProvider, policy);
         RegisterCommand<PolicyCreateCommand>(serviceProvider, policy);
 
-        var protectedItem = new CommandGroup("protecteditem", "Protected item operations – Get protected item details or list all, and enable backup protection.");
+        var protectedItem = new CommandGroup("protecteditem", "Protected item operations – Get protected item details or list all, enable backup protection, and undelete soft-deleted items.");
         azureBackup.AddSubGroup(protectedItem);
         RegisterCommand<ProtectedItemGetCommand>(serviceProvider, protectedItem);
         RegisterCommand<ProtectedItemProtectCommand>(serviceProvider, protectedItem);
+        RegisterCommand<ProtectedItemUndeleteCommand>(serviceProvider, protectedItem);
 
         var protectableItem = new CommandGroup("protectableitem", "Protectable item operations – List discovered databases available for protection.");
         azureBackup.AddSubGroup(protectableItem);

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/AzureBackupJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/AzureBackupJsonContext.cs
@@ -23,6 +23,7 @@ namespace Azure.Mcp.Tools.AzureBackup.Commands;
 [JsonSerializable(typeof(PolicyCreateCommand.PolicyCreateCommandResult))]
 [JsonSerializable(typeof(ProtectedItemGetCommand.ProtectedItemGetCommandResult))]
 [JsonSerializable(typeof(ProtectedItemProtectCommand.ProtectedItemProtectCommandResult))]
+[JsonSerializable(typeof(ProtectedItemUndeleteCommand.ProtectedItemUndeleteCommandResult))]
 [JsonSerializable(typeof(ProtectableItemListCommand.ProtectableItemListCommandResult))]
 [JsonSerializable(typeof(BackupStatusCommand.BackupStatusCommandResult))]
 [JsonSerializable(typeof(JobGetCommand.JobGetCommandResult))]

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Backup/BackupStatusCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Backup/BackupStatusCommand.cs
@@ -23,7 +23,13 @@ public sealed class BackupStatusCommand(ILogger<BackupStatusCommand> logger, IAz
 
     public override string Id => "f5612c55-054d-4fd8-964c-952e8e6b87f8";
     public override string Name => "status";
-    public override string Description => "Checks whether a datasource is protected and returns vault and policy details.";
+    public override string Description =>
+        """
+        Checks the backup status of an Azure resource and returns whether it is protected,
+        along with vault and policy details. Use this to verify if a VM, disk, storage account,
+        or other datasource is currently backed up. Requires the datasource ARM resource ID
+        and the Azure region (location) where the resource exists.
+        """;
     public override string Title => CommandTitle;
     public override ToolMetadata Metadata => new() { Destructive = false, Idempotent = true, OpenWorld = false, ReadOnly = true, LocalRequired = false, Secret = false };
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectableItem/ProtectableItemListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectableItem/ProtectableItemListCommand.cs
@@ -22,11 +22,11 @@ public sealed class ProtectableItemListCommand(ILogger<ProtectableItemListComman
     public override string Name => "list";
     public override string Description =>
         """
-        Lists protectable items (SQL databases, SAP HANA databases) discovered in the Recovery Services vault.
-        This command is only supported for RSV vaults; DPP datasources are protected by ARM resource ID directly.
-        Use after registering a container and running inquiry to discover databases available for protection.
-        Filter results by workload type or container name. Valid workload-type values include:
-        SAPHana, SAPHanaDatabase, SAPHanaSystem, SQL, SQLDataBase, SQLInstance.
+        Lists items that can be backed up (protectable items) in a Recovery Services vault,
+        such as SQL databases and SAP HANA databases discovered on registered VMs.
+        Use this to find databases and workloads available for backup protection.
+        Only supported for RSV vaults; DPP datasources are protected by ARM resource ID directly.
+        Filter results by --workload-type (e.g., SQL, SAPHana) or --container.
         """;
     public override string Title => CommandTitle;
     public override ToolMetadata Metadata => new()

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemUndeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemUndeleteCommand.cs
@@ -14,30 +14,28 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AzureBackup.Commands.ProtectedItem;
 
-public sealed class ProtectedItemProtectCommand(ILogger<ProtectedItemProtectCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<ProtectedItemProtectOptions>()
+public sealed class ProtectedItemUndeleteCommand(ILogger<ProtectedItemUndeleteCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<ProtectedItemUndeleteOptions>()
 {
-    private const string CommandTitle = "Protect Resource";
-    private readonly ILogger<ProtectedItemProtectCommand> _logger = logger;
+    private const string CommandTitle = "Undelete Protected Item";
+    private readonly ILogger<ProtectedItemUndeleteCommand> _logger = logger;
     private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
-    public override string Id => "7a6fc193-ca3c-4309-97c5-ee1e7fe90e69";
-    public override string Name => "protect";
+    public override string Id => "d8e3a1b7-5c42-4f9e-b6d1-7a2e9c3f4b58";
+    public override string Name => "undelete";
     public override string Description =>
         """
-        Enables or configures backup protection for an Azure resource by creating a
-        protected item or backup instance. Protects VMs, disks, file shares, SQL databases,
-        SAP HANA databases, and other supported datasources.
-        For VMs: pass the VM ARM resource ID as --datasource-id.
-        For workloads (SQL/HANA): pass the protectable item name from 'protectableitem list'
-        as --datasource-id (e.g., 'SAPHanaDatabase;instance;dbname'), and specify --container.
-        Requires a backup policy name via --policy. The operation is asynchronous;
-        use 'azurebackup job get' to monitor the protection job progress.
+        Undeletes or restores a soft-deleted backup item to an active protection state.
+        Use this when a backup or protected item was accidentally deleted and needs to be recovered.
+        For RSV vaults: pass the datasource ARM resource ID as --datasource-id.
+        For DPP vaults: pass the datasource ARM resource ID as --datasource-id.
+        Optionally specify --container for RSV workload items (SQL/HANA).
+        The operation is asynchronous; use 'azurebackup job get' to monitor progress.
         """;
     public override string Title => CommandTitle;
     public override ToolMetadata Metadata => new()
     {
         Destructive = true,
-        Idempotent = false,
+        Idempotent = true,
         OpenWorld = false,
         ReadOnly = false,
         LocalRequired = false,
@@ -48,18 +46,14 @@ public sealed class ProtectedItemProtectCommand(ILogger<ProtectedItemProtectComm
     {
         base.RegisterOptions(command);
         command.Options.Add(AzureBackupOptionDefinitions.DatasourceId.AsRequired());
-        command.Options.Add(AzureBackupOptionDefinitions.Policy.AsRequired());
         command.Options.Add(AzureBackupOptionDefinitions.Container);
-        command.Options.Add(AzureBackupOptionDefinitions.DatasourceType);
     }
 
-    protected override ProtectedItemProtectOptions BindOptions(ParseResult parseResult)
+    protected override ProtectedItemUndeleteOptions BindOptions(ParseResult parseResult)
     {
         var options = base.BindOptions(parseResult);
         options.DatasourceId = parseResult.GetValueOrDefault<string>(AzureBackupOptionDefinitions.DatasourceId.Name);
-        options.Policy = parseResult.GetValueOrDefault<string>(AzureBackupOptionDefinitions.Policy.Name);
         options.Container = parseResult.GetValueOrDefault<string>(AzureBackupOptionDefinitions.Container.Name);
-        options.DatasourceType = parseResult.GetValueOrDefault<string>(AzureBackupOptionDefinitions.DatasourceType.Name);
         return options;
     }
 
@@ -74,26 +68,24 @@ public sealed class ProtectedItemProtectCommand(ILogger<ProtectedItemProtectComm
 
         try
         {
-            var result = await _azureBackupService.ProtectItemAsync(
+            var result = await _azureBackupService.UndeleteProtectedItemAsync(
                 options.Vault!,
                 options.ResourceGroup!,
                 options.Subscription!,
                 options.DatasourceId!,
-                options.Policy!,
                 options.VaultType,
                 options.Container,
-                options.DatasourceType,
                 options.Tenant,
                 options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(
                 new(result),
-                AzureBackupJsonContext.Default.ProtectedItemProtectCommandResult);
+                AzureBackupJsonContext.Default.ProtectedItemUndeleteCommandResult);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error protecting item. DatasourceId: {DatasourceId}, Vault: {Vault}",
+            _logger.LogError(ex, "Error undeleting protected item. DatasourceId: {DatasourceId}, Vault: {Vault}",
                 options.DatasourceId, options.Vault);
             HandleException(context, ex);
         }
@@ -104,13 +96,16 @@ public sealed class ProtectedItemProtectCommand(ILogger<ProtectedItemProtectComm
     protected override string GetErrorMessage(Exception ex) => ex switch
     {
         ArgumentException argEx => argEx.Message,
+        KeyNotFoundException => "Soft-deleted protected item not found. Verify the datasource ID and vault.",
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.NotFound =>
+            "Soft-deleted protected item not found. Verify the datasource ID, vault name, and resource group.",
         RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.Forbidden =>
-            $"Authorization failed protecting the resource. Ensure the caller has Backup Contributor role. Details: {reqEx.Message}",
+            $"Authorization failed undeleting the protected item. Ensure the caller has Backup Contributor role. Details: {reqEx.Message}",
         RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.Conflict =>
-            "This resource is already protected. Use 'azurebackup protecteditem get' to view its status.",
+            "This protected item is not in a soft-deleted state. Use 'azurebackup protecteditem get' to view its current status.",
         RequestFailedException reqEx => reqEx.Message,
         _ => base.GetErrorMessage(ex)
     };
 
-    internal record ProtectedItemProtectCommandResult(ProtectResult Result);
+    internal record ProtectedItemUndeleteCommandResult(OperationResult Result);
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Options/ProtectedItem/ProtectedItemUndeleteOptions.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Options/ProtectedItem/ProtectedItemUndeleteOptions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Mcp.Tools.AzureBackup.Options.ProtectedItem;
+
+public class ProtectedItemUndeleteOptions : BaseAzureBackupOptions
+{
+    [JsonPropertyName(AzureBackupOptionDefinitions.DatasourceIdName)]
+    public string? DatasourceId { get; set; }
+
+    [JsonPropertyName(AzureBackupOptionDefinitions.ContainerName)]
+    public string? Container { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs
@@ -167,6 +167,18 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
             : await dppOps.ListProtectedItemsAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
     }
 
+    public async Task<OperationResult> UndeleteProtectedItemAsync(
+        string vaultName, string resourceGroup, string subscription,
+        string datasourceId, string? vaultType, string? containerName,
+        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+    {
+        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+
+        return VaultTypeResolver.IsRsv(resolvedType)
+            ? await rsvOps.UndeleteProtectedItemAsync(vaultName, resourceGroup, subscription, datasourceId, containerName, tenant, retryPolicy, cancellationToken)
+            : await dppOps.UndeleteProtectedItemAsync(vaultName, resourceGroup, subscription, datasourceId, tenant, retryPolicy, cancellationToken);
+    }
+
     public async Task<BackupPolicyInfo> GetPolicyAsync(
         string vaultName, string resourceGroup, string subscription,
         string policyName, string? vaultType, string? tenant,

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs
@@ -328,6 +328,52 @@ public sealed class DppBackupOperations(ITenantService tenantService) : BaseAzur
         return policies;
     }
 
+    public async Task<OperationResult> UndeleteProtectedItemAsync(
+        string vaultName, string resourceGroup, string subscription,
+        string datasourceId, string? tenant,
+        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+    {
+        ValidateRequiredParameters(
+            (nameof(vaultName), vaultName),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(subscription), subscription),
+            (nameof(datasourceId), datasourceId));
+
+        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
+        var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
+
+        // List soft-deleted backup instances and find the one matching the datasource ID
+        var deletedCollection = vaultResource.GetDeletedDataProtectionBackupInstances();
+
+        DeletedDataProtectionBackupInstanceResource? matchedInstance = null;
+        await foreach (var deletedInstance in deletedCollection.GetAllAsync(cancellationToken))
+        {
+            var deletedDatasourceId = deletedInstance.Data?.Properties?.DataSourceInfo?.ResourceId?.ToString();
+            if (string.Equals(deletedDatasourceId, datasourceId, StringComparison.OrdinalIgnoreCase))
+            {
+                matchedInstance = deletedInstance;
+                break;
+            }
+        }
+
+        if (matchedInstance is null)
+        {
+            throw new KeyNotFoundException(
+                $"No soft-deleted backup instance found with datasource ID '{datasourceId}' in vault '{vaultName}'. " +
+                "Verify the datasource ID is correct and the item is in a soft-deleted state.");
+        }
+
+        var undeleteOperation = await matchedInstance.UndeleteAsync(WaitUntil.Started, cancellationToken);
+        var jobId = ExtractJobIdFromOperation(undeleteOperation.GetRawResponse());
+        var monitorMessage = string.IsNullOrWhiteSpace(jobId)
+            ? $"Restore operation started, but no backup job ID was returned. Operation ID: '{undeleteOperation.Id}'."
+            : $"Use 'azurebackup job get --job {jobId}' to monitor progress.";
+
+        return new OperationResult("Accepted", jobId,
+            $"Restore of soft-deleted backup instance for datasource '{datasourceId}' has been started in vault '{vaultName}'. {monitorMessage}");
+    }
+
     public async Task<BackupJobInfo> GetJobAsync(
         string vaultName, string resourceGroup, string subscription,
         string jobId, string? tenant,

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IAzureBackupService.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IAzureBackupService.cs
@@ -24,6 +24,7 @@ public interface IAzureBackupService
     Task<ProtectedItemInfo> GetProtectedItemAsync(string vaultName, string resourceGroup, string subscription, string protectedItemName, string? vaultType = null, string? containerName = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
     Task<List<ProtectedItemInfo>> ListProtectedItemsAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
     Task<List<ProtectableItemInfo>> ListProtectableItemsAsync(string vaultName, string resourceGroup, string subscription, string? workloadType = null, string? containerName = null, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> UndeleteProtectedItemAsync(string vaultName, string resourceGroup, string subscription, string datasourceId, string? vaultType = null, string? containerName = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
 
     // Job operations
     Task<BackupJobInfo> GetJobAsync(string vaultName, string resourceGroup, string subscription, string jobId, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IDppBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IDppBackupOperations.cs
@@ -104,6 +104,15 @@ public interface IDppBackupOperations
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
+    Task<OperationResult> UndeleteProtectedItemAsync(
+        string vaultName,
+        string resourceGroup,
+        string subscription,
+        string datasourceId,
+        string? tenant,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken);
+
     Task<BackupJobInfo> GetJobAsync(
         string vaultName,
         string resourceGroup,

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IRsvBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IRsvBackupOperations.cs
@@ -116,6 +116,16 @@ public interface IRsvBackupOperations
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
+    Task<OperationResult> UndeleteProtectedItemAsync(
+        string vaultName,
+        string resourceGroup,
+        string subscription,
+        string datasourceId,
+        string? containerName,
+        string? tenant,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken);
+
     Task<BackupJobInfo> GetJobAsync(
         string vaultName,
         string resourceGroup,

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.cs
@@ -1070,6 +1070,171 @@ public sealed class RsvBackupOperations(ITenantService tenantService) : BaseAzur
         return null;
     }
 
+    public async Task<OperationResult> UndeleteProtectedItemAsync(
+        string vaultName, string resourceGroup, string subscription,
+        string datasourceId, string? containerName, string? tenant,
+        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+    {
+        ValidateRequiredParameters(
+            (nameof(vaultName), vaultName),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(subscription), subscription),
+            (nameof(datasourceId), datasourceId));
+
+        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+
+        // Find the soft-deleted protected item by datasource ID
+        var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
+        var rgResource = armClient.GetResourceGroupResource(rgId);
+
+        BackupProtectedItemData? matchedItemData = null;
+
+        // For RSV in-guest workloads (SQL/HANA), datasourceId is the protectable item name,
+        // not an ARM ID. In that case, --container is required to build the item identifier directly.
+        if (!datasourceId.StartsWith("/subscriptions/", StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrEmpty(containerName))
+            {
+                throw new ArgumentException(
+                    $"The --container parameter is required when --datasource-id is a protectable item name ('{datasourceId}'). " +
+                    "Use 'azurebackup protectableitem list' to discover containers and item names.");
+            }
+
+            // Build the protected item resource ID directly from container + item name
+            var directItemId = BackupProtectedItemResource.CreateResourceIdentifier(
+                subscription, resourceGroup, vaultName, FabricName, containerName, datasourceId);
+            var directItemResource = armClient.GetBackupProtectedItemResource(directItemId);
+            var directItem = await directItemResource.GetAsync(cancellationToken: cancellationToken);
+            matchedItemData = directItem.Value.Data;
+        }
+        else if (!string.IsNullOrEmpty(containerName))
+        {
+            // When --container is provided with an ARM ID, use it for direct lookup
+            // to avoid ambiguity (e.g., multiple file shares under one storage account).
+            var derivedItemName = RsvNamingHelper.DeriveProtectedItemName(datasourceId);
+            var directItemId = BackupProtectedItemResource.CreateResourceIdentifier(
+                subscription, resourceGroup, vaultName, FabricName, containerName, derivedItemName);
+            var directItemResource = armClient.GetBackupProtectedItemResource(directItemId);
+            var directItem = await directItemResource.GetAsync(cancellationToken: cancellationToken);
+            matchedItemData = directItem.Value.Data;
+        }
+        else
+        {
+            // ARM ID path without --container: list all protected items and match by SourceResourceId.
+            // Prefer exact matches; only allow prefix matches when unambiguous.
+            var exactMatches = new List<BackupProtectedItemData>();
+            var prefixMatches = new List<BackupProtectedItemData>();
+            await foreach (var item in rgResource.GetBackupProtectedItemsAsync(vaultName, cancellationToken: cancellationToken))
+            {
+                if (item.Data.Properties is BackupGenericProtectedItem genericItem)
+                {
+                    var sourceId = genericItem.SourceResourceId?.ToString();
+                    if (sourceId is null)
+                    {
+                        continue;
+                    }
+
+                    if (string.Equals(sourceId, datasourceId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        exactMatches.Add(item.Data);
+                    }
+                    else if (datasourceId.StartsWith(sourceId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        prefixMatches.Add(item.Data);
+                    }
+                }
+            }
+
+            if (exactMatches.Count == 1)
+            {
+                matchedItemData = exactMatches[0];
+            }
+            else if (exactMatches.Count > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Multiple protected items found with datasource ID '{datasourceId}' in vault '{vaultName}'. " +
+                    "Provide --container to disambiguate.");
+            }
+            else if (prefixMatches.Count == 1)
+            {
+                matchedItemData = prefixMatches[0];
+            }
+            else if (prefixMatches.Count > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Multiple protected items match datasource ID '{datasourceId}' in vault '{vaultName}' " +
+                    "(shared storage account prefix). Provide a more specific datasource ID or --container to disambiguate.");
+            }
+        }
+
+        if (matchedItemData is null)
+        {
+            throw new KeyNotFoundException(
+                $"No protected item found with datasource ID '{datasourceId}' in vault '{vaultName}'. " +
+                "Verify the datasource ID is correct and the item exists in this vault.");
+        }
+
+        var vaultResourceId = RecoveryServicesVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
+        var vaultResource = armClient.GetRecoveryServicesVaultResource(vaultResourceId);
+        var vault = await vaultResource.GetAsync(cancellationToken: cancellationToken);
+        var vaultLocation = vault.Value.Data.Location;
+
+        // Extract container and item name from the matched item's resource ID
+        var matchedItemId = matchedItemData.Id!;
+        var matchedContainerName = containerName ?? ExtractContainerName(matchedItemId.ToString());
+        var matchedItemName = matchedItemId.Name;
+
+        var protectedItemId = BackupProtectedItemResource.CreateResourceIdentifier(
+            subscription, resourceGroup, vaultName, FabricName, matchedContainerName, matchedItemName);
+
+        // Set IsRehydrate on the matched item's existing properties to preserve
+        // the full protection definition (PolicyId, ContainerName, etc.).
+        if (matchedItemData.Properties is not BackupGenericProtectedItem existingProperties)
+        {
+            throw new InvalidOperationException(
+                "The matched protected item does not contain properties required to perform undelete.");
+        }
+
+        existingProperties.IsRehydrate = true;
+
+        var protectedItemData = new BackupProtectedItemData(vaultLocation)
+        {
+            Properties = existingProperties
+        };
+
+        var protectedItemResource = armClient.GetBackupProtectedItemResource(protectedItemId);
+        var operation = await protectedItemResource.UpdateAsync(WaitUntil.Started, protectedItemData, cancellationToken);
+        var jobId = ExtractOperationIdFromResponse(operation.GetRawResponse());
+
+        return new OperationResult("Accepted", jobId,
+            jobId != null
+                ? $"Restore of soft-deleted protected item for datasource '{datasourceId}' has been started in vault '{vaultName}'. Use 'azurebackup job get --job {jobId}' to monitor progress."
+                : $"Restore of soft-deleted protected item for datasource '{datasourceId}' has been started in vault '{vaultName}'.");
+    }
+
+    /// <summary>
+    /// Extracts the container name from a full RSV protected item resource ID.
+    /// Format: .../protectionContainers/{containerName}/protectedItems/{itemName}
+    /// </summary>
+    private static string ExtractContainerName(string resourceId)
+    {
+        const string marker = "/protectionContainers/";
+        var idx = resourceId.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (idx < 0)
+        {
+            throw new ArgumentException($"Cannot extract container name from resource ID: {resourceId}");
+        }
+
+        var start = idx + marker.Length;
+        var end = resourceId.IndexOf("/protectedItems/", start, StringComparison.OrdinalIgnoreCase);
+        if (end < 0)
+        {
+            throw new ArgumentException($"Cannot extract container name from resource ID: {resourceId}");
+        }
+
+        return resourceId[start..end];
+    }
+
     public async Task<List<ProtectableItemInfo>> ListProtectableItemsAsync(
         string vaultName, string resourceGroup, string subscription,
         string? workloadType, string? containerName, string? tenant,

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.LiveTests/AzureBackupCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.LiveTests/AzureBackupCommandTests.cs
@@ -42,6 +42,12 @@ public class AzureBackupCommandTests(ITestOutputHelper output, TestProxyFixture 
         {
             Regex = "AzureBackupRG_mcp-test",
             Value = "Sanitized",
+        }),
+        // RSV APIs may return resource group names in lowercase in sourceResourceId
+        new GeneralRegexSanitizer(new GeneralRegexSanitizerBody()
+        {
+            Regex = "(?i)azurebackuprg_mcp-test",
+            Value = "Sanitized",
         })
     ];
 
@@ -1057,6 +1063,65 @@ public class AzureBackupCommandTests(ITestOutputHelper output, TestProxyFixture 
         Output.WriteLine($"[{DateTime.UtcNow:HH:mm:ss}] DONE: DisasterRecoveryEnableCrr_DPP");
         var opResult = result.AssertProperty("result");
         Assert.Equal("Succeeded", opResult.AssertProperty("status").GetString());
+    }
+
+    #endregion
+
+    #region Undelete Protected Item Tests
+
+    [Fact]
+    public async Task ProtectedItemUndelete_DppVault_UndeletesDisk_Successfully()
+    {
+        // The test-resources-post.ps1 script protects a disk in the DPP vault and then
+        // soft-deletes it. This test restores the soft-deleted disk backup instance.
+        var vaultName = $"{Settings.ResourceBaseName}-dpp";
+        var datasourceId = $"/subscriptions/{Settings.SubscriptionId}/resourceGroups/{Settings.ResourceGroupName}/providers/Microsoft.Compute/disks/{Settings.ResourceBaseName}-disk";
+
+        var result = await CallToolAsync(
+            "azurebackup_protecteditem_undelete",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "vault", vaultName },
+                { "datasource-id", datasourceId },
+                { "vault-type", "dpp" }
+            });
+
+        // Expect accepted (LRO started — item restore is in progress)
+        var opResult = result.AssertProperty("result");
+        Assert.Equal("Accepted", opResult.AssertProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task ProtectedItemUndelete_RsvVault_UndeletesFileShare_Successfully()
+    {
+        // The test-resources-post.ps1 script protects a file share in the RSV vault
+        // and then soft-deletes it. This test restores the soft-deleted file share backup.
+        var vaultName = $"{Settings.ResourceBaseName}-rsv";
+        var storageAccountName = $"{Settings.ResourceBaseName.Replace("-", "")}sa";
+        if (storageAccountName.Length > 24)
+        {
+            storageAccountName = storageAccountName[..24];
+        }
+
+        // File share datasource ID format for RSV matching
+        var datasourceId = $"/subscriptions/{Settings.SubscriptionId}/resourceGroups/{Settings.ResourceGroupName}/providers/Microsoft.Storage/storageAccounts/{storageAccountName}/fileServices/default/shares/{Settings.ResourceBaseName}-share";
+
+        var result = await CallToolAsync(
+            "azurebackup_protecteditem_undelete",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "vault", vaultName },
+                { "datasource-id", datasourceId },
+                { "vault-type", "rsv" }
+            });
+
+        // Expect accepted (LRO started — item restore is in progress)
+        var opResult = result.AssertProperty("result");
+        Assert.Equal("Accepted", opResult.AssertProperty("status").GetString());
     }
 
     #endregion

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.LiveTests/assets.json
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.LiveTests/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "",
   "TagPrefix": "Azure.Mcp.Tools.AzureBackup.LiveTests",
-  "Tag": "Azure.Mcp.Tools.AzureBackup.LiveTests_90cec167f5"
+  "Tag": "Azure.Mcp.Tools.AzureBackup.LiveTests_c70ee092ee"
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/AzureBackupSetupTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/AzureBackupSetupTests.cs
@@ -98,6 +98,20 @@ public class AzureBackupSetupTests
     }
 
     [Fact]
+    public void RegisterCommands_ProtectedItemGroup_ShouldHaveExpectedCommands()
+    {
+        var setup = new AzureBackupSetup();
+        var services = CreateServiceProvider(setup);
+
+        var root = setup.RegisterCommands(services);
+        var protectedItem = root.SubGroup.First(g => g.Name == "protecteditem");
+
+        Assert.Contains(protectedItem.Commands, c => c.Key == "get");
+        Assert.Contains(protectedItem.Commands, c => c.Key == "protect");
+        Assert.Contains(protectedItem.Commands, c => c.Key == "undelete");
+    }
+
+    [Fact]
     public void RegisterCommands_WithNullServiceProvider_ShouldThrow()
     {
         var setup = new AzureBackupSetup();

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/ProtectedItem/ProtectedItemUndeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/ProtectedItem/ProtectedItemUndeleteCommandTests.cs
@@ -1,0 +1,328 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text.Json;
+using Azure.Mcp.Tools.AzureBackup.Commands;
+using Azure.Mcp.Tools.AzureBackup.Commands.ProtectedItem;
+using Azure.Mcp.Tools.AzureBackup.Models;
+using Azure.Mcp.Tools.AzureBackup.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Core.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Azure.Mcp.Tools.AzureBackup.UnitTests.ProtectedItem;
+
+public class ProtectedItemUndeleteCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAzureBackupService _backupService;
+    private readonly ILogger<ProtectedItemUndeleteCommand> _logger;
+    private readonly ProtectedItemUndeleteCommand _command;
+    private readonly CommandContext _context;
+    private readonly System.CommandLine.Command _commandDefinition;
+
+    public ProtectedItemUndeleteCommandTests()
+    {
+        _backupService = Substitute.For<IAzureBackupService>();
+        _logger = Substitute.For<ILogger<ProtectedItemUndeleteCommand>>();
+
+        var collection = new ServiceCollection().AddSingleton(_backupService);
+
+        _serviceProvider = collection.BuildServiceProvider();
+        _command = new(_logger, _backupService);
+        _context = new(_serviceProvider);
+        _commandDefinition = _command.GetCommand();
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("undelete", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UndeletesItem_Successfully()
+    {
+        // Arrange
+        var expected = new OperationResult("Accepted", null, "Soft-deleted protected item restored");
+
+        _backupService.UndeleteProtectedItemAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
+            Arg.Is("/subscriptions/00000000/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/my-vm"),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--datasource-id", "/subscriptions/00000000/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/my-vm"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.ProtectedItemUndeleteCommandResult);
+
+        Assert.NotNull(result);
+        Assert.Equal("Accepted", result.Result.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DeserializationValidation()
+    {
+        // Arrange
+        var expected = new OperationResult("Accepted", "job-456", "Item restored successfully");
+
+        _backupService.UndeleteProtectedItemAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--datasource-id", "ds1"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.ProtectedItemUndeleteCommandResult);
+
+        Assert.NotNull(result);
+        Assert.Equal("Accepted", result.Result.Status);
+        Assert.Equal("job-456", result.Result.JobId);
+        Assert.Equal("Item restored successfully", result.Result.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesException()
+    {
+        // Arrange
+        _backupService.UndeleteProtectedItemAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Test error"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--datasource-id", "ds1"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Contains("Test error", response.Message);
+    }
+
+    [Theory]
+    [InlineData("--subscription sub --vault v --resource-group rg --datasource-id ds1", true)]
+    [InlineData("--subscription sub --vault v --resource-group rg", false)] // Missing datasource-id
+    public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
+    {
+        if (shouldSucceed)
+        {
+            _backupService.UndeleteProtectedItemAsync(
+                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(new OperationResult("Accepted", null, "Restored")));
+        }
+
+        var parseResult = _commandDefinition.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+
+        // Assert
+        if (shouldSucceed)
+        {
+            Assert.Equal(HttpStatusCode.OK, response.Status);
+        }
+        else
+        {
+            Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesForbiddenError()
+    {
+        // Arrange
+        _backupService.UndeleteProtectedItemAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--datasource-id", "ds1"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.Status);
+        Assert.Contains("Authorization failed", response.Message);
+        Assert.Contains("Backup Contributor", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesNotFoundError()
+    {
+        // Arrange
+        _backupService.UndeleteProtectedItemAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(404, "Not Found"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--datasource-id", "ds1"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.Status);
+        Assert.Contains("Soft-deleted protected item not found", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesConflictError()
+    {
+        // Arrange
+        _backupService.UndeleteProtectedItemAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(409, "Conflict"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--datasource-id", "ds1"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Conflict, response.Status);
+        Assert.Contains("not in a soft-deleted state", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesKeyNotFoundException()
+    {
+        // Arrange
+        _backupService.UndeleteProtectedItemAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new KeyNotFoundException("Item not found"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--datasource-id", "ds1"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.Status);
+        Assert.Contains("Soft-deleted protected item not found", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UndeletesItem_DppVault_Successfully()
+    {
+        // Arrange - DPP vaults also support undelete via the deleted instances API
+        var expected = new OperationResult("Accepted", null, "Soft-deleted backup instance restored");
+
+        _backupService.UndeleteProtectedItemAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
+            Arg.Is("/subscriptions/00000000/resourceGroups/rg/providers/Microsoft.Compute/disks/my-disk"),
+            Arg.Is("dpp"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--datasource-id", "/subscriptions/00000000/resourceGroups/rg/providers/Microsoft.Compute/disks/my-disk",
+            "--vault-type", "dpp"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.ProtectedItemUndeleteCommandResult);
+
+        Assert.NotNull(result);
+        Assert.Equal("Accepted", result.Result.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesArgumentException()
+    {
+        // Arrange
+        _backupService.UndeleteProtectedItemAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ArgumentException("Invalid datasource ID format"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--datasource-id", "ds1"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Contains("Invalid datasource ID format", response.Message);
+    }
+
+    [Fact]
+    public void BindOptions_BindsOptionsCorrectly()
+    {
+        // Arrange & Act
+        var command = _command.GetCommand();
+        var options = command.Options;
+
+        // Assert
+        Assert.Contains(options, o => o.Name == "--subscription");
+        Assert.Contains(options, o => o.Name == "--resource-group");
+        Assert.Contains(options, o => o.Name == "--vault");
+        Assert.Contains(options, o => o.Name == "--vault-type");
+        Assert.Contains(options, o => o.Name == "--datasource-id");
+        Assert.Contains(options, o => o.Name == "--container");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesContainerToService()
+    {
+        // Arrange - verify --container flows through to UndeleteProtectedItemAsync
+        var expected = new OperationResult("Accepted", null, "Restored");
+
+        _backupService.UndeleteProtectedItemAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
+            Arg.Any<string?>(), Arg.Is("IaasVMContainer;iaasvmcontainerv2;rg;myvm"), Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--datasource-id", "ds1", "--container", "IaasVMContainer;iaasvmcontainerv2;rg;myvm"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await _backupService.Received(1).UndeleteProtectedItemAsync(
+            "v", "rg", "sub", "ds1",
+            Arg.Any<string?>(), "IaasVMContainer;iaasvmcontainerv2;rg;myvm", Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/test-resources-post.ps1
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/test-resources-post.ps1
@@ -15,3 +15,160 @@ $ErrorActionPreference = "Stop"
 $testSettings = New-TestSettings @PSBoundParameters -OutputPath $PSScriptRoot
 
 Write-Host "Azure Backup test resources deployed successfully for vault: $BaseName-rsv" -ForegroundColor Yellow
+
+# ─── Setup for Undelete Tests ───
+# Creates backup instances in both RSV and DPP, then soft-deletes them
+# so the undelete live tests have real soft-deleted items to restore.
+
+$subscriptionId = (Get-AzContext).Subscription.Id
+$rsvVaultName = "$BaseName-rsv"
+$dppVaultName = "$BaseName-dpp"
+$diskId = $DeploymentOutputs["diskId"]
+$storageAccountName = $DeploymentOutputs["storageAccountName"]
+$fileShareName = $DeploymentOutputs["fileShareName"]
+$storageAccountId = $DeploymentOutputs["storageAccountId"]
+
+Write-Host "Setting up undelete test infrastructure..." -ForegroundColor Cyan
+
+# ── DPP: Create disk backup policy and protect disk ──
+Write-Host "Creating DPP disk backup policy..." -ForegroundColor Yellow
+$dppPolicyName = "undelete-disk-policy"
+
+try {
+    $existingPolicy = Get-AzDataProtectionBackupPolicy -VaultName $dppVaultName -ResourceGroupName $ResourceGroupName -Name $dppPolicyName -ErrorAction SilentlyContinue
+} catch {
+    $existingPolicy = $null
+}
+
+if (-not $existingPolicy) {
+    $policyDefn = Get-AzDataProtectionPolicyTemplate -DatasourceType AzureDisk
+    $policyDefn.PolicyRule[0].Trigger.ScheduleRepeatingTimeInterval = @("R/2024-01-01T02:00:00+00:00/P1D")
+    New-AzDataProtectionBackupPolicy -VaultName $dppVaultName -ResourceGroupName $ResourceGroupName -Name $dppPolicyName -Policy $policyDefn
+    Write-Host "DPP disk backup policy created." -ForegroundColor Green
+} else {
+    Write-Host "DPP disk backup policy already exists." -ForegroundColor Gray
+}
+
+Write-Host "Protecting disk in DPP vault..." -ForegroundColor Yellow
+$dppPolicy = Get-AzDataProtectionBackupPolicy -VaultName $dppVaultName -ResourceGroupName $ResourceGroupName -Name $dppPolicyName
+
+try {
+    $existingInstance = Get-AzDataProtectionBackupInstance -VaultName $dppVaultName -ResourceGroupName $ResourceGroupName | Where-Object {
+        $_.Property.DataSourceInfo.ResourceId -eq $diskId
+    }
+} catch {
+    $existingInstance = $null
+}
+
+if (-not $existingInstance) {
+    $diskInstance = Initialize-AzDataProtectionBackupInstance -DatasourceType AzureDisk -DatasourceLocation (Get-AzResourceGroup -Name $ResourceGroupName).Location -PolicyId $dppPolicy.Id -DatasourceId $diskId -SnapshotResourceGroupId (Get-AzResourceGroup -Name $ResourceGroupName).ResourceId
+    $protectedDisk = New-AzDataProtectionBackupInstance -VaultName $dppVaultName -ResourceGroupName $ResourceGroupName -BackupInstance $diskInstance
+    Write-Host "Disk protected in DPP vault: $($protectedDisk.Name)" -ForegroundColor Green
+    
+    # Wait for protection to be configured
+    Write-Host "Waiting 60s for DPP protection to stabilize..." -ForegroundColor Yellow
+    Start-Sleep -Seconds 60
+} else {
+    Write-Host "Disk already protected in DPP vault." -ForegroundColor Gray
+    $protectedDisk = $existingInstance
+}
+
+# Wait for protection status to become ProtectionConfigured
+Write-Host "Waiting for DPP protection status to become configured..." -ForegroundColor Yellow
+for ($i = 0; $i -lt 12; $i++) {
+    $currentInstance = Get-AzDataProtectionBackupInstance -VaultName $dppVaultName -ResourceGroupName $ResourceGroupName | Where-Object {
+        $_.Property.DataSourceInfo.ResourceId -eq $diskId
+    }
+    if ($currentInstance -and $currentInstance.Property.ProtectionStatus.Status -eq "ProtectionConfigured") {
+        Write-Host "DPP protection configured." -ForegroundColor Green
+        break
+    }
+    $protectionStatus = if ($currentInstance) { $currentInstance.Property.ProtectionStatus.Status } else { "Not returned yet" }
+    Write-Host "  Status: $protectionStatus - waiting 15s..." -ForegroundColor Gray
+    Start-Sleep -Seconds 15
+}
+
+# Soft-delete the DPP backup instance
+Write-Host "Soft-deleting DPP disk backup instance..." -ForegroundColor Yellow
+$dppInstanceName = if ($protectedDisk.Name) { $protectedDisk.Name } else { $protectedDisk[0].Name }
+try {
+    Remove-AzDataProtectionBackupInstance -VaultName $dppVaultName -ResourceGroupName $ResourceGroupName -Name $dppInstanceName
+    Write-Host "DPP disk backup instance soft-deleted." -ForegroundColor Green
+    Start-Sleep -Seconds 10
+} catch {
+    Write-Host "DPP soft-delete skipped (may already be deleted): $_" -ForegroundColor Yellow
+}
+
+# ── RSV: Enable soft delete, create file share policy, protect file share, then soft-delete ──
+Write-Host "Ensuring RSV soft delete is enabled..." -ForegroundColor Yellow
+$rsvVault = Get-AzRecoveryServicesVault -Name $rsvVaultName -ResourceGroupName $ResourceGroupName
+Set-AzRecoveryServicesVaultContext -Vault $rsvVault
+
+$vaultProperty = Get-AzRecoveryServicesVaultProperty -VaultId $rsvVault.ID
+if ($vaultProperty.SoftDeleteFeatureState -ne "Enabled") {
+    Set-AzRecoveryServicesVaultProperty -VaultId $rsvVault.ID -SoftDeleteFeatureState Enable
+    Write-Host "RSV soft delete enabled." -ForegroundColor Green
+} else {
+    Write-Host "RSV soft delete already enabled." -ForegroundColor Gray
+}
+
+# Register storage account with RSV
+Write-Host "Registering storage account with RSV..." -ForegroundColor Yellow
+try {
+    $container = Get-AzRecoveryServicesBackupContainer -ContainerType AzureStorage -FriendlyName $storageAccountName -VaultId $rsvVault.ID -ErrorAction SilentlyContinue
+    if (-not $container) {
+        Register-AzRecoveryServicesBackupContainer -ResourceId $storageAccountId -VaultId $rsvVault.ID -BackupManagementType AzureStorage -Force
+        Write-Host "Storage account registered." -ForegroundColor Green
+        Start-Sleep -Seconds 15
+    } else {
+        Write-Host "Storage account already registered." -ForegroundColor Gray
+    }
+} catch {
+    Write-Host "Storage account registration: $_" -ForegroundColor Yellow
+}
+
+# Create or get file share protection policy
+$rsvPolicyName = "undelete-fs-policy"
+Write-Host "Creating RSV file share backup policy..." -ForegroundColor Yellow
+$rsvPolicy = Get-AzRecoveryServicesBackupProtectionPolicy -VaultId $rsvVault.ID -Name $rsvPolicyName -ErrorAction SilentlyContinue
+if (-not $rsvPolicy) {
+    $schedulePolicy = Get-AzRecoveryServicesBackupSchedulePolicyObject -WorkloadType AzureFiles -ScheduleRunFrequency Daily
+    $retentionPolicy = Get-AzRecoveryServicesBackupRetentionPolicyObject -WorkloadType AzureFiles
+    $rsvPolicy = New-AzRecoveryServicesBackupProtectionPolicy -VaultId $rsvVault.ID -Name $rsvPolicyName -WorkloadType AzureFiles -RetentionPolicy $retentionPolicy -SchedulePolicy $schedulePolicy
+    Write-Host "RSV file share policy created." -ForegroundColor Green
+} else {
+    Write-Host "RSV file share policy already exists." -ForegroundColor Gray
+}
+
+# Protect the file share
+Write-Host "Protecting file share in RSV..." -ForegroundColor Yellow
+$existingFsItem = Get-AzRecoveryServicesBackupItem -VaultId $rsvVault.ID -BackupManagementType AzureStorage -WorkloadType AzureFiles -ErrorAction SilentlyContinue | Where-Object {
+    $_.FriendlyName -eq $fileShareName
+}
+
+if (-not $existingFsItem) {
+    Enable-AzRecoveryServicesBackupProtection -VaultId $rsvVault.ID -Policy $rsvPolicy -StorageAccountName $storageAccountName -Name $fileShareName
+    Write-Host "File share protected in RSV." -ForegroundColor Green
+    Start-Sleep -Seconds 30
+} else {
+    Write-Host "File share already protected in RSV." -ForegroundColor Gray
+}
+
+# Soft-delete the RSV file share backup
+Write-Host "Soft-deleting RSV file share backup..." -ForegroundColor Yellow
+$protectedFs = Get-AzRecoveryServicesBackupItem -VaultId $rsvVault.ID -BackupManagementType AzureStorage -WorkloadType AzureFiles -ErrorAction SilentlyContinue | Where-Object {
+    $_.FriendlyName -eq $fileShareName
+}
+if ($protectedFs) {
+    try {
+        Disable-AzRecoveryServicesBackupProtection -Item $protectedFs -VaultId $rsvVault.ID -RemoveRecoveryPoints -Force
+        Write-Host "RSV file share backup soft-deleted." -ForegroundColor Green
+        Start-Sleep -Seconds 10
+    } catch {
+        Write-Host "RSV soft-delete skipped: $_" -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "No protected file share found to soft-delete." -ForegroundColor Yellow
+}
+
+Write-Host "Undelete test infrastructure setup complete." -ForegroundColor Cyan

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/test-resources.bicep
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/test-resources.bicep
@@ -19,6 +19,9 @@ resource rsvVault 'Microsoft.RecoveryServices/vaults@2024-04-01' = {
     name: 'RS0'
     tier: 'Standard'
   }
+  identity: {
+    type: 'SystemAssigned'
+  }
   properties: {
     publicNetworkAccess: 'Enabled'
   }
@@ -76,3 +79,116 @@ resource appDppBackupContributorRoleAssignment 'Microsoft.Authorization/roleAssi
     description: 'Backup Contributor for ${testApplicationOid}'
   }
 }
+
+// ─── Resources for Undelete Tests ───
+
+// Managed Disk for DPP backup + undelete testing
+resource testDisk 'Microsoft.Compute/disks@2023-10-02' = {
+  name: '${baseName}-disk'
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties: {
+    creationData: {
+      createOption: 'Empty'
+    }
+    diskSizeGB: 4
+  }
+}
+
+// Disk Snapshot Contributor role for DPP vault MSI on the resource group
+// Required for DPP to take disk snapshots
+resource diskSnapshotContributorRoleDef 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  scope: subscription()
+  name: '7efff54f-a5b4-42b5-a1c5-5411624893ce' // Disk Snapshot Contributor
+}
+
+resource dppDiskSnapshotContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(diskSnapshotContributorRoleDef.id, dppVault.id, resourceGroup().id)
+  properties: {
+    principalId: dppVault.identity.principalId
+    roleDefinitionId: diskSnapshotContributorRoleDef.id
+    principalType: 'ServicePrincipal'
+    description: 'Disk Snapshot Contributor for DPP vault MSI'
+  }
+}
+
+// Disk Backup Reader role for DPP vault MSI on the disk
+resource diskBackupReaderRoleDef 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  scope: subscription()
+  name: '3e5e47e6-65f7-47ef-90b5-e5dd4d455f24' // Disk Backup Reader
+}
+
+resource dppDiskBackupReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(diskBackupReaderRoleDef.id, dppVault.id, testDisk.id)
+  scope: testDisk
+  properties: {
+    principalId: dppVault.identity.principalId
+    roleDefinitionId: diskBackupReaderRoleDef.id
+    principalType: 'ServicePrincipal'
+    description: 'Disk Backup Reader for DPP vault MSI'
+  }
+}
+
+// Output the resource IDs for the post-deployment script
+output diskId string = testDisk.id
+
+// ─── RSV Undelete Test Resources (Storage Account + File Share) ───
+
+// Storage Account for RSV file share backup + undelete testing
+// allowSharedKeyAccess=true is required for RSV file share backup integration.
+// Policy requires Reason, ETA, and DisableLocalAuth tags when shared key is enabled.
+resource testStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: take('${replace(baseName, '-', '')}sa', 24)
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+    allowSharedKeyAccess: true
+  }
+  tags: {
+    DisableLocalAuth: 'false'
+    Reason: 'RSV file share backup requires shared key auth'
+    ETA: '2027-01-01'
+    Owner: 'azurebackup-mcp-tests'
+    ServiceName: 'AzureBackup'
+    Environment: 'Test'
+  }
+}
+
+resource testFileService 'Microsoft.Storage/storageAccounts/fileServices@2023-05-01' = {
+  parent: testStorageAccount
+  name: 'default'
+}
+
+resource testFileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-05-01' = {
+  parent: testFileService
+  name: '${baseName}-share'
+  properties: {
+    shareQuota: 1
+  }
+}
+
+// Storage Account Backup Contributor for the test app on the storage account
+resource storageBackupContributorRoleDef 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  scope: subscription()
+  name: 'e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1' // Storage Account Backup Contributor
+}
+
+resource appStorageBackupContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageBackupContributorRoleDef.id, testApplicationOid, testStorageAccount.id)
+  scope: testStorageAccount
+  properties: {
+    principalId: testApplicationOid
+    roleDefinitionId: storageBackupContributorRoleDef.id
+    description: 'Storage Account Backup Contributor for ${testApplicationOid}'
+  }
+}
+
+output storageAccountId string = testStorageAccount.id
+output storageAccountName string = testStorageAccount.name
+output fileShareName string = testFileShare.name


### PR DESCRIPTION
## Summary

Adds a new `azurebackup protecteditem undelete` command that restores soft-deleted backup items to an active protection state for both RSV (Recovery Services vault) and DPP (Data Protection) vault types.

## Changes

### New Tool: `protecteditem undelete`

**RSV implementation:**
- Finds soft-deleted protected item by datasource ID (ARM resource ID or in-guest workload protectable item name)
- Disambiguates prefix matches when multiple file shares share the same storage account
- Supports in-guest workload names (SQL/HANA) with required `--container`
- When `--container` is provided with ARM ID, uses direct lookup via `RsvNamingHelper` to bypass listing
- Sets `IsRehydrate = true` on the matched item's existing properties (preserving PolicyId, ContainerName, etc.)
- Returns `Accepted` status with job ID from response headers

**DPP implementation:**
- Lists soft-deleted instances via `GetDeletedDataProtectionBackupInstances`
- Matches by datasource ID and calls `UndeleteAsync`
- Extracts job ID from `Azure-AsyncOperation` header (consistent with other DPP LROs)
- Returns `Accepted` status with job ID (null when unavailable, with operation ID in message)

### Files Added (3)
| File | Description |
|------|-------------|
| `ProtectedItemUndeleteCommand.cs` | Sealed command with error handling for 403/404/409 scenarios |
| `ProtectedItemUndeleteOptions.cs` | Options class extending `BaseAzureBackupOptions` with `DatasourceId` and `Container` |
| `ProtectedItemUndeleteCommandTests.cs` | 14 unit tests |

### Files Modified
| File | Description |
|------|-------------|
| `IAzureBackupService.cs` | Added `UndeleteProtectedItemAsync` to service contract |
| `IRsvBackupOperations.cs` | Added RSV undelete interface method |
| `IDppBackupOperations.cs` | Added DPP undelete interface method |
| `AzureBackupService.cs` | Routes undelete to RSV/DPP based on resolved vault type |
| `RsvBackupOperations.cs` | RSV implementation with `IsRehydrate=true`, prefix disambiguation, workload support |
| `DppBackupOperations.cs` | DPP implementation via `DeletedDataProtectionBackupInstanceResource.UndeleteAsync` |
| `AzureBackupSetup.cs` | Registers the new command in DI + command group |
| `AzureBackupJsonContext.cs` | AOT serialization context for `ProtectedItemUndeleteCommandResult` |
| `BackupStatusCommand.cs` | Improved description for ToolDescriptionEvaluator |
| `ProtectableItemListCommand.cs` | Improved description for ToolDescriptionEvaluator |
| `ProtectedItemProtectCommand.cs` | Improved description for ToolDescriptionEvaluator |
| `consolidated-tools.json` | Added `azurebackup_protecteditem_undelete` to `update_azure_backup_settings` |
| `README.md` | Added undelete prompt example |
| `AzureBackupSetupTests.cs` | Verifies `undelete` command registration under `protecteditem` |
| `AzureBackupCommandTests.cs` | 2 recorded live tests (DPP disk + RSV file share undelete) |
| `assets.json` | Updated recording tag |
| `test-resources.bicep` | Adds managed disk, storage account + file share, and RBAC role assignments |
| `test-resources-post.ps1` | Creates backup instances, waits for protection, then soft-deletes them |
| `azmcp-commands.md` | Command reference for `protecteditem undelete` |
| `e2eTestPrompts.md` | E2E test prompts for undelete + improved protect prompt |

## Test Results
- **344 unit tests**: All pass (14 new undelete tests)
- **45 live tests (playback)**: All pass (2 new: DPP disk + RSV file share)
- **ConsolidatedMode server test**: Passes (metadata matches `update_azure_backup_settings` group)
- **dotnet format**: No issues
- **cspell**: No spelling issues
- **Build-Local.ps1 -VerifyNpx**: All servers build, trim, and package successfully

## ToolDescriptionEvaluator Results

Ran the evaluator for all 16 Azure Backup tools against 32 test prompts.

**Before (original descriptions):** 87.5% acceptable confidence, 4 tools failing (not in top 3 or below 0.4)
**After (improved descriptions):** **100% acceptable confidence, all 32 prompts in top 3**

| Tool | Prompt 1 | Prompt 2 |
|------|----------|----------|
| `backup_status` | Rank 1, 0.60 ✅ | Rank 1, 0.55 ✅ |
| `disasterrecovery_enable-crr` | Rank 1, 0.74 ✅ | Rank 1, 0.76 ✅ |
| `governance_find-unprotected` | Rank 1, 0.58 ✅ | Rank 1, 0.63 ✅ |
| `governance_immutability` | Rank 1, 0.65 ✅ | Rank 1, 0.66 ✅ |
| `governance_soft-delete` | Rank 1, 0.63 ✅ | Rank 1, 0.72 ✅ |
| `job_get` | Rank 1, 0.63 ✅ | Rank 1, 0.63 ✅ |
| `policy_create` | Rank 1, 0.60 ✅ | Rank 1, 0.64 ✅ |
| `policy_get` | Rank 1, 0.69 ✅ | Rank 1, 0.70 ✅ |
| `protectableitem_list` | Rank 3, 0.48 ✅ | Rank 2, 0.55 ✅ |
| `protecteditem_get` | Rank 2, 0.63 ✅ | Rank 3, 0.63 ✅ |
| `protecteditem_protect` | Rank 2, 0.58 ✅ | Rank 1, 0.59 ✅ |
| **`protecteditem_undelete`** | **Rank 1, 0.72 ✅** | **Rank 1, 0.65 ✅** |
| `recoverypoint_get` | Rank 1, 0.64 ✅ | Rank 2, 0.59 ✅ |
| `vault_create` | Rank 1, 0.70 ✅ | Rank 1, 0.70 ✅ |
| `vault_get` | Rank 1, 0.71 ✅ | Rank 1, 0.72 ✅ |
| `vault_update` | Rank 1, 0.56 ✅ | Rank 1, 0.47 ✅ |

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
