### PR TITLE
[Part 4] Migrate tool command unit tests to useing CommandUnitTestsBase

### DIFF
--- a/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.UnitTests/GetSchemaTests.cs
+++ b/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.UnitTests/GetSchemaTests.cs
@@ -12,14 +12,9 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.BicepSchema.UnitTests;
 
-public class GetSchemaTests
+public class GetSchemaTests(ITestOutputHelper output)
 {
-    private readonly ITestOutputHelper _output;
-
-    public GetSchemaTests(ITestOutputHelper output)
-    {
-        _output = output;
-    }
+    private readonly ITestOutputHelper _output = output;
 
     private void SummarizeSchema(TypesDefinitionResult result, string response)
     {

--- a/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/App/LogsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/App/LogsGetCommandTests.cs
@@ -1,47 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using Azure.Mcp.Tools.Deploy.Commands.App;
 using Azure.Mcp.Tools.Deploy.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Deploy.UnitTests.Commands.App;
 
-
-public class LogsGetCommandTests
+public class LogsGetCommandTests : CommandUnitTestsBase<LogsGetCommand, IDeployService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<LogsGetCommand> _logger;
-    private readonly IDeployService _deployService;
-    private readonly Command _commandDefinition;
-    private readonly CommandContext _context;
-    private readonly LogsGetCommand _command;
-
-    public LogsGetCommandTests()
-    {
-        _logger = Substitute.For<ILogger<LogsGetCommand>>();
-        _deployService = Substitute.For<IDeployService>();
-
-        _command = new(_logger, _deployService);
-        _commandDefinition = _command.GetCommand();
-        _serviceProvider = new ServiceCollection()
-            .BuildServiceProvider();
-        _context = new(_serviceProvider);
-    }
-
     [Fact]
     public async Task Should_get_azd_app_logs()
     {
         // arrange
         var expectedLogs = "App logs retrieved:\n[2024-01-01 10:00:00] Application started\n[2024-01-01 10:01:00] Processing request";
-        _deployService.GetAzdResourceLogsAsync(
+        Service.GetAzdResourceLogsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -49,23 +26,18 @@ public class LogsGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedLogs);
 
-        var args = _commandDefinition.Parse([
+        // act
+        var result = await ExecuteCommandAsync(
             "--subscription", "test-subscription-id",
             "--workspace-folder", "C:/Users/",
             "--azd-env-name", "dotnet-demo",
-            "--limit", "10"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--limit", "10");
 
         // assert
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.Status);
         Assert.NotNull(result.Message);
-        Assert.StartsWith("App logs retrieved:", result.Message);
-        Assert.Contains("Application started", result.Message);
-
+        Assert.Equal(expectedLogs, result.Message);
     }
 
     [Fact]
@@ -73,7 +45,7 @@ public class LogsGetCommandTests
     {
         // arrange
         var expectedLogs = "App logs retrieved:\nSample log entry";
-        _deployService.GetAzdResourceLogsAsync(
+        Service.GetAzdResourceLogsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -81,28 +53,25 @@ public class LogsGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedLogs);
 
-        var args = _commandDefinition.Parse([
+        // act
+        // No limit specified - should use default
+        var result = await ExecuteCommandAsync(
             "--subscription", "test-subscription-id",
             "--workspace-folder", "C:/project",
-            "--azd-env-name", "my-env"
-            // No limit specified - should use default
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--azd-env-name", "my-env");
 
         // assert
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.Status);
         Assert.NotNull(result.Message);
-        Assert.StartsWith("App logs retrieved:", result.Message);
+        Assert.Equal(expectedLogs, result.Message);
     }
 
     [Fact]
     public async Task Should_handle_no_logs_found()
     {
         // arrange
-        _deployService.GetAzdResourceLogsAsync(
+        Service.GetAzdResourceLogsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -110,15 +79,12 @@ public class LogsGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns("No logs found.");
 
-        var args = _commandDefinition.Parse([
+        // act
+        var result = await ExecuteCommandAsync(
             "--subscription", "test-subscription-id",
             "--workspace-folder", "C:/empty-project",
             "--azd-env-name", "empty-env",
-            "--limit", "50"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--limit", "50");
 
         // assert
         Assert.NotNull(result);
@@ -131,7 +97,7 @@ public class LogsGetCommandTests
     {
         // arrange
         var errorMessage = "Error during retrieval of app logs of azd project:\nNo resource group with tag {\"azd-env-name\": test-env} found.";
-        _deployService.GetAzdResourceLogsAsync(
+        Service.GetAzdResourceLogsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -139,28 +105,24 @@ public class LogsGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(errorMessage);
 
-        var args = _commandDefinition.Parse([
+        // act
+        var result = await ExecuteCommandAsync(
             "--subscription", "test-subscription-id",
             "--workspace-folder", "C:/invalid-project",
-            "--azd-env-name", "test-env"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--azd-env-name", "test-env");
 
         // assert
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.Status);
         Assert.NotNull(result.Message);
-        Assert.StartsWith("Error during retrieval of app logs", result.Message);
-        Assert.Contains("test-env", result.Message);
+        Assert.Equal(errorMessage, result.Message);
     }
 
     [Fact]
     public async Task Should_handle_service_exception()
     {
         // arrange
-        _deployService.GetAzdResourceLogsAsync(
+        Service.GetAzdResourceLogsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -168,14 +130,11 @@ public class LogsGetCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Failed to connect to Azure"));
 
-        var args = _commandDefinition.Parse([
+        // act
+        var result = await ExecuteCommandAsync(
             "--subscription", "test-subscription-id",
             "--workspace-folder", "C:/project",
-            "--azd-env-name", "test-env"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--azd-env-name", "test-env");
 
         // assert
         Assert.NotNull(result);
@@ -187,15 +146,10 @@ public class LogsGetCommandTests
     [Fact]
     public async Task Should_validate_required_parameters()
     {
-        // arrange - missing required workspace-folder parameter
-        var args = _commandDefinition.Parse([
+        // arrange & act - missing required workspace-folder parameter
+        var result = await ExecuteCommandAsync(
             "--subscription", "test-subscription-id",
-            "--azd-env-name", "test-env"
-            // Missing workspace-folder
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--azd-env-name", "test-env");
 
         // assert
         Assert.NotNull(result);

--- a/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/Architecture/DiagramGenerateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/Architecture/DiagramGenerateCommandTests.cs
@@ -62,7 +62,7 @@ public class DiagramGenerateCommandTests
             ProjectName = "testProject",
             Services =
             [
-                new ServiceConfig
+                new()
                 {
                     Name = "website",
                     AzureComputeHost = "appservice",
@@ -70,10 +70,10 @@ public class DiagramGenerateCommandTests
                     Port = "80",
                     Dependencies =
                     [
-                        new DependencyConfig { Name = "store", ConnectionType = "system-identity", ServiceType = "azurestorageaccount" }
+                        new() { Name = "store", ConnectionType = "system-identity", ServiceType = "azurestorageaccount" }
                     ],
                 },
-                new ServiceConfig
+                new()
                 {
                     Name = "frontend",
                     Path = "testWorkspace/web",
@@ -82,10 +82,10 @@ public class DiagramGenerateCommandTests
                     Port = "8080",
                     Dependencies =
                     [
-                        new DependencyConfig { Name = "backend", ConnectionType = "http", ServiceType = "containerapp" }
+                        new() { Name = "backend", ConnectionType = "http", ServiceType = "containerapp" }
                     ]
                 },
-                new ServiceConfig
+                new()
                 {
                     Name = "backend",
                     Path = "testWorkspace/api",
@@ -94,11 +94,11 @@ public class DiagramGenerateCommandTests
                     Port = "3000",
                     Dependencies =
                     [
-                        new DependencyConfig { Name = "db", ConnectionType = "secret", ServiceType = "azurecosmosdb" },
-                        new DependencyConfig { Name = "secretStore", ConnectionType = "system-identity", ServiceType = "azurekeyvault" }
+                        new() { Name = "db", ConnectionType = "secret", ServiceType = "azurecosmosdb" },
+                        new() { Name = "secretStore", ConnectionType = "system-identity", ServiceType = "azurekeyvault" }
                     ]
                 },
-                new ServiceConfig
+                new()
                 {
                     Name = "frontendservice",
                     Path = "testWorkspace/web",
@@ -107,10 +107,10 @@ public class DiagramGenerateCommandTests
                     Port = "3001",
                     Dependencies =
                     [
-                        new DependencyConfig { Name = "backendservice", ConnectionType = "user-identity", ServiceType = "aks"}
+                        new() { Name = "backendservice", ConnectionType = "user-identity", ServiceType = "aks"}
                     ]
                 },
-                new ServiceConfig
+                new()
                 {
                     Name = "backendservice",
                     Path = "testWorkspace/api",
@@ -119,7 +119,7 @@ public class DiagramGenerateCommandTests
                     Port = "3000",
                     Dependencies =
                     [
-                        new DependencyConfig { Name = "database", ConnectionType = "user-identity", ServiceType = "azurecacheforredis" }
+                        new() { Name = "database", ConnectionType = "user-identity", ServiceType = "azurecacheforredis" }
                     ]
                 }
             ]

--- a/tools/Azure.Mcp.Tools.DeviceRegistry/tests/Azure.Mcp.Tools.DeviceRegistry.UnitTests/Namespace/NamespaceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.DeviceRegistry/tests/Azure.Mcp.Tools.DeviceRegistry.UnitTests/Namespace/NamespaceListCommandTests.cs
@@ -1,46 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.DeviceRegistry.Commands;
 using Azure.Mcp.Tools.DeviceRegistry.Commands.Namespace;
 using Azure.Mcp.Tools.DeviceRegistry.Models;
 using Azure.Mcp.Tools.DeviceRegistry.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.DeviceRegistry.UnitTests.Namespace;
 
-public class NamespaceListCommandTests
+public class NamespaceListCommandTests : CommandUnitTestsBase<NamespaceListCommand, IDeviceRegistryService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IDeviceRegistryService _deviceRegistryService;
-    private readonly ILogger<NamespaceListCommand> _logger;
-    private readonly NamespaceListCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public NamespaceListCommandTests()
-    {
-        _deviceRegistryService = Substitute.For<IDeviceRegistryService>();
-        _logger = Substitute.For<ILogger<NamespaceListCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_deviceRegistryService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public async Task ExecuteAsync_ReturnsNamespaces_WhenSubscriptionProvided()
     {
@@ -53,24 +29,17 @@ public class NamespaceListCommandTests
                 "West US", "Succeeded", "defe124a-6971-4c90-a7a9-99be82def2ab", "rg1", "Microsoft.DeviceRegistry/namespaces")
         ], false);
 
-        _deviceRegistryService.ListNamespacesAsync(
+        Service.ListNamespacesAsync(
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedNamespaces));
+            .Returns(expectedNamespaces);
 
-        var args = _commandDefinition.Parse(["--subscription", subscription]);
+        var response = await ExecuteCommandAsync("--subscription", subscription);
 
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var result = ValidateAndDeserializeResponse(response, DeviceRegistryJsonContext.Default.NamespaceListCommandResult);
 
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, DeviceRegistryJsonContext.Default.NamespaceListCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Namespaces);
         Assert.Equal(expectedNamespaces.Results.Count, result.Namespaces.Count);
         Assert.Equal(expectedNamespaces.Results.Select(n => n.Name), result.Namespaces.Select(n => n.Name));
@@ -87,25 +56,17 @@ public class NamespaceListCommandTests
                 "North Europe", "Succeeded", "cefe124a-6971-4c90-a7a9-99be82def1ab", "myRG", "Microsoft.DeviceRegistry/namespaces")
         ], false);
 
-        _deviceRegistryService.ListNamespacesAsync(
+        Service.ListNamespacesAsync(
             Arg.Is(subscription),
             Arg.Is(resourceGroup),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedNamespaces));
+            .Returns(expectedNamespaces);
 
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--resource-group", resourceGroup]);
+        var response = await ExecuteCommandAsync("--subscription", subscription, "--resource-group", resourceGroup);
 
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var result = ValidateAndDeserializeResponse(response, DeviceRegistryJsonContext.Default.NamespaceListCommandResult);
 
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, DeviceRegistryJsonContext.Default.NamespaceListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Single(result.Namespaces);
         Assert.Equal("adr-ns-01", result.Namespaces[0].Name);
     }
@@ -115,24 +76,17 @@ public class NamespaceListCommandTests
     {
         var subscription = "sub123";
 
-        _deviceRegistryService.ListNamespacesAsync(
+        Service.ListNamespacesAsync(
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(new ResourceQueryResults<DeviceRegistryNamespaceInfo>([], false));
 
-        var args = _commandDefinition.Parse(["--subscription", subscription]);
+        var response = await ExecuteCommandAsync("--subscription", subscription);
 
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var result = ValidateAndDeserializeResponse(response, DeviceRegistryJsonContext.Default.NamespaceListCommandResult);
 
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, DeviceRegistryJsonContext.Default.NamespaceListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Namespaces);
     }
 
@@ -142,16 +96,14 @@ public class NamespaceListCommandTests
         var expectedError = "Test error";
         var subscription = "sub123";
 
-        _deviceRegistryService.ListNamespacesAsync(
+        Service.ListNamespacesAsync(
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse(["--subscription", subscription]);
-
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription);
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -161,10 +113,9 @@ public class NamespaceListCommandTests
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("list", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("list", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Theory]
@@ -181,14 +132,12 @@ public class NamespaceListCommandTests
                     "North Europe", "Succeeded", "cefe124a-6971-4c90-a7a9-99be82def1ab", "rg1", "Microsoft.DeviceRegistry/namespaces")
             ], false);
 
-            _deviceRegistryService.ListNamespacesAsync(
+            Service.ListNamespacesAsync(
                 Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(expectedNamespaces));
+                .Returns(expectedNamespaces);
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
         if (shouldSucceed)
@@ -207,13 +156,11 @@ public class NamespaceListCommandTests
     {
         var subscription = "sub123";
 
-        _deviceRegistryService.ListNamespacesAsync(
+        Service.ListNamespacesAsync(
             Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var parseResult = _commandDefinition.Parse(["--subscription", subscription]);
-
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription);
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.Contains("Test error", response.Message);
@@ -224,13 +171,11 @@ public class NamespaceListCommandTests
     {
         var subscription = "sub123";
 
-        _deviceRegistryService.ListNamespacesAsync(
+        Service.ListNamespacesAsync(
             Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Resource not found"));
 
-        var parseResult = _commandDefinition.Parse(["--subscription", subscription]);
-
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription);
 
         Assert.Equal(HttpStatusCode.NotFound, response.Status);
     }
@@ -240,13 +185,11 @@ public class NamespaceListCommandTests
     {
         var subscription = "sub123";
 
-        _deviceRegistryService.ListNamespacesAsync(
+        Service.ListNamespacesAsync(
             Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.Forbidden, "Authorization failed"));
 
-        var parseResult = _commandDefinition.Parse(["--subscription", subscription]);
-
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription);
 
         Assert.Equal(HttpStatusCode.Forbidden, response.Status);
     }

--- a/tools/Azure.Mcp.Tools.EventGrid/src/Commands/Subscription/SubscriptionListCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/src/Commands/Subscription/SubscriptionListCommand.cs
@@ -97,6 +97,7 @@ public sealed class SubscriptionListCommand(ILogger<SubscriptionListCommand> log
             if (crossSubscriptionSearch)
             {
                 // Iterate all subscriptions and aggregate
+                // TODO (alzimmer): Listing all subscriptions should be done in the IEventGridService implementation.
                 var allSubs = await _subscriptionService.GetSubscriptions(options.Tenant, options.RetryPolicy, cancellationToken);
                 var aggregate = new List<EventGridSubscriptionInfo>();
                 foreach (var sub in allSubs)

--- a/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Events/EventsPublishCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Events/EventsPublishCommandTests.cs
@@ -1,58 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Net.Http;
 using System.Text.Json;
 using Azure.Mcp.Tools.EventGrid.Commands;
 using Azure.Mcp.Tools.EventGrid.Commands.Events;
 using Azure.Mcp.Tools.EventGrid.Models;
 using Azure.Mcp.Tools.EventGrid.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.EventGrid.UnitTests.Events;
 
-public class EventsPublishCommandTests
+public class EventsPublishCommandTests : CommandUnitTestsBase<EventGridPublishCommand, IEventGridService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IEventGridService _eventGridService;
-    private readonly ILogger<EventGridPublishCommand> _logger;
-    private readonly EventGridPublishCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public EventsPublishCommandTests()
-    {
-        _eventGridService = Substitute.For<IEventGridService>();
-        _logger = Substitute.For<ILogger<EventGridPublishCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_eventGridService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _eventGridService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Command_Properties_AreCorrect()
     {
-        Assert.Equal("publish", _command.Name);
-        Assert.Contains("Publish custom events to Event Grid topics", _command.Description);
-        Assert.Equal("Publish Events to Event Grid Topic", _command.Title);
+        Assert.Equal("publish", Command.Name);
+        Assert.Contains("Publish custom events to Event Grid topics", Command.Description);
+        Assert.Equal("Publish Events to Event Grid Topic", Command.Title);
     }
 
     [Fact]
     public void Command_Metadata_IsCorrect()
     {
-        var metadata = _command.Metadata;
+        var metadata = Command.Metadata;
         Assert.False(metadata.Destructive);
         Assert.False(metadata.Idempotent);
         Assert.False(metadata.OpenWorld);
@@ -83,7 +59,7 @@ public class EventsPublishCommandTests
             OperationId: Guid.NewGuid().ToString(),
             PublishedAt: DateTime.UtcNow);
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Is(subscriptionId),
             Arg.Is(resourceGroup),
             Arg.Is(topicName),
@@ -92,20 +68,18 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData]);
+            .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, EventGridJsonContext.Default.EventGridPublishCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, EventGridJsonContext.Default.EventGridPublishCommandResult);
-        Assert.NotNull(result);
         Assert.Equal("Success", result!.Result.Status);
         Assert.Equal(1, result.Result.PublishedEventCount);
     }
@@ -142,7 +116,7 @@ public class EventsPublishCommandTests
             OperationId: Guid.NewGuid().ToString(),
             PublishedAt: DateTime.UtcNow);
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Is(subscriptionId),
             Arg.Is(resourceGroup),
             Arg.Is(topicName),
@@ -151,20 +125,18 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData]);
+            .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, EventGridJsonContext.Default.EventGridPublishCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, EventGridJsonContext.Default.EventGridPublishCommandResult);
-        Assert.NotNull(result);
         Assert.Equal("Success", result!.Result.Status);
         Assert.Equal(2, result.Result.PublishedEventCount);
     }
@@ -178,7 +150,7 @@ public class EventsPublishCommandTests
         var topicName = "test-topic";
         var invalidEventData = "invalid-json";
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -187,12 +159,14 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .ThrowsAsync(new System.Text.Json.JsonException("Invalid JSON format"));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", invalidEventData]);
+            .ThrowsAsync(new JsonException("Invalid JSON format"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", invalidEventData);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -214,7 +188,7 @@ public class EventsPublishCommandTests
             data = new { message = "Hello World" }
         });
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -225,10 +199,12 @@ public class EventsPublishCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException($"Event Grid topic '{topicName}' not found in resource group '{resourceGroup}'."));
 
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData);
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status); // The base command returns InternalServerError for general exceptions by default
@@ -255,7 +231,7 @@ public class EventsPublishCommandTests
                 OperationId: Guid.NewGuid().ToString(),
                 PublishedAt: DateTime.UtcNow);
 
-            _eventGridService.PublishEventAsync(
+            Service.PublishEventAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -263,14 +239,12 @@ public class EventsPublishCommandTests
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<RetryPolicyOptions>(),
-                    Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(expectedResult));
+                Arg.Any<CancellationToken>())
+                .Returns(expectedResult);
         }
 
-        var parseResult = _commandDefinition.Parse(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -307,7 +281,7 @@ public class EventsPublishCommandTests
             OperationId: Guid.NewGuid().ToString(),
             PublishedAt: DateTime.UtcNow);
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Is(subscriptionId),
             Arg.Is<string?>(resourceGroup => resourceGroup == null), // Resource group should be null
             Arg.Is(topicName),
@@ -316,20 +290,17 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--topic", topicName, "--data", eventData]);
+            .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--topic", topicName,
+            "--data", eventData);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, EventGridJsonContext.Default.EventGridPublishCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, EventGridJsonContext.Default.EventGridPublishCommandResult);
-        Assert.NotNull(result);
         Assert.Equal("Success", result!.Result.Status);
         Assert.Equal(1, result.Result.PublishedEventCount);
     }
@@ -358,7 +329,7 @@ public class EventsPublishCommandTests
             OperationId: Guid.NewGuid().ToString(),
             PublishedAt: DateTime.UtcNow);
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Is(subscriptionId),
             Arg.Is(resourceGroup),
             Arg.Is(topicName),
@@ -367,20 +338,19 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData, "--schema", "CloudEvents"]);
+            .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData,
+            "--schema", "CloudEvents");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, EventGridJsonContext.Default.EventGridPublishCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, EventGridJsonContext.Default.EventGridPublishCommandResult);
-        Assert.NotNull(result);
         Assert.Equal("Success", result!.Result.Status);
         Assert.Equal(1, result.Result.PublishedEventCount);
     }
@@ -408,7 +378,7 @@ public class EventsPublishCommandTests
             OperationId: Guid.NewGuid().ToString(),
             PublishedAt: DateTime.UtcNow);
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Is(subscriptionId),
             Arg.Is(resourceGroup),
             Arg.Is(topicName),
@@ -417,20 +387,19 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData, "--schema", "Custom"]);
+            .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData,
+            "--schema", "Custom");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, EventGridJsonContext.Default.EventGridPublishCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, EventGridJsonContext.Default.EventGridPublishCommandResult);
-        Assert.NotNull(result);
         Assert.Equal("Success", result!.Result.Status);
         Assert.Equal(1, result.Result.PublishedEventCount);
     }
@@ -475,7 +444,7 @@ public class EventsPublishCommandTests
             OperationId: Guid.NewGuid().ToString(),
             PublishedAt: DateTime.UtcNow);
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -484,12 +453,15 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData, "--schema", schema]);
+            .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData,
+            "--schema", schema);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -516,7 +488,7 @@ public class EventsPublishCommandTests
             OperationId: Guid.NewGuid().ToString(),
             PublishedAt: DateTime.UtcNow);
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -525,12 +497,14 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData]);
+            .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -550,7 +524,7 @@ public class EventsPublishCommandTests
             dataVersion = "1.0"
         });
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -559,12 +533,14 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Azure.RequestFailedException(403, "Access denied to Event Grid topic"));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData]);
+            .ThrowsAsync(new RequestFailedException(403, "Access denied to Event Grid topic"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData);
 
         // Assert
         Assert.Equal(HttpStatusCode.Forbidden, response.Status);
@@ -585,7 +561,7 @@ public class EventsPublishCommandTests
             dataVersion = "1.0"
         });
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -596,10 +572,13 @@ public class EventsPublishCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException("Invalid event schema specified. Supported schemas are: CloudEvents, EventGrid, or Custom."));
 
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData, "--schema", "InvalidSchema"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData,
+            "--schema", "InvalidSchema");
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -620,7 +599,7 @@ public class EventsPublishCommandTests
             dataVersion = "1.0"
         });
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -629,12 +608,14 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Azure.RequestFailedException(400, "Invalid event data or schema format"));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData]);
+            .ThrowsAsync(new RequestFailedException(400, "Invalid event data or schema format"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -681,7 +662,7 @@ public class EventsPublishCommandTests
             OperationId: Guid.NewGuid().ToString(),
             PublishedAt: DateTime.UtcNow);
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -690,12 +671,14 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData]);
+            .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -725,7 +708,7 @@ public class EventsPublishCommandTests
             OperationId: Guid.NewGuid().ToString(),
             PublishedAt: DateTime.UtcNow);
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -734,12 +717,15 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData, "--schema", "CloudEvents"]);
+            .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData,
+            "--schema", "CloudEvents");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -772,7 +758,7 @@ public class EventsPublishCommandTests
             OperationId: Guid.NewGuid().ToString(),
             PublishedAt: DateTime.UtcNow);
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -781,12 +767,15 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData, "--schema", "CloudEvents"]);
+            .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData,
+            "--schema", "CloudEvents");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -817,7 +806,7 @@ public class EventsPublishCommandTests
             OperationId: Guid.NewGuid().ToString(),
             PublishedAt: DateTime.UtcNow);
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -826,12 +815,15 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData, "--schema", "Custom"]);
+            .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData,
+            "--schema", "Custom");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -869,7 +861,7 @@ public class EventsPublishCommandTests
             OperationId: Guid.NewGuid().ToString(),
             PublishedAt: DateTime.UtcNow);
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -878,12 +870,15 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData, "--schema", schema]);
+            .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData,
+            "--schema", schema);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -925,7 +920,7 @@ public class EventsPublishCommandTests
             OperationId: Guid.NewGuid().ToString(),
             PublishedAt: DateTime.UtcNow);
 
-        _eventGridService.PublishEventAsync(
+        Service.PublishEventAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -934,18 +929,19 @@ public class EventsPublishCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--resource-group", resourceGroup, "--topic", topicName, "--data", eventData, "--schema", "Custom"]);
+            .Returns(expectedResult);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--topic", topicName,
+            "--data", eventData,
+            "--schema", "Custom");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        var json = JsonSerializer.Serialize(response.Results!);
-        var result = JsonSerializer.Deserialize(json, EventGridJsonContext.Default.EventGridPublishCommandResult);
-        Assert.Equal(2, result!.Result.PublishedEventCount);
+        var result = ValidateAndDeserializeResponse(response, EventGridJsonContext.Default.EventGridPublishCommandResult);
+        Assert.Equal(2, result.Result.PublishedEventCount);
     }
 }
 

--- a/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Topic/TopicListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Topic/TopicListCommandTests.cs
@@ -1,44 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.EventGrid.Commands;
 using Azure.Mcp.Tools.EventGrid.Commands.Topic;
 using Azure.Mcp.Tools.EventGrid.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.EventGrid.UnitTests.Topic;
 
-public class TopicListCommandTests
+public class TopicListCommandTests : CommandUnitTestsBase<TopicListCommand, IEventGridService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IEventGridService _eventGridService;
-    private readonly ILogger<TopicListCommand> _logger;
-    private readonly TopicListCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public TopicListCommandTests()
-    {
-        _eventGridService = Substitute.For<IEventGridService>();
-        _logger = Substitute.For<ILogger<TopicListCommand>>();
-
-        var collection = new ServiceCollection().AddSingleton(_eventGridService);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _eventGridService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public async Task ExecuteAsync_NoParameters_ReturnsTopics()
     {
@@ -50,24 +26,17 @@ public class TopicListCommandTests
             new("topic2", "westus", "https://topic2.westus.eventgrid.azure.net/api/events", "Succeeded", "Enabled", "EventGridSchema")
         };
 
-        _eventGridService.GetTopicsAsync(Arg.Is(subscriptionId), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedTopics));
-
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId]);
+        Service.GetTopicsAsync(Arg.Is(subscriptionId), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            .Returns(expectedTopics);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, EventGridJsonContext.Default.TopicListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, EventGridJsonContext.Default.TopicListCommandResult);
-
-        Assert.NotNull(result);
-        Assert.NotNull(result!.Topics);
-        Assert.Equal(expectedTopics.Count, result.Topics!.Count);
+        Assert.NotNull(result.Topics);
+        Assert.Equal(expectedTopics.Count, result.Topics.Count);
         Assert.Equal(expectedTopics.Select(t => t.Name), result.Topics.Select(t => t.Name));
     }
 
@@ -77,22 +46,15 @@ public class TopicListCommandTests
         // Arrange
         var subscriptionId = "sub123";
 
-        _eventGridService.GetTopicsAsync(Arg.Is(subscriptionId), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.GetTopicsAsync(Arg.Is(subscriptionId), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, EventGridJsonContext.Default.TopicListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, EventGridJsonContext.Default.TopicListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Topics);
     }
 
@@ -103,13 +65,11 @@ public class TopicListCommandTests
         var expectedError = "Test error";
         var subscriptionId = "sub123";
 
-        _eventGridService.GetTopicsAsync(Arg.Is(subscriptionId), null, Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.GetTopicsAsync(Arg.Is(subscriptionId), null, Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId);
 
         // Assert
         Assert.NotNull(response);
@@ -133,14 +93,12 @@ public class TopicListCommandTests
                 new("topic1", "eastus", "https://topic1.eastus.eventgrid.azure.net/api/events", "Succeeded", "Enabled", "EventGridSchema"),
                 new("topic2", "westus", "https://topic2.westus.eventgrid.azure.net/api/events", "Succeeded", "Enabled", "EventGridSchema")
             };
-            _eventGridService.GetTopicsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Service.GetTopicsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
                 .Returns(expectedTopics);
         }
 
-        var parseResult = _commandDefinition.Parse(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/ConsumerGroup/ConsumerGroupDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/ConsumerGroup/ConsumerGroupDeleteCommandTests.cs
@@ -3,37 +3,16 @@
 
 using Azure.Mcp.Tools.EventHubs.Commands.ConsumerGroup;
 using Azure.Mcp.Tools.EventHubs.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.EventHubs.UnitTests.ConsumerGroup;
 
-public class ConsumerGroupDeleteCommandTests
+public class ConsumerGroupDeleteCommandTests : CommandUnitTestsBase<ConsumerGroupDeleteCommand, IEventHubsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IEventHubsService _eventHubsService;
-    private readonly ILogger<ConsumerGroupDeleteCommand> _logger;
-    private readonly ConsumerGroupDeleteCommand _command;
-    private readonly CommandContext _context;
-
-    public ConsumerGroupDeleteCommandTests()
-    {
-        _eventHubsService = Substitute.For<IEventHubsService>();
-        _logger = Substitute.For<ILogger<ConsumerGroupDeleteCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_eventHubsService);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _eventHubsService);
-        _context = new(_serviceProvider);
-    }
-
     [Theory]
     [InlineData("", false)]
     [InlineData("--subscription test-subscription", false)]
@@ -44,10 +23,9 @@ public class ConsumerGroupDeleteCommandTests
     public async Task ExecuteAsync_ValidatesInput(string args, bool shouldSucceed)
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(args);
         if (shouldSucceed)
         {
-            _eventHubsService.DeleteConsumerGroupAsync(
+            Service.DeleteConsumerGroupAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -60,7 +38,7 @@ public class ConsumerGroupDeleteCommandTests
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -79,9 +57,7 @@ public class ConsumerGroupDeleteCommandTests
     public async Task ExecuteAsync_DeletesConsumerGroupSuccessfully()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription test-subscription --resource-group test-rg --namespace test-namespace --eventhub test-eventhub --consumer-group test-consumer-group");
-
-        _eventHubsService.DeleteConsumerGroupAsync(
+        Service.DeleteConsumerGroupAsync(
             "test-consumer-group",
             "test-eventhub",
             "test-namespace",
@@ -93,13 +69,18 @@ public class ConsumerGroupDeleteCommandTests
             .Returns(true);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--eventhub", "test-eventhub",
+            "--consumer-group", "test-consumer-group");
 
         // Assert
         Assert.Equal(200, (int)response.Status);
         Assert.NotNull(response.Results);
 
-        await _eventHubsService.Received(1).DeleteConsumerGroupAsync(
+        await Service.Received(1).DeleteConsumerGroupAsync(
             "test-consumer-group",
             "test-eventhub",
             "test-namespace",
@@ -114,9 +95,7 @@ public class ConsumerGroupDeleteCommandTests
     public async Task ExecuteAsync_HandlesServiceError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription test-subscription --resource-group test-rg --namespace test-namespace --eventhub test-eventhub --consumer-group test-consumer-group");
-
-        _eventHubsService.DeleteConsumerGroupAsync(
+        Service.DeleteConsumerGroupAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -128,7 +107,12 @@ public class ConsumerGroupDeleteCommandTests
             .ThrowsAsync(new InvalidOperationException("Consumer group 'test-consumer-group' could not be found"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--eventhub", "test-eventhub",
+            "--consumer-group", "test-consumer-group");
 
         // Assert
         Assert.NotEqual(200, (int)response.Status);
@@ -139,9 +123,7 @@ public class ConsumerGroupDeleteCommandTests
     public async Task ExecuteAsync_HandlesAuthenticationError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription unauthorized-sub --resource-group test-rg --namespace test-namespace --eventhub test-eventhub --consumer-group test-consumer-group");
-
-        _eventHubsService.DeleteConsumerGroupAsync(
+        Service.DeleteConsumerGroupAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -153,7 +135,12 @@ public class ConsumerGroupDeleteCommandTests
             .ThrowsAsync(new UnauthorizedAccessException("The current user does not have access to subscription 'unauthorized-sub'"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "unauthorized-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--eventhub", "test-eventhub",
+            "--consumer-group", "test-consumer-group");
 
         // Assert
         Assert.NotEqual(200, (int)response.Status);
@@ -170,9 +157,7 @@ public class ConsumerGroupDeleteCommandTests
         const string eventHubName = "my-eventhub";
         const string consumerGroupName = "my-consumer-group";
 
-        var parseResult = _command.GetCommand().Parse($"--subscription {subscriptionId} --resource-group {resourceGroup} --namespace {namespaceName} --eventhub {eventHubName} --consumer-group {consumerGroupName}");
-
-        _eventHubsService.DeleteConsumerGroupAsync(
+        Service.DeleteConsumerGroupAsync(
             consumerGroupName,
             eventHubName,
             namespaceName,
@@ -184,12 +169,17 @@ public class ConsumerGroupDeleteCommandTests
             .Returns(true);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--namespace", namespaceName,
+            "--eventhub", eventHubName,
+            "--consumer-group", consumerGroupName);
 
         // Assert
         Assert.Equal(200, (int)response.Status);
 
-        await _eventHubsService.Received(1).DeleteConsumerGroupAsync(
+        await Service.Received(1).DeleteConsumerGroupAsync(
             consumerGroupName,
             eventHubName,
             namespaceName,

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/ConsumerGroup/ConsumerGroupGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/ConsumerGroup/ConsumerGroupGetCommandTests.cs
@@ -3,37 +3,16 @@
 
 using Azure.Mcp.Tools.EventHubs.Commands.ConsumerGroup;
 using Azure.Mcp.Tools.EventHubs.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.EventHubs.UnitTests.ConsumerGroup;
 
-public class ConsumerGroupGetCommandTests
+public class ConsumerGroupGetCommandTests : CommandUnitTestsBase<ConsumerGroupGetCommand, IEventHubsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IEventHubsService _eventHubsService;
-    private readonly ILogger<ConsumerGroupGetCommand> _logger;
-    private readonly ConsumerGroupGetCommand _command;
-    private readonly CommandContext _context;
-
-    public ConsumerGroupGetCommandTests()
-    {
-        _eventHubsService = Substitute.For<IEventHubsService>();
-        _logger = Substitute.For<ILogger<ConsumerGroupGetCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_eventHubsService);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _eventHubsService);
-        _context = new(_serviceProvider);
-    }
-
     [Theory]
     [InlineData("", false)]
     [InlineData("--subscription test-subscription", false)]
@@ -44,7 +23,6 @@ public class ConsumerGroupGetCommandTests
     public async Task ExecuteAsync_ValidatesInput(string args, bool shouldSucceed)
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(args);
         if (shouldSucceed)
         {
             var consumerGroups = new List<Models.ConsumerGroup>
@@ -52,7 +30,7 @@ public class ConsumerGroupGetCommandTests
                 new("test-group", "test-id", "test-rg", "test-namespace", "test-eventhub")
             };
 
-            _eventHubsService.GetConsumerGroupsAsync(
+            Service.GetConsumerGroupsAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -62,7 +40,7 @@ public class ConsumerGroupGetCommandTests
                 Arg.Any<CancellationToken>())
                 .Returns(consumerGroups);
 
-            _eventHubsService.GetConsumerGroupAsync(
+            Service.GetConsumerGroupAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -75,7 +53,7 @@ public class ConsumerGroupGetCommandTests
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -94,15 +72,13 @@ public class ConsumerGroupGetCommandTests
     public async Task ExecuteAsync_ListsConsumerGroupsSuccessfully()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription test-subscription --resource-group test-rg --namespace test-namespace --eventhub test-eventhub");
-
         var expectedConsumerGroups = new List<Models.ConsumerGroup>
         {
             new("group1", "id1", "test-rg", "test-namespace", "test-eventhub"),
             new("group2", "id2", "test-rg", "test-namespace", "test-eventhub")
         };
 
-        _eventHubsService.GetConsumerGroupsAsync(
+        Service.GetConsumerGroupsAsync(
             "test-eventhub",
             "test-namespace",
             "test-rg",
@@ -113,13 +89,17 @@ public class ConsumerGroupGetCommandTests
             .Returns(expectedConsumerGroups);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--eventhub", "test-eventhub");
 
         // Assert
         Assert.Equal(200, (int)response.Status);
         Assert.NotNull(response.Results);
 
-        await _eventHubsService.Received(1).GetConsumerGroupsAsync(
+        await Service.Received(1).GetConsumerGroupsAsync(
             "test-eventhub",
             "test-namespace",
             "test-rg",
@@ -133,8 +113,6 @@ public class ConsumerGroupGetCommandTests
     public async Task ExecuteAsync_GetsSingleConsumerGroupSuccessfully()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription test-subscription --resource-group test-rg --namespace test-namespace --eventhub test-eventhub --consumer-group test-consumer-group");
-
         var expectedConsumerGroup = new Models.ConsumerGroup(
             "test-consumer-group",
             "test-id",
@@ -146,7 +124,7 @@ public class ConsumerGroupGetCommandTests
             DateTimeOffset.UtcNow.AddDays(-1),
             DateTimeOffset.UtcNow);
 
-        _eventHubsService.GetConsumerGroupAsync(
+        Service.GetConsumerGroupAsync(
             "test-consumer-group",
             "test-eventhub",
             "test-namespace",
@@ -158,13 +136,18 @@ public class ConsumerGroupGetCommandTests
             .Returns(expectedConsumerGroup);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--eventhub", "test-eventhub",
+            "--consumer-group", "test-consumer-group");
 
         // Assert
         Assert.Equal(200, (int)response.Status);
         Assert.NotNull(response.Results);
 
-        await _eventHubsService.Received(1).GetConsumerGroupAsync(
+        await Service.Received(1).GetConsumerGroupAsync(
             "test-consumer-group",
             "test-eventhub",
             "test-namespace",
@@ -179,9 +162,7 @@ public class ConsumerGroupGetCommandTests
     public async Task ExecuteAsync_ReturnsEmptyListWhenConsumerGroupNotFound()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription test-subscription --resource-group test-rg --namespace test-namespace --eventhub test-eventhub --consumer-group nonexistent-group");
-
-        _eventHubsService.GetConsumerGroupAsync(
+        Service.GetConsumerGroupAsync(
             "nonexistent-group",
             "test-eventhub",
             "test-namespace",
@@ -193,7 +174,12 @@ public class ConsumerGroupGetCommandTests
             .Returns((Models.ConsumerGroup?)null);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--eventhub", "test-eventhub",
+            "--consumer-group", "nonexistent-group");
 
         // Assert
         Assert.Equal(200, (int)response.Status);
@@ -204,9 +190,7 @@ public class ConsumerGroupGetCommandTests
     public async Task ExecuteAsync_HandlesServiceError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription test-subscription --resource-group test-rg --namespace test-namespace --eventhub test-eventhub");
-
-        _eventHubsService.GetConsumerGroupsAsync(
+        Service.GetConsumerGroupsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -217,7 +201,11 @@ public class ConsumerGroupGetCommandTests
             .ThrowsAsync(new InvalidOperationException("Event Hub 'test-eventhub' could not be found"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--eventhub", "test-eventhub");
 
         // Assert
         Assert.NotEqual(200, (int)response.Status);
@@ -229,9 +217,7 @@ public class ConsumerGroupGetCommandTests
     public async Task ExecuteAsync_HandlesAuthenticationError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription unauthorized-sub --resource-group test-rg --namespace test-namespace --eventhub test-eventhub");
-
-        _eventHubsService.GetConsumerGroupsAsync(
+        Service.GetConsumerGroupsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -242,7 +228,11 @@ public class ConsumerGroupGetCommandTests
             .ThrowsAsync(new UnauthorizedAccessException("The current user does not have access to subscription 'unauthorized-sub'"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "unauthorized-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--eventhub", "test-eventhub");
 
         // Assert
         Assert.NotEqual(200, (int)response.Status);
@@ -254,12 +244,8 @@ public class ConsumerGroupGetCommandTests
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        // Act
-        var command = _command.GetCommand();
-
-        // Assert
-        Assert.Equal("get", command.Name);
-        Assert.False(string.IsNullOrEmpty(command.Description));
-        Assert.NotEmpty(_command.Title);
+        Assert.Equal("get", CommandDefinition.Name);
+        Assert.False(string.IsNullOrEmpty(CommandDefinition.Description));
+        Assert.NotEmpty(Command.Title);
     }
 }

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/ConsumerGroup/ConsumerGroupUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/ConsumerGroup/ConsumerGroupUpdateCommandTests.cs
@@ -3,37 +3,16 @@
 
 using Azure.Mcp.Tools.EventHubs.Commands.ConsumerGroup;
 using Azure.Mcp.Tools.EventHubs.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.EventHubs.UnitTests.ConsumerGroup;
 
-public class ConsumerGroupUpdateCommandTests
+public class ConsumerGroupUpdateCommandTests : CommandUnitTestsBase<ConsumerGroupUpdateCommand, IEventHubsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IEventHubsService _eventHubsService;
-    private readonly ILogger<ConsumerGroupUpdateCommand> _logger;
-    private readonly ConsumerGroupUpdateCommand _command;
-    private readonly CommandContext _context;
-
-    public ConsumerGroupUpdateCommandTests()
-    {
-        _eventHubsService = Substitute.For<IEventHubsService>();
-        _logger = Substitute.For<ILogger<ConsumerGroupUpdateCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_eventHubsService);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _eventHubsService);
-        _context = new(_serviceProvider);
-    }
-
     [Theory]
     [InlineData("", false)]
     [InlineData("--subscription test-subscription", false)]
@@ -45,7 +24,6 @@ public class ConsumerGroupUpdateCommandTests
     public async Task ExecuteAsync_ValidatesInput(string args, bool shouldSucceed)
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(args);
         if (shouldSucceed)
         {
             var consumerGroup = new Models.ConsumerGroup(
@@ -59,7 +37,7 @@ public class ConsumerGroupUpdateCommandTests
                 DateTimeOffset.UtcNow.AddDays(-1),
                 DateTimeOffset.UtcNow);
 
-            _eventHubsService.CreateOrUpdateConsumerGroupAsync(
+            Service.CreateOrUpdateConsumerGroupAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -73,7 +51,7 @@ public class ConsumerGroupUpdateCommandTests
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -92,8 +70,6 @@ public class ConsumerGroupUpdateCommandTests
     public async Task ExecuteAsync_CreatesConsumerGroupWithUserMetadata()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription test-subscription --resource-group test-rg --namespace test-namespace --eventhub test-eventhub --consumer-group test-consumer-group --user-metadata custom-metadata");
-
         var expectedConsumerGroup = new Models.ConsumerGroup(
             "test-consumer-group",
             "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.EventHub/namespaces/test-namespace/eventhubs/test-eventhub/consumergroups/test-consumer-group",
@@ -105,7 +81,7 @@ public class ConsumerGroupUpdateCommandTests
             DateTimeOffset.UtcNow.AddDays(-1),
             DateTimeOffset.UtcNow);
 
-        _eventHubsService.CreateOrUpdateConsumerGroupAsync(
+        Service.CreateOrUpdateConsumerGroupAsync(
             "test-consumer-group",
             "test-eventhub",
             "test-namespace",
@@ -118,13 +94,19 @@ public class ConsumerGroupUpdateCommandTests
             .Returns(expectedConsumerGroup);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--eventhub", "test-eventhub",
+            "--consumer-group", "test-consumer-group",
+            "--user-metadata", "custom-metadata");
 
         // Assert
         Assert.Equal(200, (int)response.Status);
         Assert.NotNull(response.Results);
 
-        await _eventHubsService.Received(1).CreateOrUpdateConsumerGroupAsync(
+        await Service.Received(1).CreateOrUpdateConsumerGroupAsync(
             "test-consumer-group",
             "test-eventhub",
             "test-namespace",
@@ -140,8 +122,6 @@ public class ConsumerGroupUpdateCommandTests
     public async Task ExecuteAsync_CreatesConsumerGroupWithoutUserMetadata()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription test-subscription --resource-group test-rg --namespace test-namespace --eventhub test-eventhub --consumer-group test-consumer-group");
-
         var expectedConsumerGroup = new Models.ConsumerGroup(
             "test-consumer-group",
             "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.EventHub/namespaces/test-namespace/eventhubs/test-eventhub/consumergroups/test-consumer-group",
@@ -153,7 +133,7 @@ public class ConsumerGroupUpdateCommandTests
             DateTimeOffset.UtcNow.AddDays(-1),
             DateTimeOffset.UtcNow);
 
-        _eventHubsService.CreateOrUpdateConsumerGroupAsync(
+        Service.CreateOrUpdateConsumerGroupAsync(
             "test-consumer-group",
             "test-eventhub",
             "test-namespace",
@@ -166,13 +146,18 @@ public class ConsumerGroupUpdateCommandTests
             .Returns(expectedConsumerGroup);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--eventhub", "test-eventhub",
+            "--consumer-group", "test-consumer-group");
 
         // Assert
         Assert.Equal(200, (int)response.Status);
         Assert.NotNull(response.Results);
 
-        await _eventHubsService.Received(1).CreateOrUpdateConsumerGroupAsync(
+        await Service.Received(1).CreateOrUpdateConsumerGroupAsync(
             "test-consumer-group",
             "test-eventhub",
             "test-namespace",
@@ -188,9 +173,7 @@ public class ConsumerGroupUpdateCommandTests
     public async Task ExecuteAsync_HandlesServiceError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription test-subscription --resource-group test-rg --namespace test-namespace --eventhub test-eventhub --consumer-group test-consumer-group");
-
-        _eventHubsService.CreateOrUpdateConsumerGroupAsync(
+        Service.CreateOrUpdateConsumerGroupAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -203,7 +186,12 @@ public class ConsumerGroupUpdateCommandTests
             .ThrowsAsync(new InvalidOperationException("Event Hub 'test-eventhub' could not be found"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--eventhub", "test-eventhub",
+            "--consumer-group", "test-consumer-group");
 
         // Assert
         Assert.NotEqual(200, (int)response.Status);
@@ -214,9 +202,7 @@ public class ConsumerGroupUpdateCommandTests
     public async Task ExecuteAsync_HandlesAuthenticationError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription unauthorized-sub --resource-group test-rg --namespace test-namespace --eventhub test-eventhub --consumer-group test-consumer-group");
-
-        _eventHubsService.CreateOrUpdateConsumerGroupAsync(
+        Service.CreateOrUpdateConsumerGroupAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -229,7 +215,12 @@ public class ConsumerGroupUpdateCommandTests
             .ThrowsAsync(new UnauthorizedAccessException("The current user does not have access to subscription 'unauthorized-sub'"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "unauthorized-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--eventhub", "test-eventhub",
+            "--consumer-group", "test-consumer-group");
 
         // Assert
         Assert.NotEqual(200, (int)response.Status);

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/EventHub/EventHubDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/EventHub/EventHubDeleteCommandTests.cs
@@ -3,37 +3,16 @@
 
 using Azure.Mcp.Tools.EventHubs.Commands.EventHub;
 using Azure.Mcp.Tools.EventHubs.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.EventHubs.UnitTests.EventHub;
 
-public class EventHubDeleteCommandTests
+public class EventHubDeleteCommandTests : CommandUnitTestsBase<EventHubDeleteCommand, IEventHubsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IEventHubsService _eventHubsService;
-    private readonly ILogger<EventHubDeleteCommand> _logger;
-    private readonly EventHubDeleteCommand _command;
-    private readonly CommandContext _context;
-
-    public EventHubDeleteCommandTests()
-    {
-        _eventHubsService = Substitute.For<IEventHubsService>();
-        _logger = Substitute.For<ILogger<EventHubDeleteCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_eventHubsService);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _eventHubsService);
-        _context = new(_serviceProvider);
-    }
-
     [Theory]
     [InlineData("", false)]
     [InlineData("--subscription test-subscription --eventhub test-hub --namespace test-namespace --resource-group test-rg", true)]
@@ -42,10 +21,9 @@ public class EventHubDeleteCommandTests
     public async Task ExecuteAsync_ValidatesInput(string args, bool shouldSucceed)
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(args);
         if (shouldSucceed)
         {
-            _eventHubsService.DeleteEventHubAsync(
+            Service.DeleteEventHubAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -57,7 +35,7 @@ public class EventHubDeleteCommandTests
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -76,10 +54,7 @@ public class EventHubDeleteCommandTests
     public async Task ExecuteAsync_HandlesServiceError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(
-            "--subscription test-subscription --eventhub test-hub --namespace test-namespace --resource-group test-rg");
-
-        _eventHubsService.DeleteEventHubAsync(
+        Service.DeleteEventHubAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -90,7 +65,11 @@ public class EventHubDeleteCommandTests
             .ThrowsAsync(new InvalidOperationException("Namespace 'test-namespace' not found in resource group 'test-rg'"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--eventhub", "test-hub",
+            "--namespace", "test-namespace",
+            "--resource-group", "test-rg");
 
         // Assert
         Assert.NotEqual(200, (int)response.Status);
@@ -101,10 +80,7 @@ public class EventHubDeleteCommandTests
     public async Task ExecuteAsync_HandlesAuthenticationError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(
-            "--subscription unauthorized-sub --eventhub test-hub --namespace test-namespace --resource-group test-rg");
-
-        _eventHubsService.DeleteEventHubAsync(
+        Service.DeleteEventHubAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -115,7 +91,11 @@ public class EventHubDeleteCommandTests
             .ThrowsAsync(new UnauthorizedAccessException("Authentication failed"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "unauthorized-sub",
+            "--eventhub", "test-hub",
+            "--namespace", "test-namespace",
+            "--resource-group", "test-rg");
 
         // Assert
         Assert.NotEqual(200, (int)response.Status);
@@ -126,10 +106,7 @@ public class EventHubDeleteCommandTests
     public async Task ExecuteAsync_SuccessfullyDeletesEventHub()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(
-            "--subscription test-subscription --eventhub test-hub --namespace test-namespace --resource-group test-rg");
-
-        _eventHubsService.DeleteEventHubAsync(
+        Service.DeleteEventHubAsync(
             Arg.Is("test-hub"),
             Arg.Is("test-namespace"),
             Arg.Is("test-rg"),
@@ -140,7 +117,11 @@ public class EventHubDeleteCommandTests
             .Returns(true);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--eventhub", "test-hub",
+            "--namespace", "test-namespace",
+            "--resource-group", "test-rg");
 
         // Assert
         Assert.Equal(200, (int)response.Status);
@@ -151,10 +132,7 @@ public class EventHubDeleteCommandTests
     public async Task ExecuteAsync_IdempotentWhenEventHubNotFound()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(
-            "--subscription test-subscription --eventhub nonexistent-hub --namespace test-namespace --resource-group test-rg");
-
-        _eventHubsService.DeleteEventHubAsync(
+        Service.DeleteEventHubAsync(
             Arg.Is("nonexistent-hub"),
             Arg.Is("test-namespace"),
             Arg.Is("test-rg"),
@@ -165,7 +143,11 @@ public class EventHubDeleteCommandTests
             .Returns(false);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--eventhub", "nonexistent-hub",
+            "--namespace", "test-namespace",
+            "--resource-group", "test-rg");
 
         // Assert
         Assert.Equal(200, (int)response.Status);

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/EventHub/EventHubUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/EventHub/EventHubUpdateCommandTests.cs
@@ -3,37 +3,16 @@
 
 using Azure.Mcp.Tools.EventHubs.Commands.EventHub;
 using Azure.Mcp.Tools.EventHubs.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.EventHubs.UnitTests.EventHub;
 
-public class EventHubUpdateCommandTests
+public class EventHubUpdateCommandTests : CommandUnitTestsBase<EventHubUpdateCommand, IEventHubsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IEventHubsService _eventHubsService;
-    private readonly ILogger<EventHubUpdateCommand> _logger;
-    private readonly EventHubUpdateCommand _command;
-    private readonly CommandContext _context;
-
-    public EventHubUpdateCommandTests()
-    {
-        _eventHubsService = Substitute.For<IEventHubsService>();
-        _logger = Substitute.For<ILogger<EventHubUpdateCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_eventHubsService);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _eventHubsService);
-        _context = new(_serviceProvider);
-    }
-
     [Theory]
     [InlineData("", false)]
     [InlineData("--subscription test-subscription --eventhub test-hub --namespace test-namespace --resource-group test-rg", true)]
@@ -44,7 +23,6 @@ public class EventHubUpdateCommandTests
     public async Task ExecuteAsync_ValidatesInput(string args, bool shouldSucceed)
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(args);
         if (shouldSucceed)
         {
             var eventHub = new Models.EventHub(
@@ -57,9 +35,9 @@ public class EventHubUpdateCommandTests
                 "Active",
                 DateTimeOffset.UtcNow.AddDays(-1),
                 DateTimeOffset.UtcNow,
-                new List<string> { "0", "1", "2", "3" });
+                ["0", "1", "2", "3"]);
 
-            _eventHubsService.CreateOrUpdateEventHubAsync(
+            Service.CreateOrUpdateEventHubAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -73,7 +51,7 @@ public class EventHubUpdateCommandTests
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -92,10 +70,7 @@ public class EventHubUpdateCommandTests
     public async Task ExecuteAsync_HandlesServiceError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(
-            "--subscription test-subscription --eventhub test-hub --namespace test-namespace --resource-group test-rg");
-
-        _eventHubsService.CreateOrUpdateEventHubAsync(
+        Service.CreateOrUpdateEventHubAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -108,7 +83,11 @@ public class EventHubUpdateCommandTests
             .ThrowsAsync(new InvalidOperationException("Namespace 'test-namespace' not found in resource group 'test-rg'"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--eventhub", "test-hub",
+            "--namespace", "test-namespace",
+            "--resource-group", "test-rg");
 
         // Assert
         Assert.NotEqual(200, (int)response.Status);
@@ -119,10 +98,7 @@ public class EventHubUpdateCommandTests
     public async Task ExecuteAsync_HandlesAuthenticationError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(
-            "--subscription unauthorized-sub --eventhub test-hub --namespace test-namespace --resource-group test-rg");
-
-        _eventHubsService.CreateOrUpdateEventHubAsync(
+        Service.CreateOrUpdateEventHubAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -135,7 +111,11 @@ public class EventHubUpdateCommandTests
             .ThrowsAsync(new UnauthorizedAccessException("Authentication failed"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "unauthorized-sub",
+            "--eventhub", "test-hub",
+            "--namespace", "test-namespace",
+            "--resource-group", "test-rg");
 
         // Assert
         Assert.NotEqual(200, (int)response.Status);
@@ -146,9 +126,6 @@ public class EventHubUpdateCommandTests
     public async Task ExecuteAsync_SuccessfullyCreatesEventHub()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(
-            "--subscription test-subscription --eventhub new-hub --namespace test-namespace --resource-group test-rg --partition-count 8 --message-retention-in-hours 336");
-
         var eventHub = new Models.EventHub(
             "new-hub",
             "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.EventHub/namespaces/test-namespace/eventhubs/new-hub",
@@ -159,9 +136,9 @@ public class EventHubUpdateCommandTests
             "Active",
             DateTimeOffset.UtcNow,
             DateTimeOffset.UtcNow,
-            new List<string> { "0", "1", "2", "3", "4", "5", "6", "7" });
+            ["0", "1", "2", "3", "4", "5", "6", "7"]);
 
-        _eventHubsService.CreateOrUpdateEventHubAsync(
+        Service.CreateOrUpdateEventHubAsync(
             Arg.Is("new-hub"),
             Arg.Is("test-namespace"),
             Arg.Is("test-rg"),
@@ -174,7 +151,13 @@ public class EventHubUpdateCommandTests
             .Returns(eventHub);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--eventhub", "new-hub",
+            "--namespace", "test-namespace",
+            "--resource-group", "test-rg",
+            "--partition-count", "8",
+            "--message-retention-in-hours", "336");
 
         // Assert
         Assert.Equal(200, (int)response.Status);

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceDeleteCommandTests.cs
@@ -5,50 +5,24 @@ using System.Net;
 using Azure.Mcp.Tools.EventHubs.Commands.Namespace;
 using Azure.Mcp.Tools.EventHubs.Options.Namespace;
 using Azure.Mcp.Tools.EventHubs.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.EventHubs.UnitTests.Namespace;
 
-public class NamespaceDeleteCommandTests
+public class NamespaceDeleteCommandTests : CommandUnitTestsBase<NamespaceDeleteCommand, IEventHubsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IEventHubsService _eventHubsService;
-    private readonly ILogger<NamespaceDeleteCommand> _logger;
-    private readonly NamespaceDeleteCommand _command;
-    private readonly CommandContext _context;
-
-    public NamespaceDeleteCommandTests()
-    {
-        _eventHubsService = Substitute.For<IEventHubsService>();
-        _logger = Substitute.For<ILogger<NamespaceDeleteCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_eventHubsService);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _eventHubsService);
-        _context = new(_serviceProvider);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        // Arrange & Act
-        var command = new NamespaceDeleteCommand(_logger, _eventHubsService);
-
-        // Assert
-        Assert.NotNull(command);
-        Assert.Equal("delete", command.Name);
-        Assert.Equal("Delete Event Hubs Namespace", command.Title);
-        Assert.True(command.Metadata.Destructive);
-        Assert.True(command.Metadata.Idempotent);
-        Assert.False(command.Metadata.ReadOnly);
+        Assert.Equal("delete", Command.Name);
+        Assert.Equal("Delete Event Hubs Namespace", Command.Title);
+        Assert.True(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.Idempotent);
+        Assert.False(Command.Metadata.ReadOnly);
     }
 
     [Theory]
@@ -59,11 +33,9 @@ public class NamespaceDeleteCommandTests
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed, string expectedErrorFragment)
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
-
         if (shouldSucceed)
         {
-            _eventHubsService.DeleteNamespaceAsync(
+            Service.DeleteNamespaceAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -74,7 +46,7 @@ public class NamespaceDeleteCommandTests
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -97,13 +69,7 @@ public class NamespaceDeleteCommandTests
     public async Task ExecuteAsync_DeletesNamespaceSuccessfully()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "test-namespace"
-        ]);
-
-        _eventHubsService.DeleteNamespaceAsync(
+        Service.DeleteNamespaceAsync(
             "test-namespace",
             "test-rg",
             "test-sub",
@@ -113,12 +79,15 @@ public class NamespaceDeleteCommandTests
             .Returns(true);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
-        await _eventHubsService.Received(1).DeleteNamespaceAsync(
+        await Service.Received(1).DeleteNamespaceAsync(
             "test-namespace",
             "test-rg",
             "test-sub",
@@ -131,14 +100,7 @@ public class NamespaceDeleteCommandTests
     public async Task ExecuteAsync_DeletesNamespaceWithTenant()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "test-namespace",
-            "--tenant", "test-tenant-123"
-        ]);
-
-        _eventHubsService.DeleteNamespaceAsync(
+        Service.DeleteNamespaceAsync(
             "test-namespace",
             "test-rg",
             "test-sub",
@@ -148,12 +110,16 @@ public class NamespaceDeleteCommandTests
             .Returns(true);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--tenant", "test-tenant-123");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
-        await _eventHubsService.Received(1).DeleteNamespaceAsync(
+        await Service.Received(1).DeleteNamespaceAsync(
             "test-namespace",
             "test-rg",
             "test-sub",
@@ -166,13 +132,7 @@ public class NamespaceDeleteCommandTests
     public async Task ExecuteAsync_HandlesNamespaceNotFound()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "nonexistent-namespace"
-        ]);
-
-        _eventHubsService.DeleteNamespaceAsync(
+        Service.DeleteNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -182,7 +142,10 @@ public class NamespaceDeleteCommandTests
             .ThrowsAsync(new KeyNotFoundException("Namespace not found"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "nonexistent-namespace");
 
         // Assert
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
@@ -193,13 +156,7 @@ public class NamespaceDeleteCommandTests
     public async Task ExecuteAsync_HandlesAccessDenied()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "protected-namespace"
-        ]);
-
-        _eventHubsService.DeleteNamespaceAsync(
+        Service.DeleteNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -209,7 +166,10 @@ public class NamespaceDeleteCommandTests
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "protected-namespace");
 
         // Assert
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
@@ -220,24 +180,20 @@ public class NamespaceDeleteCommandTests
     public async Task ExecuteAsync_HandlesConflictError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "conflicted-namespace"
-        ]);
-
-        var conflictException = new RequestFailedException(409, "Conflict: The namespace cannot be deleted in its current state");
-        _eventHubsService.DeleteNamespaceAsync(
+        Service.DeleteNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .ThrowsAsync(conflictException);
+            .ThrowsAsync(new RequestFailedException(409, "Conflict: The namespace cannot be deleted in its current state"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "conflicted-namespace");
 
         // Assert
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
@@ -249,13 +205,7 @@ public class NamespaceDeleteCommandTests
     public async Task ExecuteAsync_HandlesAuthenticationFailure()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "test-namespace"
-        ]);
-
-        _eventHubsService.DeleteNamespaceAsync(
+        Service.DeleteNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -265,7 +215,10 @@ public class NamespaceDeleteCommandTests
             .ThrowsAsync(new Identity.AuthenticationFailedException("Authentication failed"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace");
 
         // Assert
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
@@ -277,24 +230,20 @@ public class NamespaceDeleteCommandTests
     public async Task ExecuteAsync_HandlesResourceNotFoundError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "nonexistent-rg",
-            "--namespace", "test-namespace"
-        ]);
-
-        var notFoundException = new RequestFailedException(404, "Resource group not found");
-        _eventHubsService.DeleteNamespaceAsync(
+        Service.DeleteNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .ThrowsAsync(notFoundException);
+            .ThrowsAsync(new RequestFailedException(404, "Resource group not found"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "nonexistent-rg",
+            "--namespace", "test-namespace");
 
         // Assert
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
@@ -305,13 +254,7 @@ public class NamespaceDeleteCommandTests
     public async Task ExecuteAsync_HandlesGenericServiceError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "test-namespace"
-        ]);
-
-        _eventHubsService.DeleteNamespaceAsync(
+        Service.DeleteNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -321,7 +264,10 @@ public class NamespaceDeleteCommandTests
             .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace");
 
         // Assert
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
@@ -332,13 +278,7 @@ public class NamespaceDeleteCommandTests
     public async Task ExecuteAsync_ReturnsSuccessMessage()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "test-namespace"
-        ]);
-
-        _eventHubsService.DeleteNamespaceAsync(
+        Service.DeleteNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -348,7 +288,10 @@ public class NamespaceDeleteCommandTests
             .Returns(true);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -362,7 +305,7 @@ public class NamespaceDeleteCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
+        var parseResult = CommandDefinition.Parse([
             "--subscription", "test-sub",
             "--resource-group", "test-rg",
             "--namespace", "test-namespace",
@@ -370,9 +313,9 @@ public class NamespaceDeleteCommandTests
         ]);
 
         // Act
-        var options = _command.GetType()
+        var options = Command.GetType()
             .GetMethod("BindOptions", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-            ?.Invoke(_command, [parseResult]) as NamespaceDeleteOptions;
+            ?.Invoke(Command, [parseResult]) as NamespaceDeleteOptions;
 
         // Assert
         Assert.NotNull(options);
@@ -391,14 +334,7 @@ public class NamespaceDeleteCommandTests
         var subscription = "my-subscription";
         var tenant = "my-tenant";
 
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", subscription,
-            "--resource-group", resourceGroup,
-            "--namespace", namespaceName,
-            "--tenant", tenant
-        ]);
-
-        _eventHubsService.DeleteNamespaceAsync(
+        Service.DeleteNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -408,11 +344,15 @@ public class NamespaceDeleteCommandTests
             .Returns(true);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--resource-group", resourceGroup,
+            "--namespace", namespaceName,
+            "--tenant", tenant);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _eventHubsService.Received(1).DeleteNamespaceAsync(
+        await Service.Received(1).DeleteNamespaceAsync(
             namespaceName,
             resourceGroup,
             subscription,
@@ -425,13 +365,7 @@ public class NamespaceDeleteCommandTests
     public async Task ExecuteAsync_WithoutTenant_PassesNullTenant()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "test-namespace"
-        ]);
-
-        _eventHubsService.DeleteNamespaceAsync(
+        Service.DeleteNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -441,11 +375,14 @@ public class NamespaceDeleteCommandTests
             .Returns(true);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _eventHubsService.Received(1).DeleteNamespaceAsync(
+        await Service.Received(1).DeleteNamespaceAsync(
             "test-namespace",
             "test-rg",
             "test-sub",

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceGetCommandTests.cs
@@ -4,38 +4,17 @@
 using Azure.Mcp.Tools.EventHubs.Commands.Namespace;
 using Azure.Mcp.Tools.EventHubs.Options;
 using Azure.Mcp.Tools.EventHubs.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Models.Option;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.EventHubs.UnitTests.Namespace;
 
-public class NamespaceGetCommandTests
+public class NamespaceGetCommandTests : CommandUnitTestsBase<NamespaceGetCommand, IEventHubsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IEventHubsService _eventHubsService;
-    private readonly ILogger<NamespaceGetCommand> _logger;
-    private readonly NamespaceGetCommand _command;
-    private readonly CommandContext _context;
-
-    public NamespaceGetCommandTests()
-    {
-        _eventHubsService = Substitute.For<IEventHubsService>();
-        _logger = Substitute.For<ILogger<NamespaceGetCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_eventHubsService);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _eventHubsService);
-        _context = new(_serviceProvider);
-    }
-
     [Theory]
     [InlineData("", false)]
     [InlineData("--subscription test-subscription", true)]
@@ -45,7 +24,6 @@ public class NamespaceGetCommandTests
     public async Task ExecuteAsync_ValidatesInput(string args, bool shouldSucceed)
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(args);
         if (shouldSucceed)
         {
             // Set up appropriate service method based on arguments
@@ -70,7 +48,7 @@ public class NamespaceGetCommandTests
                     true,
                     new Dictionary<string, string> { { "env", "prod" } });
 
-                _eventHubsService.GetNamespaceAsync(
+                Service.GetNamespaceAsync(
                     Arg.Any<string>(),
                     Arg.Any<string>(),
                     Arg.Any<string>(),
@@ -101,7 +79,7 @@ public class NamespaceGetCommandTests
                         new Models.EventHubsSku("Standard", "Standard", null)),
                 };
 
-                _eventHubsService.GetNamespacesAsync(
+                Service.GetNamespacesAsync(
                     Arg.Any<string>(),
                     Arg.Any<string>(),
                     Arg.Any<string?>(),
@@ -112,7 +90,7 @@ public class NamespaceGetCommandTests
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -131,9 +109,7 @@ public class NamespaceGetCommandTests
     public async Task ExecuteAsync_HandlesServiceError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription 12345678-1234-1234-1234-123456789012 --resource-group rg-eventhubs-test");
-
-        _eventHubsService.GetNamespacesAsync(
+        Service.GetNamespacesAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
@@ -142,7 +118,9 @@ public class NamespaceGetCommandTests
             .ThrowsAsync(new InvalidOperationException("Resource Group 'rg-eventhubs-test' could not be found"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "12345678-1234-1234-1234-123456789012",
+            "--resource-group", "rg-eventhubs-test");
 
         // Assert
         Assert.NotEqual(200, (int)response.Status);
@@ -153,8 +131,7 @@ public class NamespaceGetCommandTests
     public async Task ExecuteAsync_HandlesAuthenticationError()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse("--subscription unauthorized-sub --resource-group rg-eventhubs-prod");
-        _eventHubsService.GetNamespacesAsync(
+        Service.GetNamespacesAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
@@ -163,7 +140,9 @@ public class NamespaceGetCommandTests
             .ThrowsAsync(new UnauthorizedAccessException("The current user does not have access to subscription 'unauthorized-sub'"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "unauthorized-sub",
+            "--resource-group", "rg-eventhubs-prod");
 
         // Assert
         Assert.NotEqual(200, (int)response.Status);

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceUpdateCommandTests.cs
@@ -5,51 +5,25 @@ using System.Net;
 using Azure.Mcp.Tools.EventHubs.Commands.Namespace;
 using Azure.Mcp.Tools.EventHubs.Options.Namespace;
 using Azure.Mcp.Tools.EventHubs.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.EventHubs.UnitTests.Namespace;
 
-public class NamespaceUpdateCommandTests
+public class NamespaceUpdateCommandTests : CommandUnitTestsBase<NamespaceUpdateCommand, IEventHubsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IEventHubsService _eventHubsService;
-    private readonly ILogger<NamespaceUpdateCommand> _logger;
-    private readonly NamespaceUpdateCommand _command;
-    private readonly CommandContext _context;
-
-    public NamespaceUpdateCommandTests()
-    {
-        _eventHubsService = Substitute.For<IEventHubsService>();
-        _logger = Substitute.For<ILogger<NamespaceUpdateCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_eventHubsService);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _eventHubsService);
-        _context = new(_serviceProvider);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        // Arrange & Act
-        var command = new NamespaceUpdateCommand(_logger, _eventHubsService);
-
-        // Assert
-        Assert.NotNull(command);
-        Assert.Equal("update", command.Name);
-        Assert.Equal("Create or Update Event Hubs Namespace", command.Title);
-        Assert.Contains("Create or Update a Namespace", command.Description);
-        Assert.True(command.Metadata.Destructive);
-        Assert.True(command.Metadata.Idempotent);
-        Assert.False(command.Metadata.ReadOnly);
+        Assert.Equal("update", Command.Name);
+        Assert.Equal("Create or Update Event Hubs Namespace", Command.Title);
+        Assert.Contains("Create or Update a Namespace", Command.Description);
+        Assert.True(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.Idempotent);
+        Assert.False(Command.Metadata.ReadOnly);
     }
 
     [Theory]
@@ -65,12 +39,10 @@ public class NamespaceUpdateCommandTests
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed, string expectedErrorMessage)
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
-
         if (shouldSucceed)
         {
             var updatedNamespace = CreateSampleNamespace();
-            _eventHubsService.CreateOrUpdateNamespaceAsync(
+            Service.CreateOrUpdateNamespaceAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -90,7 +62,7 @@ public class NamespaceUpdateCommandTests
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -113,17 +85,8 @@ public class NamespaceUpdateCommandTests
     public async Task ExecuteAsync_UpdatesNamespaceWithSkuChanges()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "test-namespace",
-            "--sku-name", "Premium",
-            "--sku-tier", "Premium",
-            "--sku-capacity", "4"
-        ]);
-
         var updatedNamespace = CreateSampleNamespace();
-        _eventHubsService.CreateOrUpdateNamespaceAsync(
+        Service.CreateOrUpdateNamespaceAsync(
             "test-namespace",
             "test-rg",
             "test-sub",
@@ -142,12 +105,18 @@ public class NamespaceUpdateCommandTests
             .Returns(updatedNamespace);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--sku-name", "Premium",
+            "--sku-tier", "Premium",
+            "--sku-capacity", "4");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
-        await _eventHubsService.Received(1).CreateOrUpdateNamespaceAsync(
+        await Service.Received(1).CreateOrUpdateNamespaceAsync(
             "test-namespace",
             "test-rg",
             "test-sub",
@@ -169,16 +138,8 @@ public class NamespaceUpdateCommandTests
     public async Task ExecuteAsync_UpdatesNamespaceWithAutoInflateSettings()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "test-namespace",
-            "--is-auto-inflate-enabled", "true",
-            "--maximum-throughput-units", "20"
-        ]);
-
         var updatedNamespace = CreateSampleNamespace();
-        _eventHubsService.CreateOrUpdateNamespaceAsync(
+        Service.CreateOrUpdateNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -197,7 +158,12 @@ public class NamespaceUpdateCommandTests
             .Returns(updatedNamespace);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--is-auto-inflate-enabled", "true",
+            "--maximum-throughput-units", "20");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -208,13 +174,6 @@ public class NamespaceUpdateCommandTests
     public async Task ExecuteAsync_UpdatesNamespaceWithTags()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "test-namespace",
-            "--tags", "{\"environment\":\"production\",\"team\":\"platform\"}"
-        ]);
-
         var expectedTags = new Dictionary<string, string>
         {
             { "environment", "production" },
@@ -222,7 +181,7 @@ public class NamespaceUpdateCommandTests
         };
 
         var updatedNamespace = CreateSampleNamespace();
-        _eventHubsService.CreateOrUpdateNamespaceAsync(
+        Service.CreateOrUpdateNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -246,7 +205,11 @@ public class NamespaceUpdateCommandTests
             .Returns(updatedNamespace);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--tags", "{\"environment\":\"production\",\"team\":\"platform\"}");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -256,16 +219,12 @@ public class NamespaceUpdateCommandTests
     [Fact]
     public async Task ExecuteAsync_HandlesInvalidTagsJson()
     {
-        // Arrange
-        var parseResult = _command.GetCommand().Parse([
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(
             "--subscription", "test-sub",
             "--resource-group", "test-rg",
             "--namespace", "test-namespace",
-            "--tags", "invalid-json"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+            "--tags", "invalid-json");
 
         // Assert
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
@@ -277,21 +236,8 @@ public class NamespaceUpdateCommandTests
     public async Task ExecuteAsync_UpdatesNamespaceWithAllFeatures()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "test-namespace",
-            "--location", "westus2",
-            "--sku-name", "Premium",
-            "--sku-tier", "Premium",
-            "--sku-capacity", "2",
-            "--kafka-enabled", "true",
-            "--zone-redundant", "true",
-            "--tags", "{\"env\":\"prod\"}"
-        ]);
-
         var updatedNamespace = CreateSampleNamespace();
-        _eventHubsService.CreateOrUpdateNamespaceAsync(
+        Service.CreateOrUpdateNamespaceAsync(
             "test-namespace",
             "test-rg",
             "test-sub",
@@ -310,12 +256,22 @@ public class NamespaceUpdateCommandTests
             .Returns(updatedNamespace);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--location", "westus2",
+            "--sku-name", "Premium",
+            "--sku-tier", "Premium",
+            "--sku-capacity", "2",
+            "--kafka-enabled", "true",
+            "--zone-redundant", "true",
+            "--tags", "{\"env\":\"prod\"}");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
-        await _eventHubsService.Received(1).CreateOrUpdateNamespaceAsync(
+        await Service.Received(1).CreateOrUpdateNamespaceAsync(
             "test-namespace",
             "test-rg",
             "test-sub",
@@ -337,14 +293,7 @@ public class NamespaceUpdateCommandTests
     public async Task ExecuteAsync_HandlesServiceException()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "test-namespace",
-            "--sku-name", "Premium"
-        ]);
-
-        _eventHubsService.CreateOrUpdateNamespaceAsync(
+        Service.CreateOrUpdateNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -363,7 +312,11 @@ public class NamespaceUpdateCommandTests
             .ThrowsAsync(new InvalidOperationException("Update failed"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--sku-name", "Premium");
 
         // Assert
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
@@ -374,14 +327,7 @@ public class NamespaceUpdateCommandTests
     public async Task ExecuteAsync_HandlesKeyNotFoundException()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "nonexistent-namespace",
-            "--sku-name", "Premium"
-        ]);
-
-        _eventHubsService.CreateOrUpdateNamespaceAsync(
+        Service.CreateOrUpdateNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -400,7 +346,11 @@ public class NamespaceUpdateCommandTests
             .ThrowsAsync(new KeyNotFoundException("Namespace not found"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "nonexistent-namespace",
+            "--sku-name", "Premium");
 
         // Assert
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
@@ -411,16 +361,8 @@ public class NamespaceUpdateCommandTests
     public async Task ExecuteAsync_WithTenant_PassesCorrectParameters()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--namespace", "test-namespace",
-            "--sku-name", "Premium",
-            "--tenant", "test-tenant-123"
-        ]);
-
         var updatedNamespace = CreateSampleNamespace();
-        _eventHubsService.CreateOrUpdateNamespaceAsync(
+        Service.CreateOrUpdateNamespaceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -439,11 +381,16 @@ public class NamespaceUpdateCommandTests
             .Returns(updatedNamespace);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--namespace", "test-namespace",
+            "--sku-name", "Premium",
+            "--tenant", "test-tenant-123");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _eventHubsService.Received(1).CreateOrUpdateNamespaceAsync(
+        await Service.Received(1).CreateOrUpdateNamespaceAsync(
             "test-namespace",
             "test-rg",
             "test-sub",
@@ -465,7 +412,7 @@ public class NamespaceUpdateCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange
-        var parseResult = _command.GetCommand().Parse([
+        var parseResult = CommandDefinition.Parse([
             "--subscription", "test-sub",
             "--resource-group", "test-rg",
             "--namespace", "test-namespace",
@@ -482,9 +429,9 @@ public class NamespaceUpdateCommandTests
         ]);
 
         // Act
-        var options = _command.GetType()
+        var options = Command.GetType()
             .GetMethod("BindOptions", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-            ?.Invoke(_command, [parseResult]) as NamespaceUpdateOptions;
+            ?.Invoke(Command, [parseResult]) as NamespaceUpdateOptions;
 
         // Assert
         Assert.NotNull(options);
@@ -504,13 +451,12 @@ public class NamespaceUpdateCommandTests
     }
 
     private static Models.Namespace CreateSampleNamespace()
-    {
-        return new Models.Namespace(
+        => new(
             "test-namespace",
             "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.EventHub/namespaces/test-namespace",
             "test-rg",
             "East US",
-            new Models.EventHubsSku("Standard", "Standard", null),
+            new("Standard", "Standard", null),
             "Active",
             "Succeeded",
             DateTimeOffset.UtcNow.AddDays(-1),
@@ -522,5 +468,4 @@ public class NamespaceUpdateCommandTests
             true,
             false,
             new Dictionary<string, string> { { "env", "test" } });
-    }
 }

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.UnitTests/Namespace/NamespaceUpdateCommandTests.cs
@@ -62,7 +62,7 @@ public class NamespaceUpdateCommandTests : CommandUnitTestsBase<NamespaceUpdateC
         }
 
         // Act
-        var response = await ExecuteCommandAsync(args);
+        var response = await ExecuteCommandAsync(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
 
         // Assert
         if (shouldSucceed)

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/FileShare/FileShareCheckNameAvailabilityCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/FileShare/FileShareCheckNameAvailabilityCommandTests.cs
@@ -1,47 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Tools.FileShares.Commands.FileShare;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.FileShare;
 
 /// <summary>
 /// Unit tests for FileShareCheckNameAvailabilityCommand.
 /// </summary>
-public class FileShareCheckNameAvailabilityCommandTests
+public class FileShareCheckNameAvailabilityCommandTests : CommandUnitTestsBase<FileShareCheckNameAvailabilityCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<FileShareCheckNameAvailabilityCommand> _logger;
-    private readonly FileShareCheckNameAvailabilityCommand _command;
-
-    public FileShareCheckNameAvailabilityCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<FileShareCheckNameAvailabilityCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("check-name-availability", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("check-name-availability", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Check File Share Name Availability", _command.Title);
+        Assert.Equal("check-name-availability", Command.Name);
+        Assert.Equal("Check File Share Name Availability", Command.Title);
+        Assert.Equal("check-name-availability", CommandDefinition.Name);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/FileShare/FileShareCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/FileShare/FileShareCreateCommandTests.cs
@@ -1,47 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Tools.FileShares.Commands.FileShare;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.FileShare;
 
 /// <summary>
 /// Unit tests for FileShareCreateCommand.
 /// </summary>
-public class FileShareCreateCommandTests
+public class FileShareCreateCommandTests : CommandUnitTestsBase<FileShareCreateCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<FileShareCreateCommand> _logger;
-    private readonly FileShareCreateCommand _command;
-
-    public FileShareCreateCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<FileShareCreateCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("create", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("create", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Create File Share", _command.Title);
+        Assert.Equal("create", Command.Name);
+        Assert.Equal("Create File Share", Command.Title);
+        Assert.Equal("create", CommandDefinition.Name);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/FileShare/FileShareDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/FileShare/FileShareDeleteCommandTests.cs
@@ -1,47 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Tools.FileShares.Commands.FileShare;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.FileShare;
 
 /// <summary>
 /// Unit tests for FileShareDeleteCommand.
 /// </summary>
-public class FileShareDeleteCommandTests
+public class FileShareDeleteCommandTests : CommandUnitTestsBase<FileShareDeleteCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<FileShareDeleteCommand> _logger;
-    private readonly FileShareDeleteCommand _command;
-
-    public FileShareDeleteCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<FileShareDeleteCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("delete", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("delete", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Delete File Share", _command.Title);
+        Assert.Equal("delete", Command.Name);
+        Assert.Equal("Delete File Share", Command.Title);
+        Assert.Equal("delete", CommandDefinition.Name);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/FileShare/FileShareGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/FileShare/FileShareGetCommandTests.cs
@@ -1,47 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Tools.FileShares.Commands.FileShare;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.FileShare;
 
 /// <summary>
 /// Unit tests for FileShareGetCommand.
 /// </summary>
-public class FileShareGetCommandTests
+public class FileShareGetCommandTests : CommandUnitTestsBase<FileShareGetCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<FileShareGetCommand> _logger;
-    private readonly FileShareGetCommand _command;
-
-    public FileShareGetCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<FileShareGetCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("get", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("get", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Get File Share", _command.Title);
+        Assert.Equal("get", Command.Name);
+        Assert.Equal("Get File Share", Command.Title);
+        Assert.Equal("get", CommandDefinition.Name);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/FileShare/FileShareUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/FileShare/FileShareUpdateCommandTests.cs
@@ -1,47 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Tools.FileShares.Commands.FileShare;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.FileShare;
 
 /// <summary>
 /// Unit tests for FileShareUpdateCommand.
 /// </summary>
-public class FileShareUpdateCommandTests
+public class FileShareUpdateCommandTests : CommandUnitTestsBase<FileShareUpdateCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<FileShareUpdateCommand> _logger;
-    private readonly FileShareUpdateCommand _command;
-
-    public FileShareUpdateCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<FileShareUpdateCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("update", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("update", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Update File Share", _command.Title);
+        Assert.Equal("update", Command.Name);
+        Assert.Equal("Update File Share", Command.Title);
+        Assert.Equal("update", CommandDefinition.Name);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/GlobalUsings.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/GlobalUsings.cs
@@ -4,6 +4,4 @@
 global using Azure.Mcp.Tools.FileShares.Commands.FileShare;
 global using Azure.Mcp.Tools.FileShares.Commands.Informational;
 global using Azure.Mcp.Tools.FileShares.Services;
-global using Microsoft.Extensions.Logging;
-global using NSubstitute;
 global using Xunit;

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Informational/FileShareGetLimitsCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Informational/FileShareGetLimitsCommandTests.cs
@@ -1,47 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Tools.FileShares.Commands.Informational;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.Informational;
 
 /// <summary>
 /// Unit tests for FileShareGetLimitsCommand.
 /// </summary>
-public class FileShareGetLimitsCommandTests
+public class FileShareGetLimitsCommandTests : CommandUnitTestsBase<FileShareGetLimitsCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<FileShareGetLimitsCommand> _logger;
-    private readonly FileShareGetLimitsCommand _command;
-
-    public FileShareGetLimitsCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<FileShareGetLimitsCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("limits", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("limits", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Get File Share Limits", _command.Title);
+        Assert.Equal("limits", Command.Name);
+        Assert.Equal("Get File Share Limits", Command.Title);
+        Assert.Equal("limits", CommandDefinition.Name);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Informational/FileShareGetProvisioningRecommendationCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Informational/FileShareGetProvisioningRecommendationCommandTests.cs
@@ -1,47 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Tools.FileShares.Commands.Informational;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.Informational;
 
 /// <summary>
 /// Unit tests for FileShareGetProvisioningRecommendationCommand.
 /// </summary>
-public class FileShareGetProvisioningRecommendationCommandTests
+public class FileShareGetProvisioningRecommendationCommandTests : CommandUnitTestsBase<FileShareGetProvisioningRecommendationCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<FileShareGetProvisioningRecommendationCommand> _logger;
-    private readonly FileShareGetProvisioningRecommendationCommand _command;
-
-    public FileShareGetProvisioningRecommendationCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<FileShareGetProvisioningRecommendationCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("rec", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("rec", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Get File Share Provisioning Recommendation", _command.Title);
+        Assert.Equal("rec", Command.Name);
+        Assert.Equal("Get File Share Provisioning Recommendation", Command.Title);
+        Assert.Equal("rec", CommandDefinition.Name);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Informational/FileShareGetUsageDataCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Informational/FileShareGetUsageDataCommandTests.cs
@@ -1,47 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Tools.FileShares.Commands.Informational;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.Informational;
 
 /// <summary>
 /// Unit tests for FileShareGetUsageDataCommand.
 /// </summary>
-public class FileShareGetUsageDataCommandTests
+public class FileShareGetUsageDataCommandTests : CommandUnitTestsBase<FileShareGetUsageDataCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<FileShareGetUsageDataCommand> _logger;
-    private readonly FileShareGetUsageDataCommand _command;
-
-    public FileShareGetUsageDataCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<FileShareGetUsageDataCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("usage", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("usage", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Get File Share Usage Data", _command.Title);
+        Assert.Equal("usage", Command.Name);
+        Assert.Equal("Get File Share Usage Data", Command.Title);
+        Assert.Equal("usage", CommandDefinition.Name);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/PrivateEndpointConnection/PrivateEndpointConnectionGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/PrivateEndpointConnection/PrivateEndpointConnectionGetCommandTests.cs
@@ -2,46 +2,20 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.FileShares.Commands.PrivateEndpointConnection;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.PrivateEndpointConnection;
 
 /// <summary>
 /// Unit tests for PrivateEndpointConnectionGetCommand.
 /// </summary>
-public class PrivateEndpointConnectionGetCommandTests
+public class PrivateEndpointConnectionGetCommandTests : CommandUnitTestsBase<PrivateEndpointConnectionGetCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<PrivateEndpointConnectionGetCommand> _logger;
-    private readonly PrivateEndpointConnectionGetCommand _command;
-
-    public PrivateEndpointConnectionGetCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<PrivateEndpointConnectionGetCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("get", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("get", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Get Private Endpoint Connection", _command.Title);
+        Assert.Equal("get", Command.Name);
+        Assert.Equal("Get Private Endpoint Connection", Command.Title);
+        Assert.Equal("get", CommandDefinition.Name);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/PrivateEndpointConnection/PrivateEndpointConnectionUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/PrivateEndpointConnection/PrivateEndpointConnectionUpdateCommandTests.cs
@@ -2,46 +2,20 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.FileShares.Commands.PrivateEndpointConnection;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.PrivateEndpointConnection;
 
 /// <summary>
 /// Unit tests for PrivateEndpointConnectionUpdateCommand.
 /// </summary>
-public class PrivateEndpointConnectionUpdateCommandTests
+public class PrivateEndpointConnectionUpdateCommandTests : CommandUnitTestsBase<PrivateEndpointConnectionUpdateCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<PrivateEndpointConnectionUpdateCommand> _logger;
-    private readonly PrivateEndpointConnectionUpdateCommand _command;
-
-    public PrivateEndpointConnectionUpdateCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<PrivateEndpointConnectionUpdateCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("update", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("update", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Update Private Endpoint Connection", _command.Title);
+        Assert.Equal("update", Command.Name);
+        Assert.Equal("Update Private Endpoint Connection", Command.Title);
+        Assert.Equal("update", CommandDefinition.Name);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Snapshot/SnapshotCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Snapshot/SnapshotCreateCommandTests.cs
@@ -2,46 +2,20 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.FileShares.Commands.Snapshot;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.Snapshot;
 
 /// <summary>
 /// Unit tests for SnapshotCreateCommand.
 /// </summary>
-public class SnapshotCreateCommandTests
+public class SnapshotCreateCommandTests : CommandUnitTestsBase<SnapshotCreateCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<SnapshotCreateCommand> _logger;
-    private readonly SnapshotCreateCommand _command;
-
-    public SnapshotCreateCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<SnapshotCreateCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("create", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("create", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Create File Share Snapshot", _command.Title);
+        Assert.Equal("create", Command.Name);
+        Assert.Equal("Create File Share Snapshot", Command.Title);
+        Assert.Equal("create", CommandDefinition.Name);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Snapshot/SnapshotDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Snapshot/SnapshotDeleteCommandTests.cs
@@ -2,46 +2,20 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.FileShares.Commands.Snapshot;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.Snapshot;
 
 /// <summary>
 /// Unit tests for SnapshotDeleteCommand.
 /// </summary>
-public class SnapshotDeleteCommandTests
+public class SnapshotDeleteCommandTests : CommandUnitTestsBase<SnapshotDeleteCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<SnapshotDeleteCommand> _logger;
-    private readonly SnapshotDeleteCommand _command;
-
-    public SnapshotDeleteCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<SnapshotDeleteCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("delete", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("delete", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Delete File Share Snapshot", _command.Title);
+        Assert.Equal("delete", Command.Name);
+        Assert.Equal("Delete File Share Snapshot", Command.Title);
+        Assert.Equal("delete", CommandDefinition.Name);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Snapshot/SnapshotGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Snapshot/SnapshotGetCommandTests.cs
@@ -2,46 +2,20 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.FileShares.Commands.Snapshot;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.Snapshot;
 
 /// <summary>
 /// Unit tests for SnapshotGetCommand.
 /// </summary>
-public class SnapshotGetCommandTests
+public class SnapshotGetCommandTests : CommandUnitTestsBase<SnapshotGetCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<SnapshotGetCommand> _logger;
-    private readonly SnapshotGetCommand _command;
-
-    public SnapshotGetCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<SnapshotGetCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("get", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("get", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Get File Share Snapshot", _command.Title);
+        Assert.Equal("get", Command.Name);
+        Assert.Equal("Get File Share Snapshot", Command.Title);
+        Assert.Equal("get", CommandDefinition.Name);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Snapshot/SnapshotUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.UnitTests/Snapshot/SnapshotUpdateCommandTests.cs
@@ -2,46 +2,20 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.FileShares.Commands.Snapshot;
-using Azure.Mcp.Tools.FileShares.Services;
-using Microsoft.Extensions.Logging;
-using NSubstitute;
-using Xunit;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.FileShares.UnitTests.Snapshot;
 
 /// <summary>
 /// Unit tests for SnapshotUpdateCommand.
 /// </summary>
-public class SnapshotUpdateCommandTests
+public class SnapshotUpdateCommandTests : CommandUnitTestsBase<SnapshotUpdateCommand, IFileSharesService>
 {
-    private readonly IFileSharesService _service;
-    private readonly ILogger<SnapshotUpdateCommand> _logger;
-    private readonly SnapshotUpdateCommand _command;
-
-    public SnapshotUpdateCommandTests()
-    {
-        _service = Substitute.For<IFileSharesService>();
-        _logger = Substitute.For<ILogger<SnapshotUpdateCommand>>();
-        _command = new(_logger, _service);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.NotNull(command);
-        Assert.Equal("update", command.Name);
-    }
-
-    [Fact]
-    public void Name_ReturnsCorrectValue()
-    {
-        Assert.Equal("update", _command.Name);
-    }
-
-    [Fact]
-    public void Title_ReturnsCorrectValue()
-    {
-        Assert.Equal("Update File Share Snapshot", _command.Title);
+        Assert.Equal("update", Command.Name);
+        Assert.Equal("Update File Share Snapshot", Command.Title);
+        Assert.Equal("update", CommandDefinition.Name);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Migrates Command unit tests to use `CommandUnitTestBase`. Adds new helper method to `CommandUnitTestBase` that performs common validation when a tool call was expected to succeed with a response value.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
