### PR TITLE
Change Build jobs to always produce Release builds

### DIFF
--- a/eng/pipelines/templates/jobs/build.yml
+++ b/eng/pipelines/templates/jobs/build.yml
@@ -73,7 +73,7 @@ jobs:
         -OutputPath '$(Build.ArtifactStagingDirectory)'
         -ServerName '${{ parameters.ServerName }}'
         -PlatformName '$(BuildPlatformName)'
-        -ReleaseBuild:$${{ ne(parameters.PublishTarget, 'none') }}
+        -ReleaseBuild
         -SelfContained
         -SingleFile
 

--- a/eng/pipelines/templates/jobs/build.yml
+++ b/eng/pipelines/templates/jobs/build.yml
@@ -76,6 +76,7 @@ jobs:
         -ReleaseBuild
         -SelfContained
         -SingleFile
+        -SmokeTest
 
   - task: Powershell@2
     displayName: "Run unit tests"

--- a/eng/scripts/Build-Code.ps1
+++ b/eng/scripts/Build-Code.ps1
@@ -14,6 +14,7 @@ param (
     [switch] $SingleFile,
     [switch] $ReadyToRun,
     [switch] $ReleaseBuild,
+    [switch] $SmokeTest,
     [switch] $CleanBuild,
 
     # build_info.json based parameters
@@ -75,6 +76,7 @@ function BuildServer($server) {
         $arch = $platform.architecture
         $configuration = if ($ReleaseBuild) { 'Release' } else { 'Debug' }
         $runtime = "$dotnetOs-$arch"
+        $exeName = "$($server.cliName)$($platform.extension)"
 
         $outputDir = "$OutputPath/$($platform.artifactPath)"
         Write-Host "Building $configuration $runtime, version $version in $outputDir" -ForegroundColor Green
@@ -106,6 +108,24 @@ function BuildServer($server) {
         }
 
         Invoke-LoggedMsBuildCommand $command -GroupOutput
+
+        $exePath = Join-Path $outputDir $exeName
+        if (!(Test-Path $exePath)) {
+            LogError "Expected output executable not found at '$exePath' after build."
+            $script:exitCode = 1
+            return
+        }
+        
+        if($SmokeTest) {
+            Write-Host "Running smoke test for $exeName" -ForegroundColor Yellow
+            try {
+                & $exePath tools list
+            } catch {
+                LogError "Smoke test failed for '$exeName'. Executable did not run successfully."
+                $script:exitCode = 1
+                return
+            }
+        }
     }
 
     Write-Host "`nBuild completed successfully!" -ForegroundColor Green

--- a/eng/scripts/Build-Code.ps1
+++ b/eng/scripts/Build-Code.ps1
@@ -116,14 +116,20 @@ function BuildServer($server) {
             return
         }
         
+        # Even if we call the script with the SmokeTest switch, we can only run the test if the built platform is supported on the current OS
+        $currentRid = [System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier
         if($SmokeTest) {
-            Write-Host "Running smoke test for $exeName" -ForegroundColor Yellow
-            try {
-                & $exePath tools list
-            } catch {
-                LogError "Smoke test failed for '$exeName'. Executable did not run successfully."
-                $script:exitCode = 1
-                return
+            if ($runtime -eq $currentRid) {
+                Write-Host "Running smoke test for $exeName" -ForegroundColor Yellow
+                try {
+                    & $exePath tools list
+                } catch {
+                    LogError "Smoke test failed for '$exeName'. Executable did not run successfully."
+                    $script:exitCode = 1
+                    return
+                }
+            } else { 
+                Write-Host "Skipping smoke test for cross platorm build (current platform: $currentRid, build platform: $runtime)" -ForegroundColor Yellow
             }
         }
     }

--- a/tools/Azure.Mcp.Tools.WellArchitectedFramework/tests/Azure.Mcp.Tools.WellArchitectedFramework.UnitTests/Commands/ServiceGuide/ServiceGuideGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.WellArchitectedFramework/tests/Azure.Mcp.Tools.WellArchitectedFramework.UnitTests/Commands/ServiceGuide/ServiceGuideGetCommandTests.cs
@@ -14,14 +14,10 @@ namespace Azure.Mcp.Tools.WellArchitectedFramework.UnitTests.Commands.ServiceGui
 
 public class ServiceGuideGetCommandTests : CommandUnitTestsBase<ServiceGuideGetCommand, IServiceGuideService>
 {
-    public ServiceGuideGetCommandTests() : base(services =>
+    public ServiceGuideGetCommandTests()
     {
-        // Register the real ServiceGuideService to test the actual logic, not a mock
-        services.AddSingleton<IServiceGuideService, ServiceGuideService>();
-    })
-    {
+        Services.AddSingleton<IServiceGuideService, ServiceGuideService>();
     }
-
 
     [Fact]
     public void Constructor_InitializesCommandCorrectly()


### PR DESCRIPTION
## What does this PR do?
We're currently building PRs using only Debug.  This means that the first time we build in Release mode is in a main branch build.

Rather than making Release/Debug conditional on the build shipping or not, this PR will have all of the Build stage outputs be Release builds, while still using Debug for unit and live tests.

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
