### PR TITLE
[Part 5] Migrate tool command unit tests to useing CommandUnitTestsBase

### DIFF
--- a/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/KnowledgeIndexListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/KnowledgeIndexListCommandTests.cs
@@ -1,45 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using Azure.Mcp.Tools.FoundryExtensions.Commands;
 using Azure.Mcp.Tools.FoundryExtensions.Models;
 using Azure.Mcp.Tools.FoundryExtensions.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.UnitTests;
 
-public class KnowledgeIndexListCommandTests
+public class KnowledgeIndexListCommandTests : CommandUnitTestsBase<KnowledgeIndexListCommand, IFoundryExtensionsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IFoundryExtensionsService _service;
-    private readonly KnowledgeIndexListCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public KnowledgeIndexListCommandTests()
-    {
-        _service = Substitute.For<IFoundryExtensionsService>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_service);
-        _context = new CommandContext(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("list", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("list", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Theory]
@@ -50,17 +31,12 @@ public class KnowledgeIndexListCommandTests
         // Arrange
         if (shouldSucceed)
         {
-            _service.ListKnowledgeIndexes(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
-                .Returns(
-                [
-                    new() { Name = "test-index", Type = "aisearch", Version = "1.0", Description = "Test index" }
-                ]);
+            Service.ListKnowledgeIndexes(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                .Returns([new() { Name = "test-index", Type = "aisearch", Version = "1.0", Description = "Test index" }]);
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
@@ -79,13 +55,11 @@ public class KnowledgeIndexListCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _service.ListKnowledgeIndexes(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<KnowledgeIndexInformation>>(new Exception("Test error")));
-
-        var parseResult = _commandDefinition.Parse(["--endpoint", "https://my-foundry.services.ai.azure.com/api/projects/my-project"]);
+        Service.ListKnowledgeIndexes(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--endpoint", "https://my-foundry.services.ai.azure.com/api/projects/my-project");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -103,13 +77,11 @@ public class KnowledgeIndexListCommandTests
             new() { Name = "test-index2", Type = "aisearch", Version = "1.1", Description = "Second test index" }
         };
 
-        _service.ListKnowledgeIndexes(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListKnowledgeIndexes(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedIndexes);
 
-        var parseResult = _commandDefinition.Parse(["--endpoint", "https://my-foundry.services.ai.azure.com/api/projects/my-project"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--endpoint", "https://my-foundry.services.ai.azure.com/api/projects/my-project");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/KnowledgeIndexSchemaCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/KnowledgeIndexSchemaCommandTests.cs
@@ -1,44 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using Azure.Mcp.Tools.FoundryExtensions.Commands;
 using Azure.Mcp.Tools.FoundryExtensions.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.UnitTests;
 
-public class KnowledgeIndexSchemaCommandTests
+public class KnowledgeIndexSchemaCommandTests : CommandUnitTestsBase<KnowledgeIndexSchemaCommand, IFoundryExtensionsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IFoundryExtensionsService _service;
-    private readonly KnowledgeIndexSchemaCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public KnowledgeIndexSchemaCommandTests()
-    {
-        _service = Substitute.For<IFoundryExtensionsService>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_service);
-        _context = new CommandContext(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("schema", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("schema", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Theory]
@@ -59,14 +40,12 @@ public class KnowledgeIndexSchemaCommandTests
                 Description = "desc",
                 Tags = new Dictionary<string, string?> { { "env", "test" } }
             };
-            _service.GetKnowledgeIndexSchema(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Service.GetKnowledgeIndexSchema(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
                 .Returns(mockSchema);
         }
 
-        var parseResult = _commandDefinition.Parse(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
@@ -85,13 +64,13 @@ public class KnowledgeIndexSchemaCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _service.GetKnowledgeIndexSchema(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<Models.KnowledgeIndexSchema>(new Exception("Test error")));
-
-        var parseResult = _commandDefinition.Parse(["--endpoint", "https://my-foundry.services.ai.azure.com/api/projects/my-project", "--index", "test-index"]);
+        Service.GetKnowledgeIndexSchema(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--endpoint", "https://my-foundry.services.ai.azure.com/api/projects/my-project",
+            "--index", "test-index");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -110,13 +89,13 @@ public class KnowledgeIndexSchemaCommandTests
             Version = "1.0"
         };
 
-        _service.GetKnowledgeIndexSchema(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.GetKnowledgeIndexSchema(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedSchema);
 
-        var parseResult = _commandDefinition.Parse(["--endpoint", "https://my-foundry.services.ai.azure.com/api/projects/my-project", "--index", "test-index"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--endpoint", "https://my-foundry.services.ai.azure.com/api/projects/my-project",
+            "--index", "test-index");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/OpenAiChatCompletionsCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/OpenAiChatCompletionsCreateCommandTests.cs
@@ -3,65 +3,42 @@
 
 using Azure.Mcp.Tools.FoundryExtensions.Commands;
 using Azure.Mcp.Tools.FoundryExtensions.Services;
-using NSubstitute;
+using Microsoft.Mcp.Tests.Client;
 using Xunit;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.UnitTests;
 
-public class OpenAiChatCompletionsCreateCommandTests
+public class OpenAiChatCompletionsCreateCommandTests : CommandUnitTestsBase<OpenAiChatCompletionsCreateCommand, IFoundryExtensionsService>
 {
-    private readonly IFoundryExtensionsService _foundryService;
-
-    public OpenAiChatCompletionsCreateCommandTests()
-    {
-        _foundryService = Substitute.For<IFoundryExtensionsService>();
-    }
-
     [Fact]
     public void Name_ReturnsCorrectCommandName()
     {
-        // Arrange
-        var command = new OpenAiChatCompletionsCreateCommand(_foundryService);
-
-        // Act & Assert
-        Assert.Equal("chat-completions-create", command.Name);
+        Assert.Equal("chat-completions-create", Command.Name);
     }
 
     [Fact]
     public void Description_ContainsExpectedContent()
     {
-        // Arrange
-        var command = new OpenAiChatCompletionsCreateCommand(_foundryService);
-
-        // Act & Assert
-        Assert.Contains("Create chat completions", command.Description);
-        Assert.Contains("Azure OpenAI", command.Description);
-        Assert.Contains("Microsoft Foundry", command.Description);
-        Assert.Contains("message-array", command.Description);
+        Assert.Contains("Create chat completions", Command.Description);
+        Assert.Contains("Azure OpenAI", Command.Description);
+        Assert.Contains("Microsoft Foundry", Command.Description);
+        Assert.Contains("message-array", Command.Description);
     }
 
     [Fact]
     public void Title_ReturnsCorrectValue()
     {
-        // Arrange
-        var command = new OpenAiChatCompletionsCreateCommand(_foundryService);
-
-        // Act & Assert
-        Assert.Equal("Create OpenAI Chat Completions", command.Title);
+        Assert.Equal("Create OpenAI Chat Completions", Command.Title);
     }
 
     [Fact]
     public void Metadata_HasCorrectProperties()
     {
-        // Arrange
-        var command = new OpenAiChatCompletionsCreateCommand(_foundryService);
-
-        // Act & Assert
-        Assert.False(command.Metadata.Destructive);
-        Assert.False(command.Metadata.Idempotent);
-        Assert.False(command.Metadata.OpenWorld);
-        Assert.True(command.Metadata.ReadOnly);
-        Assert.False(command.Metadata.LocalRequired);
-        Assert.False(command.Metadata.Secret);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.False(Command.Metadata.Idempotent);
+        Assert.False(Command.Metadata.OpenWorld);
+        Assert.True(Command.Metadata.ReadOnly);
+        Assert.False(Command.Metadata.LocalRequired);
+        Assert.False(Command.Metadata.Secret);
     }
 }

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/OpenAiCompletionsCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/OpenAiCompletionsCreateCommandTests.cs
@@ -1,35 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Mcp.Tools.FoundryExtensions.Commands;
 using Azure.Mcp.Tools.FoundryExtensions.Models;
 using Azure.Mcp.Tools.FoundryExtensions.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.UnitTests;
 
-public class OpenAiCompletionsCreateCommandTests
+public class OpenAiCompletionsCreateCommandTests : CommandUnitTestsBase<OpenAiCompletionsCreateCommand, IFoundryExtensionsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IFoundryExtensionsService _foundryService;
-
-    public OpenAiCompletionsCreateCommandTests()
-    {
-        _foundryService = Substitute.For<IFoundryExtensionsService>();
-
-        var collection = new ServiceCollection();
-
-        _serviceProvider = collection.BuildServiceProvider();
-    }
-
     [Fact]
     public async Task ExecuteAsync_CreatesCompletion_WhenValidOptionsProvided()
     {
@@ -43,39 +28,31 @@ public class OpenAiCompletionsCreateCommandTests
         var expectedUsage = new CompletionUsageInfo(10, 50, 60);
         var expectedResult = new CompletionResult("Azure is a cloud computing platform...", expectedUsage);
 
-        _foundryService.CreateCompletionAsync(
-                Arg.Is<string>(s => s == resourceName),
-                Arg.Is<string>(s => s == deploymentName),
-                Arg.Is<string>(s => s == promptText),
-                Arg.Is<string>(s => s == subscriptionId),
-                Arg.Is<string>(s => s == resourceGroup),
-                Arg.Any<int?>(),
-                Arg.Any<double?>(),
-                Arg.Any<string?>(),
-                Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
+        Service.CreateCompletionAsync(
+            Arg.Is(resourceName),
+            Arg.Is(deploymentName),
+            Arg.Is(promptText),
+            Arg.Is(subscriptionId),
+            Arg.Is(resourceGroup),
+            Arg.Any<int?>(),
+            Arg.Any<double?>(),
+            Arg.Any<string?>(),
+            Arg.Is(AuthMethod.Credential),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
         // Act
-        var command = new OpenAiCompletionsCreateCommand(_foundryService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", subscriptionId,
             "--resource-group", resourceGroup,
             "--resource-name", resourceName,
             "--deployment", deploymentName,
-            "--prompt-text", promptText
-        ]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--prompt-text", promptText);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, FoundryExtensionsJsonContext.Default.OpenAiCompletionsCreateCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<OpenAiCompletionsCreateCommandResult>(json);
-        Assert.NotNull(result);
         Assert.Equal(expectedResult.CompletionText, result.CompletionText);
         Assert.Equal(expectedUsage.PromptTokens, result.UsageInfo.PromptTokens);
         Assert.Equal(expectedUsage.CompletionTokens, result.UsageInfo.CompletionTokens);
@@ -97,40 +74,36 @@ public class OpenAiCompletionsCreateCommandTests
         var expectedUsage = new CompletionUsageInfo(10, 50, 60);
         var expectedResult = new CompletionResult("Azure is a cloud computing platform...", expectedUsage);
 
-        _foundryService.CreateCompletionAsync(
-                Arg.Is<string>(s => s == resourceName),
-                Arg.Is<string>(s => s == deploymentName),
-                Arg.Is<string>(s => s == promptText),
-                Arg.Is<string>(s => s == subscriptionId),
-                Arg.Is<string>(s => s == resourceGroup),
-                Arg.Is<int?>(i => i == maxTokens),
-                Arg.Is<double?>(d => d == temperature),
-                Arg.Any<string?>(),
-                Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
+        Service.CreateCompletionAsync(
+            Arg.Is(resourceName),
+            Arg.Is(deploymentName),
+            Arg.Is(promptText),
+            Arg.Is(subscriptionId),
+            Arg.Is(resourceGroup),
+            Arg.Is(maxTokens),
+            Arg.Is(temperature),
+            Arg.Any<string?>(),
+            Arg.Is(AuthMethod.Credential),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
         // Act
-        var command = new OpenAiCompletionsCreateCommand(_foundryService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", subscriptionId,
             "--resource-group", resourceGroup,
             "--resource-name", resourceName,
             "--deployment", deploymentName,
             "--prompt-text", promptText,
             "--max-tokens", maxTokens.ToString(),
-            "--temperature", temperature.ToString()
-        ]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--temperature", temperature.ToString());
 
         // Assert
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
         // Verify the service was called at least once with the core parameters
-        await _foundryService.Received(1).CreateCompletionAsync(
+        await Service.Received(1).CreateCompletionAsync(
             resourceName,
             deploymentName,
             promptText,
@@ -139,7 +112,7 @@ public class OpenAiCompletionsCreateCommandTests
             Arg.Any<int?>(),
             Arg.Any<double?>(),
             Arg.Any<string?>(),
-            Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
+            Arg.Is(AuthMethod.Credential),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
@@ -155,31 +128,27 @@ public class OpenAiCompletionsCreateCommandTests
         var resourceGroup = "test-resource-group";
         var expectedError = "Test error";
 
-        _foundryService.CreateCompletionAsync(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<int?>(),
-                Arg.Any<double?>(),
-                Arg.Any<string?>(),
-                Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
+        Service.CreateCompletionAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<int?>(),
+            Arg.Any<double?>(),
+            Arg.Any<string?>(),
+            Arg.Is(AuthMethod.Credential),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         // Act
-        var command = new OpenAiCompletionsCreateCommand(_foundryService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", subscriptionId,
             "--resource-group", resourceGroup,
             "--resource-name", resourceName,
             "--deployment", deploymentName,
-            "--prompt-text", promptText
-        ]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--prompt-text", promptText);
 
         // Assert
         Assert.NotNull(response);
@@ -190,30 +159,13 @@ public class OpenAiCompletionsCreateCommandTests
     [Fact]
     public void Command_HasCorrectName()
     {
-        // Arrange & Act
-        var command = new OpenAiCompletionsCreateCommand(_foundryService);
-
-        // Assert
-        Assert.Equal("create-completion", command.Name);
+        Assert.Equal("create-completion", Command.Name);
     }
 
     [Fact]
     public void Command_HasCorrectMetadata()
     {
-        // Arrange & Act
-        var command = new OpenAiCompletionsCreateCommand(_foundryService);
-
-        // Assert
-        Assert.False(command.Metadata.Destructive);
-        Assert.True(command.Metadata.ReadOnly);
-    }
-
-    private class OpenAiCompletionsCreateCommandResult
-    {
-        [JsonPropertyName("completionText")]
-        public string CompletionText { get; set; } = string.Empty;
-
-        [JsonPropertyName("usageInfo")]
-        public CompletionUsageInfo UsageInfo { get; set; } = new CompletionUsageInfo(0, 0, 0);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
     }
 }

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/OpenAiEmbeddingsCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/OpenAiEmbeddingsCreateCommandTests.cs
@@ -1,35 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Mcp.Tools.FoundryExtensions.Commands;
 using Azure.Mcp.Tools.FoundryExtensions.Models;
 using Azure.Mcp.Tools.FoundryExtensions.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.UnitTests;
 
-public class OpenAiEmbeddingsCreateCommandTests
+public class OpenAiEmbeddingsCreateCommandTests : CommandUnitTestsBase<OpenAiEmbeddingsCreateCommand, IFoundryExtensionsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IFoundryExtensionsService _foundryService;
-
-    public OpenAiEmbeddingsCreateCommandTests()
-    {
-        _foundryService = Substitute.For<IFoundryExtensionsService>();
-
-        var collection = new ServiceCollection();
-
-        _serviceProvider = collection.BuildServiceProvider();
-    }
-
     [Fact]
     public async Task ExecuteAsync_CreatesEmbeddings_WhenValidOptionsProvided()
     {
@@ -40,55 +25,41 @@ public class OpenAiEmbeddingsCreateCommandTests
         var subscriptionId = "test-subscription-id";
         var resourceGroup = "test-resource-group";
 
-        var expectedEmbedding = new float[] { 0.1f, 0.2f, 0.3f, 0.4f, 0.5f };
-        var expectedUsage = new EmbeddingUsageInfo(2, 2);
-        var expectedData = new List<EmbeddingData>
-        {
-            new EmbeddingData("embedding", 0, expectedEmbedding)
-        };
-        var expectedResult = new EmbeddingResult("list", expectedData, deploymentName, expectedUsage);
+        var expectedResult = new EmbeddingResult("list", [new("embedding", 0, [0.1f, 0.2f, 0.3f, 0.4f, 0.5f])], deploymentName, new(2, 2));
 
-        _foundryService.CreateEmbeddingsAsync(
-                Arg.Is<string>(s => s == resourceName),
-                Arg.Is<string>(s => s == deploymentName),
-                Arg.Is<string>(s => s == inputText),
-                Arg.Is<string>(s => s == subscriptionId),
-                Arg.Is<string>(s => s == resourceGroup),
-                Arg.Any<string?>(),
-                Arg.Is<string>(s => s == "float"),
-                Arg.Any<int?>(),
-                Arg.Any<string?>(),
-                Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
+        Service.CreateEmbeddingsAsync(
+            Arg.Is(resourceName),
+            Arg.Is(deploymentName),
+            Arg.Is(inputText),
+            Arg.Is(subscriptionId),
+            Arg.Is(resourceGroup),
+            Arg.Any<string?>(),
+            Arg.Is("float"),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Is(AuthMethod.Credential),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
         // Act
-        var command = new OpenAiEmbeddingsCreateCommand(_foundryService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", subscriptionId,
             "--resource-group", resourceGroup,
             "--resource-name", resourceName,
             "--deployment", deploymentName,
-            "--input-text", inputText
-        ]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--input-text", inputText);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, FoundryExtensionsJsonContext.Default.OpenAiEmbeddingsCreateCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<OpenAiEmbeddingsCreateCommandResult>(json);
-        Assert.NotNull(result);
         Assert.Equal(expectedResult.Object, result.EmbeddingResult.Object);
         Assert.Equal(expectedResult.Model, result.EmbeddingResult.Model);
         Assert.Equal(resourceName, result.ResourceName);
         Assert.Equal(deploymentName, result.DeploymentName);
         Assert.Equal(inputText, result.InputText);
         Assert.Single(result.EmbeddingResult.Data);
-        Assert.Equal(expectedEmbedding.Length, result.EmbeddingResult.Data[0].Embedding.Length);
+        Assert.Equal(expectedResult.Data[0].Embedding.Length, result.EmbeddingResult.Data[0].Embedding.Length);
     }
 
     [Fact]
@@ -109,48 +80,39 @@ public class OpenAiEmbeddingsCreateCommandTests
             expectedEmbedding[i] = 0.1f;
         }
 
-        var expectedUsage = new EmbeddingUsageInfo(4, 4);
-        var expectedData = new List<EmbeddingData>
-        {
-            new EmbeddingData("embedding", 0, expectedEmbedding)
-        };
-        var expectedResult = new EmbeddingResult("list", expectedData, deploymentName, expectedUsage);
+        var expectedResult = new EmbeddingResult("list", [new("embedding", 0, expectedEmbedding)], deploymentName, new(4, 4));
 
-        _foundryService.CreateEmbeddingsAsync(
-                Arg.Is<string>(s => s == resourceName),
-                Arg.Is<string>(s => s == deploymentName),
-                Arg.Is<string>(s => s == inputText),
-                Arg.Is<string>(s => s == subscriptionId),
-                Arg.Is<string>(s => s == resourceGroup),
-                Arg.Is<string>(s => s == user),
-                Arg.Is<string>(s => s == "float"),
-                Arg.Is<int?>(i => i == dimensions),
-                Arg.Any<string?>(),
-                Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
+        Service.CreateEmbeddingsAsync(
+            Arg.Is(resourceName),
+            Arg.Is(deploymentName),
+            Arg.Is(inputText),
+            Arg.Is(subscriptionId),
+            Arg.Is(resourceGroup),
+            Arg.Is(user),
+            Arg.Is("float"),
+            Arg.Is(dimensions),
+            Arg.Any<string?>(),
+            Arg.Is(AuthMethod.Credential),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
         // Act
-        var command = new OpenAiEmbeddingsCreateCommand(_foundryService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", subscriptionId,
             "--resource-group", resourceGroup,
             "--resource-name", resourceName,
             "--deployment", deploymentName,
             "--input-text", inputText,
             "--user", user,
-            "--dimensions", dimensions.ToString()
-        ]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--dimensions", dimensions.ToString());
 
         // Assert
         Assert.NotNull(response);
         Assert.NotNull(response.Results);
 
         // Verify the service was called at least once with the core parameters
-        await _foundryService.Received(1).CreateEmbeddingsAsync(
+        await Service.Received(1).CreateEmbeddingsAsync(
             resourceName,
             deploymentName,
             inputText,
@@ -160,7 +122,7 @@ public class OpenAiEmbeddingsCreateCommandTests
             Arg.Any<string>(),
             Arg.Any<int?>(),
             Arg.Any<string?>(),
-            Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
+            Arg.Is(AuthMethod.Credential),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
@@ -176,32 +138,28 @@ public class OpenAiEmbeddingsCreateCommandTests
         var resourceGroup = "test-resource-group";
         var expectedError = "Test embedding error";
 
-        _foundryService.CreateEmbeddingsAsync(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string?>(),
-                Arg.Any<string>(),
-                Arg.Any<int?>(),
-                Arg.Any<string?>(),
-                Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
+        Service.CreateEmbeddingsAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string>(),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Is(AuthMethod.Credential),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         // Act
-        var command = new OpenAiEmbeddingsCreateCommand(_foundryService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", subscriptionId,
             "--resource-group", resourceGroup,
             "--resource-name", resourceName,
             "--deployment", deploymentName,
-            "--input-text", inputText
-        ]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--input-text", inputText);
 
         // Assert
         Assert.NotNull(response);
@@ -212,23 +170,15 @@ public class OpenAiEmbeddingsCreateCommandTests
     [Fact]
     public void Command_HasCorrectName()
     {
-        // Arrange & Act
-        var command = new OpenAiEmbeddingsCreateCommand(_foundryService);
-
-        // Assert
-        Assert.Equal("embeddings-create", command.Name);
+        Assert.Equal("embeddings-create", Command.Name);
     }
 
     [Fact]
     public void Command_HasCorrectMetadata()
     {
-        // Arrange & Act
-        var command = new OpenAiEmbeddingsCreateCommand(_foundryService);
-
-        // Assert
-        Assert.False(command.Metadata.Destructive);
-        Assert.True(command.Metadata.ReadOnly);
-        Assert.False(command.Metadata.Idempotent);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
+        Assert.False(Command.Metadata.Idempotent);
     }
 
     [Theory]
@@ -242,7 +192,6 @@ public class OpenAiEmbeddingsCreateCommandTests
         var subscriptionId = "test-subscription-id";
         var resourceGroup = "test-resource-group";
 
-        var command = new OpenAiEmbeddingsCreateCommand(_foundryService);
         var parseArgs = new List<string>
         {
             "--subscription", subscriptionId,
@@ -256,11 +205,8 @@ public class OpenAiEmbeddingsCreateCommandTests
             parseArgs.AddRange(["--input-text", inputText]);
         }
 
-        var args = command.GetCommand().Parse(parseArgs.ToArray());
-        var context = new CommandContext(_serviceProvider);
-
         // Act
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(parseArgs.ToArray());
 
         // Assert
         Assert.NotNull(response);
@@ -269,20 +215,5 @@ public class OpenAiEmbeddingsCreateCommandTests
         {
             Assert.NotEqual(200, (int)response.Status);
         }
-    }
-
-    private class OpenAiEmbeddingsCreateCommandResult
-    {
-        [JsonPropertyName("embeddingResult")]
-        public EmbeddingResult EmbeddingResult { get; set; } = new EmbeddingResult("", new List<EmbeddingData>(), "", new EmbeddingUsageInfo(0, 0));
-
-        [JsonPropertyName("resourceName")]
-        public string ResourceName { get; set; } = string.Empty;
-
-        [JsonPropertyName("deploymentName")]
-        public string DeploymentName { get; set; } = string.Empty;
-
-        [JsonPropertyName("inputText")]
-        public string InputText { get; set; } = string.Empty;
     }
 }

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/OpenAiModelsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/OpenAiModelsListCommandTests.cs
@@ -1,35 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Mcp.Tools.FoundryExtensions.Commands;
 using Azure.Mcp.Tools.FoundryExtensions.Models;
 using Azure.Mcp.Tools.FoundryExtensions.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.UnitTests;
 
-public class OpenAiModelsListCommandTests
+public class OpenAiModelsListCommandTests : CommandUnitTestsBase<OpenAiModelsListCommand, IFoundryExtensionsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IFoundryExtensionsService _foundryService;
-
-    public OpenAiModelsListCommandTests()
-    {
-        _foundryService = Substitute.For<IFoundryExtensionsService>();
-
-        var collection = new ServiceCollection();
-
-        _serviceProvider = collection.BuildServiceProvider();
-    }
-
     [Fact]
     public async Task ExecuteAsync_ListsModels_WhenValidOptionsProvided()
     {
@@ -40,7 +25,7 @@ public class OpenAiModelsListCommandTests
 
         var expectedModels = new List<OpenAiModelDeployment>
         {
-            new OpenAiModelDeployment(
+            new(
                 DeploymentName: "gpt-4o",
                 ModelName: "gpt-4o",
                 ModelVersion: "2024-05-13",
@@ -49,9 +34,8 @@ public class OpenAiModelsListCommandTests
                 ProvisioningState: "Succeeded",
                 CreatedAt: DateTime.UtcNow.AddDays(-1),
                 UpdatedAt: DateTime.UtcNow,
-                Capabilities: new OpenAiModelCapabilities(true, false, true, false)
-            ),
-            new OpenAiModelDeployment(
+                Capabilities: new(true, false, true, false)),
+            new(
                 DeploymentName: "text-embedding-ada-002",
                 ModelName: "text-embedding-ada-002",
                 ModelVersion: "2",
@@ -60,39 +44,28 @@ public class OpenAiModelsListCommandTests
                 ProvisioningState: "Succeeded",
                 CreatedAt: DateTime.UtcNow.AddDays(-2),
                 UpdatedAt: DateTime.UtcNow.AddHours(-1),
-                Capabilities: new OpenAiModelCapabilities(false, true, false, false)
-            )
+                Capabilities: new(false, true, false, false))
         };
 
-        var expectedResult = new OpenAiModelsListResult(expectedModels, resourceName);
-
-        _foundryService.ListOpenAiModelsAsync(
-                Arg.Is<string>(s => s == resourceName),
-                Arg.Is<string>(s => s == subscriptionId),
-                Arg.Is<string>(s => s == resourceGroup),
-                Arg.Any<string?>(),
-                Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(expectedResult);
+        Service.ListOpenAiModelsAsync(
+            Arg.Is(resourceName),
+            Arg.Is(subscriptionId),
+            Arg.Is(resourceGroup),
+            Arg.Any<string?>(),
+            Arg.Is(AuthMethod.Credential),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new OpenAiModelsListResult(expectedModels, resourceName));
 
         // Act
-        var command = new OpenAiModelsListCommand(_foundryService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", subscriptionId,
             "--resource-group", resourceGroup,
-            "--resource-name", resourceName
-        ]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--resource-name", resourceName);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, FoundryExtensionsJsonContext.Default.OpenAiModelsListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<OpenAiModelsListCommandResult>(json);
-        Assert.NotNull(result);
         Assert.Equal(resourceName, result.ResourceName);
         Assert.Equal(resourceName, result.ModelsListResult.ResourceName);
         Assert.Equal(2, result.ModelsListResult.Models.Count);
@@ -120,35 +93,25 @@ public class OpenAiModelsListCommandTests
         var subscriptionId = "test-subscription-id";
         var resourceGroup = "test-resource-group";
 
-        var expectedResult = new OpenAiModelsListResult(new List<OpenAiModelDeployment>(), resourceName);
-
-        _foundryService.ListOpenAiModelsAsync(
-                Arg.Is<string>(s => s == resourceName),
-                Arg.Is<string>(s => s == subscriptionId),
-                Arg.Is<string>(s => s == resourceGroup),
-                Arg.Any<string?>(),
-                Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(expectedResult);
+        Service.ListOpenAiModelsAsync(
+            Arg.Is(resourceName),
+            Arg.Is(subscriptionId),
+            Arg.Is(resourceGroup),
+            Arg.Any<string?>(),
+            Arg.Is(AuthMethod.Credential),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new OpenAiModelsListResult([], resourceName));
 
         // Act
-        var command = new OpenAiModelsListCommand(_foundryService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", subscriptionId,
             "--resource-group", resourceGroup,
-            "--resource-name", resourceName
-        ]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--resource-name", resourceName);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, FoundryExtensionsJsonContext.Default.OpenAiModelsListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<OpenAiModelsListCommandResult>(json);
-        Assert.NotNull(result);
         Assert.Equal(resourceName, result.ResourceName);
         Assert.Empty(result.ModelsListResult.Models);
     }
@@ -162,25 +125,21 @@ public class OpenAiModelsListCommandTests
         var resourceGroup = "test-resource-group";
         var expectedError = "Test models list error";
 
-        _foundryService.ListOpenAiModelsAsync(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string?>(),
-                Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
+        Service.ListOpenAiModelsAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Is(AuthMethod.Credential),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         // Act
-        var command = new OpenAiModelsListCommand(_foundryService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", subscriptionId,
             "--resource-group", resourceGroup,
-            "--resource-name", resourceName
-        ]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--resource-name", resourceName);
 
         // Assert
         Assert.NotNull(response);
@@ -191,23 +150,15 @@ public class OpenAiModelsListCommandTests
     [Fact]
     public void Command_HasCorrectName()
     {
-        // Arrange & Act
-        var command = new OpenAiModelsListCommand(_foundryService);
-
-        // Assert
-        Assert.Equal("models-list", command.Name);
+        Assert.Equal("models-list", Command.Name);
     }
 
     [Fact]
     public void Command_HasCorrectMetadata()
     {
-        // Arrange & Act
-        var command = new OpenAiModelsListCommand(_foundryService);
-
-        // Assert
-        Assert.False(command.Metadata.Destructive);
-        Assert.True(command.Metadata.ReadOnly);
-        Assert.True(command.Metadata.Idempotent);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
+        Assert.True(Command.Metadata.Idempotent);
     }
 
     [Theory]
@@ -218,27 +169,21 @@ public class OpenAiModelsListCommandTests
     public async Task ExecuteAsync_ValidatesRequiredParameters(string args, bool shouldSucceed)
     {
         // Arrange
-        var command = new OpenAiModelsListCommand(_foundryService);
-        var context = new CommandContext(_serviceProvider);
-
-        var expectedResult = new OpenAiModelsListResult(new List<OpenAiModelDeployment>(), "myresource");
         if (shouldSucceed)
         {
-            _foundryService.ListOpenAiModelsAsync(
-                    Arg.Any<string>(),
-                    Arg.Any<string>(),
-                    Arg.Any<string>(),
-                    Arg.Any<string?>(),
-                    Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
-                    Arg.Any<RetryPolicyOptions?>(),
-                    Arg.Any<CancellationToken>())
-                .Returns(expectedResult);
+            Service.ListOpenAiModelsAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Is(AuthMethod.Credential),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
+                .Returns(new OpenAiModelsListResult([], "myresource"));
         }
 
-        var parseResult = command.GetCommand().Parse(args.Split(' '));
-
         // Act
-        var response = await command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         if (shouldSucceed)
@@ -260,30 +205,24 @@ public class OpenAiModelsListCommandTests
         var subscriptionId = "test-sub";
         var resourceGroup = "test-rg";
 
-        var expectedResult = new OpenAiModelsListResult(new List<OpenAiModelDeployment>(), resourceName);
-        _foundryService.ListOpenAiModelsAsync(
-                Arg.Is<string>(s => s == resourceName),
-                Arg.Is<string>(s => s == subscriptionId),
-                Arg.Is<string>(s => s == resourceGroup),
-                Arg.Any<string?>(),
-                Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(expectedResult);
-
-        var command = new OpenAiModelsListCommand(_foundryService);
-        var args = command.GetCommand().Parse([
-            "--subscription", subscriptionId,
-            "--resource-group", resourceGroup,
-            "--resource-name", resourceName
-        ]);
-        var context = new CommandContext(_serviceProvider);
+        Service.ListOpenAiModelsAsync(
+            Arg.Is(resourceName),
+            Arg.Is(subscriptionId),
+            Arg.Is(resourceGroup),
+            Arg.Any<string?>(),
+            Arg.Is(AuthMethod.Credential),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new OpenAiModelsListResult([], resourceName));
 
         // Act
-        await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        await ExecuteCommandAsync(
+            "--subscription", subscriptionId,
+            "--resource-group", resourceGroup,
+            "--resource-name", resourceName);
 
         // Assert - Verify the service was called with exact parameters
-        await _foundryService.Received(1).ListOpenAiModelsAsync(
+        await Service.Received(1).ListOpenAiModelsAsync(
             resourceName,
             subscriptionId,
             resourceGroup,
@@ -301,38 +240,25 @@ public class OpenAiModelsListCommandTests
         var subscriptionId = "test-subscription-id";
         var resourceGroup = "test-resource-group";
 
-        _foundryService.ListOpenAiModelsAsync(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string?>(),
-                Arg.Is<AuthMethod>(s => s == AuthMethod.Credential),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
+        Service.ListOpenAiModelsAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Is(AuthMethod.Credential),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Authentication failed"));
 
         // Act
-        var command = new OpenAiModelsListCommand(_foundryService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", subscriptionId,
             "--resource-group", resourceGroup,
-            "--resource-name", resourceName
-        ]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--resource-name", resourceName);
 
         // Assert
         Assert.NotNull(response);
         Assert.NotEqual(200, (int)response.Status);
         Assert.Contains("Authentication failed", response.Message);
-    }
-
-    private class OpenAiModelsListCommandResult
-    {
-        [JsonPropertyName("modelsListResult")]
-        public OpenAiModelsListResult ModelsListResult { get; set; } = new OpenAiModelsListResult(new List<OpenAiModelDeployment>(), "");
-
-        [JsonPropertyName("resourceName")]
-        public string ResourceName { get; set; } = string.Empty;
     }
 }

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/ResourceGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.UnitTests/ResourceGetCommandTests.cs
@@ -2,47 +2,28 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.FoundryExtensions.Commands;
 using Azure.Mcp.Tools.FoundryExtensions.Models;
 using Azure.Mcp.Tools.FoundryExtensions.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.UnitTests;
 
-public class ResourceGetCommandTests
+public class ResourceGetCommandTests : CommandUnitTestsBase<ResourceGetCommand, IFoundryExtensionsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IFoundryExtensionsService _foundryService;
-    private readonly ILogger<ResourceGetCommand> _logger;
-
-    public ResourceGetCommandTests()
-    {
-        _foundryService = Substitute.For<IFoundryExtensionsService>();
-        _logger = Substitute.For<ILogger<ResourceGetCommand>>();
-
-        var collection = new ServiceCollection();
-
-        _serviceProvider = collection.BuildServiceProvider();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = new ResourceGetCommand(_logger, _foundryService);
-
-        Assert.Equal("get", command.Name);
-        Assert.NotEmpty(command.Description);
-        Assert.NotNull(command.Metadata);
-        Assert.True(command.Metadata.ReadOnly);
-        Assert.True(command.Metadata.Idempotent);
-        Assert.False(command.Metadata.Destructive);
+        Assert.Equal("get", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.NotNull(Command.Metadata);
+        Assert.True(Command.Metadata.ReadOnly);
+        Assert.True(Command.Metadata.Idempotent);
+        Assert.False(Command.Metadata.Destructive);
     }
 
     [Fact]
@@ -59,7 +40,7 @@ public class ResourceGetCommandTests
                 Endpoint = "https://resource1.openai.azure.com/",
                 Kind = "OpenAI",
                 SkuName = "S0",
-                Deployments = new List<DeploymentInformation>()
+                Deployments = []
             },
             new()
             {
@@ -70,11 +51,11 @@ public class ResourceGetCommandTests
                 Endpoint = "https://resource2.openai.azure.com/",
                 Kind = "AIServices",
                 SkuName = "S0",
-                Deployments = new List<DeploymentInformation>()
+                Deployments = []
             }
         };
 
-        _foundryService.ListAiResourcesAsync(
+        Service.ListAiResourcesAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -82,18 +63,10 @@ public class ResourceGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResources);
 
-        var command = new ResourceGetCommand(_logger, _foundryService);
-        var args = command.GetCommand().Parse(["--subscription", "test-sub"]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "test-sub");
 
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, FoundryExtensionsJsonContext.Default.ResourceGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, FoundryExtensionsJsonContext.Default.ResourceGetCommandResult);
-        Assert.NotNull(result);
         Assert.NotNull(result.Resources);
         Assert.Equal(expectedResources.Count, result.Resources.Count);
     }
@@ -112,11 +85,11 @@ public class ResourceGetCommandTests
                 Endpoint = "https://resource1.openai.azure.com/",
                 Kind = "OpenAI",
                 SkuName = "S0",
-                Deployments = new List<DeploymentInformation>()
+                Deployments = []
             }
         };
 
-        _foundryService.ListAiResourcesAsync(
+        Service.ListAiResourcesAsync(
             Arg.Any<string>(),
             Arg.Is("test-rg"),
             Arg.Any<string?>(),
@@ -124,18 +97,10 @@ public class ResourceGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResources);
 
-        var command = new ResourceGetCommand(_logger, _foundryService);
-        var args = command.GetCommand().Parse(["--subscription", "test-sub", "--resource-group", "test-rg"]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "test-sub", "--resource-group", "test-rg");
 
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, FoundryExtensionsJsonContext.Default.ResourceGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, FoundryExtensionsJsonContext.Default.ResourceGetCommandResult);
-        Assert.NotNull(result);
         Assert.NotNull(result.Resources);
         Assert.Single(result.Resources);
         Assert.Equal("test-rg", result.Resources[0].ResourceGroup);
@@ -153,8 +118,8 @@ public class ResourceGetCommandTests
             Endpoint = "https://test-resource.openai.azure.com/",
             Kind = "OpenAI",
             SkuName = "S0",
-            Deployments = new List<DeploymentInformation>
-            {
+            Deployments =
+            [
                 new()
                 {
                     DeploymentName = "gpt-4o",
@@ -165,10 +130,10 @@ public class ResourceGetCommandTests
                     SkuCapacity = 100,
                     ProvisioningState = "Succeeded"
                 }
-            }
+            ]
         };
 
-        _foundryService.GetAiResourceAsync(
+        Service.GetAiResourceAsync(
             Arg.Any<string>(),
             Arg.Is("test-rg"),
             Arg.Is("test-resource"),
@@ -177,22 +142,13 @@ public class ResourceGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResource);
 
-        var command = new ResourceGetCommand(_logger, _foundryService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "test-sub",
             "--resource-group", "test-rg",
-            "--resource-name", "test-resource"
-        ]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--resource-name", "test-resource");
 
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, FoundryExtensionsJsonContext.Default.ResourceGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, FoundryExtensionsJsonContext.Default.ResourceGetCommandResult);
-        Assert.NotNull(result);
         Assert.NotNull(result.Resources);
         Assert.Single(result.Resources);
         Assert.Equal("test-resource", result.Resources[0].ResourceName);
@@ -203,7 +159,7 @@ public class ResourceGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoResourcesExist()
     {
-        _foundryService.ListAiResourcesAsync(
+        Service.ListAiResourcesAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -211,18 +167,9 @@ public class ResourceGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var command = new ResourceGetCommand(_logger, _foundryService);
-        var args = command.GetCommand().Parse(["--subscription", "test-sub"]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "test-sub");
 
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, FoundryExtensionsJsonContext.Default.ResourceGetCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, FoundryExtensionsJsonContext.Default.ResourceGetCommandResult);
         Assert.Empty(result.Resources);
     }
 
@@ -231,7 +178,7 @@ public class ResourceGetCommandTests
     {
         var expectedError = "Failed to list resources";
 
-        _foundryService.ListAiResourcesAsync(
+        Service.ListAiResourcesAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -239,10 +186,7 @@ public class ResourceGetCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var command = new ResourceGetCommand(_logger, _foundryService);
-        var args = command.GetCommand().Parse(["--subscription", "test-sub"]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "test-sub");
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -254,7 +198,7 @@ public class ResourceGetCommandTests
     {
         var expectedError = "Resource not found";
 
-        _foundryService.GetAiResourceAsync(
+        Service.GetAiResourceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -263,14 +207,10 @@ public class ResourceGetCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var command = new ResourceGetCommand(_logger, _foundryService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "test-sub",
             "--resource-group", "test-rg",
-            "--resource-name", "test-resource"
-        ]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--resource-name", "test-resource");
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -283,7 +223,7 @@ public class ResourceGetCommandTests
     [InlineData("--subscription", "test-sub", "--resource-group", "test-rg", "--resource-name", "test-resource")]
     public async Task ExecuteAsync_ValidatesInputCorrectly(params string[] args)
     {
-        _foundryService.ListAiResourcesAsync(
+        Service.ListAiResourcesAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -291,7 +231,7 @@ public class ResourceGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns([]);
 
-        _foundryService.GetAiResourceAsync(
+        Service.GetAiResourceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -300,10 +240,7 @@ public class ResourceGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(new AiResourceInformation());
 
-        var command = new ResourceGetCommand(_logger, _foundryService);
-        var parsedArgs = command.GetCommand().Parse(args);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, parsedArgs, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -321,8 +258,8 @@ public class ResourceGetCommandTests
             Endpoint = "https://test-resource.openai.azure.com/",
             Kind = "OpenAI",
             SkuName = "S0",
-            Deployments = new List<DeploymentInformation>
-            {
+            Deployments =
+            [
                 new()
                 {
                     DeploymentName = "gpt-4o",
@@ -344,10 +281,10 @@ public class ResourceGetCommandTests
                     SkuCapacity = 120,
                     ProvisioningState = "Succeeded"
                 }
-            }
+            ]
         };
 
-        _foundryService.GetAiResourceAsync(
+        Service.GetAiResourceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -356,22 +293,13 @@ public class ResourceGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(resourceWithDeployments);
 
-        var command = new ResourceGetCommand(_logger, _foundryService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "test-sub",
             "--resource-group", "test-rg",
-            "--resource-name", "test-resource"
-        ]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--resource-name", "test-resource");
 
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, FoundryExtensionsJsonContext.Default.ResourceGetCommandResult);
 
-        // Serialize and deserialize to validate JSON context
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, FoundryExtensionsJsonContext.Default.ResourceGetCommandResult);
-        Assert.NotNull(result);
         Assert.NotNull(result.Resources);
         Assert.Single(result.Resources);
 
@@ -405,15 +333,13 @@ public class ResourceGetCommandTests
     [Fact]
     public void BindOptions_BindsOptionsCorrectly()
     {
-        var command = new ResourceGetCommand(_logger, _foundryService);
-        var args = command.GetCommand().Parse([
+        var args = CommandDefinition.Parse([
             "--subscription", "test-sub",
             "--resource-group", "test-rg",
             "--resource-name", "test-resource",
             "--tenant", "test-tenant"
         ]);
 
-        var context = new CommandContext(_serviceProvider);
         // We can't directly access BindOptions, but we can verify the command parses correctly
         Assert.Empty(args.Errors);
     }

--- a/tools/Azure.Mcp.Tools.FunctionApp/tests/Azure.Mcp.Tools.FunctionApp.UnitTests/FunctionApp/FunctionAppGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/tests/Azure.Mcp.Tools.FunctionApp.UnitTests/FunctionApp/FunctionAppGetCommandTests.cs
@@ -2,38 +2,20 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.FunctionApp.Commands;
 using Azure.Mcp.Tools.FunctionApp.Commands.FunctionApp;
 using Azure.Mcp.Tools.FunctionApp.Models;
 using Azure.Mcp.Tools.FunctionApp.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.FunctionApp.UnitTests.FunctionApp;
 
-public sealed class FunctionAppGetCommandTests
+public sealed class FunctionAppGetCommandTests : CommandUnitTestsBase<FunctionAppGetCommand, IFunctionAppService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IFunctionAppService _service;
-    private readonly ILogger<FunctionAppGetCommand> _logger;
-    private readonly FunctionAppGetCommand _command;
-
-    public FunctionAppGetCommandTests()
-    {
-        _service = Substitute.For<IFunctionAppService>();
-        _logger = Substitute.For<ILogger<FunctionAppGetCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _service);
-    }
-
     [Theory]
     [InlineData("--subscription sub123", true)]
     [InlineData("--subscription sub123 --tenant tenant123", true)]
@@ -48,7 +30,7 @@ public sealed class FunctionAppGetCommandTests
                 new("functionApp1", null, "eastus", "plan1", "Running", "functionapp1.azurewebsites.net", null),
                 new("functionApp2", null, "westus", "plan2", "Stopped", "functionapp2.azurewebsites.net", null)
             };
-            _service.GetFunctionApp(
+            Service.GetFunctionApp(
                 Arg.Any<string>(),
                 Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
                 Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
@@ -58,11 +40,8 @@ public sealed class FunctionAppGetCommandTests
                 .Returns(testFunctionApps);
         }
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
@@ -86,7 +65,7 @@ public sealed class FunctionAppGetCommandTests
             new("functionApp1", "rg1", "eastus", "plan1", "Running", "functionapp1.azurewebsites.net", null),
             new("functionApp2", "rg2", "westus", "plan2", "Stopped", "functionapp2.azurewebsites.net", null)
         };
-        _service.GetFunctionApp(
+        Service.GetFunctionApp(
             Arg.Any<string>(),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
@@ -95,18 +74,12 @@ public sealed class FunctionAppGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedFunctionApps);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub123");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription sub123");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
         // Verify the mock was called
-        await _service.Received(1).GetFunctionApp(
+        await Service.Received(1).GetFunctionApp(
             Arg.Any<string>(),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
@@ -114,9 +87,7 @@ public sealed class FunctionAppGetCommandTests
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
 
-        var json = JsonSerializer.Serialize(response.Results);
-
-        var result = JsonSerializer.Deserialize(json, FunctionAppJsonContext.Default.FunctionAppGetCommandResult);
+        var result = ValidateAndDeserializeResponse(response, FunctionAppJsonContext.Default.FunctionAppGetCommandResult);
 
         Assert.NotNull(result);
         Assert.Equal(expectedFunctionApps.Count, result.FunctionApps.Count);
@@ -132,7 +103,7 @@ public sealed class FunctionAppGetCommandTests
     public async Task ExecuteAsync_ReturnsEmptyWhenNoFunctionApp()
     {
         // Arrange
-        _service.GetFunctionApp(
+        Service.GetFunctionApp(
             Arg.Any<string>(),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
@@ -141,20 +112,12 @@ public sealed class FunctionAppGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub123");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription sub123");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, FunctionAppJsonContext.Default.FunctionAppGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, FunctionAppJsonContext.Default.FunctionAppGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.FunctionApps);
     }
 
@@ -162,20 +125,17 @@ public sealed class FunctionAppGetCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _service.GetFunctionApp(
+        Service.GetFunctionApp(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<FunctionAppInfo>?>(new Exception("Test error")));
-
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub123");
+            .ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription sub123");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -186,10 +146,9 @@ public sealed class FunctionAppGetCommandTests
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("get", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("get", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Theory]
@@ -200,20 +159,17 @@ public sealed class FunctionAppGetCommandTests
     {
         if (shouldSucceed)
         {
-            _service.GetFunctionApp(
+            Service.GetFunctionApp(
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
                 Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
-                .Returns([new FunctionAppInfo("app1", "rg1", "eastus", "plan1", "Running", "app1.azurewebsites.net", null)]);
+                .Returns([new("app1", "rg1", "eastus", "plan1", "Running", "app1.azurewebsites.net", null)]);
         }
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse(args);
-
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
     }
@@ -222,7 +178,7 @@ public sealed class FunctionAppGetCommandTests
     public async Task ExecuteAsync_ReturnsFunctionApp()
     {
         var expected = new FunctionAppInfo("app1", "rg1", "eastus", "plan1", "Running", "app1.azurewebsites.net", null);
-        _service.GetFunctionApp(
+        Service.GetFunctionApp(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -231,17 +187,10 @@ public sealed class FunctionAppGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns([expected]);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub123 --resource-group rg1 --function-app app1");
+        var response = await ExecuteCommandAsync("--subscription sub123 --resource-group rg1 --function-app app1");
 
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var result = ValidateAndDeserializeResponse(response, FunctionAppJsonContext.Default.FunctionAppGetCommandResult);
 
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, FunctionAppJsonContext.Default.FunctionAppGetCommandResult);
-        Assert.NotNull(result);
         Assert.Equal(expected.Name, result.FunctionApps[0].Name);
         Assert.Equal(expected.ResourceGroupName, result.FunctionApps[0].ResourceGroupName);
     }
@@ -249,7 +198,7 @@ public sealed class FunctionAppGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsEmptyWhenNotFound()
     {
-        _service.GetFunctionApp(
+        Service.GetFunctionApp(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -258,18 +207,9 @@ public sealed class FunctionAppGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns((List<FunctionAppInfo>?)null);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub123 --resource-group rg1 --function-app app1");
+        var response = await ExecuteCommandAsync("--subscription sub123 --resource-group rg1 --function-app app1");
 
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
-
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, FunctionAppJsonContext.Default.FunctionAppGetCommandResult);
-
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, FunctionAppJsonContext.Default.FunctionAppGetCommandResult);
         Assert.Empty(result.FunctionApps);
     }
 }

--- a/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.UnitTests/Language/LanguageListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.UnitTests/Language/LanguageListCommandTests.cs
@@ -1,62 +1,39 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.Functions.Commands;
 using Azure.Mcp.Tools.Functions.Commands.Language;
 using Azure.Mcp.Tools.Functions.Models;
 using Azure.Mcp.Tools.Functions.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Services.Caching;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Functions.UnitTests.Language;
 
-public sealed class LanguageListCommandTests
+public sealed class LanguageListCommandTests : CommandUnitTestsBase<LanguageListCommand, IFunctionsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IFunctionsService _service;
-    private readonly ILogger<LanguageListCommand> _logger;
-    private readonly CommandContext _context;
-    private readonly LanguageListCommand _command;
-    private readonly Command _commandDefinition;
-
-    public LanguageListCommandTests()
-    {
-        _service = Substitute.For<IFunctionsService>();
-        _logger = Substitute.For<ILogger<LanguageListCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_service);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _context = new(_serviceProvider);
-        _command = new(_logger);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("list", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.Equal("List Supported Languages", _command.Title);
+        Assert.Equal("list", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.Equal("List Supported Languages", Command.Title);
     }
 
     [Fact]
     public void Command_HasCorrectMetadata()
     {
-        Assert.False(_command.Metadata.Destructive);
-        Assert.True(_command.Metadata.Idempotent);
-        Assert.False(_command.Metadata.OpenWorld);
-        Assert.True(_command.Metadata.ReadOnly);
-        Assert.False(_command.Metadata.LocalRequired);
-        Assert.False(_command.Metadata.Secret);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.Idempotent);
+        Assert.False(Command.Metadata.OpenWorld);
+        Assert.True(Command.Metadata.ReadOnly);
+        Assert.False(Command.Metadata.LocalRequired);
+        Assert.False(Command.Metadata.Secret);
     }
 
     [Fact]
@@ -69,10 +46,10 @@ public sealed class LanguageListCommandTests
             ExtensionBundleVersion = "[4.*, 5.0.0)",
             Languages =
             [
-                new LanguageDetails
+                new()
                 {
                     Language = "python",
-                    Info = new LanguageInfo
+                    Info = new()
                     {
                         Name = "Python",
                         Runtime = "python",
@@ -83,7 +60,7 @@ public sealed class LanguageListCommandTests
                         RunCommand = "func start",
                         BuildCommand = null,
                         ProjectFiles = ["requirements.txt"],
-                        RuntimeVersions = new RuntimeVersionInfo
+                        RuntimeVersions = new()
                         {
                             Supported = ["3.10", "3.11", "3.12", "3.13"],
                             Preview = ["3.14"],
@@ -92,17 +69,17 @@ public sealed class LanguageListCommandTests
                         InitInstructions = "Test instructions",
                         ProjectStructure = ["function_app.py"]
                     },
-                    RuntimeVersions = new RuntimeVersionInfo
+                    RuntimeVersions = new()
                     {
                         Supported = ["3.10", "3.11", "3.12", "3.13"],
                         Preview = ["3.14"],
                         Default = "3.11"
                     }
                 },
-                new LanguageDetails
+                new()
                 {
                     Language = "csharp",
-                    Info = new LanguageInfo
+                    Info = new()
                     {
                         Name = "C#",
                         Runtime = "dotnet",
@@ -113,7 +90,7 @@ public sealed class LanguageListCommandTests
                         RunCommand = "func start",
                         BuildCommand = "dotnet build",
                         ProjectFiles = [],
-                        RuntimeVersions = new RuntimeVersionInfo
+                        RuntimeVersions = new()
                         {
                             Supported = ["8", "9", "10"],
                             Deprecated = ["6", "7"],
@@ -123,7 +100,7 @@ public sealed class LanguageListCommandTests
                         InitInstructions = "Test instructions",
                         ProjectStructure = ["*.csproj"]
                     },
-                    RuntimeVersions = new RuntimeVersionInfo
+                    RuntimeVersions = new()
                     {
                         Supported = ["8", "9", "10"],
                         Deprecated = ["6", "7"],
@@ -134,21 +111,14 @@ public sealed class LanguageListCommandTests
             ]
         };
 
-        _service.GetLanguageListAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(expectedResult));
+        Service.GetLanguageListAsync(Arg.Any<CancellationToken>()).Returns(expectedResult);
 
         // Act
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync();
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var results = ValidateAndDeserializeResponse(response, FunctionsJsonContext.Default.ListLanguageListResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var results = JsonSerializer.Deserialize<List<LanguageListResult>>(json, FunctionsJsonContext.Default.ListLanguageListResult);
-
-        Assert.NotNull(results);
         Assert.Single(results);
 
         var result = results[0];
@@ -166,11 +136,10 @@ public sealed class LanguageListCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _service.GetLanguageListAsync(Arg.Any<CancellationToken>()).Returns<LanguageListResult>(_ => throw new InvalidOperationException("Service error"));
+        Service.GetLanguageListAsync(Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException("Service error"));
 
         // Act
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync();
 
         // Assert
         Assert.NotNull(response);
@@ -183,10 +152,7 @@ public sealed class LanguageListCommandTests
     {
         // Arrange - use the real service to verify actual data shape
         // GetLanguageListAsync now fetches manifest for runtime versions
-        var mockHttpClientFactory = Substitute.For<IHttpClientFactory>();
-        var languageMetadata = new LanguageMetadataProvider();
         var mockManifestService = Substitute.For<IManifestService>();
-        var mockLogger = Substitute.For<ILogger<FunctionsService>>();
 
         // Set up manifest with runtime versions
         var manifest = new TemplateManifest
@@ -201,25 +167,23 @@ public sealed class LanguageListCommandTests
                 ["PowerShell"] = new RuntimeVersionInfo { Supported = ["7.4"], Default = "7.4" }
             }
         };
-        mockManifestService.FetchManifestAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(manifest));
+        mockManifestService.FetchManifestAsync(Arg.Any<CancellationToken>()).Returns(manifest);
 
-        var mockCacheService = Substitute.For<ICacheService>();
-        var realService = new FunctionsService(mockHttpClientFactory, languageMetadata, mockManifestService, mockCacheService, mockLogger);
+        var realService = new FunctionsService(
+            Substitute.For<IHttpClientFactory>(),
+            new LanguageMetadataProvider(),
+            mockManifestService,
+            Substitute.For<ICacheService>(),
+            Substitute.For<ILogger<FunctionsService>>());
         var realResult = await realService.GetLanguageListAsync(TestContext.Current.CancellationToken);
-        _service.GetLanguageListAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(realResult));
+        Service.GetLanguageListAsync(Arg.Any<CancellationToken>()).Returns(realResult);
 
         // Act
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync();
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var results = ValidateAndDeserializeResponse(response, FunctionsJsonContext.Default.ListLanguageListResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var results = JsonSerializer.Deserialize<List<LanguageListResult>>(json, FunctionsJsonContext.Default.ListLanguageListResult);
-
-        Assert.NotNull(results);
         Assert.Single(results);
 
         var result = results[0];

--- a/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.UnitTests/Project/ProjectGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.UnitTests/Project/ProjectGetCommandTests.cs
@@ -1,68 +1,44 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.Functions.Commands;
 using Azure.Mcp.Tools.Functions.Commands.Project;
 using Azure.Mcp.Tools.Functions.Models;
 using Azure.Mcp.Tools.Functions.Options;
 using Azure.Mcp.Tools.Functions.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Functions.UnitTests.Project;
 
-public sealed class ProjectGetCommandTests
+public sealed class ProjectGetCommandTests : CommandUnitTestsBase<ProjectGetCommand, IFunctionsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IFunctionsService _service;
-    private readonly ILogger<ProjectGetCommand> _logger;
-    private readonly CommandContext _context;
-    private readonly ProjectGetCommand _command;
-    private readonly Command _commandDefinition;
-
-    public ProjectGetCommandTests()
-    {
-        _service = Substitute.For<IFunctionsService>();
-        _logger = Substitute.For<ILogger<ProjectGetCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_service);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _context = new(_serviceProvider);
-        _command = new(_logger);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("get", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.Equal("Get Project Template", _command.Title);
+        Assert.Equal("get", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.Equal("Get Project Template", Command.Title);
     }
 
     [Fact]
     public void Command_HasCorrectMetadata()
     {
-        Assert.False(_command.Metadata.Destructive);
-        Assert.True(_command.Metadata.Idempotent);
-        Assert.False(_command.Metadata.OpenWorld);
-        Assert.True(_command.Metadata.ReadOnly);
-        Assert.False(_command.Metadata.LocalRequired);
-        Assert.False(_command.Metadata.Secret);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.Idempotent);
+        Assert.False(Command.Metadata.OpenWorld);
+        Assert.True(Command.Metadata.ReadOnly);
+        Assert.False(Command.Metadata.LocalRequired);
+        Assert.False(Command.Metadata.Secret);
     }
 
     [Fact]
     public void Command_HasLanguageOption()
     {
-        var options = _commandDefinition.Options.ToList();
+        var options = CommandDefinition.Options.ToList();
         var languageOption = options.FirstOrDefault(o => o.Name == $"--{FunctionsOptionDefinitions.LanguageName}");
 
         Assert.NotNull(languageOption);
@@ -80,22 +56,14 @@ public sealed class ProjectGetCommandTests
             ProjectStructure = ["function_app.py", "host.json", "requirements.txt", ".gitignore"]
         };
 
-        _service.GetProjectTemplateAsync("python", Arg.Any<CancellationToken>()).Returns(Task.FromResult(expectedResult));
+        Service.GetProjectTemplateAsync("python", Arg.Any<CancellationToken>()).Returns(expectedResult);
 
         // Act
-        var args = _commandDefinition.Parse(["--language", "python"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "python");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var results = ValidateAndDeserializeResponse(response, FunctionsJsonContext.Default.ListProjectTemplateResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var results = JsonSerializer.Deserialize<List<ProjectTemplateResult>>(
-            json, FunctionsJsonContext.Default.ListProjectTemplateResult);
-
-        Assert.NotNull(results);
         Assert.Single(results);
 
         var result = results[0];
@@ -115,22 +83,14 @@ public sealed class ProjectGetCommandTests
             ProjectStructure = ["src/functions/", "host.json", "package.json", ".gitignore"]
         };
 
-        _service.GetProjectTemplateAsync("typescript", Arg.Any<CancellationToken>()).Returns(Task.FromResult(expectedResult));
+        Service.GetProjectTemplateAsync("typescript", Arg.Any<CancellationToken>()).Returns(expectedResult);
 
         // Act
-        var args = _commandDefinition.Parse(["--language", "typescript"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "typescript");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var results = ValidateAndDeserializeResponse(response, FunctionsJsonContext.Default.ListProjectTemplateResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var results = JsonSerializer.Deserialize<List<ProjectTemplateResult>>(
-            json, FunctionsJsonContext.Default.ListProjectTemplateResult);
-
-        Assert.NotNull(results);
         Assert.Single(results);
         Assert.Equal("typescript", results[0].Language);
     }
@@ -138,11 +98,8 @@ public sealed class ProjectGetCommandTests
     [Fact]
     public async Task ExecuteAsync_HandlesInvalidLanguage()
     {
-        // Arrange - no mock setup needed, validator catches it
-
-        // Act
-        var args = _commandDefinition.Parse(["--language", "invalid"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act - no mock setup needed, validator catches it
+        var response = await ExecuteCommandAsync("--language", "invalid");
 
         // Assert - validator returns error before service is called
         Assert.NotNull(response);
@@ -154,12 +111,11 @@ public sealed class ProjectGetCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _service.GetProjectTemplateAsync("python", Arg.Any<CancellationToken>())
-            .Returns<ProjectTemplateResult>(_ => throw new InvalidOperationException("Service error"));
+        Service.GetProjectTemplateAsync("python", Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Service error"));
 
         // Act
-        var args = _commandDefinition.Parse(["--language", "python"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "python");
 
         // Assert
         Assert.NotNull(response);
@@ -178,21 +134,14 @@ public sealed class ProjectGetCommandTests
             ProjectStructure = ["function_app.py", "host.json", "requirements.txt", "local.settings.json", ".gitignore"]
         };
 
-        _service.GetProjectTemplateAsync("python", Arg.Any<CancellationToken>()).Returns(Task.FromResult(expectedResult));
+        Service.GetProjectTemplateAsync("python", Arg.Any<CancellationToken>()).Returns(expectedResult);
 
         // Act
-        var args = _commandDefinition.Parse(["--language", "python"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "python");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var results = ValidateAndDeserializeResponse(response, FunctionsJsonContext.Default.ListProjectTemplateResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var results = JsonSerializer.Deserialize<List<ProjectTemplateResult>>(
-            json, FunctionsJsonContext.Default.ListProjectTemplateResult);
-
-        Assert.NotNull(results);
         Assert.Single(results);
 
         var result = results[0];
@@ -218,20 +167,14 @@ public sealed class ProjectGetCommandTests
             ProjectStructure = ["host.json", "local.settings.json", ".gitignore"]
         };
 
-        _service.GetProjectTemplateAsync(language, Arg.Any<CancellationToken>()).Returns(Task.FromResult(expectedResult));
+        Service.GetProjectTemplateAsync(language, Arg.Any<CancellationToken>()).Returns(expectedResult);
 
         // Act
-        var args = _commandDefinition.Parse(["--language", language]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", language);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var results = ValidateAndDeserializeResponse(response, FunctionsJsonContext.Default.ListProjectTemplateResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var results = JsonSerializer.Deserialize<List<ProjectTemplateResult>>(
-            json, FunctionsJsonContext.Default.ListProjectTemplateResult);
-
-        Assert.NotNull(results);
         Assert.Single(results);
         Assert.Equal(language, results[0].Language);
         Assert.True(results[0].ProjectStructure.Count > 0);
@@ -241,13 +184,13 @@ public sealed class ProjectGetCommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange & Act
-        var args = _commandDefinition.Parse(["--language", "java"]);
+        var args = CommandDefinition.Parse(["--language", "java"]);
 
         // Use reflection to call BindOptions since it's protected
-        var method = typeof(ProjectGetCommand).GetMethod(
+        var method = Command.GetType().GetMethod(
             "BindOptions",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var options = (ProjectGetOptions?)method?.Invoke(_command, [args]);
+        var options = (ProjectGetOptions?)method?.Invoke(Command, [args]);
 
         // Assert
         Assert.NotNull(options);

--- a/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.UnitTests/Services/FunctionsServiceHttpTests.cs
+++ b/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.UnitTests/Services/FunctionsServiceHttpTests.cs
@@ -45,11 +45,8 @@ public sealed class FunctionsServiceHttpTests
     private FunctionsService CreateService(IHttpClientFactory httpClientFactory) =>
         new(httpClientFactory, _languageMetadata, _manifestService, _cacheService, _logger);
 
-    private ManifestService CreateManifestService(IHttpClientFactory httpClientFactory)
-    {
-        var manifestLogger = Substitute.For<ILogger<ManifestService>>();
-        return new ManifestService(httpClientFactory, _cacheService, _functionsOptions, manifestLogger);
-    }
+    private ManifestService CreateManifestService(IHttpClientFactory httpClientFactory) =>
+        new(httpClientFactory, _cacheService, _functionsOptions, Substitute.For<ILogger<ManifestService>>());
 
     private static TemplateManifestEntry CreateTestEntry(string language = "python", string folderPath = "templates/python/HttpTrigger", string id = "HttpTrigger") =>
         new()
@@ -96,8 +93,7 @@ public sealed class FunctionsServiceHttpTests
         var service = CreateManifestService(httpClientFactory);
 
         // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => service.FetchManifestAsync(CancellationToken.None));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.FetchManifestAsync(CancellationToken.None));
     }
 
     [Fact]
@@ -109,8 +105,7 @@ public sealed class FunctionsServiceHttpTests
         var service = CreateManifestService(httpClientFactory);
 
         // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => service.FetchManifestAsync(CancellationToken.None));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.FetchManifestAsync(CancellationToken.None));
     }
 
     [Fact]
@@ -123,7 +118,7 @@ public sealed class FunctionsServiceHttpTests
             Templates = [CreateTestEntry("cached-lang")]
         };
         _cacheService.GetAsync<TemplateManifest>("functions", "manifest", Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-            .Returns(ValueTask.FromResult<TemplateManifest?>(cachedManifest));
+            .Returns(cachedManifest);
 
         var handler = new MockHttpMessageHandler("should not be called", HttpStatusCode.OK);
         var httpClientFactory = CreateHttpClientFactory(handler);
@@ -142,9 +137,8 @@ public sealed class FunctionsServiceHttpTests
     public async Task FetchManifestAsync_FetchesFresh_WhenCacheHasEmptyTemplates()
     {
         // Arrange - cache has manifest but with empty templates (corrupted)
-        var corruptedCache = new TemplateManifest { Version = "corrupted", Templates = [] };
         _cacheService.GetAsync<TemplateManifest>("functions", "manifest", Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
-            .Returns(ValueTask.FromResult<TemplateManifest?>(corruptedCache));
+            .Returns(new TemplateManifest { Version = "corrupted", Templates = [] });
 
         var freshManifest = new TemplateManifest
         {
@@ -375,7 +369,7 @@ public sealed class FunctionsServiceHttpTests
             Version = "1.0",
             Templates = [CreateTestEntry("python", "templates/python/HttpTrigger")]
         };
-        _manifestService.FetchManifestAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(manifest));
+        _manifestService.FetchManifestAsync(Arg.Any<CancellationToken>()).Returns(manifest);
 
         var service = CreateService(httpClientFactory);
 
@@ -398,7 +392,7 @@ public sealed class FunctionsServiceHttpTests
             Version = "1.0",
             Templates = [CreateTestEntry("python", "templates/python/HttpTrigger")]
         };
-        _manifestService.FetchManifestAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(manifest));
+        _manifestService.FetchManifestAsync(Arg.Any<CancellationToken>()).Returns(manifest);
 
         var service = CreateService(httpClientFactory);
 
@@ -423,7 +417,7 @@ public sealed class FunctionsServiceHttpTests
             Version = "1.0",
             Templates = [CreateTestEntry("python", "templates/python/HttpTrigger")]
         };
-        _manifestService.FetchManifestAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(manifest));
+        _manifestService.FetchManifestAsync(Arg.Any<CancellationToken>()).Returns(manifest);
 
         var service = CreateService(httpClientFactory);
 
@@ -505,14 +499,9 @@ public sealed class FunctionsServiceHttpTests
     /// <summary>
     /// Mock HTTP handler that returns different responses based on URL patterns.
     /// </summary>
-    private sealed class MultiResponseHttpMessageHandler : HttpMessageHandler
+    private sealed class MultiResponseHttpMessageHandler(Dictionary<string, (string Content, HttpStatusCode Status)> responses) : HttpMessageHandler
     {
-        private readonly Dictionary<string, (string Content, HttpStatusCode Status)> _responses;
-
-        public MultiResponseHttpMessageHandler(Dictionary<string, (string Content, HttpStatusCode Status)> responses)
-        {
-            _responses = responses;
-        }
+        private readonly Dictionary<string, (string Content, HttpStatusCode Status)> _responses = responses;
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -540,18 +529,11 @@ public sealed class FunctionsServiceHttpTests
     /// <summary>
     /// Mock HTTP handler with custom response headers (for rate limit testing).
     /// </summary>
-    private sealed class MockHttpMessageHandlerWithHeaders : HttpMessageHandler
+    private sealed class MockHttpMessageHandlerWithHeaders(string content, HttpStatusCode statusCode, Dictionary<string, string> headers) : HttpMessageHandler
     {
-        private readonly string _content;
-        private readonly HttpStatusCode _statusCode;
-        private readonly Dictionary<string, string> _headers;
-
-        public MockHttpMessageHandlerWithHeaders(string content, HttpStatusCode statusCode, Dictionary<string, string> headers)
-        {
-            _content = content;
-            _statusCode = statusCode;
-            _headers = headers;
-        }
+        private readonly string _content = content;
+        private readonly HttpStatusCode _statusCode = statusCode;
+        private readonly Dictionary<string, string> _headers = headers;
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -572,14 +554,9 @@ public sealed class FunctionsServiceHttpTests
     /// <summary>
     /// Mock HTTP handler that throws an exception (for network failure testing).
     /// </summary>
-    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    private sealed class ThrowingHttpMessageHandler(Exception exception) : HttpMessageHandler
     {
-        private readonly Exception _exception;
-
-        public ThrowingHttpMessageHandler(Exception exception)
-        {
-            _exception = exception;
-        }
+        private readonly Exception _exception = exception;
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {

--- a/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.UnitTests/Template/TemplateGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.UnitTests/Template/TemplateGetCommandTests.cs
@@ -1,68 +1,44 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.Functions.Commands;
 using Azure.Mcp.Tools.Functions.Commands.Template;
 using Azure.Mcp.Tools.Functions.Models;
 using Azure.Mcp.Tools.Functions.Options;
 using Azure.Mcp.Tools.Functions.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Functions.UnitTests.Template;
 
-public sealed class TemplateGetCommandTests
+public sealed class TemplateGetCommandTests : CommandUnitTestsBase<TemplateGetCommand, IFunctionsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IFunctionsService _service;
-    private readonly ILogger<TemplateGetCommand> _logger;
-    private readonly CommandContext _context;
-    private readonly TemplateGetCommand _command;
-    private readonly Command _commandDefinition;
-
-    public TemplateGetCommandTests()
-    {
-        _service = Substitute.For<IFunctionsService>();
-        _logger = Substitute.For<ILogger<TemplateGetCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_service);
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _context = new(_serviceProvider);
-        _command = new(_logger);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("get", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.Equal("Get Function Template", _command.Title);
+        Assert.Equal("get", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.Equal("Get Function Template", Command.Title);
     }
 
     [Fact]
     public void Command_HasCorrectMetadata()
     {
-        Assert.False(_command.Metadata.Destructive);
-        Assert.True(_command.Metadata.Idempotent);
-        Assert.False(_command.Metadata.OpenWorld);
-        Assert.True(_command.Metadata.ReadOnly);
-        Assert.False(_command.Metadata.LocalRequired);
-        Assert.False(_command.Metadata.Secret);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.Idempotent);
+        Assert.False(Command.Metadata.OpenWorld);
+        Assert.True(Command.Metadata.ReadOnly);
+        Assert.False(Command.Metadata.LocalRequired);
+        Assert.False(Command.Metadata.Secret);
     }
 
     [Fact]
     public void Command_HasLanguageRequiredAndTemplateOptional()
     {
-        var options = _commandDefinition.Options.ToList();
+        var options = CommandDefinition.Options.ToList();
         var languageOption = options.FirstOrDefault(o => o.Name == $"--{FunctionsOptionDefinitions.LanguageName}");
         var templateOption = options.FirstOrDefault(o => o.Name == $"--{FunctionsOptionDefinitions.TemplateName}");
         var runtimeOption = options.FirstOrDefault(o => o.Name == $"--{FunctionsOptionDefinitions.RuntimeVersionName}");
@@ -87,14 +63,14 @@ public sealed class TemplateGetCommandTests
             Language = "python",
             Triggers =
             [
-                new TemplateSummary
+                new()
                 {
                     TemplateName = "HttpTrigger",
                     DisplayName = "HTTP Trigger",
                     Description = "A function triggered by HTTP requests",
                     Resource = null
                 },
-                new TemplateSummary
+                new()
                 {
                     TemplateName = "BlobTrigger",
                     DisplayName = "Blob Storage Trigger",
@@ -104,7 +80,7 @@ public sealed class TemplateGetCommandTests
             ],
             InputBindings =
             [
-                new TemplateSummary
+                new()
                 {
                     TemplateName = "BlobInput",
                     DisplayName = "Blob Storage Input",
@@ -115,22 +91,14 @@ public sealed class TemplateGetCommandTests
             OutputBindings = []
         };
 
-        _service.GetTemplateListAsync("python", Arg.Any<CancellationToken>()).Returns(Task.FromResult(expectedResult));
+        Service.GetTemplateListAsync("python", Arg.Any<CancellationToken>()).Returns(expectedResult);
 
         // Act - no --template means list mode
-        var args = _commandDefinition.Parse(["--language", "python"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "python");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, FunctionsJsonContext.Default.TemplateGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<TemplateGetCommandResult>(
-            json, FunctionsJsonContext.Default.TemplateGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.TemplateList);
         Assert.Null(result.FunctionTemplate);
         Assert.Equal("python", result.TemplateList.Language);
@@ -154,43 +122,35 @@ public sealed class TemplateGetCommandTests
             Resource = null,
             Files =
             [
-                new ProjectTemplateFile { FileName = "function_app.py", Content = "import azure.functions as func\napp = func.FunctionApp()" },
-                new ProjectTemplateFile { FileName = "README.md", Content = "# HTTP Trigger template" },
-                new ProjectTemplateFile { FileName = "host.json", Content = "{ \"version\": \"2.0\" }" },
-                new ProjectTemplateFile { FileName = "local.settings.json", Content = "{ \"Values\": {} }" },
-                new ProjectTemplateFile { FileName = "requirements.txt", Content = "azure-functions" }
+                new() { FileName = "function_app.py", Content = "import azure.functions as func\napp = func.FunctionApp()" },
+                new() { FileName = "README.md", Content = "# HTTP Trigger template" },
+                new() { FileName = "host.json", Content = "{ \"version\": \"2.0\" }" },
+                new() { FileName = "local.settings.json", Content = "{ \"Values\": {} }" },
+                new() { FileName = "requirements.txt", Content = "azure-functions" }
             ],
             FunctionFiles =
             [
-                new ProjectTemplateFile { FileName = "function_app.py", Content = "import azure.functions as func\napp = func.FunctionApp()" },
-                new ProjectTemplateFile { FileName = "README.md", Content = "# HTTP Trigger template" }
+                new() { FileName = "function_app.py", Content = "import azure.functions as func\napp = func.FunctionApp()" },
+                new() { FileName = "README.md", Content = "# HTTP Trigger template" }
             ],
             ProjectFiles =
             [
-                new ProjectTemplateFile { FileName = "host.json", Content = "{ \"version\": \"2.0\" }" },
-                new ProjectTemplateFile { FileName = "local.settings.json", Content = "{ \"Values\": {} }" },
-                new ProjectTemplateFile { FileName = "requirements.txt", Content = "azure-functions" }
+                new() { FileName = "host.json", Content = "{ \"version\": \"2.0\" }" },
+                new() { FileName = "local.settings.json", Content = "{ \"Values\": {} }" },
+                new() { FileName = "requirements.txt", Content = "azure-functions" }
             ],
             MergeInstructions = "## Merging Template Files"
         };
 
-        _service.GetFunctionTemplateAsync("python", "HttpTrigger", null, TemplateOutput.New, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
+        Service.GetFunctionTemplateAsync("python", "HttpTrigger", null, TemplateOutput.New, Arg.Any<CancellationToken>())
+            .Returns(expectedResult);
 
         // Act - with --template means get mode, default mode is New
-        var args = _commandDefinition.Parse(["--language", "python", "--template", "HttpTrigger"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "python", "--template", "HttpTrigger");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, FunctionsJsonContext.Default.TemplateGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<TemplateGetCommandResult>(
-            json, FunctionsJsonContext.Default.TemplateGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Null(result.TemplateList);
         Assert.NotNull(result.FunctionTemplate);
         Assert.Equal("python", result.FunctionTemplate.Language);
@@ -220,35 +180,27 @@ public sealed class TemplateGetCommandTests
             Resource = null,
             FunctionFiles =
             [
-                new ProjectTemplateFile { FileName = "function_app.py", Content = "import azure.functions as func\napp = func.FunctionApp()" },
-                new ProjectTemplateFile { FileName = "README.md", Content = "# HTTP Trigger template" }
+                new() { FileName = "function_app.py", Content = "import azure.functions as func\napp = func.FunctionApp()" },
+                new() { FileName = "README.md", Content = "# HTTP Trigger template" }
             ],
             ProjectFiles =
             [
-                new ProjectTemplateFile { FileName = "host.json", Content = "{ \"version\": \"2.0\" }" },
-                new ProjectTemplateFile { FileName = "local.settings.json", Content = "{ \"Values\": {} }" },
-                new ProjectTemplateFile { FileName = "requirements.txt", Content = "azure-functions" }
+                new() { FileName = "host.json", Content = "{ \"version\": \"2.0\" }" },
+                new() { FileName = "local.settings.json", Content = "{ \"Values\": {} }" },
+                new() { FileName = "requirements.txt", Content = "azure-functions" }
             ],
             MergeInstructions = "## Merging Template Files"
         };
 
-        _service.GetFunctionTemplateAsync("python", "HttpTrigger", null, TemplateOutput.Add, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
+        Service.GetFunctionTemplateAsync("python", "HttpTrigger", null, TemplateOutput.Add, Arg.Any<CancellationToken>())
+            .Returns(expectedResult);
 
         // Act - with --output Add
-        var args = _commandDefinition.Parse(["--language", "python", "--template", "HttpTrigger", "--output", "Add"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "python", "--template", "HttpTrigger", "--output", "Add");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, FunctionsJsonContext.Default.TemplateGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<TemplateGetCommandResult>(
-            json, FunctionsJsonContext.Default.TemplateGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.Null(result.TemplateList);
         Assert.NotNull(result.FunctionTemplate);
         Assert.Equal("python", result.FunctionTemplate.Language);
@@ -273,26 +225,21 @@ public sealed class TemplateGetCommandTests
             BindingType = "trigger",
             Files =
             [
-                new ProjectTemplateFile { FileName = "src/functions/httpTrigger.ts", Content = "import { app } from '@azure/functions';" },
-                new ProjectTemplateFile { FileName = "package.json", Content = "{ \"devDependencies\": { \"@types/node\": \"22.x\" } }" }
+                new() { FileName = "src/functions/httpTrigger.ts", Content = "import { app } from '@azure/functions';" },
+                new() { FileName = "package.json", Content = "{ \"devDependencies\": { \"@types/node\": \"22.x\" } }" }
             ]
         };
 
-        _service.GetFunctionTemplateAsync("typescript", "HttpTrigger", "22", TemplateOutput.New, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
+        Service.GetFunctionTemplateAsync("typescript", "HttpTrigger", "22", TemplateOutput.New, Arg.Any<CancellationToken>())
+            .Returns(expectedResult);
 
         // Act
-        var args = _commandDefinition.Parse(["--language", "typescript", "--template", "HttpTrigger", "--runtime-version", "22"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "typescript", "--template", "HttpTrigger", "--runtime-version", "22");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, FunctionsJsonContext.Default.TemplateGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<TemplateGetCommandResult>(
-            json, FunctionsJsonContext.Default.TemplateGetCommandResult);
-
-        Assert.NotNull(result?.FunctionTemplate);
+        Assert.NotNull(result.FunctionTemplate);
         Assert.Equal("typescript", result.FunctionTemplate.Language);
         Assert.NotNull(result.FunctionTemplate.Files);
         Assert.Equal(2, result.FunctionTemplate.Files.Count);
@@ -302,11 +249,8 @@ public sealed class TemplateGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ListMode_HandlesInvalidLanguage()
     {
-        // Arrange - no mock setup needed, validator catches it
-
-        // Act
-        var args = _commandDefinition.Parse(["--language", "invalid"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act - no mock setup needed, validator catches it
+        var response = await ExecuteCommandAsync("--language", "invalid");
 
         // Assert - validator returns error before service is called
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -317,13 +261,11 @@ public sealed class TemplateGetCommandTests
     public async Task ExecuteAsync_GetMode_HandlesInvalidTemplate()
     {
         // Arrange
-        _service.GetFunctionTemplateAsync("python", "NonExistent", null, TemplateOutput.New, Arg.Any<CancellationToken>())
-            .Returns<FunctionTemplateResult>(_ => throw new ArgumentException(
-                "Template \"NonExistent\" not found for language \"python\"."));
+        Service.GetFunctionTemplateAsync("python", "NonExistent", null, TemplateOutput.New, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ArgumentException("Template \"NonExistent\" not found for language \"python\"."));
 
         // Act
-        var args = _commandDefinition.Parse(["--language", "python", "--template", "NonExistent"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "python", "--template", "NonExistent");
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -334,12 +276,11 @@ public sealed class TemplateGetCommandTests
     public async Task ExecuteAsync_GetMode_HandlesInvalidRuntimeVersion()
     {
         // Arrange
-        _service.GetFunctionTemplateAsync("java", "HttpTrigger", "99", TemplateOutput.New, Arg.Any<CancellationToken>())
-            .Returns<FunctionTemplateResult>(_ => throw new ArgumentException("Invalid runtime version \"99\" for java."));
+        Service.GetFunctionTemplateAsync("java", "HttpTrigger", "99", TemplateOutput.New, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ArgumentException("Invalid runtime version \"99\" for java."));
 
         // Act
-        var args = _commandDefinition.Parse(["--language", "java", "--template", "HttpTrigger", "--runtime-version", "99"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "java", "--template", "HttpTrigger", "--runtime-version", "99");
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -350,12 +291,11 @@ public sealed class TemplateGetCommandTests
     public async Task ExecuteAsync_ListMode_HandlesServiceErrors()
     {
         // Arrange
-        _service.GetTemplateListAsync("python", Arg.Any<CancellationToken>())
-            .Returns<TemplateListResult>(_ => throw new InvalidOperationException("Network error"));
+        Service.GetTemplateListAsync("python", Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Network error"));
 
         // Act
-        var args = _commandDefinition.Parse(["--language", "python"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "python");
 
         // Assert
         Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
@@ -366,12 +306,11 @@ public sealed class TemplateGetCommandTests
     public async Task ExecuteAsync_GetMode_HandlesServiceErrors()
     {
         // Arrange
-        _service.GetFunctionTemplateAsync("python", "HttpTrigger", null, TemplateOutput.New, Arg.Any<CancellationToken>())
-            .Returns<FunctionTemplateResult>(_ => throw new InvalidOperationException("Could not fetch template"));
+        Service.GetFunctionTemplateAsync("python", "HttpTrigger", null, TemplateOutput.New, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Could not fetch template"));
 
         // Act
-        var args = _commandDefinition.Parse(["--language", "python", "--template", "HttpTrigger"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "python", "--template", "HttpTrigger");
 
         // Assert
         Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
@@ -387,14 +326,14 @@ public sealed class TemplateGetCommandTests
             Language = "typescript",
             Triggers =
             [
-                new TemplateSummary
+                new()
                 {
                     TemplateName = "HttpTrigger",
                     DisplayName = "HTTP Trigger",
                     Description = "Triggered by HTTP",
                     Resource = null
                 },
-                new TemplateSummary
+                new()
                 {
                     TemplateName = "TimerTrigger",
                     DisplayName = "Timer Trigger",
@@ -404,7 +343,7 @@ public sealed class TemplateGetCommandTests
             ],
             InputBindings =
             [
-                new TemplateSummary
+                new()
                 {
                     TemplateName = "CosmosDBInput",
                     DisplayName = "Cosmos DB Input",
@@ -414,7 +353,7 @@ public sealed class TemplateGetCommandTests
             ],
             OutputBindings =
             [
-                new TemplateSummary
+                new()
                 {
                     TemplateName = "ServiceBusOutput",
                     DisplayName = "Service Bus Output",
@@ -424,21 +363,15 @@ public sealed class TemplateGetCommandTests
             ]
         };
 
-        _service.GetTemplateListAsync("typescript", Arg.Any<CancellationToken>()).Returns(Task.FromResult(expectedResult));
+        Service.GetTemplateListAsync("typescript", Arg.Any<CancellationToken>()).Returns(expectedResult);
 
         // Act
-        var args = _commandDefinition.Parse(["--language", "typescript"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "typescript");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, FunctionsJsonContext.Default.TemplateGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<TemplateGetCommandResult>(
-            json, FunctionsJsonContext.Default.TemplateGetCommandResult);
-
-        Assert.NotNull(result?.TemplateList);
+        Assert.NotNull(result.TemplateList);
         Assert.Equal("typescript", result.TemplateList.Language);
         Assert.Equal(2, result.TemplateList.Triggers.Count);
         Assert.Single(result.TemplateList.InputBindings);
@@ -468,7 +401,7 @@ public sealed class TemplateGetCommandTests
             Resource = null,
             FunctionFiles =
             [
-                new ProjectTemplateFile
+                new()
                 {
                     FileName = "src/main/java/com/function/Function.java",
                     Content = "package com.function;\nimport com.microsoft.azure.functions.*;"
@@ -476,27 +409,22 @@ public sealed class TemplateGetCommandTests
             ],
             ProjectFiles =
             [
-                new ProjectTemplateFile { FileName = "host.json", Content = "{ \"version\": \"2.0\" }" },
-                new ProjectTemplateFile { FileName = "local.settings.json", Content = "{ \"Values\": {} }" }
+                new() { FileName = "host.json", Content = "{ \"version\": \"2.0\" }" },
+                new() { FileName = "local.settings.json", Content = "{ \"Values\": {} }" }
             ],
             MergeInstructions = "## Merging Template Files"
         };
 
-        _service.GetFunctionTemplateAsync("java", "HttpTrigger", null, TemplateOutput.Add, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedResult));
+        Service.GetFunctionTemplateAsync("java", "HttpTrigger", null, TemplateOutput.Add, Arg.Any<CancellationToken>())
+            .Returns(expectedResult);
 
         // Act
-        var args = _commandDefinition.Parse(["--language", "java", "--template", "HttpTrigger", "--output", "Add"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", "java", "--template", "HttpTrigger", "--output", "Add");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, FunctionsJsonContext.Default.TemplateGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<TemplateGetCommandResult>(
-            json, FunctionsJsonContext.Default.TemplateGetCommandResult);
-
-        Assert.NotNull(result?.FunctionTemplate);
+        Assert.NotNull(result.FunctionTemplate);
         Assert.Equal("java", result.FunctionTemplate.Language);
         Assert.Equal("HttpTrigger", result.FunctionTemplate.TemplateName);
         Assert.Equal("A function that responds to HTTP requests", result.FunctionTemplate.Description);
@@ -527,7 +455,7 @@ public sealed class TemplateGetCommandTests
             Language = language,
             Triggers =
             [
-                new TemplateSummary
+                new()
                 {
                     TemplateName = "HttpTrigger",
                     DisplayName = "HTTP Trigger",
@@ -536,20 +464,15 @@ public sealed class TemplateGetCommandTests
             ]
         };
 
-        _service.GetTemplateListAsync(language, Arg.Any<CancellationToken>()).Returns(Task.FromResult(expectedResult));
+        Service.GetTemplateListAsync(language, Arg.Any<CancellationToken>()).Returns(expectedResult);
 
         // Act
-        var args = _commandDefinition.Parse(["--language", language]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--language", language);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, FunctionsJsonContext.Default.TemplateGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<TemplateGetCommandResult>(
-            json, FunctionsJsonContext.Default.TemplateGetCommandResult);
-
-        Assert.NotNull(result?.TemplateList);
+        Assert.NotNull(result.TemplateList);
         Assert.Equal(language, result.TemplateList.Language);
         Assert.Single(result.TemplateList.Triggers);
     }
@@ -558,12 +481,12 @@ public sealed class TemplateGetCommandTests
     public void BindOptions_BindsAllOptionsCorrectly()
     {
         // Arrange & Act
-        var args = _commandDefinition.Parse(["--language", "java", "--template", "HttpTrigger", "--runtime-version", "21", "--output", "Add"]);
+        var args = CommandDefinition.Parse(["--language", "java", "--template", "HttpTrigger", "--runtime-version", "21", "--output", "Add"]);
 
-        var method = typeof(TemplateGetCommand).GetMethod(
+        var method = Command.GetType().GetMethod(
             "BindOptions",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var options = (TemplateGetOptions?)method?.Invoke(_command, [args]);
+        var options = (TemplateGetOptions?)method?.Invoke(Command, [args]);
 
         // Assert
         Assert.NotNull(options);
@@ -577,12 +500,12 @@ public sealed class TemplateGetCommandTests
     public void BindOptions_TemplateIsNullWhenOmitted()
     {
         // Arrange & Act - only language provided, no template
-        var args = _commandDefinition.Parse(["--language", "python"]);
+        var args = CommandDefinition.Parse(["--language", "python"]);
 
-        var method = typeof(TemplateGetCommand).GetMethod(
+        var method = Command.GetType().GetMethod(
             "BindOptions",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var options = (TemplateGetOptions?)method?.Invoke(_command, [args]);
+        var options = (TemplateGetOptions?)method?.Invoke(Command, [args]);
 
         // Assert
         Assert.NotNull(options);

--- a/tools/Azure.Mcp.Tools.Grafana/tests/Azure.Mcp.Tools.Grafana.UnitTests/WorkspaceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/tests/Azure.Mcp.Tools.Grafana.UnitTests/WorkspaceListCommandTests.cs
@@ -2,50 +2,27 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.Grafana.Commands;
 using Azure.Mcp.Tools.Grafana.Commands.Workspace;
 using Azure.Mcp.Tools.Grafana.Models;
 using Azure.Mcp.Tools.Grafana.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Grafana.UnitTests;
 
-public sealed class WorkspaceListCommandTests
+public sealed class WorkspaceListCommandTests : CommandUnitTestsBase<WorkspaceListCommand, IGrafanaService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IGrafanaService _grafana;
-    private readonly ILogger<WorkspaceListCommand> _logger;
-
-    public WorkspaceListCommandTests()
-    {
-        _grafana = Substitute.For<IGrafanaService>();
-        _logger = Substitute.For<ILogger<WorkspaceListCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_grafana);
-
-        _serviceProvider = collection.BuildServiceProvider();
-    }
-
     [Fact]
     public void Constructor_Should_Initialize_Command_Properly()
     {
-        // Arrange & Act
-        var command = new WorkspaceListCommand(_grafana, _logger);
-
-        // Assert
-        Assert.NotNull(command);
-        Assert.Equal("list", command.Name);
-        Assert.Equal("List Grafana Workspaces", command.Title);
-        Assert.Contains("List all Grafana workspace resources", command.Description);
+        Assert.Equal("list", Command.Name);
+        Assert.Equal("List Grafana Workspaces", Command.Title);
+        Assert.Contains("List all Grafana workspace resources", Command.Description);
     }
 
     [Fact]
@@ -84,48 +61,32 @@ public sealed class WorkspaceListCommandTests
             )
         ], false);
 
-        _grafana.ListWorkspacesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspacesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedWorkspaces);
 
-        var command = new WorkspaceListCommand(_grafana, _logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123"]);
-        var context = new CommandContext(_serviceProvider);
-
         // Act
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, GrafanaJsonContext.Default.WorkspaceListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-
-        Assert.Contains("grafana-workspace-1", json);
-        Assert.Contains("grafana-workspace-2", json);
+        Assert.NotNull(result.Workspaces);
+        Assert.Contains(result.Workspaces, w => w.Name == "grafana-workspace-1");
+        Assert.Contains(result.Workspaces, w => w.Name == "grafana-workspace-2");
     }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoWorkspacesExist()
     {
         // Arrange
-        _grafana.ListWorkspacesAsync("sub123", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspacesAsync("sub123", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(new ResourceQueryResults<GrafanaWorkspace>([], false));
 
-        var command = new WorkspaceListCommand(_grafana, _logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123"]);
-        var context = new CommandContext(_serviceProvider);
-
         // Act
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, GrafanaJsonContext.Default.WorkspaceListCommandResult);
-
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, GrafanaJsonContext.Default.WorkspaceListCommandResult);
         Assert.Empty(result.Workspaces);
     }
 
@@ -151,15 +112,11 @@ public sealed class WorkspaceListCommandTests
             )
         ], false);
 
-        _grafana.ListWorkspacesAsync("sub123", "tenant456", Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspacesAsync("sub123", "tenant456", Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedWorkspaces);
 
-        var command = new WorkspaceListCommand(_grafana, _logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--tenant", "tenant456"]);
-        var context = new CommandContext(_serviceProvider);
-
         // Act
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub123", "--tenant", "tenant456");
 
         // Assert
         Assert.NotNull(response);
@@ -173,15 +130,11 @@ public sealed class WorkspaceListCommandTests
         var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
         var subscriptionId = "sub123";
 
-        _grafana.ListWorkspacesAsync(subscriptionId, null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspacesAsync(subscriptionId, null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var command = new WorkspaceListCommand(_grafana, _logger);
-        var args = command.GetCommand().Parse(["--subscription", subscriptionId]);
-        var context = new CommandContext(_serviceProvider);
-
         // Act
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId);
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Admin/AdminSettingsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Admin/AdminSettingsGetCommandTests.cs
@@ -1,18 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Admin;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Administration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Helpers;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using Microsoft.Mcp.Tests.Helpers;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -20,34 +16,16 @@ using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.UnitTests.Admin;
 
-public class AdminSettingsGetCommandTests
+public class AdminSettingsGetCommandTests : CommandUnitTestsBase<AdminSettingsGetCommand, IKeyVaultService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IKeyVaultService _keyVaultService;
-    private readonly ILogger<AdminSettingsGetCommand> _logger;
-    private readonly AdminSettingsGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
     private const string KnownSubscriptionId = "knownSubscription";
     private const string KnownVaultName = "knownVaultName";
-
-    public AdminSettingsGetCommandTests()
-    {
-        _keyVaultService = Substitute.For<IKeyVaultService>();
-        _logger = Substitute.For<ILogger<AdminSettingsGetCommand>>();
-
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-        _command = new(_logger, _keyVaultService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsSettingsDictionary()
     {
         // We return null from service (simplest stub); command should still succeed with empty dictionary.
-        _keyVaultService.GetVaultSettings(
+        Service.GetVaultSettings(
             Arg.Is(KnownVaultName),
             Arg.Is(KnownSubscriptionId),
             Arg.Any<string?>(),
@@ -55,20 +33,9 @@ public class AdminSettingsGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns((GetSettingsResult)null!);
 
-        var args = _commandDefinition.Parse([
-            "--vault", KnownVaultName,
-            "--subscription", KnownSubscriptionId
-        ]);
+        var response = await ExecuteCommandAsync("--vault", KnownVaultName, "--subscription", KnownSubscriptionId);
 
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        // Deserialize the wrapped result to verify structure and empty settings dictionary
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, KeyVaultJsonContext.Default.AdminSettingsGetCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.AdminSettingsGetCommandResult);
         Assert.Equal(KnownVaultName, result.Name);
         Assert.NotNull(result.Settings);
     }
@@ -77,21 +44,15 @@ public class AdminSettingsGetCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         var expectedError = "Test error";
-        _keyVaultService
-            .GetVaultSettings(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
+        Service.GetVaultSettings(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse([
-            "--vault", KnownVaultName,
-            "--subscription", KnownSubscriptionId
-        ]);
-
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--vault", KnownVaultName, "--subscription", KnownSubscriptionId);
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.Contains(expectedError, response.Message);
@@ -119,18 +80,16 @@ public class AdminSettingsGetCommandTests
         if (shouldSucceed)
         {
             // Service returns null result -> treated as empty settings
-            _keyVaultService
-                .GetVaultSettings(
-                    Arg.Any<string>(),
-                    Arg.Any<string>(),
-                    Arg.Any<string?>(),
-                    Arg.Any<RetryPolicyOptions?>(),
-                    Arg.Any<CancellationToken>())
+            Service.GetVaultSettings(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<CancellationToken>())
                 .Returns((GetSettingsResult)null!);
         }
 
-        var parseResult = _commandDefinition.Parse(string.IsNullOrWhiteSpace(args) ? Array.Empty<string>() : args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
         if (!shouldSucceed)

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Certificate/CertificateCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Certificate/CertificateCreateCommandTests.cs
@@ -1,43 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using Azure.Mcp.Tools.KeyVault.Commands.Certificate;
 using Azure.Mcp.Tools.KeyVault.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.UnitTests.Certificate;
 
-public class CertificateCreateCommandTests
+public class CertificateCreateCommandTests : CommandUnitTestsBase<CertificateCreateCommand, IKeyVaultService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IKeyVaultService _keyVaultService;
-    private readonly ILogger<CertificateCreateCommand> _logger;
-    private readonly CertificateCreateCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
     private const string _knownSubscriptionId = "knownSubscription";
     private const string _knownVaultName = "knownVaultName";
     private const string _knownCertificateName = "knownCertificateName";
-
-    public CertificateCreateCommandTests()
-    {
-        _keyVaultService = Substitute.For<IKeyVaultService>();
-        _logger = Substitute.For<ILogger<CertificateCreateCommand>>();
-
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-        _command = new(_logger, _keyVaultService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
 
     [Fact]
     public async Task ExecuteAsync_CallsServiceCorrectly()
@@ -47,35 +26,29 @@ public class CertificateCreateCommandTests
 
         // TODO (vcolin7): Find a way to mock CertificateOperation
         // We'll test that the service is called correctly, but let it fail since mocking the return is complex
-        _keyVaultService
-            .CreateCertificate(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownCertificateName),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.CreateCertificate(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownCertificateName),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--certificate", _knownCertificateName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert - Verify the service was called with correct parameters
-        await _keyVaultService
-            .Received(1)
-            .CreateCertificate(
-                _knownVaultName,
-                _knownCertificateName,
-                _knownSubscriptionId,
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>());
+        await Service.Received(1).CreateCertificate(
+            _knownVaultName,
+            _knownCertificateName,
+            _knownSubscriptionId,
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
 
         // Should handle the exception
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -84,15 +57,11 @@ public class CertificateCreateCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsInvalidObject_IfCertificateNameIsEmpty()
     {
-        // Arrange - No need to mock service since validation should fail before service is called
-        var args = _commandDefinition.Parse([
+        // Arrange & Act - No need to mock service since validation should fail before service is called
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--certificate", "",
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert - Should return validation error response
         Assert.NotNull(response);
@@ -106,24 +75,20 @@ public class CertificateCreateCommandTests
         // Arrange
         var expectedError = "Test error";
 
-        _keyVaultService
-            .CreateCertificate(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownCertificateName),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.CreateCertificate(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownCertificateName),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--certificate", _knownCertificateName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Certificate/CertificateGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Certificate/CertificateGetCommandTests.cs
@@ -1,43 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using Azure.Mcp.Tools.KeyVault.Commands.Certificate;
 using Azure.Mcp.Tools.KeyVault.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.UnitTests.Certificate;
 
-public class CertificateGetCommandTests
+public class CertificateGetCommandTests : CommandUnitTestsBase<CertificateGetCommand, IKeyVaultService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IKeyVaultService _keyVaultService;
-    private readonly ILogger<CertificateGetCommand> _logger;
-    private readonly CertificateGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
     private const string _knownSubscriptionId = "knownSubscription";
     private const string _knownVaultName = "knownVaultName";
     private const string _knownCertificateName = "knownCertificateName";
-
-    public CertificateGetCommandTests()
-    {
-        _keyVaultService = Substitute.For<IKeyVaultService>();
-        _logger = Substitute.For<ILogger<CertificateGetCommand>>();
-
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-        _command = new(_logger, _keyVaultService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
 
     [Fact]
     public async Task ExecuteAsync_CallsServiceCorrectly()
@@ -47,35 +26,29 @@ public class CertificateGetCommandTests
 
         // TODO (vcolin7): Find a way to mock KeyVaultCertificateWithPolicy
         // We'll test that the service is called correctly, but let it fail since mocking the return is complex
-        _keyVaultService
-            .GetCertificate(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownCertificateName),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.GetCertificate(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownCertificateName),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--certificate", _knownCertificateName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert - Verify the service was called with correct parameters
-        await _keyVaultService
-            .Received(1)
-            .GetCertificate(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownCertificateName),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>());
+        await Service.Received(1).GetCertificate(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownCertificateName),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
 
         // Should handle the exception
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -87,24 +60,20 @@ public class CertificateGetCommandTests
         // Arrange
         var expectedError = "Test error";
 
-        _keyVaultService
-            .GetCertificate(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownCertificateName),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.GetCertificate(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownCertificateName),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--certificate", _knownCertificateName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert
         Assert.NotNull(response);
@@ -118,32 +87,22 @@ public class CertificateGetCommandTests
         // Arrange
         var expectedCertificates = new List<string> { "cert1", "cert2", "cert3" };
 
-        _keyVaultService
-            .ListCertificates(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ListCertificates(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedCertificates);
 
-        var args = _commandDefinition.Parse([
-            "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--vault", _knownVaultName,
+            "--subscription", _knownSubscriptionId);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, Commands.KeyVaultJsonContext.Default.CertificateGetCommandResult);
 
-        var json = System.Text.Json.JsonSerializer.Serialize(response.Results);
-        var result = System.Text.Json.JsonSerializer.Deserialize(json, Commands.KeyVaultJsonContext.Default.CertificateGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Certificates);
         Assert.Null(result.Certificate);
         Assert.Equal(expectedCertificates.Count, result.Certificates.Count);
@@ -156,22 +115,18 @@ public class CertificateGetCommandTests
         // Arrange
         var expectedError = "List error";
 
-        _keyVaultService
-            .ListCertificates(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ListCertificates(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse([
-            "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--vault", _knownVaultName,
+            "--subscription", _knownSubscriptionId);
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Certificate/CertificateImportCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Certificate/CertificateImportCommandTests.cs
@@ -6,23 +6,16 @@ using System.Net;
 using Azure.Mcp.Tools.KeyVault.Commands.Certificate;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.UnitTests.Certificate;
 
-public class CertificateImportCommandTests
+public class CertificateImportCommandTests : CommandUnitTestsBase<CertificateImportCommand, IKeyVaultService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IKeyVaultService _keyVaultService;
-    private readonly ILogger<CertificateImportCommand> _logger;
-    private readonly CertificateImportCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
 
     private const string _knownSubscription = "knownSubscription";
     private const string _knownVault = "knownVault";
@@ -30,55 +23,38 @@ public class CertificateImportCommandTests
     // Generate a deterministic base64 string from readable words to avoid cspell warnings on opaque text.
     private static readonly string _fakePfxBase64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("sample certificate data"));
 
-    public CertificateImportCommandTests()
-    {
-        _keyVaultService = Substitute.For<IKeyVaultService>();
-        _logger = Substitute.For<ILogger<CertificateImportCommand>>();
-
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-        _command = new(_logger, _keyVaultService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public async Task ExecuteAsync_CallsService_WithExpectedParameters()
     {
         // Arrange
-        _keyVaultService
-            .ImportCertificate(
-                _knownVault,
-                _knownCertName,
-                _fakePfxBase64,
-                null,
-                _knownSubscription,
-                Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ImportCertificate(
+            _knownVault,
+            _knownCertName,
+            _fakePfxBase64,
+            null,
+            _knownSubscription,
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error")); // force exception to avoid building return object
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVault,
             "--certificate", _knownCertName,
             "--certificate-data", _fakePfxBase64,
-            "--subscription", _knownSubscription
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscription);
 
         // Assert
-        await _keyVaultService
-            .Received(1)
-            .ImportCertificate(
-                _knownVault,
-                _knownCertName,
-                _fakePfxBase64,
-                null,
-                _knownSubscription,
-                Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>());
+        await Service.Received(1).ImportCertificate(
+            _knownVault,
+            _knownCertName,
+            _fakePfxBase64,
+            null,
+            _knownSubscription,
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status); // due to forced exception
     }
 
@@ -96,11 +72,8 @@ public class CertificateImportCommandTests
     [MemberData(nameof(InvalidArgumentCases))]
     public async Task ExecuteAsync_RejectsInvalidArguments(string argLine)
     {
-        // Arrange
-        var args = _commandDefinition.Parse(argLine.Split(' ', StringSplitOptions.RemoveEmptyEntries));
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(argLine.Split(' ', StringSplitOptions.RemoveEmptyEntries));
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -110,26 +83,22 @@ public class CertificateImportCommandTests
     public async Task ExecuteAsync_HandlesServiceException()
     {
         var expected = "boom";
-        _keyVaultService
-            .ImportCertificate(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string?>(),
-                Arg.Any<string>(),
-                Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ImportCertificate(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expected));
 
-        var args = _commandDefinition.Parse([
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVault,
             "--certificate", _knownCertName,
             "--certificate-data", _fakePfxBase64,
-            "--subscription", _knownSubscription
-        ]);
-
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscription);
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.StartsWith(expected, response.Message);
@@ -141,40 +110,34 @@ public class CertificateImportCommandTests
         // Arrange - minimal mock PEM (not a valid cert, but exercises the code path)
         var pem = "-----BEGIN CERTIFICATE-----\nABCDEF123456\n-----END CERTIFICATE-----";
 
-        _keyVaultService
-            .ImportCertificate(
-                _knownVault,
-                _knownCertName,
-                pem,
-                null,
-                _knownSubscription,
-                Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ImportCertificate(
+            _knownVault,
+            _knownCertName,
+            pem,
+            null,
+            _knownSubscription,
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVault,
             "--certificate", _knownCertName,
             "--certificate-data", pem,
-            "--subscription", _knownSubscription
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscription);
 
         // Assert - ensure the PEM (with header) was passed through untouched
-        await _keyVaultService
-            .Received(1)
-            .ImportCertificate(
-                _knownVault,
-                _knownCertName,
-                pem,
-                null,
-                _knownSubscription,
-                Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>());
+        await Service.Received(1).ImportCertificate(
+            _knownVault,
+            _knownCertName,
+            pem,
+            null,
+            _knownSubscription,
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
     }
 
@@ -183,39 +146,33 @@ public class CertificateImportCommandTests
     {
         var password = "P@ssw0rd!";
 
-        _keyVaultService
-            .ImportCertificate(
-                _knownVault,
-                _knownCertName,
-                _fakePfxBase64,
-                password,
-                _knownSubscription,
-                Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ImportCertificate(
+            _knownVault,
+            _knownCertName,
+            _fakePfxBase64,
+            password,
+            _knownSubscription,
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
-        var args = _commandDefinition.Parse([
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVault,
             "--certificate", _knownCertName,
             "--certificate-data", _fakePfxBase64,
             "--password", password,
-            "--subscription", _knownSubscription
-        ]);
+            "--subscription", _knownSubscription);
 
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
-
-        await _keyVaultService
-            .Received(1)
-            .ImportCertificate(
-                _knownVault,
-                _knownCertName,
-                _fakePfxBase64,
-                password,
-                _knownSubscription,
-                Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>());
+        await Service.Received(1).ImportCertificate(
+            _knownVault,
+            _knownCertName,
+            _fakePfxBase64,
+            password,
+            _knownSubscription,
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>());
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
     }
 
@@ -227,37 +184,34 @@ public class CertificateImportCommandTests
         try
         {
             await File.WriteAllBytesAsync(tempPath, [1, 2, 3, 4], TestContext.Current.CancellationToken);
-            _keyVaultService
-                .ImportCertificate(
-                    _knownVault,
-                    _knownCertName,
-                    tempPath,
-                    null,
-                    _knownSubscription,
-                    Arg.Any<string?>(),
-                    Arg.Any<RetryPolicyOptions>(),
-                    Arg.Any<CancellationToken>())
+            Service.ImportCertificate(
+                _knownVault,
+                _knownCertName,
+                tempPath,
+                null,
+                _knownSubscription,
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
                 .ThrowsAsync(new Exception("Test error"));
-            var args = _commandDefinition.Parse([
+
+            // Act
+            var response = await ExecuteCommandAsync(
                 "--vault", _knownVault,
                 "--certificate", _knownCertName,
                 "--certificate-data", tempPath,
-                "--subscription", _knownSubscription
-            ]);
-            // Act
-            var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+                "--subscription", _knownSubscription);
+
             // Assert - ensure the raw path was passed through
-            await _keyVaultService
-                .Received(1)
-                .ImportCertificate(
-                    _knownVault,
-                    _knownCertName,
-                    tempPath,
-                    null,
-                    _knownSubscription,
-                    Arg.Any<string?>(),
-                    Arg.Any<RetryPolicyOptions>(),
-                    Arg.Any<CancellationToken>());
+            await Service.Received(1).ImportCertificate(
+                _knownVault,
+                _knownCertName,
+                tempPath,
+                null,
+                _knownSubscription,
+                Arg.Any<string?>(),
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>());
             Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         }
         finally
@@ -276,26 +230,22 @@ public class CertificateImportCommandTests
         var invalidData = "not-valid-base64-or-path";
         var errorMessage = $"Error importing certificate '{_knownCertName}' into vault {_knownVault}: The provided certificate-data is neither a file path, raw PEM, nor base64 encoded content.";
 
-        _keyVaultService
-            .ImportCertificate(
-                _knownVault,
-                _knownCertName,
-                invalidData,
-                null,
-                _knownSubscription,
-                Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ImportCertificate(
+            _knownVault,
+            _knownCertName,
+            invalidData,
+            null,
+            _knownSubscription,
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(errorMessage));
 
-        var args = _commandDefinition.Parse([
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVault,
             "--certificate", _knownCertName,
             "--certificate-data", invalidData,
-            "--subscription", _knownSubscription
-        ]);
-
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscription);
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.StartsWith(errorMessage, response.Message);
@@ -308,27 +258,23 @@ public class CertificateImportCommandTests
         var password = "WrongPassword";
         var mismatchMessage = $"Error importing certificate '{_knownCertName}' into vault {_knownVault}: Invalid password or certificate data.";
 
-        _keyVaultService
-            .ImportCertificate(
-                _knownVault,
-                _knownCertName,
-                _fakePfxBase64,
-                password,
-                _knownSubscription,
-                Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ImportCertificate(
+            _knownVault,
+            _knownCertName,
+            _fakePfxBase64,
+            password,
+            _knownSubscription,
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(mismatchMessage));
 
-        var args = _commandDefinition.Parse([
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVault,
             "--certificate", _knownCertName,
             "--certificate-data", _fakePfxBase64,
             "--password", password,
-            "--subscription", _knownSubscription
-        ]);
-
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscription);
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.StartsWith(mismatchMessage, response.Message);

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Key/KeyCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Key/KeyCreateCommandTests.cs
@@ -1,33 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Key;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Keys;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.UnitTests.Key;
 
-public class KeyCreateCommandTests
+public class KeyCreateCommandTests : CommandUnitTestsBase<KeyCreateCommand, IKeyVaultService>
 {
-
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IKeyVaultService _keyVaultService;
-    private readonly ILogger<KeyCreateCommand> _logger;
-    private readonly KeyCreateCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
     private const string _knownSubscriptionId = "knownSubscription";
     private const string _knownVaultName = "knownVaultName";
     private const string _knownKeyName = "knownKeyName";
@@ -36,14 +24,6 @@ public class KeyCreateCommandTests
 
     public KeyCreateCommandTests()
     {
-        _keyVaultService = Substitute.For<IKeyVaultService>();
-        _logger = Substitute.For<ILogger<KeyCreateCommand>>();
-
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-        _command = new(_logger, _keyVaultService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-
         _knownKeyVaultKey = new KeyVaultKey(_knownKeyName);
 
         var jsonWebKey = new JsonWebKey([KeyOperation.Encrypt])
@@ -61,35 +41,26 @@ public class KeyCreateCommandTests
     public async Task ExecuteAsync_CreatesKey_WithValidInput()
     {
         // Arrange
-        _keyVaultService
-            .CreateKey(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownKeyName),
-                Arg.Is(_knownKeyType.ToString()),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.CreateKey(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownKeyName),
+            Arg.Is(_knownKeyType.ToString()),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(_knownKeyVaultKey);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--key", _knownKeyName,
             "--key-type", _knownKeyType.ToString(),
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var retrievedKey = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.KeyCreateCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var retrievedKey = JsonSerializer.Deserialize(json, KeyVaultJsonContext.Default.KeyCreateCommandResult);
-
-        Assert.NotNull(retrievedKey);
         Assert.Equal(_knownKeyName, retrievedKey.Name);
         Assert.Equal(_knownKeyType.ToString(), retrievedKey.KeyType);
     }
@@ -97,16 +68,12 @@ public class KeyCreateCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsInvalidObject_IfKeyNameIsEmpty()
     {
-        // Arrange - No need to mock service since validation should fail before service is called
-        var args = _commandDefinition.Parse([
+        // Arrange & Act - No need to mock service since validation should fail before service is called
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--key", "",
             "--key-type", _knownKeyType.ToString(),
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert - Should return validation error response
         Assert.NotNull(response);
@@ -120,26 +87,22 @@ public class KeyCreateCommandTests
         // Arrange
         var expectedError = "Test error";
 
-        _keyVaultService
-            .CreateKey(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownKeyName),
-                Arg.Is(_knownKeyType.ToString()),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.CreateKey(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownKeyName),
+            Arg.Is(_knownKeyType.ToString()),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--key", _knownKeyName,
             "--key-type", _knownKeyType.ToString(),
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Key/KeyGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Key/KeyGetCommandTests.cs
@@ -1,33 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Key;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Keys;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.UnitTests.Key;
 
-public class KeyGetCommandTests
+public class KeyGetCommandTests : CommandUnitTestsBase<KeyGetCommand, IKeyVaultService>
 {
-
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IKeyVaultService _keyVaultService;
-    private readonly ILogger<KeyGetCommand> _logger;
-    private readonly KeyGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
     private const string _knownSubscriptionId = "knownSubscription";
     private const string _knownVaultName = "knownVaultName";
     private const string _knownKeyName = "knownKeyName";
@@ -36,14 +24,6 @@ public class KeyGetCommandTests
 
     public KeyGetCommandTests()
     {
-        _keyVaultService = Substitute.For<IKeyVaultService>();
-        _logger = Substitute.For<ILogger<KeyGetCommand>>();
-
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-        _command = new(_logger, _keyVaultService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-
         _knownKeyVaultKey = new KeyVaultKey(_knownKeyName);
 
         var jsonWebKey = new JsonWebKey([KeyOperation.Encrypt])
@@ -61,34 +41,24 @@ public class KeyGetCommandTests
     public async Task ExecuteAsync_ReturnsKey()
     {
         // Arrange
-        _keyVaultService
-            .GetKey(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownKeyName),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.GetKey(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownKeyName),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(_knownKeyVaultKey);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--key", _knownKeyName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var retrievedKey = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.KeyGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var retrievedKey = JsonSerializer.Deserialize(json, KeyVaultJsonContext.Default.KeyGetCommandResult);
-
-        Assert.NotNull(retrievedKey);
         Assert.NotNull(retrievedKey.Key);
         Assert.Null(retrievedKey.Keys);
         Assert.Equal(_knownKeyName, retrievedKey.Key.Name);
@@ -101,24 +71,20 @@ public class KeyGetCommandTests
         // Arrange
         var expectedError = "Test error";
 
-        _keyVaultService
-            .GetKey(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownKeyName),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.GetKey(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownKeyName),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--key", _knownKeyName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert
         Assert.NotNull(response);
@@ -132,33 +98,23 @@ public class KeyGetCommandTests
         // Arrange
         var expectedKeys = new List<string> { "key1", "key2", "key3" };
 
-        _keyVaultService
-            .ListKeys(
-                Arg.Is(_knownVaultName),
-                Arg.Is(false),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ListKeys(
+            Arg.Is(_knownVaultName),
+            Arg.Is(false),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedKeys);
 
-        var args = _commandDefinition.Parse([
-            "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--vault", _knownVaultName,
+            "--subscription", _knownSubscriptionId);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.KeyGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, KeyVaultJsonContext.Default.KeyGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Keys);
         Assert.Null(result.Key);
         Assert.Equal(expectedKeys.Count, result.Keys.Count);
@@ -171,34 +127,24 @@ public class KeyGetCommandTests
         // Arrange
         var expectedKeys = new List<string> { "key1", "key2", "managed-key1" };
 
-        _keyVaultService
-            .ListKeys(
-                Arg.Is(_knownVaultName),
-                Arg.Is(true),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ListKeys(
+            Arg.Is(_knownVaultName),
+            Arg.Is(true),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedKeys);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--subscription", _knownSubscriptionId,
-            "--include-managed", "true"
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--include-managed", "true");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.KeyGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, KeyVaultJsonContext.Default.KeyGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Keys);
         Assert.Null(result.Key);
         Assert.Equal(expectedKeys.Count, result.Keys.Count);
@@ -211,23 +157,19 @@ public class KeyGetCommandTests
         // Arrange
         var expectedError = "List error";
 
-        _keyVaultService
-            .ListKeys(
-                Arg.Is(_knownVaultName),
-                Arg.Any<bool>(),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ListKeys(
+            Arg.Is(_knownVaultName),
+            Arg.Any<bool>(),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse([
-            "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--vault", _knownVaultName,
+            "--subscription", _knownSubscriptionId);
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Secret/SecretCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Secret/SecretCreateCommandTests.cs
@@ -1,85 +1,51 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Secret;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Secrets;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.UnitTests.Secret;
 
-public class SecretCreateCommandTests
+public class SecretCreateCommandTests : CommandUnitTestsBase<SecretCreateCommand, IKeyVaultService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IKeyVaultService _keyVaultService;
-    private readonly ILogger<SecretCreateCommand> _logger;
-    private readonly SecretCreateCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
     private const string _knownSubscriptionId = "knownSubscription";
     private const string _knownVaultName = "knownVaultName";
     private const string _knownSecretName = "knownSecretName";
     private const string _knownSecretValue = "knownSecretValue";
-    private readonly KeyVaultSecret _knownKeyVaultSecret;
-
-    public SecretCreateCommandTests()
-    {
-        _keyVaultService = Substitute.For<IKeyVaultService>();
-        _logger = Substitute.For<ILogger<SecretCreateCommand>>();
-
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-        _command = new(_logger, _keyVaultService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-
-        _knownKeyVaultSecret = new KeyVaultSecret(_knownSecretName, _knownSecretValue);
-    }
+    private readonly KeyVaultSecret _knownKeyVaultSecret = new(_knownSecretName, _knownSecretValue);
 
     [Fact]
     public async Task ExecuteAsync_CreatesSecret_WhenValidInput()
     {
         // Arrange
-        _keyVaultService
-            .CreateSecret(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownSecretName),
-                Arg.Is(_knownSecretValue),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.CreateSecret(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownSecretName),
+            Arg.Is(_knownSecretValue),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(_knownKeyVaultSecret);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--secret", _knownSecretName,
             "--value", _knownSecretValue,
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var retrievedSecret = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.SecretCreateCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var retrievedSecret = JsonSerializer.Deserialize(json, KeyVaultJsonContext.Default.SecretCreateCommandResult);
-
-        Assert.NotNull(retrievedSecret);
         Assert.Equal(_knownSecretName, retrievedSecret.Name);
         Assert.Equal(_knownSecretValue, retrievedSecret.Value);
     }
@@ -87,15 +53,11 @@ public class SecretCreateCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsInvalidObject_IfSecretNameIsEmpty()
     {
-        // Arrange - No need to mock service since validation should fail before service is called
-        var args = _commandDefinition.Parse([
+        // Arrange & Act - No need to mock service since validation should fail before service is called
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--secret", "",
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert - Should return validation error response
         Assert.NotNull(response);
@@ -109,26 +71,22 @@ public class SecretCreateCommandTests
         // Arrange
         var expectedError = "Test error";
 
-        _keyVaultService
-            .CreateSecret(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownSecretName),
-                Arg.Is(_knownSecretValue),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.CreateSecret(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownSecretName),
+            Arg.Is(_knownSecretValue),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--secret", _knownSecretName,
             "--value", _knownSecretValue,
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Secret/SecretGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Secret/SecretGetCommandTests.cs
@@ -12,72 +12,43 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.UnitTests.Secret;
 
-public class SecretGetCommandTests
+public class SecretGetCommandTests : CommandUnitTestsBase<SecretGetCommand, IKeyVaultService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IKeyVaultService _keyVaultService;
-    private readonly ILogger<SecretGetCommand> _logger;
-    private readonly SecretGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
     private const string _knownSubscriptionId = "knownSubscription";
     private const string _knownVaultName = "knownVaultName";
     private const string _knownSecretName = "knownSecretName";
     private const string _knownSecretValue = "knownSecretValue";
-    private readonly KeyVaultSecret _knownKeyVaultSecret;
-
-    public SecretGetCommandTests()
-    {
-        _keyVaultService = Substitute.For<IKeyVaultService>();
-        _logger = Substitute.For<ILogger<SecretGetCommand>>();
-
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-        _command = new(_logger, _keyVaultService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-
-        _knownKeyVaultSecret = new KeyVaultSecret(_knownSecretName, _knownSecretValue);
-    }
+    private readonly KeyVaultSecret _knownKeyVaultSecret = new(_knownSecretName, _knownSecretValue);
 
     [Fact]
     public async Task ExecuteAsync_ReturnsSecret()
     {
         // Arrange
-        _keyVaultService
-            .GetSecret(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownSecretName),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.GetSecret(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownSecretName),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(_knownKeyVaultSecret);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--secret", _knownSecretName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var retrievedSecret = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.SecretGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var retrievedSecret = JsonSerializer.Deserialize(json, KeyVaultJsonContext.Default.SecretGetCommandResult);
-
-        Assert.NotNull(retrievedSecret);
         Assert.NotNull(retrievedSecret.Secret);
         Assert.Null(retrievedSecret.Secrets);
         Assert.Equal(_knownSecretName, retrievedSecret.Secret.Name);
@@ -90,24 +61,20 @@ public class SecretGetCommandTests
         // Arrange
         var expectedError = "Test error";
 
-        _keyVaultService
-            .GetSecret(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.GetSecret(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--secret", _knownSecretName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--subscription", _knownSubscriptionId);
 
         // Assert
         Assert.NotNull(response);
@@ -121,32 +88,22 @@ public class SecretGetCommandTests
         // Arrange
         var expectedSecrets = new List<string> { "secret1", "secret2", "secret3" };
 
-        _keyVaultService
-            .ListSecrets(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ListSecrets(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns(expectedSecrets);
 
-        var args = _commandDefinition.Parse([
-            "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--vault", _knownVaultName,
+            "--subscription", _knownSubscriptionId);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.SecretGetCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, KeyVaultJsonContext.Default.SecretGetCommandResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Secrets);
         Assert.Null(result.Secret);
         Assert.Equal(expectedSecrets.Count, result.Secrets.Count);
@@ -159,22 +116,18 @@ public class SecretGetCommandTests
         // Arrange
         var expectedError = "List error";
 
-        _keyVaultService
-            .ListSecrets(
-                Arg.Is(_knownVaultName),
-                Arg.Is(_knownSubscriptionId),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.ListSecrets(
+            Arg.Is(_knownVaultName),
+            Arg.Is(_knownSubscriptionId),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse([
-            "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId
-        ]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--vault", _knownVaultName,
+            "--subscription", _knownSubscriptionId);
 
         // Assert
         Assert.NotNull(response);


### PR DESCRIPTION
## What does this PR do?

Migrates Command unit tests to use `CommandUnitTestBase`. Adds new helper method to `CommandUnitTestBase` that performs common validation when a tool call was expected to succeed with a response value.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
