### PR TITLE
[Part 7] Migrate tool command unit tests to useing CommandUnitTestsBase

### DIFF
--- a/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.UnitTests/Product/ProductGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.UnitTests/Product/ProductGetCommandTests.cs
@@ -1,51 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using Azure.Mcp.Tools.Marketplace.Commands.Product;
 using Azure.Mcp.Tools.Marketplace.Models;
 using Azure.Mcp.Tools.Marketplace.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Marketplace.UnitTests.Product;
 
-public class ProductGetCommandTests
+public class ProductGetCommandTests : CommandUnitTestsBase<ProductGetCommand, IMarketplaceService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IMarketplaceService _marketplaceService;
-    private readonly ILogger<ProductGetCommand> _logger;
-    private readonly ProductGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public ProductGetCommandTests()
-    {
-        _marketplaceService = Substitute.For<IMarketplaceService>();
-        _logger = Substitute.For<ILogger<ProductGetCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _marketplaceService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("get", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
-        Assert.Contains("marketplace product", command.Description.ToLower());
+        Assert.Equal("get", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
+        Assert.Contains("marketplace product", CommandDefinition.Description.ToLower());
     }
 
     [Fact]
@@ -60,7 +36,7 @@ public class ProductGetCommandTests
             DisplayName = "Test Product"
         };
 
-        _marketplaceService.GetProduct(
+        Service.GetProduct(
             Arg.Is(productId),
             Arg.Is(subscriptionId),
             Arg.Any<bool?>(),
@@ -76,10 +52,8 @@ public class ProductGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedProduct);
 
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--product-id", productId]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId, "--product-id", productId);
 
         // Assert
         Assert.NotNull(response);
@@ -90,11 +64,8 @@ public class ProductGetCommandTests
     [Fact]
     public async Task ExecuteAsync_WithMissingSubscription_ReturnsValidationError()
     {
-        // Arrange
-        var args = _commandDefinition.Parse(["--product-id", "test-product"]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync("--product-id", "test-product");
 
         // Assert
         Assert.NotNull(response);
@@ -110,7 +81,7 @@ public class ProductGetCommandTests
         var subscriptionId = "test-sub";
         var productId = "test-product";
 
-        _marketplaceService.GetProduct(
+        Service.GetProduct(
             Arg.Is(productId),
             Arg.Is(subscriptionId),
             Arg.Any<bool?>(),
@@ -126,10 +97,8 @@ public class ProductGetCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _commandDefinition.Parse(["--subscription", subscriptionId, "--product-id", productId]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId, "--product-id", productId);
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.UnitTests/Product/ProductListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.UnitTests/Product/ProductListCommandTests.cs
@@ -271,8 +271,8 @@ public class ProductListCommandTests : CommandUnitTestsBase<ProductListCommand, 
         var result = ValidateAndDeserializeResponse(response, MarketplaceJsonContext.Default.ProductListCommandResult);
 
         Assert.Equal(expectedNextCursor, result.NextCursor);
-        Assert.Contains(result.Products, p => p.DisplayName == "test-product-1");
-        Assert.Contains(result.Products, p => p.DisplayName == "test-product-2");
+        Assert.Contains(result.Products, p => p.UniqueProductId == "test-product-1");
+        Assert.Contains(result.Products, p => p.UniqueProductId == "test-product-2");
     }
 
     [Fact]
@@ -316,7 +316,7 @@ public class ProductListCommandTests : CommandUnitTestsBase<ProductListCommand, 
         var result = ValidateAndDeserializeResponse(response, MarketplaceJsonContext.Default.ProductListCommandResult);
 
         Assert.Null(result.NextCursor);
-        Assert.Contains(result.Products, p => p.DisplayName == "test-product");
+        Assert.Contains(result.Products, p => p.UniqueProductId == "test-product");
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.UnitTests/Product/ProductListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.UnitTests/Product/ProductListCommandTests.cs
@@ -2,47 +2,27 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
+using Azure.Mcp.Tools.Marketplace.Commands;
 using Azure.Mcp.Tools.Marketplace.Commands.Product;
 using Azure.Mcp.Tools.Marketplace.Models;
 using Azure.Mcp.Tools.Marketplace.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Marketplace.UnitTests.Product;
 
-public class ProductListCommandTests
+public class ProductListCommandTests : CommandUnitTestsBase<ProductListCommand, IMarketplaceService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IMarketplaceService _marketplaceService;
-    private readonly ILogger<ProductListCommand> _logger;
-    private readonly ProductListCommand _command;
-    private readonly CommandContext _context;
-    public ProductListCommandTests()
-    {
-        _marketplaceService = Substitute.For<IMarketplaceService>();
-        _logger = Substitute.For<ILogger<ProductListCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _marketplaceService);
-        _context = new(_serviceProvider);
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("list", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
-        Assert.Contains("marketplace products", command.Description.ToLower());
+        Assert.Equal("list", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
+        Assert.Contains("marketplace products", CommandDefinition.Description.ToLower());
     }
 
     [Fact]
@@ -64,7 +44,7 @@ public class ProductListCommandTests
             }
         };
 
-        _marketplaceService.ListProducts(
+        Service.ListProducts(
             Arg.Is(subscriptionId),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -78,10 +58,8 @@ public class ProductListCommandTests
             Arg.Any<CancellationToken>())
             .Returns(new ProductListResponseWithNextCursor { Items = expectedProducts });
 
-        var args = _command.GetCommand().Parse(["--subscription", subscriptionId]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId);
 
         // Assert
         Assert.NotNull(response);
@@ -105,7 +83,7 @@ public class ProductListCommandTests
             }
         };
 
-        _marketplaceService.ListProducts(
+        Service.ListProducts(
             Arg.Is(subscriptionId),
             Arg.Is(language),
             Arg.Is(search),
@@ -119,14 +97,11 @@ public class ProductListCommandTests
             Arg.Any<CancellationToken>())
             .Returns(new ProductListResponseWithNextCursor { Items = expectedProducts });
 
-        var args = _command.GetCommand().Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscriptionId,
             "--search", search,
-            "--language", language
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--language", language);
 
         // Assert
         Assert.NotNull(response);
@@ -137,11 +112,8 @@ public class ProductListCommandTests
     [Fact]
     public async Task ExecuteAsync_WithMissingSubscription_ReturnsValidationError()
     {
-        // Arrange
-        var args = _command.GetCommand().Parse(["--search", "test"]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync("--search", "test");
 
         // Assert
         Assert.NotNull(response);
@@ -155,7 +127,7 @@ public class ProductListCommandTests
         // Arrange
         var subscriptionId = "test-sub";
 
-        _marketplaceService.ListProducts(
+        Service.ListProducts(
             Arg.Is(subscriptionId),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -169,10 +141,8 @@ public class ProductListCommandTests
             Arg.Any<CancellationToken>())
             .Returns(new ProductListResponseWithNextCursor { Items = [] });
 
-        var args = _command.GetCommand().Parse(["--subscription", subscriptionId]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId);
 
         // Assert
         Assert.NotNull(response);
@@ -187,7 +157,7 @@ public class ProductListCommandTests
         var expectedError = "Test error";
         var subscriptionId = "test-sub";
 
-        _marketplaceService.ListProducts(
+        Service.ListProducts(
             Arg.Is(subscriptionId),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -201,10 +171,8 @@ public class ProductListCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var args = _command.GetCommand().Parse(["--subscription", subscriptionId]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId);
 
         // Assert
         Assert.NotNull(response);
@@ -229,7 +197,7 @@ public class ProductListCommandTests
             }
         };
 
-        _marketplaceService.ListProducts(
+        Service.ListProducts(
             Arg.Is(subscriptionId),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -243,15 +211,12 @@ public class ProductListCommandTests
             Arg.Any<CancellationToken>())
             .Returns(new ProductListResponseWithNextCursor { Items = expectedProducts });
 
-        var args = _command.GetCommand().Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", subscriptionId,
             "--filter", filter,
             "--orderby", orderBy,
-            "--select", select
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--select", select);
 
         // Assert
         Assert.NotNull(response);
@@ -285,7 +250,7 @@ public class ProductListCommandTests
             NextCursor = expectedNextCursor
         };
 
-        _marketplaceService.ListProducts(
+        Service.ListProducts(
             Arg.Is(subscriptionId),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -299,21 +264,15 @@ public class ProductListCommandTests
             Arg.Any<CancellationToken>())
             .Returns(productsListResult);
 
-        var args = _command.GetCommand().Parse(["--subscription", subscriptionId]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, MarketplaceJsonContext.Default.ProductListCommandResult);
 
-        // Verify the response contains the NextCursor by checking the serialized result
-        var resultJson = JsonSerializer.Serialize(response.Results);
-        Assert.Contains(expectedNextCursor, resultJson);
-        Assert.Contains("test-product-1", resultJson);
-        Assert.Contains("test-product-2", resultJson);
+        Assert.Equal(expectedNextCursor, result.NextCursor);
+        Assert.Contains(result.Products, p => p.DisplayName == "test-product-1");
+        Assert.Contains(result.Products, p => p.DisplayName == "test-product-2");
     }
 
     [Fact]
@@ -336,7 +295,7 @@ public class ProductListCommandTests
             NextCursor = null // No next cursor
         };
 
-        _marketplaceService.ListProducts(
+        Service.ListProducts(
             Arg.Is(subscriptionId),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -350,21 +309,14 @@ public class ProductListCommandTests
             Arg.Any<CancellationToken>())
             .Returns(productsListResult);
 
-        var args = _command.GetCommand().Parse(["--subscription", subscriptionId]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, MarketplaceJsonContext.Default.ProductListCommandResult);
 
-        // Verify the response contains null NextCursor
-        var resultJson = JsonSerializer.Serialize(response.Results);
-        Assert.Contains("test-product", resultJson);
-        // The NextCursor should be null and serialized as such
-        Assert.DoesNotContain("\"nextCursor\"", resultJson);
+        Assert.Null(result.NextCursor);
+        Assert.Contains(result.Products, p => p.DisplayName == "test-product");
     }
 
     [Fact]
@@ -382,7 +334,7 @@ public class ProductListCommandTests
             }
         };
 
-        _marketplaceService.ListProducts(
+        Service.ListProducts(
             Arg.Is(subscriptionId),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -396,13 +348,8 @@ public class ProductListCommandTests
             Arg.Any<CancellationToken>())
             .Returns(new ProductListResponseWithNextCursor { Items = expectedProducts });
 
-        var args = _command.GetCommand().Parse([
-            "--subscription", subscriptionId,
-            "--expand", expand
-        ]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId, "--expand", expand);
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/ActivityLog/ActivityLogListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/ActivityLog/ActivityLogListCommandTests.cs
@@ -1,46 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.Monitor.Commands;
 using Azure.Mcp.Tools.Monitor.Commands.ActivityLog;
 using Azure.Mcp.Tools.Monitor.Models.ActivityLog;
 using Azure.Mcp.Tools.Monitor.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.ActivityLog;
 
-public sealed class ActivityLogListCommandTests
+public sealed class ActivityLogListCommandTests : CommandUnitTestsBase<ActivityLogListCommand, IMonitorService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IMonitorService _monitorService;
-    private readonly ILogger<ActivityLogListCommand> _logger;
-    private readonly ActivityLogListCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
     private const string _knownSubscription = "knownSubscription";
     private const string _knownResourceName = "myResource";
-
-    public ActivityLogListCommandTests()
-    {
-        _monitorService = Substitute.For<IMonitorService>();
-        _logger = Substitute.For<ILogger<ActivityLogListCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _monitorService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
 
     [Theory]
     [InlineData($"--subscription {_knownSubscription} --resource-name {_knownResourceName}", true)]
@@ -63,10 +40,10 @@ public sealed class ActivityLogListCommandTests
                     OperationName = new() { LocalizedValue = "Create Storage Account", Value = "Microsoft.Storage/storageAccounts/write" },
                     Level = ActivityLogEventLevel.Informational,
                     EventTimestamp = "2023-01-01T00:00:00Z",
-                    Properties = new Dictionary<string, object>()
+                    Properties = []
                 }
             };
-            _monitorService.ListActivityLogs(
+            Service.ListActivityLogs(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -81,10 +58,10 @@ public sealed class ActivityLogListCommandTests
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse(args), TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
-        Assert.Equal(shouldSucceed ? (HttpStatusCode)200 : (HttpStatusCode)400, response.Status);
+        Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
         if (shouldSucceed)
         {
             Assert.NotNull(response.Results);
@@ -109,7 +86,7 @@ public sealed class ActivityLogListCommandTests
                 OperationName = new() { LocalizedValue = "Create Storage Account", Value = "Microsoft.Storage/storageAccounts/write" },
                 Level = ActivityLogEventLevel.Informational,
                 EventTimestamp = "2023-01-01T00:00:00Z",
-                Properties = new Dictionary<string, object>()
+                Properties = []
             },
             new()
             {
@@ -118,11 +95,11 @@ public sealed class ActivityLogListCommandTests
                 OperationName = new() { LocalizedValue = "Update Storage Account", Value = "Microsoft.Storage/storageAccounts/write" },
                 Level = ActivityLogEventLevel.Warning,
                 EventTimestamp = "2023-01-01T01:00:00Z",
-                Properties = new Dictionary<string, object>()
+                Properties = []
             }
         };
 
-        _monitorService.ListActivityLogs(
+        Service.ListActivityLogs(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -136,14 +113,13 @@ public sealed class ActivityLogListCommandTests
             .Returns(expectedActivityLogs);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse($"--subscription {_knownSubscription} --resource-name {_knownResourceName}"), TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--resource-name", _knownResourceName);
 
         // Assert
-        Assert.Equal((HttpStatusCode)200, response.Status);
-        Assert.NotNull(response.Results);
-
         // Verify the mock was called
-        await _monitorService.Received(1).ListActivityLogs(
+        await Service.Received(1).ListActivityLogs(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -155,10 +131,8 @@ public sealed class ActivityLogListCommandTests
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MonitorJsonContext.Default.ActivityLogListCommandResult);
+        var result = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.ActivityLogListCommandResult);
 
-        Assert.NotNull(result);
         Assert.Equal(expectedActivityLogs.Count, result.ActivityLogs.Count);
         Assert.Equal(expectedActivityLogs[0].Description, result.ActivityLogs[0].Description);
         Assert.Equal(expectedActivityLogs[0].Level, result.ActivityLogs[0].Level);
@@ -170,7 +144,7 @@ public sealed class ActivityLogListCommandTests
     public async Task ExecuteAsync_ReturnsEmptyListWhenNoActivityLogs()
     {
         // Arrange
-        _monitorService.ListActivityLogs(
+        Service.ListActivityLogs(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -181,19 +155,16 @@ public sealed class ActivityLogListCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(new List<ActivityLogEventData>());
+            .Returns([]);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse($"--subscription {_knownSubscription} --resource-name {_knownResourceName}"), TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--resource-name", _knownResourceName);
 
         // Assert
-        Assert.Equal((HttpStatusCode)200, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.ActivityLogListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MonitorJsonContext.Default.ActivityLogListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.ActivityLogs);
     }
 
@@ -201,7 +172,7 @@ public sealed class ActivityLogListCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _monitorService.ListActivityLogs(
+        Service.ListActivityLogs(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -212,10 +183,12 @@ public sealed class ActivityLogListCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<ActivityLogEventData>>(new Exception("Test error")));
+            .ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse($"--subscription {_knownSubscription} --resource-name {_knownResourceName}"), TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--resource-name", _knownResourceName);
 
         // Assert
         Assert.Equal((HttpStatusCode)500, response.Status);
@@ -233,7 +206,7 @@ public sealed class ActivityLogListCommandTests
         // Arrange
         var args = $"--subscription {_knownSubscription} {partialArgs}";
 
-        _monitorService.ListActivityLogs(
+        Service.ListActivityLogs(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -244,8 +217,8 @@ public sealed class ActivityLogListCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(new List<ActivityLogEventData>
-            {
+            .Returns(
+            [
                 new()
                 {
                     Description = "Test activity log",
@@ -253,14 +226,14 @@ public sealed class ActivityLogListCommandTests
                     OperationName = new() { LocalizedValue = "Create Storage Account", Value = "Microsoft.Storage/storageAccounts/write" },
                     Level = ActivityLogEventLevel.Informational,
                     EventTimestamp = "2023-01-01T00:00:00Z",
-                    Properties = new Dictionary<string, object>()
+                    Properties = []
                 }
-            });
+            ]);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse(args), TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
-        Assert.Equal(shouldSucceed ? (HttpStatusCode)200 : (HttpStatusCode)400, response.Status);
+        Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
     }
 }

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/HealthModels/Entity/EntityGetHealthCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/HealthModels/Entity/EntityGetHealthCommandTests.cs
@@ -66,7 +66,7 @@ public class EntityGetHealthCommandTests : CommandUnitTestsBase<EntityGetHealthC
 
     [Fact]
     public async Task ExecuteAsync_WithMissingRequiredParameters_ReturnsBadRequest()
-    {        
+    {
         // Arrange & Act - missing entity parameter
         var result = await ExecuteCommandAsync(
             "--health-model", TestHealthModel,

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/HealthModels/Entity/EntityGetHealthCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/HealthModels/Entity/EntityGetHealthCommandTests.cs
@@ -1,30 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using System.Text.Json.Nodes;
 using Azure.Mcp.Tools.Monitor.Commands.HealthModels.Entity;
 using Azure.Mcp.Tools.Monitor.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.HealthModels.Entity;
 
-public class EntityGetHealthCommandTests
+public class EntityGetHealthCommandTests : CommandUnitTestsBase<EntityGetHealthCommand, IMonitorHealthModelService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<EntityGetHealthCommand> _logger;
-    private readonly IMonitorHealthModelService _monitorHealthService;
-    private readonly EntityGetHealthCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
     // Sample test data
     private const string TestEntity = "entity123";
     private const string TestHealthModel = "healthModel1";
@@ -32,46 +23,37 @@ public class EntityGetHealthCommandTests
     private const string TestSubscription = "sub123";
     private const string TestTenant = "tenant123";
 
-    public EntityGetHealthCommandTests()
-    {
-        _monitorHealthService = Substitute.For<IMonitorHealthModelService>();
-        _logger = Substitute.For<ILogger<EntityGetHealthCommand>>();
-
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-        _command = new EntityGetHealthCommand(_logger, _monitorHealthService);
-        _context = new CommandContext(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public async Task ExecuteAsync_WithValidParameters_ReturnsEntityHealth()
     {
         // Arrange
-        JsonNode mockResponse = JsonNode.Parse(@"{""entityId"": ""entity123"", ""health"": ""Healthy"", ""timestamp"": ""2023-05-01T12:00:00Z""}") ?? "";
+        JsonNode mockResponse = new JsonObject([new("entityId", "entity123"), new("health", "Healthy"), new("timestamp", "2023-05-01T12:00:00Z")]);
 
-        _monitorHealthService
-            .GetEntityHealth(
-                TestEntity,
-                TestHealthModel,
-                TestResourceGroup,
-                TestSubscription,
-                Arg.Any<AuthMethod?>(),
-                TestTenant,
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
+        Service.GetEntityHealth(
+            TestEntity,
+            TestHealthModel,
+            TestResourceGroup,
+            TestSubscription,
+            Arg.Any<AuthMethod?>(),
+            TestTenant,
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(mockResponse);
 
-        var args = _commandDefinition.Parse($"--entity {TestEntity} --health-model {TestHealthModel} --resource-group {TestResourceGroup} --subscription {TestSubscription} --tenant {TestTenant}");
-
         // Act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var result = await ExecuteCommandAsync(
+            "--entity", TestEntity,
+            "--health-model", TestHealthModel,
+            "--resource-group", TestResourceGroup,
+            "--subscription", TestSubscription,
+            "--tenant", TestTenant);
 
         // Assert
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.Status);
         Assert.NotNull(result.Results);
 
-        await _monitorHealthService.Received(1).GetEntityHealth(
+        await Service.Received(1).GetEntityHealth(
             TestEntity,
             TestHealthModel,
             TestResourceGroup,
@@ -84,11 +66,12 @@ public class EntityGetHealthCommandTests
 
     [Fact]
     public async Task ExecuteAsync_WithMissingRequiredParameters_ReturnsBadRequest()
-    {        // Arrange - missing entity parameter
-        var args = _commandDefinition.Parse($"--health-model {TestHealthModel} --resource-group {TestResourceGroup} --subscription {TestSubscription}");
-
-        // Act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+    {        
+        // Arrange & Act - missing entity parameter
+        var result = await ExecuteCommandAsync(
+            "--health-model", TestHealthModel,
+            "--resource-group", TestResourceGroup,
+            "--subscription", TestSubscription);
 
         // Assert
         Assert.NotNull(result);
@@ -96,7 +79,7 @@ public class EntityGetHealthCommandTests
         Assert.Contains("required", result.Message, StringComparison.OrdinalIgnoreCase);
 
         // Verify service was not called
-        await _monitorHealthService.DidNotReceive().GetEntityHealth(
+        await Service.DidNotReceive().GetEntityHealth(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -111,29 +94,30 @@ public class EntityGetHealthCommandTests
     public async Task ExecuteAsync_EntityNotFound_ReturnsNotFound()
     {
         // Arrange
-        _monitorHealthService
-            .GetEntityHealth(
-                TestEntity,
-                TestHealthModel,
-                TestResourceGroup,
-                TestSubscription,
-                Arg.Any<AuthMethod?>(),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<JsonNode>(new KeyNotFoundException("Entity not found")));
-
-        var args = _commandDefinition.Parse($"--entity {TestEntity} --health-model {TestHealthModel} --resource-group {TestResourceGroup} --subscription {TestSubscription}");
+        Service.GetEntityHealth(
+            TestEntity,
+            TestHealthModel,
+            TestResourceGroup,
+            TestSubscription,
+            Arg.Any<AuthMethod?>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new KeyNotFoundException("Entity not found"));
 
         // Act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var result = await ExecuteCommandAsync(
+            "--entity", TestEntity,
+            "--health-model", TestHealthModel,
+            "--resource-group", TestResourceGroup,
+            "--subscription", TestSubscription);
 
         // Assert
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.NotFound, result.Status);
         Assert.Contains("not found", result.Message, StringComparison.OrdinalIgnoreCase);
 
-        await _monitorHealthService.Received(1).GetEntityHealth(
+        await Service.Received(1).GetEntityHealth(
             TestEntity,
             TestHealthModel,
             TestResourceGroup,
@@ -148,29 +132,30 @@ public class EntityGetHealthCommandTests
     public async Task ExecuteAsync_InvalidArgument_ReturnsBadRequest()
     {
         // Arrange
-        _monitorHealthService
-            .GetEntityHealth(
-                TestEntity,
-                TestHealthModel,
-                TestResourceGroup,
-                TestSubscription,
-                Arg.Any<AuthMethod?>(),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<JsonNode>(new ArgumentException("Invalid health model format")));
-
-        var args = _commandDefinition.Parse($"--entity {TestEntity} --health-model {TestHealthModel} --resource-group {TestResourceGroup} --subscription {TestSubscription}");
+        Service.GetEntityHealth(
+            TestEntity,
+            TestHealthModel,
+            TestResourceGroup,
+            TestSubscription,
+            Arg.Any<AuthMethod?>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ArgumentException("Invalid health model format"));
 
         // Act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var result = await ExecuteCommandAsync(
+            "--entity", TestEntity,
+            "--health-model", TestHealthModel,
+            "--resource-group", TestResourceGroup,
+            "--subscription", TestSubscription);
 
         // Assert
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.BadRequest, result.Status);
         Assert.Contains("Invalid argument", result.Message);
 
-        await _monitorHealthService.Received(1).GetEntityHealth(
+        await Service.Received(1).GetEntityHealth(
             TestEntity,
             TestHealthModel,
             TestResourceGroup,
@@ -186,29 +171,30 @@ public class EntityGetHealthCommandTests
     {
         // Arrange
         var expectedError = "Unexpected error occurred";
-        _monitorHealthService
-            .GetEntityHealth(
-                TestEntity,
-                TestHealthModel,
-                TestResourceGroup,
-                TestSubscription,
-                Arg.Any<AuthMethod?>(),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<JsonNode>(new Exception(expectedError)));
-
-        var args = _commandDefinition.Parse($"--entity {TestEntity} --health-model {TestHealthModel} --resource-group {TestResourceGroup} --subscription {TestSubscription}");
+        Service.GetEntityHealth(
+            TestEntity,
+            TestHealthModel,
+            TestResourceGroup,
+            TestSubscription,
+            Arg.Any<AuthMethod?>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception(expectedError));
 
         // Act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var result = await ExecuteCommandAsync(
+            "--entity", TestEntity,
+            "--health-model", TestHealthModel,
+            "--resource-group", TestResourceGroup,
+            "--subscription", TestSubscription);
 
         // Assert
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.InternalServerError, result.Status);
         Assert.Contains(expectedError, result.Message);
 
-        await _monitorHealthService.Received(1).GetEntityHealth(
+        await Service.Received(1).GetEntityHealth(
             TestEntity,
             TestHealthModel,
             TestResourceGroup,
@@ -223,36 +209,38 @@ public class EntityGetHealthCommandTests
     public async Task ExecuteAsync_WithAuthMethod_PassesAuthMethodToService()
     {
         // Arrange
-        var mockResponse = JsonNode.Parse(@"{""entityId"": ""entity123"", ""health"": ""Healthy""}") ?? "";
+        var mockResponse = new JsonObject([new("entityId", "entity123"), new("health", "Healthy")]);
         var authMethod = AuthMethod.Credential.ToString().ToLowerInvariant();
 
-        _monitorHealthService
-            .GetEntityHealth(
-                TestEntity,
-                TestHealthModel,
-                TestResourceGroup,
-                TestSubscription,
-                Arg.Is<AuthMethod>(a => a == AuthMethod.Credential),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
+        Service.GetEntityHealth(
+            TestEntity,
+            TestHealthModel,
+            TestResourceGroup,
+            TestSubscription,
+            Arg.Is(AuthMethod.Credential),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
             .Returns(mockResponse);
 
-        var args = _commandDefinition.Parse($"--entity {TestEntity} --health-model {TestHealthModel} --resource-group {TestResourceGroup} --subscription {TestSubscription} --auth-method {authMethod}");
-
         // Act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var result = await ExecuteCommandAsync(
+            "--entity", TestEntity,
+            "--health-model", TestHealthModel,
+            "--resource-group", TestResourceGroup,
+            "--subscription", TestSubscription,
+            "--auth-method", authMethod);
 
         // Assert
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.Status);
 
-        await _monitorHealthService.Received(1).GetEntityHealth(
+        await Service.Received(1).GetEntityHealth(
             TestEntity,
             TestHealthModel,
             TestResourceGroup,
             TestSubscription,
-            Arg.Is<AuthMethod>(a => a == AuthMethod.Credential),
+            Arg.Is(AuthMethod.Credential),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
@@ -262,32 +250,35 @@ public class EntityGetHealthCommandTests
     public async Task ExecuteAsync_WithRetryPolicy_PassesRetryPolicyToService()
     {
         // Arrange
-        var mockResponse = JsonNode.Parse(@"{""entityId"": ""entity123"", ""health"": ""Healthy""}") ?? "";
+        var mockResponse = new JsonObject([new("entityId", "entity123"), new("health", "Healthy")]);
         const double RetryDelay = 3;
         const int MaxRetries = 5;
 
-        _monitorHealthService
-            .GetEntityHealth(
-                TestEntity,
-                TestHealthModel,
-                TestResourceGroup,
-                TestSubscription,
-                Arg.Any<AuthMethod?>(),
-                Arg.Any<string>(),
-                Arg.Is<RetryPolicyOptions>(r => r.DelaySeconds == RetryDelay && r.MaxRetries == MaxRetries),
-                Arg.Any<CancellationToken>())
+        Service.GetEntityHealth(
+            TestEntity,
+            TestHealthModel,
+            TestResourceGroup,
+            TestSubscription,
+            Arg.Any<AuthMethod?>(),
+            Arg.Any<string>(),
+            Arg.Is<RetryPolicyOptions>(r => r.DelaySeconds == RetryDelay && r.MaxRetries == MaxRetries),
+            Arg.Any<CancellationToken>())
             .Returns(mockResponse);
 
-        var args = _commandDefinition.Parse($"--entity {TestEntity} --health-model {TestHealthModel} --resource-group {TestResourceGroup} --subscription {TestSubscription} --retry-delay {RetryDelay} --retry-max-retries {MaxRetries}");
-
         // Act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var result = await ExecuteCommandAsync(
+            "--entity", TestEntity,
+            "--health-model", TestHealthModel,
+            "--resource-group", TestResourceGroup,
+            "--subscription", TestSubscription,
+            "--retry-delay", RetryDelay.ToString(),
+            "--retry-max-retries", MaxRetries.ToString());
 
         // Assert
         Assert.NotNull(result);
         Assert.Equal(HttpStatusCode.OK, result.Status);
 
-        await _monitorHealthService.Received(1).GetEntityHealth(
+        await Service.Received(1).GetEntityHealth(
             TestEntity,
             TestHealthModel,
             TestResourceGroup,

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Instrumentation/Models/OnboardingSpecBuilderTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Instrumentation/Models/OnboardingSpecBuilderTests.cs
@@ -1,7 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Azure.Mcp.Tools.Monitor.Models;
 using Xunit;
 
-namespace Azure.Mcp.Tools.Monitor.UnitTests.Models;
+namespace Azure.Mcp.Tools.Monitor.UnitTests.Instrumentation.Models;
 
 public sealed class OnboardingSpecBuilderTests
 {
@@ -59,7 +62,7 @@ public sealed class OnboardingSpecBuilderTests
             Id = "invalid",
             Type = ActionType.ManualStep,
             Description = "Invalid because details are missing required instructions",
-            Details = new Dictionary<string, object>(),
+            Details = [],
             Order = 0
         };
 

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Instrumentation/Models/OnboardingSpecValidatorTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Instrumentation/Models/OnboardingSpecValidatorTests.cs
@@ -1,7 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Azure.Mcp.Tools.Monitor.Models;
 using Xunit;
 
-namespace Azure.Mcp.Tools.Monitor.UnitTests.Models;
+namespace Azure.Mcp.Tools.Monitor.UnitTests.Instrumentation.Models;
 
 public sealed class OnboardingSpecValidatorTests
 {

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Instrumentation/Tools/GetLearningResourceToolTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Instrumentation/Tools/GetLearningResourceToolTests.cs
@@ -4,7 +4,7 @@
 using Azure.Mcp.Tools.Monitor.Tools;
 using Xunit;
 
-namespace Azure.Mcp.Tools.Monitor.UnitTests.Tools;
+namespace Azure.Mcp.Tools.Monitor.UnitTests.Instrumentation.Tools;
 
 public sealed class GetLearningResourceToolTests
 {

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Instrumentation/Tools/OrchestratorToolTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Instrumentation/Tools/OrchestratorToolTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Text.Json;
 using Azure.Mcp.Tools.Monitor.Detectors;
 using Azure.Mcp.Tools.Monitor.Generators;
@@ -7,7 +10,7 @@ using Azure.Mcp.Tools.Monitor.Tools;
 using NSubstitute;
 using Xunit;
 
-namespace Azure.Mcp.Tools.Monitor.UnitTests.Tools;
+namespace Azure.Mcp.Tools.Monitor.UnitTests.Instrumentation.Tools;
 
 public sealed class OrchestratorToolTests
 {
@@ -76,7 +79,7 @@ public sealed class OrchestratorToolTests
         {
             var analyzer = CreateAnalyzer(
                 state: InstrumentationState.Brownfield,
-                existingInstrumentation: new ExistingInstrumentation { Type = InstrumentationType.ApplicationInsightsSdk },
+                existingInstrumentation: new() { Type = InstrumentationType.ApplicationInsightsSdk },
                 generators: []);
 
             var tool = new OrchestratorTool(analyzer);

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Instrumentation/Tools/SendBrownfieldAnalysisToolTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Instrumentation/Tools/SendBrownfieldAnalysisToolTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Text.Json;
 using Azure.Mcp.Tools.Monitor.Detectors;
 using Azure.Mcp.Tools.Monitor.Generators;
@@ -7,7 +10,7 @@ using Azure.Mcp.Tools.Monitor.Tools;
 using NSubstitute;
 using Xunit;
 
-namespace Azure.Mcp.Tools.Monitor.UnitTests.Tools;
+namespace Azure.Mcp.Tools.Monitor.UnitTests.Instrumentation.Tools;
 
 public sealed class SendBrownfieldAnalysisToolTests
 {

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Log/ResourceLogQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Log/ResourceLogQueryCommandTests.cs
@@ -1,29 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using System.Text.Json.Nodes;
 using Azure.Mcp.Tools.Monitor.Commands.Log;
 using Azure.Mcp.Tools.Monitor.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.Log;
 
-public sealed class ResourceLogQueryCommandTests
+public sealed class ResourceLogQueryCommandTests : CommandUnitTestsBase<ResourceLogQueryCommand, IMonitorService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IMonitorService _monitorService;
-    private readonly ILogger<ResourceLogQueryCommand> _logger;
-    private readonly ResourceLogQueryCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
     private const string _knownSubscription = "knownSubscription";
     private const string _knownResourceId = "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/storage1";
     private const string _knownTable = "StorageEvents";
@@ -31,19 +22,6 @@ public sealed class ResourceLogQueryCommandTests
     private const string _knownTenant = "knownTenant";
     private const string _knownHours = "24";
     private const string _knownLimit = "100";
-
-    public ResourceLogQueryCommandTests()
-    {
-        _monitorService = Substitute.For<IMonitorService>();
-        _logger = Substitute.For<ILogger<ResourceLogQueryCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _monitorService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
 
     [Theory]
     [InlineData($"--subscription {_knownSubscription} --resource-id {_knownResourceId} --table {_knownTable} --query \"{_knownQuery}\"", true)]
@@ -58,10 +36,10 @@ public sealed class ResourceLogQueryCommandTests
         {
             var mockResults = new List<JsonNode>
             {
-                JsonNode.Parse(@"{""TimeGenerated"": ""2023-01-01T12:00:00Z"", ""Message"": ""Resource log entry""}") ?? JsonNode.Parse("{}") ?? new JsonObject(),
-                JsonNode.Parse(@"{""TimeGenerated"": ""2023-01-01T12:01:00Z"", ""Message"": ""Another resource log entry""}") ?? JsonNode.Parse("{}") ?? new JsonObject()
+                new JsonObject([new("TimeGenerated", "2023-01-01T12:00:00Z"), new("Message", "Resource log entry")]),
+                new JsonObject([new("TimeGenerated", "2023-01-01T12:01:00Z"), new("Message", "Another resource log entry")])
             };
-            _monitorService.QueryResourceLogs(
+            Service.QueryResourceLogs(
                 _knownSubscription,
                 _knownResourceId,
                 _knownQuery,
@@ -75,7 +53,7 @@ public sealed class ResourceLogQueryCommandTests
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse(args), TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
@@ -96,11 +74,11 @@ public sealed class ResourceLogQueryCommandTests
         // Arrange
         var mockResults = new List<JsonNode>
         {
-            JsonNode.Parse($@"{{""TimeGenerated"": ""2023-01-01T12:00:00Z"", ""ResourceId"": ""{_knownResourceId}"", ""Level"": ""Info""}}") ?? new JsonObject(),
-            JsonNode.Parse($@"{{""TimeGenerated"": ""2023-01-01T12:01:00Z"", ""ResourceId"": ""{_knownResourceId}"", ""Level"": ""Warning""}}") ?? new JsonObject(),
-            JsonNode.Parse($@"{{""TimeGenerated"": ""2023-01-01T12:02:00Z"", ""ResourceId"": ""{_knownResourceId}"", ""Level"": ""Error""}}") ?? new JsonObject()
+            new JsonObject([new("TimeGenerated", "2023-01-01T12:00:00Z"), new("ResourceId", _knownResourceId), new("Level", "Info")]),
+            new JsonObject([new("TimeGenerated", "2023-01-01T12:01:00Z"), new("ResourceId", _knownResourceId), new("Level", "Warning")]),
+            new JsonObject([new("TimeGenerated", "2023-01-01T12:02:00Z"), new("ResourceId", _knownResourceId), new("Level", "Error")])
         };
-        _monitorService.QueryResourceLogs(
+        Service.QueryResourceLogs(
             _knownSubscription,
             _knownResourceId,
             _knownQuery,
@@ -112,17 +90,19 @@ public sealed class ResourceLogQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockResults);
 
-        var args = _commandDefinition.Parse($"--subscription {_knownSubscription} --resource-id {_knownResourceId} --table {_knownTable} --query \"{_knownQuery}\"");
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--resource-id", _knownResourceId,
+            "--table", _knownTable,
+            "--query", _knownQuery);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
         // Verify the mock was called
-        await _monitorService.Received(1).QueryResourceLogs(
+        await Service.Received(1).QueryResourceLogs(
             _knownSubscription,
             _knownResourceId,
             _knownQuery,
@@ -138,8 +118,8 @@ public sealed class ResourceLogQueryCommandTests
     public async Task ExecuteAsync_CallsServiceWithCorrectParameters()
     {
         // Arrange
-        var mockResults = new List<JsonNode> { JsonNode.Parse(@"{""result"": ""data""}") ?? new JsonObject() };
-        _monitorService.QueryResourceLogs(
+        var mockResults = new List<JsonNode> { new JsonObject([new("result", "data")]) };
+        Service.QueryResourceLogs(
             _knownSubscription,
             _knownResourceId,
             _knownQuery,
@@ -151,14 +131,19 @@ public sealed class ResourceLogQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockResults);
 
-        var args = _commandDefinition.Parse($"--subscription {_knownSubscription} --resource-id {_knownResourceId} --table {_knownTable} --query \"{_knownQuery}\" --hours {_knownHours} --limit {_knownLimit} --tenant {_knownTenant}");
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--resource-id", _knownResourceId,
+            "--table", _knownTable,
+            "--query", _knownQuery,
+            "--hours", _knownHours,
+            "--limit", _knownLimit,
+            "--tenant", _knownTenant);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _monitorService.Received(1).QueryResourceLogs(
+        await Service.Received(1).QueryResourceLogs(
             _knownSubscription,
             _knownResourceId,
             _knownQuery,
@@ -174,8 +159,8 @@ public sealed class ResourceLogQueryCommandTests
     public async Task ExecuteAsync_WithDefaultParameters_UsesExpectedDefaults()
     {
         // Arrange
-        var mockResults = new List<JsonNode> { JsonNode.Parse(@"{""result"": ""data""}") ?? new JsonObject() };
-        _monitorService.QueryResourceLogs(
+        var mockResults = new List<JsonNode> { new JsonObject([new("result", "data")]) };
+        Service.QueryResourceLogs(
             _knownSubscription,
             _knownResourceId,
             _knownQuery,
@@ -187,14 +172,16 @@ public sealed class ResourceLogQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockResults);
 
-        var args = _commandDefinition.Parse($"--subscription {_knownSubscription} --resource-id {_knownResourceId} --table {_knownTable} --query \"{_knownQuery}\"");
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--resource-id", _knownResourceId,
+            "--table", _knownTable,
+            "--query", _knownQuery);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _monitorService.Received(1).QueryResourceLogs(
+        await Service.Received(1).QueryResourceLogs(
             _knownSubscription,
             _knownResourceId,
             _knownQuery,
@@ -210,7 +197,7 @@ public sealed class ResourceLogQueryCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _monitorService.QueryResourceLogs(
+        Service.QueryResourceLogs(
             _knownSubscription,
             _knownResourceId,
             _knownQuery,
@@ -220,12 +207,14 @@ public sealed class ResourceLogQueryCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<JsonNode>>(new Exception("Test error")));
-
-        var args = _commandDefinition.Parse($"--subscription {_knownSubscription} --resource-id {_knownResourceId} --table {_knownTable} --query \"{_knownQuery}\"");
+            .ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--resource-id", _knownResourceId,
+            "--table", _knownTable,
+            "--query", _knownQuery);
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -240,8 +229,8 @@ public sealed class ResourceLogQueryCommandTests
         var complexResourceId = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/my-vm";
         var query = "| where Level == 'Error'";
         var table = "VMEvents";
-        var mockResults = new List<JsonNode> { JsonNode.Parse(@"{""result"": ""vm data""}") ?? new JsonObject() };
-        _monitorService.QueryResourceLogs(
+        var mockResults = new List<JsonNode> { new JsonObject([new("result", "vm data")]) };
+        Service.QueryResourceLogs(
             _knownSubscription,
             complexResourceId,
             query,
@@ -253,14 +242,16 @@ public sealed class ResourceLogQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockResults);
 
-        var args = _commandDefinition.Parse($"--subscription {_knownSubscription} --resource-id \"{complexResourceId}\" --table {table} --query \"{query}\"");
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--resource-id", complexResourceId,
+            "--table", table,
+            "--query", query);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _monitorService.Received(1).QueryResourceLogs(
+        await Service.Received(1).QueryResourceLogs(
             _knownSubscription,
             complexResourceId,
             query,

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Log/WorkspaceLogQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Log/WorkspaceLogQueryCommandTests.cs
@@ -1,29 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using System.Text.Json.Nodes;
 using Azure.Mcp.Tools.Monitor.Commands.Log;
 using Azure.Mcp.Tools.Monitor.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.Log;
 
-public sealed class WorkspaceLogQueryCommandTests
+public sealed class WorkspaceLogQueryCommandTests : CommandUnitTestsBase<WorkspaceLogQueryCommand, IMonitorService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IMonitorService _monitorService;
-    private readonly ILogger<WorkspaceLogQueryCommand> _logger;
-    private readonly WorkspaceLogQueryCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
     private const string _knownSubscription = "knownSubscription";
     private const string _knownWorkspace = "knownWorkspace";
     private const string _knownResourceGroup = "knownResourceGroup";
@@ -32,19 +23,6 @@ public sealed class WorkspaceLogQueryCommandTests
     private const string _knownHours = "24";
     private const string _knownLimit = "100";
     private const string _knownQuery = "| limit 10";
-
-    public WorkspaceLogQueryCommandTests()
-    {
-        _monitorService = Substitute.For<IMonitorService>();
-        _logger = Substitute.For<ILogger<WorkspaceLogQueryCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _monitorService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
 
     [Theory]
     [InlineData($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --resource-group {_knownResourceGroup} --table {_knownTable} --query \"{_knownQuery}\"", true)]
@@ -59,10 +37,10 @@ public sealed class WorkspaceLogQueryCommandTests
         {
             var mockResults = new List<JsonNode>
             {
-                JsonNode.Parse(@"{""TimeGenerated"": ""2023-01-01T12:00:00Z"", ""Message"": ""Test log entry""}") ?? JsonNode.Parse("{}") ?? new JsonObject(),
-                JsonNode.Parse(@"{""TimeGenerated"": ""2023-01-01T12:01:00Z"", ""Message"": ""Another log entry""}") ?? JsonNode.Parse("{}") ?? new JsonObject()
+                new JsonObject([new("TimeGenerated", "2023-01-01T12:00:00Z"), new("Message", "Test log entry")]),
+                new JsonObject([new("TimeGenerated", "2023-01-01T12:01:00Z"), new("Message", "Another log entry")])
             };
-            _monitorService.QueryWorkspaceLogs(
+            Service.QueryWorkspaceLogs(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -76,7 +54,7 @@ public sealed class WorkspaceLogQueryCommandTests
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse(args), TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
@@ -97,11 +75,11 @@ public sealed class WorkspaceLogQueryCommandTests
         // Arrange
         var mockResults = new List<JsonNode>
         {
-            JsonNode.Parse(@"{""TimeGenerated"": ""2023-01-01T12:00:00Z"", ""Message"": ""Test log entry"", ""Level"": ""Info""}") ?? new JsonObject(),
-            JsonNode.Parse(@"{""TimeGenerated"": ""2023-01-01T12:01:00Z"", ""Message"": ""Another log entry"", ""Level"": ""Warning""}") ?? new JsonObject(),
-            JsonNode.Parse(@"{""TimeGenerated"": ""2023-01-01T12:02:00Z"", ""Message"": ""Error occurred"", ""Level"": ""Error""}") ?? new JsonObject()
+            new JsonObject([new("TimeGenerated", "2023-01-01T12:00:00Z"), new("Message", "Test log entry"), new("Level", "Info")]),
+            new JsonObject([new("TimeGenerated", "2023-01-01T12:01:00Z"), new("Message", "Another log entry"), new("Level", "Warning")]),
+            new JsonObject([new("TimeGenerated", "2023-01-01T12:02:00Z"), new("Message", "Error occurred"), new("Level", "Error")]),
         };
-        _monitorService.QueryWorkspaceLogs(
+        Service.QueryWorkspaceLogs(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -113,17 +91,20 @@ public sealed class WorkspaceLogQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockResults);
 
-        var args = _commandDefinition.Parse($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --resource-group {_knownResourceGroup} --table {_knownTable} --query \"{_knownQuery}\"");
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--workspace", _knownWorkspace,
+            "--resource-group", _knownResourceGroup,
+            "--table", _knownTable,
+            "--query", _knownQuery);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
         // Verify the mock was called
-        await _monitorService.Received(1).QueryWorkspaceLogs(
+        await Service.Received(1).QueryWorkspaceLogs(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -139,8 +120,8 @@ public sealed class WorkspaceLogQueryCommandTests
     public async Task ExecuteAsync_CallsServiceWithCorrectParameters()
     {
         // Arrange
-        var mockResults = new List<JsonNode> { JsonNode.Parse(@"{""result"": ""data""}") ?? new JsonObject() };
-        _monitorService.QueryWorkspaceLogs(
+        var mockResults = new List<JsonNode> { new JsonObject([new("result", "data")]) };
+        Service.QueryWorkspaceLogs(
             _knownSubscription,
             _knownWorkspace,
             _knownQuery,
@@ -152,14 +133,20 @@ public sealed class WorkspaceLogQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockResults);
 
-        var args = _commandDefinition.Parse($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --resource-group {_knownResourceGroup} --table {_knownTable} --query \"{_knownQuery}\" --hours {_knownHours} --limit {_knownLimit} --tenant {_knownTenant}");
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--workspace", _knownWorkspace,
+            "--resource-group", _knownResourceGroup,
+            "--table", _knownTable,
+            "--query", _knownQuery,
+            "--hours", _knownHours,
+            "--limit", _knownLimit,
+            "--tenant", _knownTenant);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _monitorService.Received(1).QueryWorkspaceLogs(
+        await Service.Received(1).QueryWorkspaceLogs(
             _knownSubscription,
             _knownWorkspace,
             _knownQuery,
@@ -175,8 +162,8 @@ public sealed class WorkspaceLogQueryCommandTests
     public async Task ExecuteAsync_WithDefaultParameters_UsesExpectedDefaults()
     {
         // Arrange
-        var mockResults = new List<JsonNode> { JsonNode.Parse(@"{""result"": ""data""}") ?? new JsonObject() };
-        _monitorService.QueryWorkspaceLogs(
+        var mockResults = new List<JsonNode> { new JsonObject([new("result", "data")]) };
+        Service.QueryWorkspaceLogs(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -188,14 +175,17 @@ public sealed class WorkspaceLogQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(mockResults);
 
-        var args = _commandDefinition.Parse($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --resource-group {_knownResourceGroup} --table {_knownTable} --query \"{_knownQuery}\"");
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--workspace", _knownWorkspace,
+            "--resource-group", _knownResourceGroup,
+            "--table", _knownTable,
+            "--query", _knownQuery);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _monitorService.Received(1).QueryWorkspaceLogs(
+        await Service.Received(1).QueryWorkspaceLogs(
             _knownSubscription,
             _knownWorkspace,
             _knownQuery,
@@ -211,7 +201,7 @@ public sealed class WorkspaceLogQueryCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _monitorService.QueryWorkspaceLogs(
+        Service.QueryWorkspaceLogs(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -221,12 +211,15 @@ public sealed class WorkspaceLogQueryCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<JsonNode>>(new Exception("Test error")));
-
-        var args = _commandDefinition.Parse($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --resource-group {_knownResourceGroup} --table {_knownTable} --query \"{_knownQuery}\"");
+            .ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--workspace", _knownWorkspace,
+            "--resource-group", _knownResourceGroup,
+            "--table", _knownTable,
+            "--query", _knownQuery);
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Metrics/MetricsDefinitionsCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Metrics/MetricsDefinitionsCommandTests.cs
@@ -5,64 +5,45 @@ using System.Net;
 using Azure.Mcp.Tools.Monitor.Commands.Metrics;
 using Azure.Mcp.Tools.Monitor.Models;
 using Azure.Mcp.Tools.Monitor.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.Metrics;
 
-public class MetricsDefinitionsCommandTests
+public class MetricsDefinitionsCommandTests : CommandUnitTestsBase<MetricsDefinitionsCommand, IMonitorMetricsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IMonitorMetricsService _service;
-    private readonly ILogger<MetricsDefinitionsCommand> _logger;
-    private readonly MetricsDefinitionsCommand _command;
-
-    public MetricsDefinitionsCommandTests()
-    {
-        _service = Substitute.For<IMonitorMetricsService>();
-        _logger = Substitute.For<ILogger<MetricsDefinitionsCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _service);
-    }
-
     #region Constructor and Command Setup Tests
 
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("definitions", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
-        Assert.Contains("List available metric definitions", command.Description);
+        Assert.Equal("definitions", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
+        Assert.Contains("List available metric definitions", CommandDefinition.Description);
     }
 
     [Fact]
     public void Name_ReturnsDefinitions()
     {
-        Assert.Equal("definitions", _command.Name);
+        Assert.Equal("definitions", Command.Name);
     }
 
     [Fact]
     public void Title_ReturnsCorrectTitle()
     {
-        Assert.Equal("List Azure Monitor Metric Definitions", _command.Title);
+        Assert.Equal("List Azure Monitor Metric Definitions", Command.Title);
     }
 
     [Fact]
     public void GetCommand_RegistersAllRequiredOptions()
     {
-        var command = _command.GetCommand();
-
         // Check that all required options are present
-        var optionNames = command.Options.Select(o => o.Name).ToList();
+        var optionNames = CommandDefinition.Options.Select(o => o.Name).ToList();
 
         Assert.Contains("--subscription", optionNames);
         Assert.Contains("--resource-type", optionNames);
@@ -88,7 +69,7 @@ public class MetricsDefinitionsCommandTests
         // Arrange
         if (shouldSucceed)
         {
-            _service.ListMetricDefinitionsAsync(
+            Service.ListMetricDefinitionsAsync(
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
@@ -113,11 +94,8 @@ public class MetricsDefinitionsCommandTests
                 ]);
         }
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
@@ -153,7 +131,7 @@ public class MetricsDefinitionsCommandTests
             }
         };
 
-        _service.ListMetricDefinitionsAsync(
+        Service.ListMetricDefinitionsAsync(
             "sub1",
             null, // resource-group may be null if not provided or not parsed from resource-id
             "Microsoft.Storage/storageAccounts",
@@ -165,18 +143,19 @@ public class MetricsDefinitionsCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResults);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse(
-            "--resource test --subscription sub1 --resource-type Microsoft.Storage/storageAccounts --metric-namespace Microsoft.Storage/storageAccounts --tenant tenant1");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--resource", "test",
+            "--subscription", "sub1",
+            "--resource-type", "Microsoft.Storage/storageAccounts",
+            "--metric-namespace", "Microsoft.Storage/storageAccounts",
+            "--tenant", "tenant1");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
         Assert.Equal("All 1 metric definitions returned.", response.Message);
-        await _service.Received(1).ListMetricDefinitionsAsync(
+        await Service.Received(1).ListMetricDefinitionsAsync(
             "sub1",
             null,
             "Microsoft.Storage/storageAccounts",
@@ -192,7 +171,7 @@ public class MetricsDefinitionsCommandTests
     public async Task ExecuteAsync_WithSearchString_CallsServiceWithSearchParameter()
     {
         // Arrange
-        _service.ListMetricDefinitionsAsync(
+        Service.ListMetricDefinitionsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -213,18 +192,18 @@ public class MetricsDefinitionsCommandTests
                 }
             ]);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--resource test --subscription sub1 --search-string cpu");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--resource", "test",
+            "--subscription", "sub1",
+            "--search-string", "cpu");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
         // Verify the service was called with the search string
-        await _service.Received(1).ListMetricDefinitionsAsync(
+        await Service.Received(1).ListMetricDefinitionsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -251,7 +230,7 @@ public class MetricsDefinitionsCommandTests
             }
         };
 
-        _service.ListMetricDefinitionsAsync(
+        Service.ListMetricDefinitionsAsync(
             "sub1",
             null, // resource-group may be null if not provided or not parsed from resource-id
             "Microsoft.Storage/storageAccounts",
@@ -263,18 +242,21 @@ public class MetricsDefinitionsCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResults);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse(
-            "--resource test --subscription sub1 --resource-type Microsoft.Storage/storageAccounts --metric-namespace Microsoft.Storage/storageAccounts --search-string memory --tenant tenant1 --limit 20");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--resource", "test",
+            "--subscription", "sub1",
+            "--resource-type", "Microsoft.Storage/storageAccounts",
+            "--metric-namespace", "Microsoft.Storage/storageAccounts",
+            "--search-string", "memory",
+            "--tenant", "tenant1",
+            "--limit", "20");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
         Assert.Equal("All 1 metric definitions returned.", response.Message);
-        await _service.Received(1).ListMetricDefinitionsAsync(
+        await Service.Received(1).ListMetricDefinitionsAsync(
             "sub1",
             null,
             "Microsoft.Storage/storageAccounts",
@@ -294,7 +276,7 @@ public class MetricsDefinitionsCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _service.ListMetricDefinitionsAsync(
+        Service.ListMetricDefinitionsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -304,13 +286,10 @@ public class MetricsDefinitionsCommandTests
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<MetricDefinition>>(new Exception("Test error")));
-
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--resource test --subscription sub1");
+            .ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "test", "--subscription", "sub1");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -323,7 +302,7 @@ public class MetricsDefinitionsCommandTests
     {
         // Arrange
         var exception = new Exception("Service unavailable");
-        _service.ListMetricDefinitionsAsync(
+        Service.ListMetricDefinitionsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -333,17 +312,17 @@ public class MetricsDefinitionsCommandTests
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<MetricDefinition>>(exception));
-
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--resource test --subscription sub1 --resource-group rg1");
+            .ThrowsAsync(exception);
 
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--resource", "test",
+            "--subscription", "sub1",
+            "--resource-group", "rg1");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
-        _logger.Received(1).Log(
+        Logger.Received(1).Log(
             LogLevel.Error,
             Arg.Any<EventId>(),
             Arg.Is<object>(o => o.ToString()!.Contains("Error listing metric definitions")),
@@ -383,7 +362,7 @@ public class MetricsDefinitionsCommandTests
             }
         };
 
-        _service.ListMetricDefinitionsAsync(
+        Service.ListMetricDefinitionsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -395,11 +374,8 @@ public class MetricsDefinitionsCommandTests
             Arg.Any<CancellationToken>())
             .Returns(metricDefinitions);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--resource test --subscription sub1");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "test", "--subscription", "sub1");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -411,7 +387,7 @@ public class MetricsDefinitionsCommandTests
     public async Task ExecuteAsync_WithNoResults_ReturnsNullResults()
     {
         // Arrange
-        _service.ListMetricDefinitionsAsync(
+        Service.ListMetricDefinitionsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -423,11 +399,8 @@ public class MetricsDefinitionsCommandTests
             Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--resource test --subscription sub1");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "test", "--subscription", "sub1");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -438,7 +411,7 @@ public class MetricsDefinitionsCommandTests
     public async Task ExecuteAsync_WithNullResults_ReturnsNullResults()
     {
         // Arrange
-        _service.ListMetricDefinitionsAsync(
+        Service.ListMetricDefinitionsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -450,11 +423,8 @@ public class MetricsDefinitionsCommandTests
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<List<MetricDefinition>>(null!));
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--resource test --subscription sub1");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "test", "--subscription", "sub1");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -471,7 +441,7 @@ public class MetricsDefinitionsCommandTests
         // Arrange
         var metricDefinitions = GenerateMetricDefinitions(15); // More than default limit of 10
 
-        _service.ListMetricDefinitionsAsync(
+        Service.ListMetricDefinitionsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -483,11 +453,8 @@ public class MetricsDefinitionsCommandTests
             Arg.Any<CancellationToken>())
             .Returns(metricDefinitions);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--resource test --subscription sub1");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "test", "--subscription", "sub1");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -496,7 +463,7 @@ public class MetricsDefinitionsCommandTests
         Assert.Contains("Results truncated to 10 of 15", response.Message);
         Assert.Contains("metric definitions", response.Message);
         // Verify service receives all data but command applies limit internally
-        await _service.Received(1).ListMetricDefinitionsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListMetricDefinitionsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -505,7 +472,7 @@ public class MetricsDefinitionsCommandTests
         // Arrange
         var metricDefinitions = GenerateMetricDefinitions(20);
 
-        _service.ListMetricDefinitionsAsync(
+        Service.ListMetricDefinitionsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -517,11 +484,8 @@ public class MetricsDefinitionsCommandTests
             Arg.Any<CancellationToken>())
             .Returns(metricDefinitions);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--resource test --subscription sub1 --limit 5");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "test", "--subscription", "sub1", "--limit", "5");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -530,7 +494,7 @@ public class MetricsDefinitionsCommandTests
         Assert.Contains("Results truncated to 5 of 20", response.Message);
         Assert.Contains("metric definitions", response.Message);
         // Verify service is called correctly
-        await _service.Received(1).ListMetricDefinitionsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListMetricDefinitionsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -539,7 +503,7 @@ public class MetricsDefinitionsCommandTests
         // Arrange - Create more results than the limit
         var metricDefinitions = GenerateMetricDefinitions(25);
 
-        _service.ListMetricDefinitionsAsync(
+        Service.ListMetricDefinitionsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -551,11 +515,8 @@ public class MetricsDefinitionsCommandTests
             Arg.Any<CancellationToken>())
             .Returns(metricDefinitions);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--resource test --subscription sub1 --limit 8");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "test", "--subscription", "sub1", "--limit", "8");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -564,7 +525,7 @@ public class MetricsDefinitionsCommandTests
         Assert.Contains("Results truncated to 8 of 25", response.Message);
         Assert.Contains("Use --search-string to filter results", response.Message);
         // Verify the service was called
-        await _service.Received(1).ListMetricDefinitionsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListMetricDefinitionsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -573,7 +534,7 @@ public class MetricsDefinitionsCommandTests
         // Arrange - Create fewer results than the limit
         var metricDefinitions = GenerateMetricDefinitions(3);
 
-        _service.ListMetricDefinitionsAsync(
+        Service.ListMetricDefinitionsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -585,11 +546,8 @@ public class MetricsDefinitionsCommandTests
             Arg.Any<CancellationToken>())
             .Returns(metricDefinitions);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--resource test --subscription sub1 --limit 10");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "test", "--subscription", "sub1", "--limit", "10");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -597,7 +555,7 @@ public class MetricsDefinitionsCommandTests
         // Verify that all results are returned without truncation
         Assert.Equal("All 3 metric definitions returned.", response.Message);
         // Verify the service was called
-        await _service.Received(1).ListMetricDefinitionsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListMetricDefinitionsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 
     #endregion
@@ -619,7 +577,7 @@ public class MetricsDefinitionsCommandTests
             }
         };
 
-        _service.ListMetricDefinitionsAsync(
+        Service.ListMetricDefinitionsAsync(
             "test-subscription",
             null, // resource-group may be null if not provided or not parsed from resource-id
             "Microsoft.Compute/virtualMachines",
@@ -631,18 +589,21 @@ public class MetricsDefinitionsCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResults);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse(
-            "--subscription test-subscription --resource-type Microsoft.Compute/virtualMachines --resource test-vm --metric-namespace Microsoft.Compute/virtualMachines --search-string performance --tenant test-tenant --limit 25");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "test-subscription",
+            "--resource-type", "Microsoft.Compute/virtualMachines",
+            "--resource", "test-vm",
+            "--metric-namespace", "Microsoft.Compute/virtualMachines",
+            "--search-string", "performance",
+            "--tenant", "test-tenant",
+            "--limit", "25");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
         Assert.Equal("All 1 metric definitions returned.", response.Message);
-        await _service.Received(1).ListMetricDefinitionsAsync(
+        await Service.Received(1).ListMetricDefinitionsAsync(
             "test-subscription",
             null,
             "Microsoft.Compute/virtualMachines",
@@ -663,7 +624,7 @@ public class MetricsDefinitionsCommandTests
         var definitions = new List<MetricDefinition>();
         for (int i = 0; i < count; i++)
         {
-            definitions.Add(new MetricDefinition
+            definitions.Add(new()
             {
                 Name = $"Metric{i}",
                 Description = $"Description for metric {i}",

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Metrics/MetricsQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Metrics/MetricsQueryCommandTests.cs
@@ -2,67 +2,44 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.Monitor.Commands;
 using Azure.Mcp.Tools.Monitor.Commands.Metrics;
 using Azure.Mcp.Tools.Monitor.Models;
 using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.Metrics;
 
-public class MetricsQueryCommandTests
+public class MetricsQueryCommandTests : CommandUnitTestsBase<MetricsQueryCommand, IMonitorMetricsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IMonitorMetricsService _service;
-    private readonly ILogger<MetricsQueryCommand> _logger;
-    private readonly MetricsQueryCommand _command;
-
-    public MetricsQueryCommandTests()
-    {
-        _service = Substitute.For<IMonitorMetricsService>();
-        _logger = Substitute.For<ILogger<MetricsQueryCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _service);
-    }
-
     #region Constructor and Properties Tests
 
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        // Act
-        var command = _command.GetCommand();
-
-        // Assert
-        Assert.Equal("query", command.Name);
-        Assert.Equal("Query Azure Monitor Metrics", _command.Title);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
-        Assert.Contains("Query Azure Monitor metrics for a resource", command.Description);
+        Assert.Equal("query", CommandDefinition.Name);
+        Assert.Equal("Query Azure Monitor Metrics", Command.Title);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
+        Assert.Contains("Query Azure Monitor metrics for a resource", CommandDefinition.Description);
     }
 
     [Fact]
     public void Name_ReturnsCorrectValue()
     {
-        // Act & Assert
-        Assert.Equal("query", _command.Name);
+        Assert.Equal("query", Command.Name);
     }
 
     [Fact]
     public void Title_ReturnsCorrectValue()
     {
-        // Act & Assert
-        Assert.Equal("Query Azure Monitor Metrics", _command.Title);
+        Assert.Equal("Query Azure Monitor Metrics", Command.Title);
     }
     #endregion
 
@@ -71,11 +48,7 @@ public class MetricsQueryCommandTests
     [Fact]
     public void RegisterOptions_AddsAllExpectedOptions()
     {
-        // Act
-        var command = _command.GetCommand();
-
-        // Assert - Check that all expected options are registered
-        var options = command.Options.Select(o => o.Name).ToList();
+        var options = CommandDefinition.Options.Select(o => o.Name).ToList();
 
         // Base options from BaseMetricsCommand
         Assert.Contains("--resource-group", options);
@@ -93,7 +66,7 @@ public class MetricsQueryCommandTests
         Assert.Contains("--max-buckets", options);
 
         // Verify required options are marked as required
-        var requiredOptions = command.Options.Where(o => o.Required).Select(o => o.Name).ToList();
+        var requiredOptions = CommandDefinition.Options.Where(o => o.Required).Select(o => o.Name).ToList();
         Assert.Contains("--resource", requiredOptions);
         Assert.Contains("--metric-names", requiredOptions);
     }
@@ -106,12 +79,7 @@ public class MetricsQueryCommandTests
     public async Task ExecuteAsync_BindsAllOptionsCorrectly()
     {
         // Arrange
-        var args = "--subscription sub1 --resource-group rg1 --resource-type Microsoft.Storage/storageAccounts --resource sa1 " +
-                   "--metric-names CPU,Memory --start-time 2023-01-01T00:00:00Z --end-time 2023-01-02T00:00:00Z " +
-                   "--interval PT1M --aggregation Average --filter \"dimension eq 'value'\" --metric-namespace Microsoft.Storage " +
-                   "--max-buckets 100";
-
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -128,14 +96,23 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse(args);
-
         // Act
-        await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource-group", "rg1",
+            "--resource-type", "Microsoft.Storage/storageAccounts",
+            "--resource", "sa1",
+            "--metric-names", "CPU,Memory",
+            "--start-time", "2023-01-01T00:00:00Z",
+            "--end-time", "2023-01-02T00:00:00Z",
+            "--interval", "PT1M",
+            "--aggregation", "Average",
+            "--filter", "dimension eq 'value'",
+            "--metric-namespace", "Microsoft.Storage",
+            "--max-buckets", "100");
 
         // Assert - Verify all parameters were passed correctly to the service
-        await _service.Received(1).QueryMetricsAsync(
+        await Service.Received(1).QueryMetricsAsync(
             "sub1", // subscription
             "rg1", // resource group
             "Microsoft.Storage/storageAccounts", // resource type
@@ -156,9 +133,7 @@ public class MetricsQueryCommandTests
     public async Task ExecuteAsync_HandlesOptionalParameters()
     {
         // Arrange
-        var args = "--subscription sub1 --resource sa1 --metric-names CPU --metric-namespace microsoft.compute/virtualmachines";
-
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -175,14 +150,15 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse(args);
-
         // Act
-        await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-names", "CPU",
+            "--metric-namespace", "microsoft.compute/virtualmachines");
 
         // Assert - Verify optional parameters are null when not provided
-        await _service.Received(1).QueryMetricsAsync(
+        await Service.Received(1).QueryMetricsAsync(
             Arg.Is<string>(t => t == "sub1"), // subscription
             Arg.Is<string?>(t => t == null), // resource group (not provided)
             Arg.Is<string?>(t => t == null), // resource type (not provided)
@@ -212,14 +188,12 @@ public class MetricsQueryCommandTests
     [InlineData(",CPU", false)]
     public async Task Validate_MetricNames_ValidatesCorrectly(string metricNames, bool shouldBeValid)
     {
-        // Arrange
-        var args = $"--subscription sub1 --resource sa1 --metric-namespace microsoft.compute/virtualmachines --metric-names \"{metricNames}\"";
-        var parseResult = _command.GetCommand().Parse(args);
-        var commandResult = parseResult.CommandResult;
-
-        var context = new CommandContext(_serviceProvider);
-        // Act
-        var result = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var result = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-namespace", "microsoft.compute/virtualmachines",
+            "--metric-names", metricNames);
 
         // Assert
         if (!shouldBeValid)
@@ -267,7 +241,7 @@ public class MetricsQueryCommandTests
             }
         };
 
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -284,32 +258,24 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResults);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-        Assert.Equal("Success", response.Message);
-
-        // Verify the actual content of the results
-        var results = GetResult(response.Results);
-        Assert.NotNull(results);
-        Assert.Single(results);
-        Assert.Equal("CPU", results[0].Name);
-        Assert.Equal("Percent", results[0].Unit);
-        Assert.Single(results[0].TimeSeries);
-        Assert.Equal([45.5, 50.2, 48.1], results[0].TimeSeries[0].AvgBuckets!);
+        var results = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.MetricsQueryCommandResult);
+        Assert.Single(results.Results);
+        var result = results.Results[0];
+        Assert.Equal("CPU", result.Name);
+        Assert.Equal("Percent", result.Unit);
+        Assert.Single(result.TimeSeries);
+        Assert.Equal([45.5, 50.2, 48.1], result.TimeSeries[0].AvgBuckets!);
     }
 
     [Fact]
     public async Task ExecuteAsync_EmptyResults_ReturnsSuccessWithEmptyResults()
     {
         // Arrange
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -326,26 +292,23 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names CPU --metric-namespace microsoft.compute/virtualmachines");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-names", "CPU",
+            "--metric-namespace", "microsoft.compute/virtualmachines");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        var results = GetResult(response.Results);
-        Assert.NotNull(results);
-        Assert.Empty(results);
+        var results = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.MetricsQueryCommandResult);
+        Assert.Empty(results.Results);
     }
 
     [Fact]
     public async Task ExecuteAsync_CallsServiceWithCorrectParameters()
     {
         // Arrange
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -360,19 +323,23 @@ public class MetricsQueryCommandTests
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
-            .Returns(new List<MetricResult>());
-
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse(
-            "--subscription sub1 --resource-group rg1 --resource-type Microsoft.Storage/storageAccounts --metric-namespace microsoft.compute/virtualmachines " +
-            "--resource sa1 --metric-names CPU,Memory --start-time 2023-01-01T00:00:00Z " +
-            "--end-time 2023-01-02T00:00:00Z --interval PT1M --aggregation Average");
+            .Returns([]);
 
         // Act
-        await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource-group", "rg1",
+            "--resource-type", "Microsoft.Storage/storageAccounts",
+            "--metric-namespace", "microsoft.compute/virtualmachines",
+            "--resource", "sa1",
+            "--metric-names", "CPU,Memory",
+            "--start-time", "2023-01-01T00:00:00Z",
+            "--end-time", "2023-01-02T00:00:00Z",
+            "--interval", "PT1M",
+            "--aggregation", "Average");
 
         // Assert
-        await _service.Received(1).QueryMetricsAsync(
+        await Service.Received(1).QueryMetricsAsync(
             "sub1",
             "rg1",
             "Microsoft.Storage/storageAccounts",
@@ -398,12 +365,8 @@ public class MetricsQueryCommandTests
     [InlineData("--subscription sub1 --resource sa1")] // Missing metric-names
     public async Task ExecuteAsync_InvalidInput_ReturnsBadRequest(string args)
     {
-        // Arrange
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse(args);
-
-        // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -439,7 +402,7 @@ public class MetricsQueryCommandTests
             }
         };
 
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -456,11 +419,12 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(resultsWithTooManyBuckets);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names CPU --metric-namespace microsoft.compute/virtualmachines");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-names", "CPU",
+            "--metric-namespace", "microsoft.compute/virtualmachines");
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -494,7 +458,7 @@ public class MetricsQueryCommandTests
             }
         };
 
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -511,11 +475,13 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(resultsWithTooManyBuckets);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names Memory --max-buckets 25 --metric-namespace microsoft.compute/virtualmachines");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-names", "Memory",
+            "--max-buckets", "25",
+            "--metric-namespace", "microsoft.compute/virtualmachines");
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -572,7 +538,7 @@ public class MetricsQueryCommandTests
             }
         };
 
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -589,11 +555,12 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(results);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names TestMetric --metric-namespace microsoft.compute/virtualmachines");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-names", "TestMetric",
+            "--metric-namespace", "microsoft.compute/virtualmachines");
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -624,7 +591,7 @@ public class MetricsQueryCommandTests
             }
         };
 
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -641,11 +608,12 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(resultsWithinLimit);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names CPU --metric-namespace microsoft.compute/virtualmachines");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-names", "CPU",
+            "--metric-namespace", "microsoft.compute/virtualmachines");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -676,7 +644,7 @@ public class MetricsQueryCommandTests
             }
         };
 
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -693,14 +661,15 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(resultsWithTooManyBuckets);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names CPU --metric-namespace microsoft.compute/virtualmachines");
-
         // Act
-        await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-names", "CPU",
+            "--metric-namespace", "microsoft.compute/virtualmachines");
 
         // Assert
-        _logger.Received(1).Log(
+        Logger.Received(1).Log(
             LogLevel.Warning,
             Arg.Any<EventId>(),
             Arg.Is<object>(o => o.ToString()!.Contains("Bucket limit exceeded")),
@@ -717,7 +686,7 @@ public class MetricsQueryCommandTests
     {
         // Arrange
         var expectedException = new Exception("Service unavailable");
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -734,11 +703,12 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(expectedException);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names CPU --metric-namespace microsoft.compute/virtualmachines");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-names", "CPU",
+            "--metric-namespace", "microsoft.compute/virtualmachines");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -751,7 +721,7 @@ public class MetricsQueryCommandTests
     {
         // Arrange
         var expectedException = new Exception("Service error");
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -768,14 +738,15 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(expectedException);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names CPU --metric-namespace microsoft.compute/virtualmachines");
-
         // Act
-        await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-names", "CPU",
+            "--metric-namespace", "microsoft.compute/virtualmachines");
 
         // Assert
-        _logger.Received(1).Log(
+        Logger.Received(1).Log(
             LogLevel.Error,
             Arg.Any<EventId>(),
             Arg.Is<object>(o => o.ToString()!.Contains("Error querying metrics")),
@@ -819,7 +790,7 @@ public class MetricsQueryCommandTests
             }
         };
 
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -836,11 +807,12 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(results);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names CPU,Memory --metric-namespace microsoft.compute/virtualmachines");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-names", "CPU,Memory",
+            "--metric-namespace", "microsoft.compute/virtualmachines");
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -872,7 +844,7 @@ public class MetricsQueryCommandTests
             }
         };
 
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -889,11 +861,12 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(results);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names CPU --metric-namespace microsoft.compute/virtualmachines");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-names", "CPU",
+            "--metric-namespace", "microsoft.compute/virtualmachines");
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -925,7 +898,7 @@ public class MetricsQueryCommandTests
             }
         };
 
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -942,11 +915,12 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(results);
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names CPU --metric-namespace microsoft.compute/virtualmachines");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-names", "CPU",
+            "--metric-namespace", "microsoft.compute/virtualmachines");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -957,7 +931,7 @@ public class MetricsQueryCommandTests
     public async Task ExecuteAsync_NullResults_ReturnsSuccessWithEmptyResults()
     {
         // Arrange
-        _service.QueryMetricsAsync(
+        Service.QueryMetricsAsync(
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -974,11 +948,12 @@ public class MetricsQueryCommandTests
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult((List<MetricResult>)null!));
 
-        var context = new CommandContext(_serviceProvider);
-        var parseResult = _command.GetCommand().Parse("--subscription sub1 --resource sa1 --metric-names CPU --metric-namespace microsoft.compute/virtualmachines");
-
         // Act
-        var response = await _command.ExecuteAsync(context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource", "sa1",
+            "--metric-names", "CPU",
+            "--metric-namespace", "microsoft.compute/virtualmachines");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -986,14 +961,4 @@ public class MetricsQueryCommandTests
     }
 
     #endregion
-
-    private List<MetricResult>? GetResult(ResponseResult? result)
-    {
-        if (result == null)
-        {
-            return null;
-        }
-        var json = JsonSerializer.Serialize(result);
-        return JsonSerializer.Deserialize(json, MonitorJsonContext.Default.MetricsQueryCommandResult)?.Results;
-    }
 }

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Metrics/MonitorMetricsServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Metrics/MonitorMetricsServiceTests.cs
@@ -32,14 +32,14 @@ public class MonitorMetricsServiceTests
 
         // Setup default behaviors
         _resourceResolverService.ResolveResourceIdAsync(
-                Arg.Any<string>(),
-                Arg.Any<string?>(),
-                Arg.Any<string?>(),
-                Arg.Any<string>(),
-                Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new ResourceIdentifier(TestResourceId)));
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new ResourceIdentifier(TestResourceId));
     }
 
     #region Constructor Tests
@@ -48,16 +48,14 @@ public class MonitorMetricsServiceTests
     public void Constructor_WithValidParameters_Succeeds()
     {
         // Act & Assert - Constructor should not throw
-        var service = new MonitorMetricsService(_resourceResolverService, _tenantService);
-        Assert.NotNull(service);
+        Assert.NotNull(_service);
     }
 
     [Fact]
     public void Constructor_WithNullResourceResolverService_ThrowsArgumentNullException()
     {
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() =>
-            new MonitorMetricsService(null!, _tenantService));
+        Assert.Throws<ArgumentNullException>(() => new MonitorMetricsService(null!, _tenantService));
     }
     #endregion
 
@@ -69,19 +67,14 @@ public class MonitorMetricsServiceTests
     [InlineData("not-a-date")]
     public async Task QueryMetricsAsync_WithInvalidStartTime_ThrowsException(string invalidStartTime)
     {
-        // Arrange
-        var metricNames = new[] { "Transactions" };
-        var metricNamespace = "Microsoft.Storage/storageAccounts";
-
-        // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
             _service.QueryMetricsAsync(
                 TestSubscription,
                 TestResourceGroup,
                 TestResourceType,
                 TestResourceName,
-                metricNamespace,
-                metricNames,
+                "Microsoft.Storage/storageAccounts",
+                ["Transactions"],
                 startTime: invalidStartTime,
                 cancellationToken: TestContext.Current.CancellationToken));
 
@@ -94,19 +87,14 @@ public class MonitorMetricsServiceTests
     [InlineData("not-a-date")]
     public async Task QueryMetricsAsync_WithInvalidEndTime_ThrowsArgumentException(string invalidEndTime)
     {
-        // Arrange
-        var metricNames = new[] { "Transactions" };
-        var metricNamespace = "Microsoft.Storage/storageAccounts";
-
-        // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
             _service.QueryMetricsAsync(
                 TestSubscription,
                 TestResourceGroup,
                 TestResourceType,
                 TestResourceName,
-                metricNamespace,
-                metricNames,
+                "Microsoft.Storage/storageAccounts",
+                ["Transactions"],
                 endTime: invalidEndTime,
                 cancellationToken: TestContext.Current.CancellationToken));
 
@@ -119,19 +107,14 @@ public class MonitorMetricsServiceTests
     [InlineData("1 hour")]
     public async Task QueryMetricsAsync_WithInvalidInterval_ThrowsException(string invalidInterval)
     {
-        // Arrange
-        var metricNames = new[] { "Transactions" };
-        var metricNamespace = "Microsoft.Storage/storageAccounts";
-
-        // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
             _service.QueryMetricsAsync(
                 TestSubscription,
                 TestResourceGroup,
                 TestResourceType,
                 TestResourceName,
-                metricNamespace,
-                metricNames,
+                "Microsoft.Storage/storageAccounts",
+                ["Transactions"],
                 interval: invalidInterval,
                 cancellationToken: TestContext.Current.CancellationToken));
 
@@ -143,19 +126,14 @@ public class MonitorMetricsServiceTests
     [InlineData("")]
     public async Task QueryMetricsAsync_WithNullOrEmptySubscription_ThrowsException(string? subscription)
     {
-        // Arrange
-        var metricNames = new[] { "Transactions" };
-        var metricNamespace = "Microsoft.Storage/storageAccounts";
-
-        // Act & Assert
         await Assert.ThrowsAsync<ArgumentException>(() =>
         _service.QueryMetricsAsync(
             subscription!,
             TestResourceGroup,
             TestResourceType,
             TestResourceName,
-            metricNamespace,
-            metricNames,
+            "Microsoft.Storage/storageAccounts",
+            ["Transactions"],
             cancellationToken: TestContext.Current.CancellationToken));
     }
 
@@ -164,21 +142,15 @@ public class MonitorMetricsServiceTests
     [InlineData("")]
     public async Task QueryMetricsAsync_WithNullOrEmptyResourceName_ThrowsArgumentException(string? resourceName)
     {
-        // Arrange
-        var metricNames = new[] { "Transactions" };
-        var metricNamespace = "Microsoft.Storage/storageAccounts";
-
-        // Act & Assert
         await Assert.ThrowsAsync<ArgumentException>(() =>
             _service.QueryMetricsAsync(
                 TestSubscription,
                 TestResourceGroup,
                 TestResourceType,
                 resourceName!,
-                metricNamespace,
-                metricNames,
-                cancellationToken: TestContext.Current.CancellationToken)
-            );
+                "Microsoft.Storage/storageAccounts",
+                ["Transactions"],
+                cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -215,8 +187,6 @@ public class MonitorMetricsServiceTests
     public async Task QueryMetricsAsync_WithResourceResolutionFailure_ThrowsException()
     {
         // Arrange
-        var metricNames = new[] { "Transactions" };
-        var metricNamespace = "Microsoft.Storage/storageAccounts";
         _resourceResolverService.ResolveResourceIdAsync(
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
@@ -234,8 +204,8 @@ public class MonitorMetricsServiceTests
                 TestResourceGroup,
                 TestResourceType,
                 TestResourceName,
-                metricNamespace,
-                metricNames,
+                "Microsoft.Storage/storageAccounts",
+                ["Transactions"],
                 cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Contains("Resource not found", exception.Message);

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Table/TableListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Table/TableListCommandTests.cs
@@ -1,47 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.Monitor.Commands;
 using Azure.Mcp.Tools.Monitor.Commands.Table;
 using Azure.Mcp.Tools.Monitor.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.Table;
 
-public sealed class TableListCommandTests
+public sealed class TableListCommandTests : CommandUnitTestsBase<TableListCommand, IMonitorService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IMonitorService _monitorService;
-    private readonly ILogger<TableListCommand> _logger;
-    private readonly TableListCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
     private const string _knownSubscription = "knownSubscription";
     private const string _knownWorkspace = "knownWorkspace";
     private const string _knownResourceGroupName = "knownResourceGroup";
     private const string _knownTableType = "CustomLog";
-
-    public TableListCommandTests()
-    {
-        _monitorService = Substitute.For<IMonitorService>();
-        _logger = Substitute.For<ILogger<TableListCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _monitorService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
 
     [Theory]
     [InlineData($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --table-type {_knownTableType} --resource-group {_knownResourceGroupName}", true)]
@@ -59,7 +36,7 @@ public sealed class TableListCommandTests
                 "AppRequests",
                 "AppDependencies"
             };
-            _monitorService.ListTables(
+            Service.ListTables(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -71,7 +48,7 @@ public sealed class TableListCommandTests
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse(args), TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
@@ -97,7 +74,7 @@ public sealed class TableListCommandTests
             "AppDependencies",
             "AppMetrics"
         };
-        _monitorService.ListTables(
+        Service.ListTables(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -107,21 +84,15 @@ public sealed class TableListCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedTables);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", _knownSubscription,
             "--workspace", _knownWorkspace,
-            "--resource-group", _knownResourceGroupName
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-group", _knownResourceGroupName);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
         // Verify the mock was called
-        await _monitorService.Received(1).ListTables(
+        await Service.Received(1).ListTables(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -130,10 +101,8 @@ public sealed class TableListCommandTests
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MonitorJsonContext.Default.TableListCommandResult);
+        var result = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.TableListCommandResult);
 
-        Assert.NotNull(result);
         Assert.Equal(expectedTables.Count, result.Tables.Count);
         Assert.Equal(expectedTables[0], result.Tables[0]);
         Assert.Equal(expectedTables[1], result.Tables[1]);
@@ -146,7 +115,7 @@ public sealed class TableListCommandTests
     {
         // Arrange
         var expectedTables = new List<string> { "CustomTable1", "CustomTable2" };
-        _monitorService.ListTables(
+        Service.ListTables(
             _knownSubscription,
             _knownResourceGroupName,
             _knownWorkspace,
@@ -156,19 +125,16 @@ public sealed class TableListCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedTables);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", _knownSubscription,
             "--workspace", _knownWorkspace,
             "--resource-group", _knownResourceGroupName,
-            "--table-type", _knownTableType
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--table-type", _knownTableType);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _monitorService.Received(1).ListTables(
+        await Service.Received(1).ListTables(
             _knownSubscription,
             _knownResourceGroupName,
             _knownWorkspace,
@@ -182,7 +148,7 @@ public sealed class TableListCommandTests
     public async Task ExecuteAsync_ReturnsEmptyWhenNoTables()
     {
         // Arrange
-        _monitorService.ListTables(
+        Service.ListTables(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -192,23 +158,15 @@ public sealed class TableListCommandTests
             Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", _knownSubscription,
             "--workspace", _knownWorkspace,
-            "--resource-group", _knownResourceGroupName
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-group", _knownResourceGroupName);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.TableListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MonitorJsonContext.Default.TableListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Tables);
     }
 
@@ -216,7 +174,7 @@ public sealed class TableListCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _monitorService.ListTables(
+        Service.ListTables(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -224,16 +182,13 @@ public sealed class TableListCommandTests
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<string>>(new Exception("Test error")));
-
-        var args = _commandDefinition.Parse([
-            "--subscription", _knownSubscription,
-            "--workspace", _knownWorkspace,
-            "--resource-group", _knownResourceGroupName
-        ]);
+            .ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--workspace", _knownWorkspace,
+            "--resource-group", _knownResourceGroupName);
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/TableType/TableTypeListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/TableType/TableTypeListCommandTests.cs
@@ -1,46 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.Monitor.Commands;
 using Azure.Mcp.Tools.Monitor.Commands.TableType;
 using Azure.Mcp.Tools.Monitor.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.TableType;
 
-public sealed class TableTypeListCommandTests
+public sealed class TableTypeListCommandTests : CommandUnitTestsBase<TableTypeListCommand, IMonitorService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IMonitorService _monitorService;
-    private readonly ILogger<TableTypeListCommand> _logger;
-    private readonly TableTypeListCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
     private const string _knownSubscription = "knownSubscription";
     private const string _knownWorkspace = "knownWorkspace";
     private const string _knownResourceGroup = "knownResourceGroup";
-
-    public TableTypeListCommandTests()
-    {
-        _monitorService = Substitute.For<IMonitorService>();
-        _logger = Substitute.For<ILogger<TableTypeListCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _monitorService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
 
     [Theory]
     [InlineData($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --resource-group {_knownResourceGroup}", true)]
@@ -57,7 +34,7 @@ public sealed class TableTypeListCommandTests
                 "AzureMetrics",
                 "SystemEvents"
             };
-            _monitorService.ListTableTypes(
+            Service.ListTableTypes(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -68,7 +45,7 @@ public sealed class TableTypeListCommandTests
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse(args), TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
@@ -94,7 +71,7 @@ public sealed class TableTypeListCommandTests
             "SystemEvents",
             "ApplicationEvents"
         };
-        _monitorService.ListTableTypes(
+        Service.ListTableTypes(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -103,21 +80,15 @@ public sealed class TableTypeListCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedTableTypes);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", _knownSubscription,
             "--workspace", _knownWorkspace,
-            "--resource-group", _knownResourceGroup
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-group", _knownResourceGroup);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
         // Verify the mock was called
-        await _monitorService.Received(1).ListTableTypes(
+        await Service.Received(1).ListTableTypes(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -125,10 +96,8 @@ public sealed class TableTypeListCommandTests
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MonitorJsonContext.Default.TableTypeListCommandResult);
+        var result = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.TableTypeListCommandResult);
 
-        Assert.NotNull(result);
         Assert.Equal(expectedTableTypes.Count, result.TableTypes.Count);
         Assert.Equal(expectedTableTypes[0], result.TableTypes[0]);
         Assert.Equal(expectedTableTypes[1], result.TableTypes[1]);
@@ -141,7 +110,7 @@ public sealed class TableTypeListCommandTests
     {
         // Arrange
         var expectedTableTypes = new List<string> { "CustomLog", "AzureMetrics" };
-        _monitorService.ListTableTypes(
+        Service.ListTableTypes(
             _knownSubscription,
             _knownResourceGroup,
             _knownWorkspace,
@@ -150,18 +119,15 @@ public sealed class TableTypeListCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedTableTypes);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", _knownSubscription,
             "--workspace", _knownWorkspace,
-            "--resource-group", _knownResourceGroup
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-group", _knownResourceGroup);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _monitorService.Received(1).ListTableTypes(
+        await Service.Received(1).ListTableTypes(
             _knownSubscription,
             _knownResourceGroup,
             _knownWorkspace,
@@ -174,7 +140,7 @@ public sealed class TableTypeListCommandTests
     public async Task ExecuteAsync_ReturnsEmptyWhenNoTableTypes()
     {
         // Arrange
-        _monitorService.ListTableTypes(
+        Service.ListTableTypes(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -183,23 +149,14 @@ public sealed class TableTypeListCommandTests
             Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var args = _commandDefinition.Parse([
+        // Act
+        var response = await ExecuteCommandAsync(
             "--subscription", _knownSubscription,
             "--workspace", _knownWorkspace,
-            "--resource-group", _knownResourceGroup
-        ]);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-group", _knownResourceGroup);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MonitorJsonContext.Default.TableTypeListCommandResult);
-
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.TableTypeListCommandResult);
         Assert.Empty(result.TableTypes);
     }
 
@@ -207,23 +164,20 @@ public sealed class TableTypeListCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _monitorService.ListTableTypes(
+        Service.ListTableTypes(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<string>>(new Exception("Test error")));
-
-        var args = _commandDefinition.Parse([
-            "--subscription", _knownSubscription,
-            "--workspace", _knownWorkspace,
-            "--resource-group", _knownResourceGroup
-        ]);
+            .ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", _knownSubscription,
+            "--workspace", _knownWorkspace,
+            "--resource-group", _knownResourceGroup);
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsCreateOrUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsCreateOrUpdateCommandTests.cs
@@ -1,70 +1,48 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
+using Azure.Mcp.Tools.Monitor.Commands;
 using Azure.Mcp.Tools.Monitor.Commands.WebTests;
 using Azure.Mcp.Tools.Monitor.Models.WebTests;
 using Azure.Mcp.Tools.Monitor.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.WebTests;
 
-public class WebTestsCreateOrUpdateCommandTests
+public class WebTestsCreateOrUpdateCommandTests : CommandUnitTestsBase<WebTestsCreateOrUpdateCommand, IMonitorWebTestService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IMonitorWebTestService _service;
-    private readonly ILogger<WebTestsCreateOrUpdateCommand> _logger;
-    private readonly WebTestsCreateOrUpdateCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public WebTestsCreateOrUpdateCommandTests()
-    {
-        _service = Substitute.For<IMonitorWebTestService>();
-        _logger = Substitute.For<ILogger<WebTestsCreateOrUpdateCommand>>();
-
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-        _command = new(_logger, _service);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     #region Constructor and Properties Tests
 
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("createorupdate", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
-        Assert.Contains("Create or update", command.Description);
+        Assert.Equal("createorupdate", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
+        Assert.Contains("Create or update", CommandDefinition.Description);
     }
 
     [Fact]
     public void Name_ReturnsCorrectValue()
     {
-        Assert.Equal("createorupdate", _command.Name);
+        Assert.Equal("createorupdate", Command.Name);
     }
 
     [Fact]
     public void Title_ReturnsCorrectValue()
     {
-        Assert.Equal("Create or update a web test in Azure Monitor", _command.Title);
+        Assert.Equal("Create or update a web test in Azure Monitor", Command.Title);
     }
 
     [Fact]
     public void Description_ContainsRequiredInformation()
     {
-        var description = _command.Description;
+        var description = Command.Description;
         Assert.Contains("Create or update", description);
         Assert.Contains("standard web test", description);
     }
@@ -72,7 +50,7 @@ public class WebTestsCreateOrUpdateCommandTests
     [Fact]
     public void Metadata_IsConfiguredCorrectly()
     {
-        var metadata = _command.Metadata;
+        var metadata = Command.Metadata;
         Assert.True(metadata.Destructive);
         Assert.True(metadata.Idempotent);
         Assert.False(metadata.ReadOnly);
@@ -88,8 +66,7 @@ public class WebTestsCreateOrUpdateCommandTests
     [Fact]
     public void RegisterOptions_AddsAllExpectedOptions()
     {
-        var command = _command.GetCommand();
-        var options = command.Options.Select(o => o.Name).ToList();
+        var options = CommandDefinition.Options.Select(o => o.Name).ToList();
 
         // Required base options
         Assert.Contains("--subscription", options);
@@ -108,7 +85,7 @@ public class WebTestsCreateOrUpdateCommandTests
         Assert.Contains("--timeout", options);
 
         // Verify required options are marked as required
-        var requiredOptions = command.Options.Where(o => o.Required).Select(o => o.Name).ToList();
+        var requiredOptions = CommandDefinition.Options.Where(o => o.Required).Select(o => o.Name).ToList();
         Assert.Contains("--resource-group", requiredOptions);
         Assert.Contains("--webtest-resource", requiredOptions);
     }
@@ -142,10 +119,10 @@ public class WebTestsCreateOrUpdateCommandTests
         };
 
         // Setup GetWebTest to throw (resource doesn't exist - CREATE scenario)
-        _service.GetWebTest("sub1", "rg1", "newwebtest", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetWebTest("sub1", "rg1", "newwebtest", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Resource not found"));
 
-        _service.CreateWebTest(
+        Service.CreateWebTest(
             "sub1",
             "rg1",
             "newwebtest",
@@ -173,20 +150,15 @@ public class WebTestsCreateOrUpdateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-        Assert.Equal("Success", response.Message);
+        var result = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.WebTestsCreateOrUpdateCommandResult);
 
-        var result = GetResult(response.Results);
-        Assert.NotNull(result);
-        Assert.Equal("newwebtest", result.ResourceName);
-        Assert.Equal("eastus", result.Location);
+        Assert.NotNull(result.WebTest);
+        Assert.Equal("newwebtest", result.WebTest.ResourceName);
+        Assert.Equal("eastus", result.WebTest.Location);
     }
 
     [Fact]
@@ -201,13 +173,11 @@ public class WebTestsCreateOrUpdateCommandTests
         };
 
         // Setup GetWebTest to throw (resource doesn't exist - CREATE scenario)
-        _service.GetWebTest("sub1", "rg1", "newwebtest", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetWebTest("sub1", "rg1", "newwebtest", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Resource not found"));
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert - Command catches validation errors and returns InternalServerError
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -252,10 +222,10 @@ public class WebTestsCreateOrUpdateCommandTests
         };
 
         // Setup GetWebTest to return existing resource (UPDATE scenario)
-        _service.GetWebTest("sub1", "rg1", "existingwebtest", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetWebTest("sub1", "rg1", "existingwebtest", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(existingWebTest);
 
-        _service.UpdateWebTest(
+        Service.UpdateWebTest(
             "sub1",
             "rg1",
             "existingwebtest",
@@ -283,20 +253,16 @@ public class WebTestsCreateOrUpdateCommandTests
             Arg.Any<CancellationToken>())
             .Returns(updatedWebTest);
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.WebTestsCreateOrUpdateCommandResult);
 
-        var result = GetResult(response.Results);
-        Assert.NotNull(result);
-        Assert.Equal("existingwebtest", result.ResourceName);
-        Assert.False(result.IsEnabled);
-        Assert.Equal(600, result.FrequencyInSeconds);
+        Assert.NotNull(result.WebTest);
+        Assert.Equal("existingwebtest", result.WebTest.ResourceName);
+        Assert.False(result.WebTest.IsEnabled);
+        Assert.Equal(600, result.WebTest.FrequencyInSeconds);
     }
 
     #endregion
@@ -310,12 +276,8 @@ public class WebTestsCreateOrUpdateCommandTests
     [InlineData("--resource-group rg1 --webtest-resource test1")]         // Missing subscription
     public async Task ExecuteAsync_MissingRequiredParameters_ReturnsBadRequest(string args)
     {
-        // Arrange
-        var argArray = string.IsNullOrEmpty(args) ? Array.Empty<string>() : args.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        var parseResult = _commandDefinition.Parse(argArray);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -325,22 +287,6 @@ public class WebTestsCreateOrUpdateCommandTests
     #endregion
 
     #region ExecuteAsync Tests - Error Handling
-
-    #endregion
-
-    #region Helper Methods
-
-    private WebTestDetailedInfo? GetResult(ResponseResult? result)
-    {
-        if (result == null)
-        {
-            return null;
-        }
-        var json = JsonSerializer.Serialize(result);
-        return JsonSerializer.Deserialize<WebTestsCreateOrUpdateCommandResult>(json)?.webTest;
-    }
-
-    private record WebTestsCreateOrUpdateCommandResult(WebTestDetailedInfo webTest);
 
     #endregion
 }

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsGetCommandTests.cs
@@ -1,70 +1,49 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
+using Azure.Mcp.Tools.Monitor.Commands;
 using Azure.Mcp.Tools.Monitor.Commands.WebTests;
 using Azure.Mcp.Tools.Monitor.Models.WebTests;
 using Azure.Mcp.Tools.Monitor.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.WebTests;
 
-public class WebTestsGetCommandTests
+public class WebTestsGetCommandTests : CommandUnitTestsBase<WebTestsGetCommand, IMonitorWebTestService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IMonitorWebTestService _service;
-    private readonly ILogger<WebTestsGetCommand> _logger;
-    private readonly WebTestsGetCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public WebTestsGetCommandTests()
-    {
-        _service = Substitute.For<IMonitorWebTestService>();
-        _logger = Substitute.For<ILogger<WebTestsGetCommand>>();
-
-        _serviceProvider = new ServiceCollection().BuildServiceProvider();
-        _command = new(_logger, _service);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     #region Constructor and Properties Tests
 
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("get", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
-        Assert.Contains("Gets details for a specific web test", command.Description);
+        Assert.Equal("get", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
+        Assert.Contains("Gets details for a specific web test", CommandDefinition.Description);
     }
 
     [Fact]
     public void Name_ReturnsCorrectValue()
     {
-        Assert.Equal("get", _command.Name);
+        Assert.Equal("get", Command.Name);
     }
 
     [Fact]
     public void Title_ReturnsCorrectValue()
     {
-        Assert.Equal("Get or list web tests", _command.Title);
+        Assert.Equal("Get or list web tests", Command.Title);
     }
 
     [Fact]
     public void Description_ContainsRequiredInformation()
     {
-        var description = _command.Description;
+        var description = Command.Description;
         Assert.Contains("specific web test or lists all web tests", description);
         Assert.Contains("--webtest-resource is provided", description);
         Assert.Contains("--webtest-resource is omitted", description);
@@ -73,7 +52,7 @@ public class WebTestsGetCommandTests
     [Fact]
     public void Metadata_IsConfiguredCorrectly()
     {
-        var metadata = _command.Metadata;
+        var metadata = Command.Metadata;
         Assert.False(metadata.Destructive);
         Assert.True(metadata.Idempotent);
         Assert.True(metadata.ReadOnly);
@@ -89,8 +68,7 @@ public class WebTestsGetCommandTests
     [Fact]
     public void RegisterOptions_AddsAllExpectedOptions()
     {
-        var command = _command.GetCommand();
-        var options = command.Options.Select(o => o.Name).ToList();
+        var options = CommandDefinition.Options.Select(o => o.Name).ToList();
 
         // Base options from BaseMonitorWebTestsCommand (subscription from SubscriptionCommand)
         Assert.Contains("--subscription", options);
@@ -100,7 +78,7 @@ public class WebTestsGetCommandTests
         Assert.Contains("--webtest-resource", options);
 
         // Verify webtest-resource is optional (for list functionality)
-        var requiredOptions = command.Options.Where(o => o.Required).Select(o => o.Name).ToList();
+        var requiredOptions = CommandDefinition.Options.Where(o => o.Required).Select(o => o.Name).ToList();
         Assert.DoesNotContain("--webtest-resource", requiredOptions);
     }
 
@@ -112,7 +90,6 @@ public class WebTestsGetCommandTests
     public async Task ExecuteAsync_BindsAllOptionsCorrectly()
     {
         // Arrange
-        var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1" };
         var expectedResult = new WebTestDetailedInfo
         {
             ResourceName = "webtest1",
@@ -121,16 +98,17 @@ public class WebTestsGetCommandTests
             Id = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/webtests/webtest1"
         };
 
-        _service.GetWebTest("sub1", "rg1", "webtest1", null, Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetWebTest("sub1", "rg1", "webtest1", null, Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource-group", "rg1",
+            "--webtest-resource", "webtest1");
 
         // Assert
-        await _service.Received(1).GetWebTest("sub1", "rg1", "webtest1", null, Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).GetWebTest("sub1", "rg1", "webtest1", null, Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 
     #endregion
@@ -141,7 +119,6 @@ public class WebTestsGetCommandTests
     public async Task ExecuteAsync_ValidInput_ReturnsSuccess()
     {
         // Arrange
-        var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1" };
         var expectedResult = new WebTestDetailedInfo
         {
             ResourceName = "webtest1",
@@ -157,38 +134,32 @@ public class WebTestsGetCommandTests
             AppInsightsComponentId = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Insights/components/appinsights1"
         };
 
-        _service.GetWebTest("sub1", "rg1", "webtest1", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetWebTest("sub1", "rg1", "webtest1", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource-group", "rg1",
+            "--webtest-resource", "webtest1");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-        Assert.Equal("Success", response.Message);
+        var result = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.WebTestsGetCommandResult);
 
-        // Verify the actual content of the results
-        var result = GetResult(response.Results);
-        Assert.NotNull(result);
-        Assert.Equal("webtest1", result.ResourceName);
-        Assert.Equal("eastus", result.Location);
-        Assert.Equal("ping", result.Kind);
-        Assert.Equal(300, result.FrequencyInSeconds);
-        Assert.Equal(30, result.TimeoutInSeconds);
-        Assert.True(result.IsEnabled);
+        Assert.NotNull(result.WebTest);
+        Assert.Equal("webtest1", result.WebTest.ResourceName);
+        Assert.Equal("eastus", result.WebTest.Location);
+        Assert.Equal("ping", result.WebTest.Kind);
+        Assert.Equal(300, result.WebTest.FrequencyInSeconds);
+        Assert.Equal(30, result.WebTest.TimeoutInSeconds);
+        Assert.True(result.WebTest.IsEnabled);
     }
 
     [Fact]
     public async Task ExecuteAsync_WebTestNotFound_ReturnsNotFound()
     {
         // Arrange
-        var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "nonexistent" };
-
-        // The service throws an exception when a web test is not found (as seen in implementation)
-        _service.GetWebTest(
+        Service.GetWebTest(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -197,10 +168,11 @@ public class WebTestsGetCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Error retrieving details for web test 'nonexistent'"));
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource-group", "rg1",
+            "--webtest-resource", "nonexistent");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status); // Exception handling returns 500, not 404
@@ -217,16 +189,17 @@ public class WebTestsGetCommandTests
             Location = "eastus"
         };
 
-        _service.GetWebTest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetWebTest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
-        var parseResult = _commandDefinition.Parse(["--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1"]);
-
         // Act
-        await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource-group", "rg1",
+            "--webtest-resource", "webtest1");
 
         // Assert
-        await _service.Received(1).GetWebTest("sub1", "rg1", "webtest1", null, Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).GetWebTest("sub1", "rg1", "webtest1", null, Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 
     #endregion
@@ -239,12 +212,8 @@ public class WebTestsGetCommandTests
     [InlineData("--webtest-resource webtest1")]                            // Missing subscription
     public async Task ExecuteAsync_InvalidInput_ReturnsBadRequest(string args)
     {
-        // Arrange
-        var argArray = string.IsNullOrEmpty(args) ? Array.Empty<string>() : args.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        var parseResult = _commandDefinition.Parse(argArray);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
@@ -260,7 +229,6 @@ public class WebTestsGetCommandTests
     public async Task ExecuteAsync_ListAllWebTests_ReturnsSuccess()
     {
         // Arrange
-        var args = new string[] { "--subscription", "sub1" };
         var expectedResults = new List<WebTestSummaryInfo>
         {
             new()
@@ -277,32 +245,25 @@ public class WebTestsGetCommandTests
             }
         };
 
-        _service.ListWebTests("sub1", null, Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ListWebTests("sub1", null, Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedResults);
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub1");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-        Assert.Equal("Success", response.Message);
+        var results = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.WebTestsGetCommandListResult);
 
-        // Verify the actual content of the results
-        var results = GetListResult(response.Results);
-        Assert.NotNull(results);
-        Assert.Equal(2, results.Count);
-        Assert.Equal("webtest1", results[0].ResourceName);
-        Assert.Equal("webtest2", results[1].ResourceName);
+        Assert.NotNull(results.WebTests);
+        Assert.Equal(2, results.WebTests.Count);
+        Assert.Equal("webtest1", results.WebTests[0].ResourceName);
+        Assert.Equal("webtest2", results.WebTests[1].ResourceName);
     }
 
     [Fact]
     public async Task ExecuteAsync_ListWebTestsWithResourceGroup_ReturnsFilteredResults()
     {
         // Arrange
-        var args = new string[] { "--subscription", "sub1", "--resource-group", "rg1" };
         var expectedResults = new List<WebTestSummaryInfo>
         {
             new()
@@ -313,41 +274,33 @@ public class WebTestsGetCommandTests
             }
         };
 
-        _service.ListWebTests("sub1", "rg1", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ListWebTests("sub1", "rg1", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns(expectedResults);
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub1", "--resource-group", "rg1");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var results = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.WebTestsGetCommandListResult);
 
-        var results = GetListResult(response.Results);
-        Assert.NotNull(results);
-        Assert.Single(results);
-        Assert.Equal("webtest1", results[0].ResourceName);
-        Assert.Equal("rg1", results[0].ResourceGroup);
+        Assert.NotNull(results.WebTests);
+        Assert.Single(results.WebTests);
+        Assert.Equal("webtest1", results.WebTests[0].ResourceName);
+        Assert.Equal("rg1", results.WebTests[0].ResourceGroup);
     }
 
     [Fact]
     public async Task ExecuteAsync_ListCallsServiceWithCorrectParameters()
     {
         // Arrange
-        var expectedResults = new List<WebTestSummaryInfo>();
-
-        _service.ListWebTests(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(expectedResults);
-
-        var parseResult = _commandDefinition.Parse(["--subscription", "sub1", "--resource-group", "rg1"]);
+        Service.ListWebTests(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns([]);
 
         // Act
-        await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        await ExecuteCommandAsync("--subscription", "sub1", "--resource-group", "rg1"); 
 
         // Assert
-        await _service.Received(1).ListWebTests("sub1", "rg1", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListWebTests("sub1", "rg1", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
     }
 
     #endregion
@@ -359,7 +312,7 @@ public class WebTestsGetCommandTests
     {
         // Arrange
         var expectedException = new Exception("Service unavailable");
-        _service.GetWebTest(
+        Service.GetWebTest(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -368,10 +321,11 @@ public class WebTestsGetCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(expectedException);
 
-        var parseResult = _commandDefinition.Parse(["--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1"]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource-group", "rg1",
+            "--webtest-resource", "webtest1");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -384,7 +338,7 @@ public class WebTestsGetCommandTests
     {
         // Arrange
         var expectedException = new Exception("Service error");
-        _service.GetWebTest(
+        Service.GetWebTest(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -393,46 +347,20 @@ public class WebTestsGetCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(expectedException);
 
-        var parseResult = _commandDefinition.Parse(["--subscription", "sub1", "--resource-group", "rg1", "--webtest-resource", "webtest1"]);
-
         // Act
-        await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        await ExecuteCommandAsync(
+            "--subscription", "sub1",
+            "--resource-group", "rg1",
+            "--webtest-resource", "webtest1");
 
         // Assert
-        _logger.Received(1).Log(
+        Logger.Received(1).Log(
             LogLevel.Error,
             Arg.Any<EventId>(),
             Arg.Is<object>(o => o.ToString()!.Contains("Error retrieving web test")),
             expectedException,
             Arg.Any<Func<object, Exception?, string>>());
     }
-
-    #endregion
-
-    #region Helper Methods
-
-    private WebTestDetailedInfo? GetResult(ResponseResult? result)
-    {
-        if (result == null)
-        {
-            return null;
-        }
-        var json = JsonSerializer.Serialize(result);
-        return JsonSerializer.Deserialize<WebTestsGetCommandResult>(json)?.webTest;
-    }
-
-    private List<WebTestSummaryInfo>? GetListResult(ResponseResult? result)
-    {
-        if (result == null)
-        {
-            return null;
-        }
-        var json = JsonSerializer.Serialize(result);
-        return JsonSerializer.Deserialize<WebTestsGetCommandListResult>(json)?.webTests;
-    }
-
-    private record WebTestsGetCommandResult(WebTestDetailedInfo webTest);
-    private record WebTestsGetCommandListResult(List<WebTestSummaryInfo> webTests);
 
     #endregion
 }

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsGetCommandTests.cs
@@ -297,7 +297,7 @@ public class WebTestsGetCommandTests : CommandUnitTestsBase<WebTestsGetCommand, 
             .Returns([]);
 
         // Act
-        await ExecuteCommandAsync("--subscription", "sub1", "--resource-group", "rg1"); 
+        await ExecuteCommandAsync("--subscription", "sub1", "--resource-group", "rg1");
 
         // Assert
         await Service.Received(1).ListWebTests("sub1", "rg1", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Workspace/WorkspaceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Workspace/WorkspaceListCommandTests.cs
@@ -1,46 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.Monitor.Commands;
 using Azure.Mcp.Tools.Monitor.Commands.Workspace;
 using Azure.Mcp.Tools.Monitor.Models;
 using Azure.Mcp.Tools.Monitor.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.UnitTests.Workspace;
 
-public sealed class WorkspaceListCommandTests
+public sealed class WorkspaceListCommandTests : CommandUnitTestsBase<WorkspaceListCommand, IMonitorService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IMonitorService _monitorService;
-    private readonly ILogger<WorkspaceListCommand> _logger;
-    private readonly WorkspaceListCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-
     private const string _knownSubscription = "knownSubscription";
-
-    public WorkspaceListCommandTests()
-    {
-        _monitorService = Substitute.For<IMonitorService>();
-        _logger = Substitute.For<ILogger<WorkspaceListCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _command = new(_logger, _monitorService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
 
     [Theory]
     [InlineData($"--subscription {_knownSubscription}", true)]
@@ -56,12 +32,12 @@ public sealed class WorkspaceListCommandTests
                 new() { Name = "workspace1", CustomerId = "guid1" },
                 new() { Name = "workspace2", CustomerId = "guid2" }
             };
-            _monitorService.ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Service.ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
                 .Returns(testWorkspaces);
         }
 
         // Act
-        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse(args), TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
@@ -86,23 +62,18 @@ public sealed class WorkspaceListCommandTests
             new() { Name = "workspace2", CustomerId = "guid2" },
             new() { Name = "workspace3", CustomerId = "guid3" }
         };
-        _monitorService.ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedWorkspaces);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse($"--subscription {_knownSubscription}"), TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync($"--subscription {_knownSubscription}");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
         // Verify the mock was called
-        await _monitorService.Received(1).ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MonitorJsonContext.Default.WorkspaceListCommandResult);
+        var result = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.WorkspaceListCommandResult);
 
-        Assert.NotNull(result);
         Assert.Equal(expectedWorkspaces.Count, result.Workspaces.Count);
         Assert.Equal(expectedWorkspaces[0].Name, result.Workspaces[0].Name);
         Assert.Equal(expectedWorkspaces[0].CustomerId, result.Workspaces[0].CustomerId);
@@ -114,20 +85,15 @@ public sealed class WorkspaceListCommandTests
     public async Task ExecuteAsync_ReturnsEmptyWhenNoWorkspaces()
     {
         // Arrange
-        _monitorService.ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse($"--subscription {_knownSubscription}"), TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync($"--subscription {_knownSubscription}");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.WorkspaceListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MonitorJsonContext.Default.WorkspaceListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Workspaces);
     }
 
@@ -135,11 +101,11 @@ public sealed class WorkspaceListCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _monitorService.ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<WorkspaceInfo>>(new Exception("Test error")));
+        Service.ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, _commandDefinition.Parse($"--subscription {_knownSubscription}"), TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync($"--subscription {_knownSubscription}");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Database/DatabaseQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Database/DatabaseQueryCommandTests.cs
@@ -2,78 +2,48 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.MySql.Commands;
 using Azure.Mcp.Tools.MySql.Commands.Database;
 using Azure.Mcp.Tools.MySql.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.MySql.UnitTests.Database;
 
-public class DatabaseQueryCommandTests
+public class DatabaseQueryCommandTests : CommandUnitTestsBase<DatabaseQueryCommand, IMySqlService>
 {
-
-    private readonly IMySqlService _mysqlService;
-    private readonly ILogger<DatabaseQueryCommand> _logger;
-
-    public DatabaseQueryCommandTests()
-    {
-        _mysqlService = Substitute.For<IMySqlService>();
-        _logger = Substitute.For<ILogger<DatabaseQueryCommand>>();
-
-    }
-
     [Fact]
     public async Task ExecuteAsync_ReturnsResults_WhenQuerySucceeds()
     {
         var expectedResults = new List<string> { "id, name", "1, John", "2, Jane" };
-        _mysqlService.ExecuteQueryAsync("sub123", "rg1", "user1", "server1", "db1", "SELECT * FROM users", Arg.Any<CancellationToken>()).Returns(expectedResults);
+        Service.ExecuteQueryAsync("sub123", "rg1", "user1", "server1", "db1", "SELECT * FROM users", Arg.Any<CancellationToken>()).Returns(expectedResults);
 
-        var command = new DatabaseQueryCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
             "--server", "server1",
             "--database", "db1",
-            "--query", "SELECT * FROM users"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
+            "--query", "SELECT * FROM users");
 
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
-
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MySqlJsonContext.Default.DatabaseQueryCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, MySqlJsonContext.Default.DatabaseQueryCommandResult);
         Assert.Equal(expectedResults, result.Results);
     }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenQueryFails()
     {
-        _mysqlService.ExecuteQueryAsync("sub123", "rg1", "user1", "server1", "db1", "INVALID SQL", Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException("Syntax error"));
+        Service.ExecuteQueryAsync("sub123", "rg1", "user1", "server1", "db1", "INVALID SQL", Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException("Syntax error"));
 
-        var command = new DatabaseQueryCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
             "--server", "server1",
             "--database", "db1",
-            "--query", "INVALID SQL"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
-
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--query", "INVALID SQL");
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -83,9 +53,7 @@ public class DatabaseQueryCommandTests
     [Fact]
     public void Metadata_IsConfiguredCorrectly()
     {
-        var command = new DatabaseQueryCommand(_logger, _mysqlService);
-
-        Assert.False(command.Metadata.Destructive);
-        Assert.True(command.Metadata.ReadOnly);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
     }
 }

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/MySqlListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/MySqlListCommandTests.cs
@@ -2,53 +2,29 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.MySql.Commands;
 using Azure.Mcp.Tools.MySql.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.MySql.UnitTests;
 
-public class MySqlListCommandTests
+public class MySqlListCommandTests : CommandUnitTestsBase<MySqlListCommand, IMySqlService>
 {
-    private readonly IMySqlService _mysqlService;
-    private readonly ILogger<MySqlListCommand> _logger;
-
-    public MySqlListCommandTests()
-    {
-        _mysqlService = Substitute.For<IMySqlService>();
-        _logger = Substitute.For<ILogger<MySqlListCommand>>();
-    }
-
     [Fact]
     public async Task ExecuteAsync_ListsServers_WhenNoServerOrDatabaseProvided()
     {
         var expectedServers = new List<string> { "mysql-server-1", "mysql-server-2", "mysql-server-3" };
-        _mysqlService.ListServersAsync("sub123", "rg1", "user1", Arg.Any<CancellationToken>()).Returns(expectedServers);
+        Service.ListServersAsync("sub123", "rg1", "user1", Arg.Any<CancellationToken>()).Returns(expectedServers);
 
-        var command = new MySqlListCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
+            "--user", "user1");
 
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
-
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.Equal("Success", response.Message);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MySqlJsonContext.Default.MySqlListCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, MySqlJsonContext.Default.MySqlListCommandResult);
         Assert.Equal(expectedServers, result.Servers);
         Assert.Null(result.Databases);
         Assert.Null(result.Tables);
@@ -58,27 +34,15 @@ public class MySqlListCommandTests
     public async Task ExecuteAsync_ListsDatabases_WhenServerProvided()
     {
         var expectedDatabases = new List<string> { "db1", "db2", "db3" };
-        _mysqlService.ListDatabasesAsync("sub123", "rg1", "user1", "server1", Arg.Any<CancellationToken>()).Returns(expectedDatabases);
+        Service.ListDatabasesAsync("sub123", "rg1", "user1", "server1", Arg.Any<CancellationToken>()).Returns(expectedDatabases);
 
-        var command = new MySqlListCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
-            "--server", "server1"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
+            "--server", "server1");
 
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
-
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.Equal("Success", response.Message);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MySqlJsonContext.Default.MySqlListCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, MySqlJsonContext.Default.MySqlListCommandResult);
         Assert.Null(result.Servers);
         Assert.Equal(expectedDatabases, result.Databases);
         Assert.Null(result.Tables);
@@ -88,28 +52,16 @@ public class MySqlListCommandTests
     public async Task ExecuteAsync_ListsTables_WhenServerAndDatabaseProvided()
     {
         var expectedTables = new List<string> { "users", "products", "orders" };
-        _mysqlService.GetTablesAsync("sub123", "rg1", "user1", "server1", "db1", Arg.Any<CancellationToken>()).Returns(expectedTables);
+        Service.GetTablesAsync("sub123", "rg1", "user1", "server1", "db1", Arg.Any<CancellationToken>()).Returns(expectedTables);
 
-        var command = new MySqlListCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
             "--server", "server1",
-            "--database", "db1"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
+            "--database", "db1");
 
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
-
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.Equal("Success", response.Message);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MySqlJsonContext.Default.MySqlListCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, MySqlJsonContext.Default.MySqlListCommandResult);
         Assert.Null(result.Servers);
         Assert.Null(result.Databases);
         Assert.Equal(expectedTables, result.Tables);
@@ -118,25 +70,14 @@ public class MySqlListCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsNull_WhenNoServersExist()
     {
-        _mysqlService.ListServersAsync("sub123", "rg1", "user1", Arg.Any<CancellationToken>()).Returns([]);
+        Service.ListServersAsync("sub123", "rg1", "user1", Arg.Any<CancellationToken>()).Returns([]);
 
-        var command = new MySqlListCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
+            "--user", "user1");
 
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
-
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MySqlJsonContext.Default.MySqlListCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, MySqlJsonContext.Default.MySqlListCommandResult);
         Assert.NotNull(result.Servers);
         Assert.Empty(result.Servers);
         Assert.Null(result.Databases);
@@ -146,26 +87,15 @@ public class MySqlListCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsNull_WhenNoDatabasesExist()
     {
-        _mysqlService.ListDatabasesAsync("sub123", "rg1", "user1", "server1", Arg.Any<CancellationToken>()).Returns([]);
+        Service.ListDatabasesAsync("sub123", "rg1", "user1", "server1", Arg.Any<CancellationToken>()).Returns([]);
 
-        var command = new MySqlListCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
-            "--server", "server1"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
+            "--server", "server1");
 
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
-
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MySqlJsonContext.Default.MySqlListCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, MySqlJsonContext.Default.MySqlListCommandResult);
         Assert.Null(result.Servers);
         Assert.NotNull(result.Databases);
         Assert.Empty(result.Databases);
@@ -175,27 +105,16 @@ public class MySqlListCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsNull_WhenNoTablesExist()
     {
-        _mysqlService.GetTablesAsync("sub123", "rg1", "user1", "server1", "db1", Arg.Any<CancellationToken>()).Returns([]);
+        Service.GetTablesAsync("sub123", "rg1", "user1", "server1", "db1", Arg.Any<CancellationToken>()).Returns([]);
 
-        var command = new MySqlListCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
             "--server", "server1",
-            "--database", "db1"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
+            "--database", "db1");
 
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
-
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MySqlJsonContext.Default.MySqlListCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, MySqlJsonContext.Default.MySqlListCommandResult);
         Assert.Null(result.Servers);
         Assert.Null(result.Databases);
         Assert.NotNull(result.Tables);
@@ -205,18 +124,13 @@ public class MySqlListCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenListServersThrows()
     {
-        _mysqlService.ListServersAsync("sub123", "rg1", "user1", Arg.Any<CancellationToken>())
+        Service.ListServersAsync("sub123", "rg1", "user1", Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
-        var command = new MySqlListCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
-
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--user", "user1");
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -226,19 +140,14 @@ public class MySqlListCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenListDatabasesThrows()
     {
-        _mysqlService.ListDatabasesAsync("sub123", "rg1", "user1", "server1", Arg.Any<CancellationToken>())
+        Service.ListDatabasesAsync("sub123", "rg1", "user1", "server1", Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
-        var command = new MySqlListCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
-            "--server", "server1"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
-
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--server", "server1");
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -248,20 +157,15 @@ public class MySqlListCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenGetTablesThrows()
     {
-        _mysqlService.GetTablesAsync("sub123", "rg1", "user1", "server1", "db1", Arg.Any<CancellationToken>())
+        Service.GetTablesAsync("sub123", "rg1", "user1", "server1", "db1", Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
-        var command = new MySqlListCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
             "--server", "server1",
-            "--database", "db1"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
-
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--database", "db1");
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -271,24 +175,20 @@ public class MySqlListCommandTests
     [Fact]
     public void Metadata_IsConfiguredCorrectly()
     {
-        var command = new MySqlListCommand(_logger, _mysqlService);
-
-        Assert.False(command.Metadata.Destructive);
-        Assert.True(command.Metadata.ReadOnly);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
     }
 
     [Fact]
     public void Name_IsCorrect()
     {
-        var command = new MySqlListCommand(_logger, _mysqlService);
-        Assert.Equal("list", command.Name);
+        Assert.Equal("list", Command.Name);
     }
 
     [Fact]
     public void Description_IsCorrect()
     {
-        var command = new MySqlListCommand(_logger, _mysqlService);
-        Assert.Contains("List MySQL servers", command.Description);
-        Assert.Contains("databases, or tables", command.Description);
+        Assert.Contains("List MySQL servers", Command.Description);
+        Assert.Contains("databases, or tables", Command.Description);
     }
 }

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Server/ServerConfigGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Server/ServerConfigGetCommandTests.cs
@@ -18,7 +18,7 @@ public class ServerConfigGetCommandTests : CommandUnitTestsBase<ServerConfigGetC
     [Fact]
     public async Task ExecuteAsync_ReturnsConfiguration_WhenSuccessful()
     {
-        var expectedConfig = JsonSerializer.Serialize(new
+        var expectedConfig = JsonSerializer.Serialize(new()
         {
             ServerName = "test-server",
             Location = "East US",

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Server/ServerConfigGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Server/ServerConfigGetCommandTests.cs
@@ -6,30 +6,15 @@ using System.Text.Json;
 using Azure.Mcp.Tools.MySql.Commands;
 using Azure.Mcp.Tools.MySql.Commands.Server;
 using Azure.Mcp.Tools.MySql.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.MySql.UnitTests.Server;
 
-public class ServerConfigGetCommandTests
+public class ServerConfigGetCommandTests : CommandUnitTestsBase<ServerConfigGetCommand, IMySqlService>
 {
-
-    private readonly IMySqlService _mysqlService;
-    private readonly ILogger<ServerConfigGetCommand> _logger;
-
-    public ServerConfigGetCommandTests()
-    {
-        _mysqlService = Substitute.For<IMySqlService>();
-        _logger = Substitute.For<ILogger<ServerConfigGetCommand>>();
-
-
-
-    }
-
     [Fact]
     public async Task ExecuteAsync_ReturnsConfiguration_WhenSuccessful()
     {
@@ -42,48 +27,31 @@ public class ServerConfigGetCommandTests
             StorageSizeGB = 20,
             BackupRetentionDays = 7,
             GeoRedundantBackup = "Disabled"
-        }, new JsonSerializerOptions { WriteIndented = true });
+        }, MySqlJsonContext.Default.ServerConfigGetResult);
 
-        _mysqlService.GetServerConfigAsync("sub123", "rg1", "user1", "test-server", Arg.Any<CancellationToken>()).Returns(expectedConfig);
+        Service.GetServerConfigAsync("sub123", "rg1", "user1", "test-server", Arg.Any<CancellationToken>()).Returns(expectedConfig);
 
-        var command = new ServerConfigGetCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
-            "--server", "test-server"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
+            "--server", "test-server");
 
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
-
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.Equal("Success", response.Message);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MySqlJsonContext.Default.ServerConfigGetCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, MySqlJsonContext.Default.ServerConfigGetCommandResult);
         Assert.Equal(expectedConfig, result.Configuration);
     }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenServiceThrows()
     {
-        _mysqlService.GetServerConfigAsync("sub123", "rg1", "user1", "test-server", Arg.Any<CancellationToken>())
+        Service.GetServerConfigAsync("sub123", "rg1", "user1", "test-server", Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
-        var command = new ServerConfigGetCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
-            "--server", "test-server"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
-
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--server", "test-server");
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -93,9 +61,7 @@ public class ServerConfigGetCommandTests
     [Fact]
     public void Metadata_IsConfiguredCorrectly()
     {
-        var command = new ServerConfigGetCommand(_logger, _mysqlService);
-
-        Assert.False(command.Metadata.Destructive);
-        Assert.True(command.Metadata.ReadOnly);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
     }
 }

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Server/ServerParamGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Server/ServerParamGetCommandTests.cs
@@ -2,60 +2,32 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.MySql.Commands;
 using Azure.Mcp.Tools.MySql.Commands.Server;
 using Azure.Mcp.Tools.MySql.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.MySql.UnitTests.Server;
 
-public class ServerParamGetCommandTests
+public class ServerParamGetCommandTests : CommandUnitTestsBase<ServerParamGetCommand, IMySqlService>
 {
-
-    private readonly IMySqlService _mysqlService;
-    private readonly ILogger<ServerParamGetCommand> _logger;
-
-    public ServerParamGetCommandTests()
-    {
-        _mysqlService = Substitute.For<IMySqlService>();
-        _logger = Substitute.For<ILogger<ServerParamGetCommand>>();
-
-
-
-    }
-
     [Fact]
     public async Task ExecuteAsync_ReturnsParameter_WhenSuccessful()
     {
         var expectedValue = "ON";
-        _mysqlService.GetServerParameterAsync("sub123", "rg1", "user1", "test-server", "max_connections", Arg.Any<CancellationToken>()).Returns(expectedValue);
+        Service.GetServerParameterAsync("sub123", "rg1", "user1", "test-server", "max_connections", Arg.Any<CancellationToken>()).Returns(expectedValue);
 
-        var command = new ServerParamGetCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
             "--server", "test-server",
-            "--param", "max_connections"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
+            "--param", "max_connections");
 
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
-
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.Equal("Success", response.Message);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MySqlJsonContext.Default.ServerParamGetCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, MySqlJsonContext.Default.ServerParamGetCommandResult);
         Assert.Equal("max_connections", result.Parameter);
         Assert.Equal(expectedValue, result.Value);
     }
@@ -63,20 +35,15 @@ public class ServerParamGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenServiceThrows()
     {
-        _mysqlService.GetServerParameterAsync("sub123", "rg1", "user1", "test-server", "invalid_param", Arg.Any<CancellationToken>())
+        Service.GetServerParameterAsync("sub123", "rg1", "user1", "test-server", "invalid_param", Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Parameter 'invalid_param' not found."));
 
-        var command = new ServerParamGetCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
             "--server", "test-server",
-            "--param", "invalid_param"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
-
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--param", "invalid_param");
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -86,9 +53,7 @@ public class ServerParamGetCommandTests
     [Fact]
     public void Metadata_IsConfiguredCorrectly()
     {
-        var command = new ServerParamGetCommand(_logger, _mysqlService);
-
-        Assert.False(command.Metadata.Destructive);
-        Assert.True(command.Metadata.ReadOnly);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
     }
 }

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Server/ServerParamSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Server/ServerParamSetCommandTests.cs
@@ -2,61 +2,33 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.MySql.Commands;
 using Azure.Mcp.Tools.MySql.Commands.Server;
 using Azure.Mcp.Tools.MySql.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.MySql.UnitTests.Server;
 
-public class ServerParamSetCommandTests
+public class ServerParamSetCommandTests : CommandUnitTestsBase<ServerParamSetCommand, IMySqlService>
 {
-
-    private readonly IMySqlService _mysqlService;
-    private readonly ILogger<ServerParamSetCommand> _logger;
-
-    public ServerParamSetCommandTests()
-    {
-        _mysqlService = Substitute.For<IMySqlService>();
-        _logger = Substitute.For<ILogger<ServerParamSetCommand>>();
-
-
-
-    }
-
     [Fact]
     public async Task ExecuteAsync_SetsParameter_WhenSuccessful()
     {
         var newValue = "100";
-        _mysqlService.SetServerParameterAsync("sub123", "rg1", "user1", "test-server", "max_connections", newValue, Arg.Any<CancellationToken>()).Returns(newValue);
+        Service.SetServerParameterAsync("sub123", "rg1", "user1", "test-server", "max_connections", newValue, Arg.Any<CancellationToken>()).Returns(newValue);
 
-        var command = new ServerParamSetCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
             "--server", "test-server",
             "--param", "max_connections",
-            "--value", newValue
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
+            "--value", newValue);
 
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
-
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.Equal("Success", response.Message);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MySqlJsonContext.Default.ServerParamSetCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, MySqlJsonContext.Default.ServerParamSetCommandResult);
         Assert.Equal("max_connections", result.Parameter);
         Assert.Equal(newValue, result.Value);
     }
@@ -64,21 +36,16 @@ public class ServerParamSetCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenServiceThrows()
     {
-        _mysqlService.SetServerParameterAsync("sub123", "rg1", "user1", "test-server", "invalid_param", "100", Arg.Any<CancellationToken>())
+        Service.SetServerParameterAsync("sub123", "rg1", "user1", "test-server", "invalid_param", "100", Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Parameter 'invalid_param' not found."));
 
-        var command = new ServerParamSetCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
             "--server", "test-server",
             "--param", "invalid_param",
-            "--value", "100"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
-
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--value", "100");
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -88,9 +55,7 @@ public class ServerParamSetCommandTests
     [Fact]
     public void Metadata_IsConfiguredCorrectly()
     {
-        var command = new ServerParamSetCommand(_logger, _mysqlService);
-
-        Assert.True(command.Metadata.Destructive);
-        Assert.False(command.Metadata.ReadOnly);
+        Assert.True(Command.Metadata.Destructive);
+        Assert.False(Command.Metadata.ReadOnly);
     }
 }

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Table/TableSchemaGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Table/TableSchemaGetCommandTests.cs
@@ -2,80 +2,48 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.MySql.Commands;
 using Azure.Mcp.Tools.MySql.Commands.Table;
 using Azure.Mcp.Tools.MySql.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.MySql.UnitTests.Table;
 
-public class TableSchemaGetCommandTests
+public class TableSchemaGetCommandTests : CommandUnitTestsBase<TableSchemaGetCommand, IMySqlService>
 {
-
-    private readonly IMySqlService _mysqlService;
-    private readonly ILogger<TableSchemaGetCommand> _logger;
-
-    public TableSchemaGetCommandTests()
-    {
-        _mysqlService = Substitute.For<IMySqlService>();
-        _logger = Substitute.For<ILogger<TableSchemaGetCommand>>();
-
-
-
-    }
-
     [Fact]
     public async Task ExecuteAsync_ReturnsSchema_WhenSuccessful()
     {
         var expectedSchema = new List<string> { "id INT PRIMARY KEY", "name VARCHAR(100) NOT NULL", "email VARCHAR(255)" };
-        _mysqlService.GetTableSchemaAsync("sub123", "rg1", "user1", "server1", "db1", "users", Arg.Any<CancellationToken>()).Returns(expectedSchema);
+        Service.GetTableSchemaAsync("sub123", "rg1", "user1", "server1", "db1", "users", Arg.Any<CancellationToken>()).Returns(expectedSchema);
 
-        var command = new TableSchemaGetCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
             "--server", "server1",
             "--database", "db1",
-            "--table", "users"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
+            "--table", "users");
 
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
-
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, MySqlJsonContext.Default.TableSchemaGetCommandResult);
-        Assert.NotNull(result);
+        var result = ValidateAndDeserializeResponse(response, MySqlJsonContext.Default.TableSchemaGetCommandResult);
         Assert.Equal(expectedSchema, result.Schema);
     }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenTableNotFound()
     {
-        _mysqlService.GetTableSchemaAsync("sub123", "rg1", "user1", "server1", "db1", "nonexistent", Arg.Any<CancellationToken>()).ThrowsAsync(new ArgumentException("Table not found"));
+        Service.GetTableSchemaAsync("sub123", "rg1", "user1", "server1", "db1", "nonexistent", Arg.Any<CancellationToken>()).ThrowsAsync(new ArgumentException("Table not found"));
 
-        var command = new TableSchemaGetCommand(_logger, _mysqlService);
-        var args = command.GetCommand().Parse([
+        var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
             "--user", "user1",
             "--server", "server1",
             "--database", "db1",
-            "--table", "nonexistent"
-        ]);
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
-
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            "--table", "nonexistent");
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -85,9 +53,7 @@ public class TableSchemaGetCommandTests
     [Fact]
     public void Metadata_IsConfiguredCorrectly()
     {
-        var command = new TableSchemaGetCommand(_logger, _mysqlService);
-
-        Assert.False(command.Metadata.Destructive);
-        Assert.True(command.Metadata.ReadOnly);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Migrates Command unit tests to use `CommandUnitTestBase`. Adds new helper method to `CommandUnitTestBase` that performs common validation when a tool call was expected to succeed with a response value.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
