### PR TITLE
[Part 3] Migrate tool command unit tests to useing CommandUnitTestsBase

### DIFF
--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/AzureBackupSetupTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/AzureBackupSetupTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Mcp.Core.Services.Azure.Tenant;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Mcp.Core.Commands;
 using NSubstitute;
 using Xunit;
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Backup/BackupStatusCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Backup/BackupStatusCommandTests.cs
@@ -2,47 +2,24 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Backup;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.Backup;
 
-public class BackupStatusCommandTests
+public class BackupStatusCommandTests : CommandUnitTestsBase<BackupStatusCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<BackupStatusCommand> _logger;
-    private readonly BackupStatusCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public BackupStatusCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<BackupStatusCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
+        var command = Command.GetCommand();
         Assert.Equal("status", command.Name);
         Assert.NotNull(command.Description);
         Assert.NotEmpty(command.Description);
@@ -62,24 +39,24 @@ public class BackupStatusCommandTests
             null,
             null);
 
-        _backupService.GetBackupStatusAsync(
-            Arg.Is(expectedDatasourceId), Arg.Is("sub1"), Arg.Is("eastus"),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub1", "--datasource-id", expectedDatasourceId, "--location", "eastus"]);
+        Service.GetBackupStatusAsync(
+            Arg.Is(expectedDatasourceId),
+            Arg.Is("sub1"),
+            Arg.Is("eastus"),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expected);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--datasource-id", expectedDatasourceId,
+            "--location", "eastus");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.BackupStatusCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.BackupStatusCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("Protected", result.Status.ProtectionStatus);
         Assert.NotNull(result.Status.VaultId);
         Assert.Equal("DefaultPolicy", result.Status.PolicyName);
@@ -99,24 +76,24 @@ public class BackupStatusCommandTests
             null,
             null);
 
-        _backupService.GetBackupStatusAsync(
-            Arg.Is(expectedDatasourceId), Arg.Is("sub1"), Arg.Is("eastus"),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub1", "--datasource-id", expectedDatasourceId, "--location", "eastus"]);
+        Service.GetBackupStatusAsync(
+            Arg.Is(expectedDatasourceId),
+            Arg.Is("sub1"),
+            Arg.Is("eastus"),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expected);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--datasource-id", expectedDatasourceId,
+            "--location", "eastus");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.BackupStatusCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.BackupStatusCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("NotProtected", result.Status.ProtectionStatus);
         Assert.Null(result.Status.VaultId);
         Assert.Null(result.Status.PolicyName);
@@ -126,15 +103,20 @@ public class BackupStatusCommandTests
     public async Task ExecuteAsync_HandlesGenericException()
     {
         // Arrange
-        _backupService.GetBackupStatusAsync(
-            Arg.Is("ds1"), Arg.Is("sub1"), Arg.Is("eastus"),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetBackupStatusAsync(
+            Arg.Is("ds1"),
+            Arg.Is("sub1"),
+            Arg.Is("eastus"),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub1", "--datasource-id", "ds1", "--location", "eastus"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--datasource-id", "ds1",
+            "--location", "eastus");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -145,15 +127,20 @@ public class BackupStatusCommandTests
     public async Task ExecuteAsync_HandlesNotFoundError()
     {
         // Arrange
-        _backupService.GetBackupStatusAsync(
-            Arg.Is("ds1"), Arg.Is("sub1"), Arg.Is("eastus"),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetBackupStatusAsync(
+            Arg.Is("ds1"),
+            Arg.Is("sub1"),
+            Arg.Is("eastus"),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub1", "--datasource-id", "ds1", "--location", "eastus"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--datasource-id", "ds1",
+            "--location", "eastus");
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.Status);
@@ -164,15 +151,20 @@ public class BackupStatusCommandTests
     public async Task ExecuteAsync_HandlesForbiddenError()
     {
         // Arrange
-        _backupService.GetBackupStatusAsync(
-            Arg.Is("ds1"), Arg.Is("sub1"), Arg.Is("eastus"),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetBackupStatusAsync(
+            Arg.Is("ds1"),
+            Arg.Is("sub1"),
+            Arg.Is("eastus"),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub1", "--datasource-id", "ds1", "--location", "eastus"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--datasource-id", "ds1",
+            "--location", "eastus");
 
         // Assert
         Assert.Equal(HttpStatusCode.Forbidden, response.Status);
@@ -188,16 +180,18 @@ public class BackupStatusCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.GetBackupStatusAsync(
-                Arg.Is("ds1"), Arg.Is("sub1"), Arg.Is("eastus"),
-                Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new BackupStatusResult("ds1", "Protected", "v1", "pol", null, null, null)));
+            Service.GetBackupStatusAsync(
+                Arg.Is("ds1"),
+                Arg.Is("sub1"),
+                Arg.Is("eastus"),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+                .Returns(new BackupStatusResult("ds1", "Protected", "v1", "pol", null, null, null));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -224,24 +218,24 @@ public class BackupStatusCommandTests
             "Completed",
             "Healthy");
 
-        _backupService.GetBackupStatusAsync(
-            Arg.Is(expectedDatasourceId), Arg.Is("sub1"), Arg.Is("eastus"),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub1", "--datasource-id", expectedDatasourceId, "--location", "eastus"]);
+        Service.GetBackupStatusAsync(
+            Arg.Is(expectedDatasourceId),
+            Arg.Is("sub1"),
+            Arg.Is("eastus"),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expected);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--datasource-id", expectedDatasourceId,
+            "--location", "eastus");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.BackupStatusCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.BackupStatusCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("Protected", result.Status.ProtectionStatus);
         Assert.Equal("DefaultPolicy", result.Status.PolicyName);
         Assert.Equal("Completed", result.Status.LastBackupStatus);
@@ -251,13 +245,10 @@ public class BackupStatusCommandTests
     [Fact]
     public void BindOptions_BindsOptionsCorrectly()
     {
-        // Arrange
-        var args = _commandDefinition.Parse(["--subscription", "sub1", "--datasource-id", "/subscriptions/test/vm1", "--location", "westus2"]);
-
         // Act - use reflection or test via ExecuteAsync
         // The binding is tested implicitly through ExecuteAsync tests above
         // Verify the command has the right options registered
-        var command = _command.GetCommand();
+        var command = Command.GetCommand();
         var options = command.Options;
 
         Assert.Contains(options, o => o.Name == "--datasource-id");
@@ -273,18 +264,23 @@ public class BackupStatusCommandTests
         var expectedSubscription = "sub1";
         var expectedLocation = "eastus";
 
-        _backupService.GetBackupStatusAsync(
-            Arg.Is(expectedDatasourceId), Arg.Is(expectedSubscription), Arg.Is(expectedLocation),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new BackupStatusResult(expectedDatasourceId, "Protected", null, null, null, null, null)));
-
-        var args = _commandDefinition.Parse(["--subscription", expectedSubscription, "--datasource-id", expectedDatasourceId, "--location", expectedLocation]);
+        Service.GetBackupStatusAsync(
+            Arg.Is(expectedDatasourceId),
+            Arg.Is(expectedSubscription),
+            Arg.Is(expectedLocation),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new BackupStatusResult(expectedDatasourceId, "Protected", null, null, null, null, null));
 
         // Act
-        await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        await ExecuteCommandAsync(
+            "--subscription", expectedSubscription,
+            "--datasource-id", expectedDatasourceId,
+            "--location", expectedLocation);
 
         // Assert
-        await _backupService.Received(1).GetBackupStatusAsync(
+        await Service.Received(1).GetBackupStatusAsync(
             expectedDatasourceId,
             expectedSubscription,
             expectedLocation,

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/DisasterRecovery/DisasterRecoveryEnableCrrCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/DisasterRecovery/DisasterRecoveryEnableCrrCommandTests.cs
@@ -2,47 +2,24 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.DisasterRecovery;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.DisasterRecovery;
 
-public class DisasterRecoveryEnableCrrCommandTests
+public class DisasterRecoveryEnableCrrCommandTests : CommandUnitTestsBase<DisasterRecoveryEnableCrrCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<DisasterRecoveryEnableCrrCommand> _logger;
-    private readonly DisasterRecoveryEnableCrrCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public DisasterRecoveryEnableCrrCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<DisasterRecoveryEnableCrrCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
+        var command = Command.GetCommand();
         Assert.Equal("enable-crr", command.Name);
         Assert.NotNull(command.Description);
         Assert.NotEmpty(command.Description);
@@ -52,26 +29,25 @@ public class DisasterRecoveryEnableCrrCommandTests
     public async Task ExecuteAsync_EnablesCrr_Successfully()
     {
         // Arrange
-        var expected = new OperationResult("Succeeded", null, "Cross-region restore enabled");
-
-        _backupService.ConfigureCrossRegionRestoreAsync(
-            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
+        Service.ConfigureCrossRegionRestoreAsync(
+            Arg.Is("v"),
+            Arg.Is("rg"),
+            Arg.Is("sub"),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new OperationResult("Succeeded", null, "Cross-region restore enabled"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.DisasterRecoveryEnableCrrCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.DisasterRecoveryEnableCrrCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("Succeeded", result.Result.Status);
     }
 
@@ -79,15 +55,21 @@ public class DisasterRecoveryEnableCrrCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange
-        _backupService.ConfigureCrossRegionRestoreAsync(
-            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ConfigureCrossRegionRestoreAsync(
+            Arg.Is("v"),
+            Arg.Is("rg"),
+            Arg.Is("sub"),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -98,15 +80,21 @@ public class DisasterRecoveryEnableCrrCommandTests
     public async Task ExecuteAsync_HandlesNotFoundError()
     {
         // Arrange
-        _backupService.ConfigureCrossRegionRestoreAsync(
-            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ConfigureCrossRegionRestoreAsync(
+            Arg.Is("v"),
+            Arg.Is("rg"),
+            Arg.Is("sub"),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg");
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.Status);
@@ -117,15 +105,21 @@ public class DisasterRecoveryEnableCrrCommandTests
     public async Task ExecuteAsync_HandlesBadRequestForNonGrsVault()
     {
         // Arrange
-        _backupService.ConfigureCrossRegionRestoreAsync(
-            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ConfigureCrossRegionRestoreAsync(
+            Arg.Is("v"),
+            Arg.Is("rg"),
+            Arg.Is("sub"),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(400, "CRR not supported"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg");
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -136,15 +130,16 @@ public class DisasterRecoveryEnableCrrCommandTests
     public async Task ExecuteAsync_HandlesConflictWhenAlreadyEnabled()
     {
         // Arrange
-        _backupService.ConfigureCrossRegionRestoreAsync(
+        Service.ConfigureCrossRegionRestoreAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(409, "Already enabled"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg");
 
         // Assert
         Assert.Equal(HttpStatusCode.Conflict, response.Status);
@@ -158,8 +153,11 @@ public class DisasterRecoveryEnableCrrCommandTests
     [InlineData("recovery")]
     public async Task ExecuteAsync_RejectsInvalidVaultType(string vaultType)
     {
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--vault-type", vaultType]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--vault-type", vaultType);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("--vault-type must be", response.Message);
     }
@@ -171,13 +169,16 @@ public class DisasterRecoveryEnableCrrCommandTests
     [InlineData("DPP")]
     public async Task ExecuteAsync_AcceptsValidVaultType(string vaultType)
     {
-        _backupService.ConfigureCrossRegionRestoreAsync(
+        Service.ConfigureCrossRegionRestoreAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(vaultType),
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
+            .Returns(new OperationResult("Succeeded", null, null));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--vault-type", vaultType]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--vault-type", vaultType);
         Assert.Equal(HttpStatusCode.OK, response.Status);
     }
 
@@ -188,16 +189,14 @@ public class DisasterRecoveryEnableCrrCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.ConfigureCrossRegionRestoreAsync(
+            Service.ConfigureCrossRegionRestoreAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
                 Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
+                .Returns(new OperationResult("Succeeded", null, null));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -214,8 +213,7 @@ public class DisasterRecoveryEnableCrrCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = Command.GetCommand().Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");
@@ -228,26 +226,20 @@ public class DisasterRecoveryEnableCrrCommandTests
     public async Task ExecuteAsync_DeserializationValidation()
     {
         // Arrange
-        var expected = new OperationResult("Succeeded", null, "Cross-region restore enabled");
-
-        _backupService.ConfigureCrossRegionRestoreAsync(
+        Service.ConfigureCrossRegionRestoreAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
+            .Returns(new OperationResult("Succeeded", null, "Cross-region restore enabled"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.DisasterRecoveryEnableCrrCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.DisasterRecoveryEnableCrrCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("Succeeded", result.Result.Status);
         Assert.Equal("Cross-region restore enabled", result.Result.Message);
     }

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Governance/GovernanceFindUnprotectedCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Governance/GovernanceFindUnprotectedCommandTests.cs
@@ -2,47 +2,24 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Governance;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.Governance;
 
-public class GovernanceFindUnprotectedCommandTests
+public class GovernanceFindUnprotectedCommandTests : CommandUnitTestsBase<GovernanceFindUnprotectedCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<GovernanceFindUnprotectedCommand> _logger;
-    private readonly GovernanceFindUnprotectedCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public GovernanceFindUnprotectedCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<GovernanceFindUnprotectedCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
+        var command = Command.GetCommand();
         Assert.Equal("find-unprotected", command.Name);
         Assert.NotNull(command.Description);
         Assert.NotEmpty(command.Description);
@@ -58,24 +35,17 @@ public class GovernanceFindUnprotectedCommandTests
             new("/subscriptions/.../sql1", "sql1", "Microsoft.Sql/servers", "rg2", "westus", null)
         };
 
-        _backupService.FindUnprotectedResourcesAsync(
+        Service.FindUnprotectedResourcesAsync(
             Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResources));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub123"]);
+            .Returns(expectedResources);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.GovernanceFindUnprotectedCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.GovernanceFindUnprotectedCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(2, result.Resources.Count);
         Assert.Equal("vm1", result.Resources[0].Name);
     }
@@ -84,23 +54,17 @@ public class GovernanceFindUnprotectedCommandTests
     public async Task ExecuteAsync_ReturnsEmpty_WhenAllProtected()
     {
         // Arrange
-        _backupService.FindUnprotectedResourcesAsync(
+        Service.FindUnprotectedResourcesAsync(
             Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new List<UnprotectedResourceInfo>()));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub123"]);
+            .Returns([]);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.GovernanceFindUnprotectedCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.GovernanceFindUnprotectedCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Resources);
     }
 
@@ -108,15 +72,13 @@ public class GovernanceFindUnprotectedCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange
-        _backupService.FindUnprotectedResourcesAsync(
+        Service.FindUnprotectedResourcesAsync(
             Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub123"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -129,16 +91,14 @@ public class GovernanceFindUnprotectedCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.FindUnprotectedResourcesAsync(
+            Service.FindUnprotectedResourcesAsync(
                 Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
                 Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new List<UnprotectedResourceInfo>()));
+                .Returns([]);
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -155,8 +115,7 @@ public class GovernanceFindUnprotectedCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");
@@ -168,27 +127,24 @@ public class GovernanceFindUnprotectedCommandTests
     [Fact]
     public void BindOptions_DoesNotContainOldResourceGroupFilterOption()
     {
-        var command = _command.GetCommand();
-        Assert.DoesNotContain(command.Options, o => o.Name == "--resource-group-filter");
+        Assert.DoesNotContain(CommandDefinition.Options, o => o.Name == "--resource-group-filter");
     }
 
     [Fact]
     public async Task ExecuteAsync_WithResourceGroup_PassesValueToService()
     {
         // Arrange
-        _backupService.FindUnprotectedResourcesAsync(
+        Service.FindUnprotectedResourcesAsync(
             Arg.Is("sub123"), Arg.Any<string?>(), Arg.Is("myRG"), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new List<UnprotectedResourceInfo>()));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub123", "--resource-group", "myRG"]);
+            .Returns([]);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123", "--resource-group", "myRG");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _backupService.Received(1).FindUnprotectedResourcesAsync(
+        await Service.Received(1).FindUnprotectedResourcesAsync(
             "sub123", Arg.Any<string?>(), "myRG",
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
@@ -203,24 +159,17 @@ public class GovernanceFindUnprotectedCommandTests
             new("/subscriptions/.../vm1", "vm1", "Microsoft.Compute/virtualMachines", "rg1", "eastus", null)
         };
 
-        _backupService.FindUnprotectedResourcesAsync(
+        Service.FindUnprotectedResourcesAsync(
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResources));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub123"]);
+            .Returns(expectedResources);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.GovernanceFindUnprotectedCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.GovernanceFindUnprotectedCommandResult);
-
-        Assert.NotNull(result);
         Assert.Single(result.Resources);
         Assert.Equal("vm1", result.Resources[0].Name);
         Assert.Equal("Microsoft.Compute/virtualMachines", result.Resources[0].ResourceType);

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Governance/GovernanceImmutabilityCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Governance/GovernanceImmutabilityCommandTests.cs
@@ -2,47 +2,24 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Governance;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.Governance;
 
-public class GovernanceImmutabilityCommandTests
+public class GovernanceImmutabilityCommandTests : CommandUnitTestsBase<GovernanceImmutabilityCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<GovernanceImmutabilityCommand> _logger;
-    private readonly GovernanceImmutabilityCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public GovernanceImmutabilityCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<GovernanceImmutabilityCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
+        var command = Command.GetCommand();
         Assert.Equal("immutability", command.Name);
         Assert.NotNull(command.Description);
         Assert.NotEmpty(command.Description);
@@ -52,27 +29,21 @@ public class GovernanceImmutabilityCommandTests
     public async Task ExecuteAsync_ConfiguresImmutability_Successfully()
     {
         // Arrange
-        var expected = new OperationResult("Succeeded", null, "Immutability configured");
-
-        _backupService.ConfigureImmutabilityAsync(
+        Service.ConfigureImmutabilityAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("Enabled"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--immutability-state", "Enabled"]);
+            .Returns(new OperationResult("Succeeded", null, "Immutability configured"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--immutability-state", "Enabled");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.GovernanceImmutabilityCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.GovernanceImmutabilityCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("Succeeded", result.Result.Status);
     }
 
@@ -80,16 +51,17 @@ public class GovernanceImmutabilityCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange
-        _backupService.ConfigureImmutabilityAsync(
+        Service.ConfigureImmutabilityAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("Enabled"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--immutability-state", "Enabled"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--immutability-state", "Enabled");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -104,16 +76,14 @@ public class GovernanceImmutabilityCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.ConfigureImmutabilityAsync(
+            Service.ConfigureImmutabilityAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("Enabled"),
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
+                .Returns(new OperationResult("Succeeded", null, null));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -130,8 +100,7 @@ public class GovernanceImmutabilityCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Governance/GovernanceSoftDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Governance/GovernanceSoftDeleteCommandTests.cs
@@ -2,76 +2,46 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Governance;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.Governance;
 
-public class GovernanceSoftDeleteCommandTests
+public class GovernanceSoftDeleteCommandTests : CommandUnitTestsBase<GovernanceSoftDeleteCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<GovernanceSoftDeleteCommand> _logger;
-    private readonly GovernanceSoftDeleteCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public GovernanceSoftDeleteCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<GovernanceSoftDeleteCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("soft-delete", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("soft-delete", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Fact]
     public async Task ExecuteAsync_ConfiguresSoftDelete_Successfully()
     {
         // Arrange
-        var expected = new OperationResult("Succeeded", null, "Soft delete configured");
-
-        _backupService.ConfigureSoftDeleteAsync(
+        Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("AlwaysOn"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--soft-delete", "AlwaysOn"]);
+            .Returns(new OperationResult("Succeeded", null, "Soft delete configured"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--soft-delete", "AlwaysOn");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.GovernanceSoftDeleteCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.GovernanceSoftDeleteCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("Succeeded", result.Result.Status);
     }
 
@@ -79,16 +49,17 @@ public class GovernanceSoftDeleteCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange
-        _backupService.ConfigureSoftDeleteAsync(
+        Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--soft-delete", "On"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--soft-delete", "On");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -103,16 +74,14 @@ public class GovernanceSoftDeleteCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.ConfigureSoftDeleteAsync(
+            Service.ConfigureSoftDeleteAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
+                .Returns(new OperationResult("Succeeded", null, null));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -129,16 +98,17 @@ public class GovernanceSoftDeleteCommandTests
     public async Task ExecuteAsync_HandlesNotFoundError()
     {
         // Arrange
-        _backupService.ConfigureSoftDeleteAsync(
+        Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--soft-delete", "On"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--soft-delete", "On");
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.Status);
@@ -149,16 +119,17 @@ public class GovernanceSoftDeleteCommandTests
     public async Task ExecuteAsync_HandlesConflictError()
     {
         // Arrange
-        _backupService.ConfigureSoftDeleteAsync(
+        Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(409, "Cannot change"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--soft-delete", "On"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--soft-delete", "On");
 
         // Assert
         Assert.Equal(HttpStatusCode.Conflict, response.Status);
@@ -169,16 +140,17 @@ public class GovernanceSoftDeleteCommandTests
     public async Task ExecuteAsync_HandlesForbiddenError()
     {
         // Arrange
-        _backupService.ConfigureSoftDeleteAsync(
+        Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--soft-delete", "On"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--soft-delete", "On");
 
         // Assert
         Assert.Equal(HttpStatusCode.Forbidden, response.Status);
@@ -192,12 +164,12 @@ public class GovernanceSoftDeleteCommandTests
     [InlineData("always")]
     public async Task ExecuteAsync_RejectsInvalidSoftDeleteState(string softDeleteState)
     {
-        // Arrange
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--soft-delete", softDeleteState]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--soft-delete", softDeleteState);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -211,12 +183,13 @@ public class GovernanceSoftDeleteCommandTests
     [InlineData("abc")] // non-numeric
     public async Task ExecuteAsync_RejectsInvalidRetentionDays(string retentionDays)
     {
-        // Arrange
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--soft-delete", "On", "--soft-delete-retention-days", retentionDays]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--soft-delete", "On",
+            "--soft-delete-retention-days", retentionDays);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -230,16 +203,18 @@ public class GovernanceSoftDeleteCommandTests
     public async Task ExecuteAsync_AcceptsValidRetentionDays(string retentionDays)
     {
         // Arrange
-        _backupService.ConfigureSoftDeleteAsync(
+        Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--soft-delete", "On", "--soft-delete-retention-days", retentionDays]);
+            .Returns(new OperationResult("Succeeded", null, null));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--soft-delete", "On",
+            "--soft-delete-retention-days", retentionDays);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -249,24 +224,22 @@ public class GovernanceSoftDeleteCommandTests
     public async Task ExecuteAsync_DeserializationValidation()
     {
         // Arrange
-        var expected = new OperationResult("Succeeded", null, "Soft delete set to 'On'");
-
-        _backupService.ConfigureSoftDeleteAsync(
+        Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--soft-delete", "On", "--soft-delete-retention-days", "30"]);
+            .Returns(new OperationResult("Succeeded", null, "Soft delete set to 'On'"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--soft-delete", "On",
+            "--soft-delete-retention-days", "30");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.GovernanceSoftDeleteCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.GovernanceSoftDeleteCommandResult);
+
         Assert.Equal("Succeeded", result.Result.Status);
     }
 
@@ -274,8 +247,7 @@ public class GovernanceSoftDeleteCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Job/JobGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Job/JobGetCommandTests.cs
@@ -2,50 +2,26 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Job;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.Job;
 
-public class JobGetCommandTests
+public class JobGetCommandTests : CommandUnitTestsBase<JobGetCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<JobGetCommand> _logger;
-    private readonly JobGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public JobGetCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<JobGetCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("get", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("get", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Fact]
@@ -61,7 +37,7 @@ public class JobGetCommandTests
             new("id2", "job2", "rsv", "Restore", "InProgress", DateTimeOffset.UtcNow.AddMinutes(-30), null, "SQLDataBase", "sql1")
         };
 
-        _backupService.ListJobsAsync(
+        Service.ListJobsAsync(
             Arg.Is(vault),
             Arg.Is(resourceGroup),
             Arg.Is(subscription),
@@ -69,21 +45,17 @@ public class JobGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedJobs));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vault, "--resource-group", resourceGroup]);
+            .Returns(expectedJobs);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vault,
+            "--resource-group", resourceGroup);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.JobGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.JobGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(2, result.Jobs.Count);
         Assert.Equal("job1", result.Jobs[0].Name);
     }
@@ -98,7 +70,7 @@ public class JobGetCommandTests
         var jobId = "job1";
         var expectedJob = new BackupJobInfo("id1", jobId, "rsv", "Backup", "Completed", DateTimeOffset.UtcNow.AddHours(-2), DateTimeOffset.UtcNow.AddHours(-1), "AzureIaasVM", "vm1");
 
-        _backupService.GetJobAsync(
+        Service.GetJobAsync(
             Arg.Is(vault),
             Arg.Is(resourceGroup),
             Arg.Is(subscription),
@@ -107,21 +79,18 @@ public class JobGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedJob));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vault, "--resource-group", resourceGroup, "--job", jobId]);
+            .Returns(expectedJob);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vault,
+            "--resource-group", resourceGroup,
+            "--job", jobId);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.JobGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.JobGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Single(result.Jobs);
         Assert.Equal(jobId, result.Jobs[0].Name);
     }
@@ -130,22 +99,19 @@ public class JobGetCommandTests
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoJobsExist()
     {
         // Arrange
-        _backupService.ListJobsAsync(
+        Service.ListJobsAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new List<BackupJobInfo>()));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
+            .Returns([]);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.JobGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.JobGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Jobs);
     }
 
@@ -153,14 +119,15 @@ public class JobGetCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange
-        _backupService.ListJobsAsync(
+        Service.ListJobsAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -171,14 +138,16 @@ public class JobGetCommandTests
     public async Task ExecuteAsync_HandlesNotFound()
     {
         // Arrange
-        _backupService.GetJobAsync(
+        Service.GetJobAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("nonexistent"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Job not found"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--job", "nonexistent"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--job", "nonexistent");
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.Status);
@@ -193,19 +162,17 @@ public class JobGetCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.ListJobsAsync(
+            Service.ListJobsAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new List<BackupJobInfo>()));
+                .Returns([]);
 
-            _backupService.GetJobAsync(
+            Service.GetJobAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("j1"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new BackupJobInfo("id", "j1", "rsv", "Backup", "Completed", null, null, "VM", "vm1")));
+                .Returns(new BackupJobInfo("id", "j1", "rsv", "Backup", "Completed", null, null, "VM", "vm1"));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -222,8 +189,7 @@ public class JobGetCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Policy/PolicyCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Policy/PolicyCreateCommandTests.cs
@@ -2,78 +2,49 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Policy;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.Policy;
 
-public class PolicyCreateCommandTests
+public class PolicyCreateCommandTests : CommandUnitTestsBase<PolicyCreateCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<PolicyCreateCommand> _logger;
-    private readonly PolicyCreateCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public PolicyCreateCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<PolicyCreateCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("create", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("create", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Fact]
     public async Task ExecuteAsync_CreatesPolicy_Successfully()
     {
         // Arrange
-        var expected = new OperationResult("Succeeded", null, "Policy created successfully");
-
-        _backupService.CreatePolicyAsync(
+        Service.CreatePolicyAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("myPolicy"), Arg.Is("AzureIaasVM"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--policy", "myPolicy", "--workload-type", "AzureIaasVM"]);
+            .Returns(new OperationResult("Succeeded", null, "Policy created successfully"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--policy", "myPolicy",
+            "--workload-type", "AzureIaasVM");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.PolicyCreateCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.PolicyCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("Succeeded", result.Result.Status);
     }
 
@@ -81,17 +52,19 @@ public class PolicyCreateCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange
-        _backupService.CreatePolicyAsync(
+        Service.CreatePolicyAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("p"), Arg.Is("AzureIaasVM"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--policy", "p", "--workload-type", "AzureIaasVM"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--policy", "p",
+            "--workload-type", "AzureIaasVM");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -105,17 +78,15 @@ public class PolicyCreateCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.CreatePolicyAsync(
+            Service.CreatePolicyAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("p"), Arg.Is("VM"),
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
                 Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
+                .Returns(new OperationResult("Succeeded", null, null));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -132,8 +103,7 @@ public class PolicyCreateCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");
@@ -149,8 +119,7 @@ public class PolicyCreateCommandTests
     [Fact]
     public void BindOptions_DoesNotContainRemovedRetentionOptions()
     {
-        var command = _command.GetCommand();
-        var optionNames = command.Options.Select(o => o.Name).ToList();
+        var optionNames = CommandDefinition.Options.Select(o => o.Name).ToList();
 
         Assert.DoesNotContain("--schedule-frequency", optionNames);
         Assert.DoesNotContain("--weekly-retention-weeks", optionNames);
@@ -162,28 +131,23 @@ public class PolicyCreateCommandTests
     public async Task ExecuteAsync_DeserializationValidation()
     {
         // Arrange
-        var expected = new OperationResult("Succeeded", null, "Policy created successfully");
-
-        _backupService.CreatePolicyAsync(
+        Service.CreatePolicyAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--policy", "p", "--workload-type", "VM"]);
+            .Returns(Task.FromResult(new OperationResult("Succeeded", null, "Policy created successfully")));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--policy", "p",
+            "--workload-type", "VM");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.PolicyCreateCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.PolicyCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("Succeeded", result.Result.Status);
         Assert.Equal("Policy created successfully", result.Result.Message);
     }
@@ -192,17 +156,19 @@ public class PolicyCreateCommandTests
     public async Task ExecuteAsync_HandlesAuthorizationFailure()
     {
         // Arrange
-        _backupService.CreatePolicyAsync(
+        Service.CreatePolicyAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("p"), Arg.Is("VM"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--policy", "p", "--workload-type", "VM"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--policy", "p",
+            "--workload-type", "VM");
 
         // Assert
         Assert.Equal(HttpStatusCode.Forbidden, response.Status);

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Policy/PolicyGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Policy/PolicyGetCommandTests.cs
@@ -2,50 +2,26 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Policy;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.Policy;
 
-public class PolicyGetCommandTests
+public class PolicyGetCommandTests : CommandUnitTestsBase<PolicyGetCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<PolicyGetCommand> _logger;
-    private readonly PolicyGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public PolicyGetCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<PolicyGetCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("get", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("get", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Fact]
@@ -61,7 +37,7 @@ public class PolicyGetCommandTests
             new("id2", "CustomPolicy", "rsv", ["SQLDataBase"], 3, null, null, null)
         };
 
-        _backupService.ListPoliciesAsync(
+        Service.ListPoliciesAsync(
             Arg.Is(vault),
             Arg.Is(resourceGroup),
             Arg.Is(subscription),
@@ -69,22 +45,17 @@ public class PolicyGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedPolicies));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vault, "--resource-group", resourceGroup]);
+            .Returns(expectedPolicies);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vault,
+            "--resource-group", resourceGroup);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.PolicyGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.PolicyGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(2, result.Policies.Count);
         Assert.Equal("DefaultPolicy", result.Policies[0].Name);
     }
@@ -97,9 +68,8 @@ public class PolicyGetCommandTests
         var vault = "myVault";
         var resourceGroup = "myRg";
         var policyName = "DefaultPolicy";
-        var expectedPolicy = new BackupPolicyInfo("id1", policyName, "rsv", ["AzureIaasVM"], 5, null, null, null);
 
-        _backupService.GetPolicyAsync(
+        Service.GetPolicyAsync(
             Arg.Is(vault),
             Arg.Is(resourceGroup),
             Arg.Is(subscription),
@@ -108,21 +78,18 @@ public class PolicyGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedPolicy));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vault, "--resource-group", resourceGroup, "--policy", policyName]);
+            .Returns(new BackupPolicyInfo("id1", policyName, "rsv", ["AzureIaasVM"], 5, null, null, null));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vault,
+            "--resource-group", resourceGroup,
+            "--policy", policyName);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.PolicyGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.PolicyGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Single(result.Policies);
         Assert.Equal(policyName, result.Policies[0].Name);
     }
@@ -135,7 +102,7 @@ public class PolicyGetCommandTests
         var vault = "myVault";
         var resourceGroup = "myRg";
 
-        _backupService.ListPoliciesAsync(
+        Service.ListPoliciesAsync(
             Arg.Is(vault),
             Arg.Is(resourceGroup),
             Arg.Is(subscription),
@@ -143,20 +110,17 @@ public class PolicyGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new List<BackupPolicyInfo>()));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vault, "--resource-group", resourceGroup]);
+            .Returns([]);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vault,
+            "--resource-group", resourceGroup);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.PolicyGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.PolicyGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Policies);
     }
 
@@ -168,14 +132,15 @@ public class PolicyGetCommandTests
         var vault = "myVault";
         var resourceGroup = "myRg";
 
-        _backupService.ListPoliciesAsync(
+        Service.ListPoliciesAsync(
             Arg.Is(vault), Arg.Is(resourceGroup), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vault, "--resource-group", resourceGroup]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vault,
+            "--resource-group", resourceGroup);
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -191,14 +156,16 @@ public class PolicyGetCommandTests
         var resourceGroup = "myRg";
         var policyName = "nonexistent";
 
-        _backupService.GetPolicyAsync(
+        Service.GetPolicyAsync(
             Arg.Is(vault), Arg.Is(resourceGroup), Arg.Is(subscription), Arg.Is(policyName), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Policy not found"));
 
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vault, "--resource-group", resourceGroup, "--policy", policyName]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vault,
+            "--resource-group", resourceGroup,
+            "--policy", policyName);
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.Status);
@@ -213,19 +180,17 @@ public class PolicyGetCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.ListPoliciesAsync(
+            Service.ListPoliciesAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new List<BackupPolicyInfo>()));
+                .Returns([]);
 
-            _backupService.GetPolicyAsync(
+            Service.GetPolicyAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub123"), Arg.Is("p"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new BackupPolicyInfo("id1", "p", "rsv", ["VM"], 1, null, null, null)));
+                .Returns(new BackupPolicyInfo("id1", "p", "rsv", ["VM"], 1, null, null, null));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -242,8 +207,7 @@ public class PolicyGetCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/ProtectableItem/ProtectableItemListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/ProtectableItem/ProtectableItemListCommandTests.cs
@@ -2,50 +2,26 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.ProtectableItem;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.ProtectableItem;
 
-public class ProtectableItemListCommandTests
+public class ProtectableItemListCommandTests : CommandUnitTestsBase<ProtectableItemListCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<ProtectableItemListCommand> _logger;
-    private readonly ProtectableItemListCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public ProtectableItemListCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<ProtectableItemListCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("list", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("list", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Fact]
@@ -58,24 +34,20 @@ public class ProtectableItemListCommandTests
             new("id2", "db2", "SAPHanaDatabase", "SAPHana", "HanaDb", "server2", "instance2", "NotProtected", "container2")
         };
 
-        _backupService.ListProtectableItemsAsync(
+        Service.ListProtectableItemsAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedItems));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
+            .Returns(expectedItems);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.ProtectableItemListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.ProtectableItemListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(2, result.Items.Count);
     }
 
@@ -83,23 +55,20 @@ public class ProtectableItemListCommandTests
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoItemsExist()
     {
         // Arrange
-        _backupService.ListProtectableItemsAsync(
+        Service.ListProtectableItemsAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new List<ProtectableItemInfo>()));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
+            .Returns([]);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.ProtectableItemListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.ProtectableItemListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Items);
     }
 
@@ -107,15 +76,16 @@ public class ProtectableItemListCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange
-        _backupService.ListProtectableItemsAsync(
+        Service.ListProtectableItemsAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -129,16 +99,14 @@ public class ProtectableItemListCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.ListProtectableItemsAsync(
+            Service.ListProtectableItemsAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(),
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new List<ProtectableItemInfo>()));
+                .Returns([]);
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -155,8 +123,7 @@ public class ProtectableItemListCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/ProtectedItem/ProtectedItemGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/ProtectedItem/ProtectedItemGetCommandTests.cs
@@ -2,50 +2,26 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.ProtectedItem;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.ProtectedItem;
 
-public class ProtectedItemGetCommandTests
+public class ProtectedItemGetCommandTests : CommandUnitTestsBase<ProtectedItemGetCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<ProtectedItemGetCommand> _logger;
-    private readonly ProtectedItemGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public ProtectedItemGetCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<ProtectedItemGetCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("get", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("get", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Fact]
@@ -61,7 +37,7 @@ public class ProtectedItemGetCommandTests
             new("id2", "sql1", "rsv", "Protected", "SQLDataBase", "/subscriptions/.../sql1", "SqlPolicy", DateTimeOffset.UtcNow, "container1")
         };
 
-        _backupService.ListProtectedItemsAsync(
+        Service.ListProtectedItemsAsync(
             Arg.Is(vault),
             Arg.Is(resourceGroup),
             Arg.Is(subscription),
@@ -69,21 +45,17 @@ public class ProtectedItemGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedItems));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vault, "--resource-group", resourceGroup]);
+            .Returns(expectedItems);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vault,
+            "--resource-group", resourceGroup);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.ProtectedItemGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.ProtectedItemGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(2, result.ProtectedItems.Count);
         Assert.Equal("vm1", result.ProtectedItems[0].Name);
     }
@@ -98,7 +70,7 @@ public class ProtectedItemGetCommandTests
         var itemName = "vm1";
         var expectedItem = new ProtectedItemInfo("id1", itemName, "rsv", "Protected", "AzureIaasVM", "/subscriptions/.../vm1", "DefaultPolicy", DateTimeOffset.UtcNow, null);
 
-        _backupService.GetProtectedItemAsync(
+        Service.GetProtectedItemAsync(
             Arg.Is(vault),
             Arg.Is(resourceGroup),
             Arg.Is(subscription),
@@ -108,21 +80,18 @@ public class ProtectedItemGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedItem));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vault, "--resource-group", resourceGroup, "--protected-item", itemName]);
+            .Returns(expectedItem);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vault,
+            "--resource-group", resourceGroup,
+            "--protected-item", itemName);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.ProtectedItemGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.ProtectedItemGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Single(result.ProtectedItems);
         Assert.Equal(itemName, result.ProtectedItems[0].Name);
     }
@@ -135,22 +104,19 @@ public class ProtectedItemGetCommandTests
         var vault = "myVault";
         var resourceGroup = "myRg";
 
-        _backupService.ListProtectedItemsAsync(
+        Service.ListProtectedItemsAsync(
             Arg.Is(vault), Arg.Is(resourceGroup), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new List<ProtectedItemInfo>()));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vault, "--resource-group", resourceGroup]);
+            .Returns([]);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vault,
+            "--resource-group", resourceGroup);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.ProtectedItemGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.ProtectedItemGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.ProtectedItems);
     }
 
@@ -158,14 +124,15 @@ public class ProtectedItemGetCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange
-        _backupService.ListProtectedItemsAsync(
+        Service.ListProtectedItemsAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -176,14 +143,16 @@ public class ProtectedItemGetCommandTests
     public async Task ExecuteAsync_HandlesNotFound()
     {
         // Arrange
-        _backupService.GetProtectedItemAsync(
+        Service.GetProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("nonexistent"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Item not found"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--protected-item", "nonexistent"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--protected-item", "nonexistent");
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.Status);
@@ -198,19 +167,17 @@ public class ProtectedItemGetCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.ListProtectedItemsAsync(
+            Service.ListProtectedItemsAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new List<ProtectedItemInfo>()));
+                .Returns([]);
 
-            _backupService.GetProtectedItemAsync(
+            Service.GetProtectedItemAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item1"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult(new ProtectedItemInfo("id", "item1", "rsv", "Protected", "VM", "/sub/vm", "pol", null, null)));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -227,8 +194,7 @@ public class ProtectedItemGetCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/ProtectedItem/ProtectedItemProtectCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/ProtectedItem/ProtectedItemProtectCommandTests.cs
@@ -2,77 +2,48 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.ProtectedItem;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.ProtectedItem;
 
-public class ProtectedItemProtectCommandTests
+public class ProtectedItemProtectCommandTests : CommandUnitTestsBase<ProtectedItemProtectCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<ProtectedItemProtectCommand> _logger;
-    private readonly ProtectedItemProtectCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public ProtectedItemProtectCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<ProtectedItemProtectCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("protect", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("protect", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Fact]
     public async Task ExecuteAsync_ProtectsItem_Successfully()
     {
         // Arrange
-        var expected = new ProtectResult("Succeeded", "vm1-backup", "job123", "Protection enabled");
-
-        _backupService.ProtectItemAsync(
+        Service.ProtectItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("/subscriptions/.../vm1"), Arg.Is("DefaultPolicy"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--datasource-id", "/subscriptions/.../vm1", "--policy", "DefaultPolicy"]);
+            .Returns(new ProtectResult("Succeeded", "vm1-backup", "job123", "Protection enabled"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--datasource-id", "/subscriptions/.../vm1",
+            "--policy", "DefaultPolicy");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.ProtectedItemProtectCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.ProtectedItemProtectCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("Succeeded", result.Result.Status);
     }
 
@@ -80,16 +51,18 @@ public class ProtectedItemProtectCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange
-        _backupService.ProtectItemAsync(
+        Service.ProtectItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("/subscriptions/.../vm1"), Arg.Is("DefaultPolicy"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--datasource-id", "/subscriptions/.../vm1", "--policy", "DefaultPolicy"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--datasource-id", "/subscriptions/.../vm1",
+            "--policy", "DefaultPolicy");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -103,16 +76,14 @@ public class ProtectedItemProtectCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.ProtectItemAsync(
+            Service.ProtectItemAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"), Arg.Is("pol1"),
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new ProtectResult("Succeeded", "item1", "job1", null)));
+                .Returns(new ProtectResult("Succeeded", "item1", "job1", null));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -129,16 +100,18 @@ public class ProtectedItemProtectCommandTests
     public async Task ExecuteAsync_HandlesForbiddenError()
     {
         // Arrange
-        _backupService.ProtectItemAsync(
+        Service.ProtectItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("/subscriptions/.../vm1"), Arg.Is("DefaultPolicy"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--datasource-id", "/subscriptions/.../vm1", "--policy", "DefaultPolicy"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--datasource-id", "/subscriptions/.../vm1",
+            "--policy", "DefaultPolicy");
 
         // Assert
         Assert.Equal(HttpStatusCode.Forbidden, response.Status);
@@ -150,8 +123,7 @@ public class ProtectedItemProtectCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/ProtectedItem/ProtectedItemUndeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/ProtectedItem/ProtectedItemUndeleteCommandTests.cs
@@ -2,78 +2,48 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.ProtectedItem;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.ProtectedItem;
 
-public class ProtectedItemUndeleteCommandTests
+public class ProtectedItemUndeleteCommandTests : CommandUnitTestsBase<ProtectedItemUndeleteCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<ProtectedItemUndeleteCommand> _logger;
-    private readonly ProtectedItemUndeleteCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public ProtectedItemUndeleteCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<ProtectedItemUndeleteCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("undelete", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("undelete", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Fact]
     public async Task ExecuteAsync_UndeletesItem_Successfully()
     {
         // Arrange
-        var expected = new OperationResult("Accepted", null, "Soft-deleted protected item restored");
-
-        _backupService.UndeleteProtectedItemAsync(
+        Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
             Arg.Is("/subscriptions/00000000/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/my-vm"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--datasource-id", "/subscriptions/00000000/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/my-vm"]);
+            .Returns(new OperationResult("Accepted", null, "Soft-deleted protected item restored"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--datasource-id", "/subscriptions/00000000/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/my-vm");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.ProtectedItemUndeleteCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.ProtectedItemUndeleteCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("Accepted", result.Result.Status);
     }
 
@@ -81,25 +51,21 @@ public class ProtectedItemUndeleteCommandTests
     public async Task ExecuteAsync_DeserializationValidation()
     {
         // Arrange
-        var expected = new OperationResult("Accepted", "job-456", "Item restored successfully");
-
-        _backupService.UndeleteProtectedItemAsync(
+        Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--datasource-id", "ds1"]);
+            .Returns(new OperationResult("Accepted", "job-456", "Item restored successfully"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--datasource-id", "ds1");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.ProtectedItemUndeleteCommandResult);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.ProtectedItemUndeleteCommandResult);
 
-        Assert.NotNull(result);
         Assert.Equal("Accepted", result.Result.Status);
         Assert.Equal("job-456", result.Result.JobId);
         Assert.Equal("Item restored successfully", result.Result.Message);
@@ -109,16 +75,17 @@ public class ProtectedItemUndeleteCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange
-        _backupService.UndeleteProtectedItemAsync(
+        Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--datasource-id", "ds1"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--datasource-id", "ds1");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -132,16 +99,14 @@ public class ProtectedItemUndeleteCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.UndeleteProtectedItemAsync(
+            Service.UndeleteProtectedItemAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new OperationResult("Accepted", null, "Restored")));
+                .Returns(new OperationResult("Accepted", null, "Restored"));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -158,16 +123,17 @@ public class ProtectedItemUndeleteCommandTests
     public async Task ExecuteAsync_HandlesForbiddenError()
     {
         // Arrange
-        _backupService.UndeleteProtectedItemAsync(
+        Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--datasource-id", "ds1"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--datasource-id", "ds1");
 
         // Assert
         Assert.Equal(HttpStatusCode.Forbidden, response.Status);
@@ -179,16 +145,17 @@ public class ProtectedItemUndeleteCommandTests
     public async Task ExecuteAsync_HandlesNotFoundError()
     {
         // Arrange
-        _backupService.UndeleteProtectedItemAsync(
+        Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not Found"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--datasource-id", "ds1"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--datasource-id", "ds1");
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.Status);
@@ -199,16 +166,17 @@ public class ProtectedItemUndeleteCommandTests
     public async Task ExecuteAsync_HandlesConflictError()
     {
         // Arrange
-        _backupService.UndeleteProtectedItemAsync(
+        Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(409, "Conflict"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--datasource-id", "ds1"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--datasource-id", "ds1");
 
         // Assert
         Assert.Equal(HttpStatusCode.Conflict, response.Status);
@@ -219,16 +187,17 @@ public class ProtectedItemUndeleteCommandTests
     public async Task ExecuteAsync_HandlesKeyNotFoundException()
     {
         // Arrange
-        _backupService.UndeleteProtectedItemAsync(
+        Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new KeyNotFoundException("Item not found"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--datasource-id", "ds1"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--datasource-id", "ds1");
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.Status);
@@ -239,29 +208,23 @@ public class ProtectedItemUndeleteCommandTests
     public async Task ExecuteAsync_UndeletesItem_DppVault_Successfully()
     {
         // Arrange - DPP vaults also support undelete via the deleted instances API
-        var expected = new OperationResult("Accepted", null, "Soft-deleted backup instance restored");
-
-        _backupService.UndeleteProtectedItemAsync(
+        Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
             Arg.Is("/subscriptions/00000000/resourceGroups/rg/providers/Microsoft.Compute/disks/my-disk"),
             Arg.Is("dpp"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--datasource-id", "/subscriptions/00000000/resourceGroups/rg/providers/Microsoft.Compute/disks/my-disk",
-            "--vault-type", "dpp"]);
+            .Returns(new OperationResult("Accepted", null, "Soft-deleted backup instance restored"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--datasource-id", "/subscriptions/00000000/resourceGroups/rg/providers/Microsoft.Compute/disks/my-disk",
+            "--vault-type", "dpp");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.ProtectedItemUndeleteCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.ProtectedItemUndeleteCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("Accepted", result.Result.Status);
     }
 
@@ -269,16 +232,17 @@ public class ProtectedItemUndeleteCommandTests
     public async Task ExecuteAsync_HandlesArgumentException()
     {
         // Arrange
-        _backupService.UndeleteProtectedItemAsync(
+        Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException("Invalid datasource ID format"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--datasource-id", "ds1"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--datasource-id", "ds1");
 
         // Assert
         Assert.Contains("Invalid datasource ID format", response.Message);
@@ -288,8 +252,7 @@ public class ProtectedItemUndeleteCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");
@@ -304,23 +267,23 @@ public class ProtectedItemUndeleteCommandTests
     public async Task ExecuteAsync_PassesContainerToService()
     {
         // Arrange - verify --container flows through to UndeleteProtectedItemAsync
-        var expected = new OperationResult("Accepted", null, "Restored");
-
-        _backupService.UndeleteProtectedItemAsync(
+        Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
             Arg.Any<string?>(), Arg.Is("IaasVMContainer;iaasvmcontainerv2;rg;myvm"), Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--datasource-id", "ds1", "--container", "IaasVMContainer;iaasvmcontainerv2;rg;myvm"]);
+            .Returns(new OperationResult("Accepted", null, "Restored"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--datasource-id", "ds1",
+            "--container", "IaasVMContainer;iaasvmcontainerv2;rg;myvm");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _backupService.Received(1).UndeleteProtectedItemAsync(
+        await Service.Received(1).UndeleteProtectedItemAsync(
             "v", "rg", "sub", "ds1",
             Arg.Any<string?>(), "IaasVMContainer;iaasvmcontainerv2;rg;myvm", Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/RecoveryPoint/RecoveryPointGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/RecoveryPoint/RecoveryPointGetCommandTests.cs
@@ -2,50 +2,26 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.RecoveryPoint;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.RecoveryPoint;
 
-public class RecoveryPointGetCommandTests
+public class RecoveryPointGetCommandTests : CommandUnitTestsBase<RecoveryPointGetCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<RecoveryPointGetCommand> _logger;
-    private readonly RecoveryPointGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public RecoveryPointGetCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<RecoveryPointGetCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("get", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("get", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Fact]
@@ -62,7 +38,7 @@ public class RecoveryPointGetCommandTests
             new("rp2", "rp2", "rsv", DateTimeOffset.UtcNow.AddDays(-2), "Incremental")
         };
 
-        _backupService.ListRecoveryPointsAsync(
+        Service.ListRecoveryPointsAsync(
             Arg.Is(vault),
             Arg.Is(resourceGroup),
             Arg.Is(subscription),
@@ -72,21 +48,18 @@ public class RecoveryPointGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedPoints));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vault, "--resource-group", resourceGroup, "--protected-item", protectedItem]);
+            .Returns(expectedPoints);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vault,
+            "--resource-group", resourceGroup,
+            "--protected-item", protectedItem);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.RecoveryPointGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.RecoveryPointGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(2, result.RecoveryPoints.Count);
         Assert.Equal("rp1", result.RecoveryPoints[0].Name);
     }
@@ -100,9 +73,8 @@ public class RecoveryPointGetCommandTests
         var resourceGroup = "myRg";
         var protectedItem = "vm1";
         var rpId = "rp1";
-        var expectedRp = new RecoveryPointInfo("rp1", rpId, "rsv", DateTimeOffset.UtcNow.AddDays(-1), "Full");
 
-        _backupService.GetRecoveryPointAsync(
+        Service.GetRecoveryPointAsync(
             Arg.Is(vault),
             Arg.Is(resourceGroup),
             Arg.Is(subscription),
@@ -113,21 +85,19 @@ public class RecoveryPointGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedRp));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vault, "--resource-group", resourceGroup, "--protected-item", protectedItem, "--recovery-point", rpId]);
+            .Returns(new RecoveryPointInfo("rp1", rpId, "rsv", DateTimeOffset.UtcNow.AddDays(-1), "Full"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vault,
+            "--resource-group", resourceGroup,
+            "--protected-item", protectedItem,
+            "--recovery-point", rpId);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.RecoveryPointGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.RecoveryPointGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Single(result.RecoveryPoints);
         Assert.Equal(rpId, result.RecoveryPoints[0].Name);
     }
@@ -136,22 +106,20 @@ public class RecoveryPointGetCommandTests
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoRecoveryPointsExist()
     {
         // Arrange
-        _backupService.ListRecoveryPointsAsync(
+        Service.ListRecoveryPointsAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new List<RecoveryPointInfo>()));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--protected-item", "item"]);
+            .Returns([]);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--protected-item", "item");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.RecoveryPointGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.RecoveryPointGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.RecoveryPoints);
     }
 
@@ -159,14 +127,16 @@ public class RecoveryPointGetCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange
-        _backupService.ListRecoveryPointsAsync(
+        Service.ListRecoveryPointsAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--protected-item", "item"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--protected-item", "item");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -177,14 +147,17 @@ public class RecoveryPointGetCommandTests
     public async Task ExecuteAsync_HandlesNotFound()
     {
         // Arrange
-        _backupService.GetRecoveryPointAsync(
+        Service.GetRecoveryPointAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Is("nonexistent"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Recovery point not found"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--protected-item", "item", "--recovery-point", "nonexistent"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--protected-item", "item",
+            "--recovery-point", "nonexistent");
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.Status);
@@ -199,19 +172,17 @@ public class RecoveryPointGetCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.ListRecoveryPointsAsync(
+            Service.ListRecoveryPointsAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new List<RecoveryPointInfo>()));
+                .Returns([]);
 
-            _backupService.GetRecoveryPointAsync(
+            Service.GetRecoveryPointAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Is("rp1"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new RecoveryPointInfo("rp1", "rp1", "rsv", DateTimeOffset.UtcNow, "Full")));
+                .Returns(new RecoveryPointInfo("rp1", "rp1", "rsv", DateTimeOffset.UtcNow, "Full"));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -228,8 +199,7 @@ public class RecoveryPointGetCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Vault/VaultCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Vault/VaultCreateCommandTests.cs
@@ -2,76 +2,48 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Vault;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.Vault;
 
-public class VaultCreateCommandTests
+public class VaultCreateCommandTests : CommandUnitTestsBase<VaultCreateCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<VaultCreateCommand> _logger;
-    private readonly VaultCreateCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public VaultCreateCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<VaultCreateCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("create", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("create", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Fact]
     public async Task ExecuteAsync_CreatesVault_Successfully()
     {
         // Arrange
-        var expected = new VaultCreateResult("id1", "myVault", "rsv", "eastus", "Succeeded");
-
-        _backupService.CreateVaultAsync(
+        Service.CreateVaultAsync(
             Arg.Is("myVault"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("rsv"), Arg.Is("eastus"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "myVault", "--resource-group", "rg", "--vault-type", "rsv", "--location", "eastus"]);
+            .Returns(new VaultCreateResult("id1", "myVault", "rsv", "eastus", "Succeeded"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "myVault",
+            "--resource-group", "rg",
+            "--vault-type", "rsv",
+            "--location", "eastus");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.VaultCreateCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.VaultCreateCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("myVault", result.Vault.Name);
     }
 
@@ -79,15 +51,18 @@ public class VaultCreateCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange
-        _backupService.CreateVaultAsync(
+        Service.CreateVaultAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("rsv"), Arg.Is("eastus"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--vault-type", "rsv", "--location", "eastus"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--vault-type", "rsv",
+            "--location", "eastus");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -101,16 +76,14 @@ public class VaultCreateCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.CreateVaultAsync(
+            Service.CreateVaultAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("rsv"), Arg.Is("eastus"),
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new VaultCreateResult("id", "v", "rsv", "eastus", "Succeeded")));
+                .Returns(new VaultCreateResult("id", "v", "rsv", "eastus", "Succeeded"));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -127,8 +100,7 @@ public class VaultCreateCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Vault/VaultGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Vault/VaultGetCommandTests.cs
@@ -2,50 +2,26 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Vault;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.Vault;
 
-public class VaultGetCommandTests
+public class VaultGetCommandTests : CommandUnitTestsBase<VaultGetCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<VaultGetCommand> _logger;
-    private readonly VaultGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public VaultGetCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<VaultGetCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("get", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("get", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Fact]
@@ -59,29 +35,21 @@ public class VaultGetCommandTests
             new("id2", "vault2", "dpp", "westus", "rg2", "Succeeded", "Standard", "LocallyRedundant", null, null, null, null, null, null)
         };
 
-        _backupService.ListVaultsAsync(
+        Service.ListVaultsAsync(
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedVaults));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription]);
+            .Returns(expectedVaults);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.VaultGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.VaultGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(2, result.Vaults.Count);
         Assert.Equal("vault1", result.Vaults[0].Name);
         Assert.Equal("vault2", result.Vaults[1].Name);
@@ -96,7 +64,7 @@ public class VaultGetCommandTests
         var resourceGroup = "myRg";
         var expectedVault = new BackupVaultInfo("id1", vaultName, "rsv", "eastus", resourceGroup, "Succeeded", "Standard", "GeoRedundant", null, null, null, null, null, null);
 
-        _backupService.GetVaultAsync(
+        Service.GetVaultAsync(
             Arg.Is(vaultName),
             Arg.Is(resourceGroup),
             Arg.Is(subscription),
@@ -104,22 +72,17 @@ public class VaultGetCommandTests
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedVault));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vaultName, "--resource-group", resourceGroup]);
+            .Returns(expectedVault);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vaultName,
+            "--resource-group", resourceGroup);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.VaultGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.VaultGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Single(result.Vaults);
         Assert.Equal(vaultName, result.Vaults[0].Name);
         Assert.Equal("eastus", result.Vaults[0].Location);
@@ -131,28 +94,21 @@ public class VaultGetCommandTests
         // Arrange
         var subscription = "sub123";
 
-        _backupService.ListVaultsAsync(
+        Service.ListVaultsAsync(
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new List<BackupVaultInfo>()));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription]);
+            .Returns([]);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.VaultGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.VaultGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Vaults);
     }
 
@@ -162,7 +118,7 @@ public class VaultGetCommandTests
         // Arrange
         var subscription = "sub123";
 
-        _backupService.ListVaultsAsync(
+        Service.ListVaultsAsync(
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -171,10 +127,8 @@ public class VaultGetCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", subscription]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription);
 
         // Assert
         Assert.NotNull(response);
@@ -190,7 +144,7 @@ public class VaultGetCommandTests
         var vaultName = "nonexistent";
         var resourceGroup = "myRg";
 
-        _backupService.GetVaultAsync(
+        Service.GetVaultAsync(
             Arg.Is(vaultName),
             Arg.Is(resourceGroup),
             Arg.Is(subscription),
@@ -200,10 +154,11 @@ public class VaultGetCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Vault not found"));
 
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--vault", vaultName, "--resource-group", resourceGroup]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--vault", vaultName,
+            "--resource-group", resourceGroup);
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.Status);
@@ -217,8 +172,7 @@ public class VaultGetCommandTests
     [InlineData("recovery")]
     public async Task ExecuteAsync_RejectsInvalidVaultType(string vaultType)
     {
-        var args = _commandDefinition.Parse(["--subscription", "sub123", "--vault-type", vaultType]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123", "--vault-type", vaultType);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("--vault-type must be", response.Message);
     }
@@ -230,12 +184,11 @@ public class VaultGetCommandTests
     [InlineData("DPP")]
     public async Task ExecuteAsync_AcceptsValidVaultType(string vaultType)
     {
-        _backupService.ListVaultsAsync(
+        Service.ListVaultsAsync(
             Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new List<BackupVaultInfo>()));
+            .Returns([]);
 
-        var args = _commandDefinition.Parse(["--subscription", "sub123", "--vault-type", vaultType]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123", "--vault-type", vaultType);
         Assert.Equal(HttpStatusCode.OK, response.Status);
     }
 
@@ -246,19 +199,17 @@ public class VaultGetCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.ListVaultsAsync(
+            Service.ListVaultsAsync(
                 Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new List<BackupVaultInfo>()));
+                .Returns([]);
 
-            _backupService.GetVaultAsync(
+            Service.GetVaultAsync(
                 Arg.Is("myVault"), Arg.Is("myRg"), Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new BackupVaultInfo("id1", "myVault", "rsv", "eastus", "myRg", "Succeeded", "Standard", "GeoRedundant", null, null, null, null, null, null)));
+                .Returns(new BackupVaultInfo("id1", "myVault", "rsv", "eastus", "myRg", "Succeeded", "Standard", "GeoRedundant", null, null, null, null, null, null));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -276,8 +227,7 @@ public class VaultGetCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Vault/VaultUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Vault/VaultUpdateCommandTests.cs
@@ -2,77 +2,48 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Vault;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBackup.UnitTests.Vault;
 
-public class VaultUpdateCommandTests
+public class VaultUpdateCommandTests : CommandUnitTestsBase<VaultUpdateCommand, IAzureBackupService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IAzureBackupService _backupService;
-    private readonly ILogger<VaultUpdateCommand> _logger;
-    private readonly VaultUpdateCommand _command;
-    private readonly CommandContext _context;
-    private readonly System.CommandLine.Command _commandDefinition;
-
-    public VaultUpdateCommandTests()
-    {
-        _backupService = Substitute.For<IAzureBackupService>();
-        _logger = Substitute.For<ILogger<VaultUpdateCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_backupService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _backupService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("update", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("update", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Fact]
     public async Task ExecuteAsync_UpdatesVault_Successfully()
     {
         // Arrange
-        var expected = new OperationResult("Succeeded", null, "Vault updated successfully");
-
-        _backupService.UpdateVaultAsync(
+        Service.UpdateVaultAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Is("SystemAssigned"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expected));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--identity-type", "SystemAssigned"]);
+            .Returns(new OperationResult("Succeeded", null, "Vault updated successfully"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--identity-type", "SystemAssigned");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBackupJsonContext.Default.VaultUpdateCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.VaultUpdateCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal("Succeeded", result.Result.Status);
     }
 
@@ -80,16 +51,18 @@ public class VaultUpdateCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange
-        _backupService.UpdateVaultAsync(
+        Service.UpdateVaultAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Is("SystemAssigned"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--identity-type", "SystemAssigned"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--identity-type", "SystemAssigned");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -99,11 +72,11 @@ public class VaultUpdateCommandTests
     [Fact]
     public async Task ExecuteAsync_RejectsUpdateWithNoChanges()
     {
-        // Arrange - no update options provided, only required base options
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act - no update options provided, only required base options
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg");
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -114,16 +87,18 @@ public class VaultUpdateCommandTests
     public async Task ExecuteAsync_HandlesNotFoundError()
     {
         // Arrange
-        _backupService.UpdateVaultAsync(
+        Service.UpdateVaultAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Is("SystemAssigned"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--identity-type", "SystemAssigned"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--identity-type", "SystemAssigned");
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.Status);
@@ -141,17 +116,15 @@ public class VaultUpdateCommandTests
     {
         if (shouldSucceed)
         {
-            _backupService.UpdateVaultAsync(
+            Service.UpdateVaultAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
+                .Returns(new OperationResult("Succeeded", null, null));
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -171,12 +144,12 @@ public class VaultUpdateCommandTests
     [InlineData("invalid")]
     public async Task ExecuteAsync_RejectsInvalidIdentityType(string identityType)
     {
-        // Arrange
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--identity-type", identityType]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--identity-type", identityType);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -191,17 +164,18 @@ public class VaultUpdateCommandTests
     public async Task ExecuteAsync_AcceptsValidIdentityType(string identityType)
     {
         // Arrange
-        _backupService.UpdateVaultAsync(
+        Service.UpdateVaultAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Is(identityType), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--identity-type", identityType]);
+            .Returns(new OperationResult("Succeeded", null, null));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--identity-type", identityType);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -214,12 +188,12 @@ public class VaultUpdateCommandTests
     [InlineData("abc")] // non-numeric
     public async Task ExecuteAsync_RejectsInvalidSoftDeleteRetentionDays(string retentionDays)
     {
-        // Arrange
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--soft-delete-retention-days", retentionDays]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--soft-delete-retention-days", retentionDays);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -233,17 +207,18 @@ public class VaultUpdateCommandTests
     public async Task ExecuteAsync_AcceptsValidSoftDeleteRetentionDays(string retentionDays)
     {
         // Arrange
-        _backupService.UpdateVaultAsync(
+        Service.UpdateVaultAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
-
-        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
-            "--soft-delete-retention-days", retentionDays]);
+            .Returns(new OperationResult("Succeeded", null, null));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--vault", "v",
+            "--resource-group", "rg",
+            "--soft-delete-retention-days", retentionDays);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -253,8 +228,7 @@ public class VaultUpdateCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         // Assert
         Assert.Contains(options, o => o.Name == "--subscription");


### PR DESCRIPTION
## What does this PR do?

Migrates Command unit tests to use `CommandUnitTestBase`. Adds new helper method to `CommandUnitTestBase` that performs common validation when a tool call was expected to succeed with a response value.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
