### PR TITLE
[Part 11] Migrate tool command unit tests to useing CommandUnitTestsBase

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ServiceInfoCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ServiceInfoCommandTests.cs
@@ -1,34 +1,20 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
-using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Areas.Server.Commands;
 using Microsoft.Mcp.Core.Configuration;
-using Microsoft.Mcp.Core.Models.Command;
-using NSubstitute;
+using Microsoft.Mcp.Tests.Client;
 using Xunit;
 
 namespace Azure.Mcp.Core.UnitTests.Areas.Server.Commands;
 
-public class ServiceInfoCommandTests
+public class ServiceInfoCommandTests : CommandUnitTestsBase<ServiceInfoCommand, object>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<ServiceInfoCommand> _logger;
     private readonly McpServerConfiguration _mcpServerConfiguration;
-    private readonly CommandContext _context;
-    private readonly ServiceInfoCommand _command;
-    private readonly Command _commandDefinition;
 
     public ServiceInfoCommandTests()
     {
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _context = new(_serviceProvider);
-        _logger = Substitute.For<ILogger<ServiceInfoCommand>>();
         _mcpServerConfiguration = new McpServerConfiguration
         {
             Name = "Test-Name?",
@@ -36,24 +22,17 @@ public class ServiceInfoCommandTests
             DisplayName = "Test Display",
             RootCommandGroupName = "azmcp"
         };
-        _command = new(Microsoft.Extensions.Options.Options.Create(_mcpServerConfiguration), _logger);
-        _commandDefinition = _command.GetCommand();
+        Services.AddSingleton(_mcpServerConfiguration);
     }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsCorrectProperties()
     {
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ServiceInfoJsonContext.Default.ServiceInfoCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ServiceInfoJsonContext.Default.ServiceInfoCommandResult);
-
-        Assert.NotNull(result);
         Assert.Equal(_mcpServerConfiguration.Name, result.Name);
         Assert.Equal(_mcpServerConfiguration.Version, result.Version);
     }

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ServiceInfoCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ServiceInfoCommandTests.cs
@@ -22,7 +22,7 @@ public class ServiceInfoCommandTests : CommandUnitTestsBase<ServiceInfoCommand, 
             DisplayName = "Test Display",
             RootCommandGroupName = "azmcp"
         };
-        Services.AddSingleton(_mcpServerConfiguration);
+        Services.AddSingleton(Microsoft.Extensions.Options.Options.Create(_mcpServerConfiguration));
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.AzureBestPractices/tests/Azure.Mcp.Tools.AzureBestPractices.UnitTests/AIAppBestPracticesCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBestPractices/tests/Azure.Mcp.Tools.AzureBestPractices.UnitTests/AIAppBestPracticesCommandTests.cs
@@ -1,52 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
-using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBestPractices.Commands;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
-using NSubstitute;
+using Microsoft.Mcp.Tests.Client;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBestPractices.UnitTests;
 
-public class AIAppBestPracticesCommandTests
+public class AIAppBestPracticesCommandTests : CommandUnitTestsBase<AIAppBestPracticesCommand, object>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<AIAppBestPracticesCommand> _logger;
-    private readonly CommandContext _context;
-    private readonly AIAppBestPracticesCommand _command;
-    private readonly Command _commandDefinition;
-
-    public AIAppBestPracticesCommandTests()
-    {
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _context = new(_serviceProvider);
-        _logger = Substitute.For<ILogger<AIAppBestPracticesCommand>>();
-        _command = new(_logger);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public async Task ExecuteAsync_ReturnsAzureAIAppBestPractices()
     {
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBestPracticesJsonContext.Default.ListString);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<string[]>(json);
-
-        Assert.NotNull(result);
         Assert.Contains("Microsoft Agent Framework", result[0]);
         Assert.Contains("AIProjectClient", result[0]);
         Assert.Contains("Build and Verification", result[0]);
@@ -57,18 +27,18 @@ public class AIAppBestPracticesCommandTests
     [Fact]
     public void Command_HasCorrectProperties()
     {
-        Assert.Equal("ai_app", _command.Name);
-        Assert.Equal("Get AI App Best Practices", _command.Title);
-        Assert.Equal("6c29659e-406d-4b9b-8150-e3d4fd7ba31c", _command.Id);
-        Assert.Contains("AI applications in Azure", _command.Description);
-        Assert.Contains("Microsoft Foundry", _command.Description);
-        Assert.Contains("AI agents, chatbots, workflows", _command.Description);
+        Assert.Equal("ai_app", Command.Name);
+        Assert.Equal("Get AI App Best Practices", Command.Title);
+        Assert.Equal("6c29659e-406d-4b9b-8150-e3d4fd7ba31c", Command.Id);
+        Assert.Contains("AI applications in Azure", Command.Description);
+        Assert.Contains("Microsoft Foundry", Command.Description);
+        Assert.Contains("AI agents, chatbots, workflows", Command.Description);
     }
 
     [Fact]
     public void Command_HasCorrectMetadata()
     {
-        var metadata = _command.Metadata;
+        var metadata = Command.Metadata;
 
         Assert.False(metadata.Destructive);
         Assert.True(metadata.Idempotent);

--- a/tools/Azure.Mcp.Tools.AzureBestPractices/tests/Azure.Mcp.Tools.AzureBestPractices.UnitTests/BestPracticesCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBestPractices/tests/Azure.Mcp.Tools.AzureBestPractices.UnitTests/BestPracticesCommandTests.cs
@@ -1,52 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureBestPractices.Commands;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
-using NSubstitute;
+using Microsoft.Mcp.Tests.Client;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureBestPractices.UnitTests;
 
-public class BestPracticesCommandTests
+public class BestPracticesCommandTests : CommandUnitTestsBase<BestPracticesCommand, object>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<BestPracticesCommand> _logger;
-    private readonly CommandContext _context;
-    private readonly BestPracticesCommand _command;
-    private readonly Command _commandDefinition;
-
-    public BestPracticesCommandTests()
-    {
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _context = new(_serviceProvider);
-        _logger = Substitute.For<ILogger<BestPracticesCommand>>();
-        _command = new(_logger);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public async Task ExecuteAsync_GeneralCodeGeneration_ReturnsAzureBestPractices()
     {
-        var args = _commandDefinition.Parse(["--resource", "general", "--action", "code-generation"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "general", "--action", "code-generation");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBestPracticesJsonContext.Default.ListString);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<string[]>(json);
-
-        Assert.NotNull(result);
         Assert.Contains("Implement retry logic with exponential backoff for transient failures", result[0]);
         Assert.Contains("Managed Identity (Azure-hosted)", result[0]);
     }
@@ -54,18 +25,11 @@ public class BestPracticesCommandTests
     [Fact]
     public async Task ExecuteAsync_GeneralDeployment_ReturnsAzureBestPractices()
     {
-        var args = _commandDefinition.Parse(["--resource", "general", "--action", "deployment"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "general", "--action", "deployment");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBestPracticesJsonContext.Default.ListString);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<string[]>(json);
-
-        Assert.NotNull(result);
         Assert.Contains("Your IaC files must include:", result[0]);
         Assert.Contains("Quality requirements for IaC files:", result[0]);
     }
@@ -73,18 +37,11 @@ public class BestPracticesCommandTests
     [Fact]
     public async Task ExecuteAsync_AzureFunctionsCodeGeneration_ReturnsAzureBestPractices()
     {
-        var args = _commandDefinition.Parse(["--resource", "azurefunctions", "--action", "code-generation"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "azurefunctions", "--action", "code-generation");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBestPracticesJsonContext.Default.ListString);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<string[]>(json);
-
-        Assert.NotNull(result);
         Assert.Contains("Use the latest programming models (v4 for TypeScript/JavaScript, v2 for Python)", result[0]);
         Assert.Contains("Azure Functions Core Tools for creating Function Apps", result[0]);
     }
@@ -92,18 +49,11 @@ public class BestPracticesCommandTests
     [Fact]
     public async Task ExecuteAsync_AzureFunctionsDeployment_ReturnsAzureBestPractices()
     {
-        var args = _commandDefinition.Parse(["--resource", "azurefunctions", "--action", "deployment"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "azurefunctions", "--action", "deployment");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBestPracticesJsonContext.Default.ListString);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<string[]>(json);
-
-        Assert.NotNull(result);
         Assert.Contains("Flex Consumption plan (FC1)", result[0]);
         Assert.Contains("Always use Linux OS for Python", result[0]);
         Assert.Contains("Function authentication", result[0]);
@@ -113,18 +63,11 @@ public class BestPracticesCommandTests
     [Fact]
     public async Task ExecuteAsync_StaticWebAppAll_ReturnsAzureBestPractices()
     {
-        var args = _commandDefinition.Parse(["--resource", "static-web-app", "--action", "all"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "static-web-app", "--action", "all");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBestPracticesJsonContext.Default.ListString);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<string[]>(json);
-
-        Assert.NotNull(result);
         Assert.Contains("Deployment Path Selection", result[0]);
         Assert.Contains("**PREFERRED PATH: Azure Developer CLI (azd)**", result[0]);
         Assert.Contains("**ALTERNATIVE PATH: SWA CLI**", result[0]);
@@ -134,26 +77,18 @@ public class BestPracticesCommandTests
     [Fact]
     public async Task ExecuteAsync_CodingAgentAll_ReturnsAzureBestPractices()
     {
-        var args = _commandDefinition.Parse(["--resource", "coding-agent", "--action", "all"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "coding-agent", "--action", "all");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBestPracticesJsonContext.Default.ListString);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<string[]>(json);
-
-        Assert.NotNull(result);
         Assert.Contains("azd coding-agent config", result[0]);
     }
 
     [Fact]
     public async Task ExecuteAsync_InvalidResource_ReturnsBadRequest()
     {
-        var args = _commandDefinition.Parse(["--resource", "invalid", "--action", "code-generation"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "invalid", "--action", "code-generation");
 
         // Assert
         Assert.NotNull(response);
@@ -164,8 +99,7 @@ public class BestPracticesCommandTests
     [Fact]
     public async Task ExecuteAsync_StaticWebAppWithInvalidAction_ReturnsBadRequest()
     {
-        var args = _commandDefinition.Parse(["--resource", "static-web-app", "--action", "code-generation"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "static-web-app", "--action", "code-generation");
 
         // Assert
         Assert.NotNull(response);
@@ -176,8 +110,7 @@ public class BestPracticesCommandTests
     [Fact]
     public async Task ExecuteAsync_CodingAgentWithInvalidAction_ReturnsBadRequest()
     {
-        var args = _commandDefinition.Parse(["--resource", "coding-agent", "--action", "code-generation"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "coding-agent", "--action", "code-generation");
 
         // Assert
         Assert.NotNull(response);
@@ -188,8 +121,7 @@ public class BestPracticesCommandTests
     [Fact]
     public async Task ExecuteAsync_InvalidAction_ReturnsBadRequest()
     {
-        var args = _commandDefinition.Parse(["--resource", "general", "--action", "invalid"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "general", "--action", "invalid");
 
         // Assert
         Assert.NotNull(response);
@@ -200,18 +132,11 @@ public class BestPracticesCommandTests
     [Fact]
     public async Task ExecuteAsync_GeneralWithAllAction_ReturnsAzureBestPractices()
     {
-        var args = _commandDefinition.Parse(["--resource", "general", "--action", "all"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "general", "--action", "all");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBestPracticesJsonContext.Default.ListString);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<string[]>(json);
-
-        Assert.NotNull(result);
         // Should contain content from both code-generation and deployment files
         Assert.Contains("Implement retry logic with exponential backoff for transient failures", result[0]);
         Assert.Contains("Managed Identity (Azure-hosted)", result[0]);
@@ -222,18 +147,11 @@ public class BestPracticesCommandTests
     [Fact]
     public async Task ExecuteAsync_AzureFunctionsWithAllAction_ReturnsAzureBestPractices()
     {
-        var args = _commandDefinition.Parse(["--resource", "azurefunctions", "--action", "all"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "azurefunctions", "--action", "all");
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureBestPracticesJsonContext.Default.ListString);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<string[]>(json);
-
-        Assert.NotNull(result);
         // Should contain content from both code-generation and deployment files
         Assert.Contains("Use the latest programming models (v4 for TypeScript/JavaScript, v2 for Python)", result[0]);
         Assert.Contains("Azure Functions Core Tools for creating Function Apps", result[0]);
@@ -246,8 +164,7 @@ public class BestPracticesCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingResource_ReturnsBadRequest()
     {
-        var args = _commandDefinition.Parse(["--action", "code-generation"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--action", "code-generation");
 
         // Assert
         Assert.NotNull(response);
@@ -258,8 +175,7 @@ public class BestPracticesCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingAction_ReturnsBadRequest()
     {
-        var args = _commandDefinition.Parse(["--resource", "general"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource", "general");
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AvmDocumentationGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AvmDocumentationGetCommandTests.cs
@@ -1,60 +1,38 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureTerraform.Commands;
-using Azure.Mcp.Tools.AzureTerraform.Models;
 using Azure.Mcp.Tools.AzureTerraform.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureTerraform.UnitTests;
 
-public class AvmDocumentationGetCommandTests
+public class AvmDocumentationGetCommandTests : CommandUnitTestsBase<AvmDocumentationGetCommand, IAvmDocsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<AvmDocumentationGetCommand> _logger;
-    private readonly IAvmDocsService _avmDocsService;
-    private readonly CommandContext _context;
-    private readonly AvmDocumentationGetCommand _command;
-    private readonly Command _commandDefinition;
-
-    public AvmDocumentationGetCommandTests()
-    {
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-        _context = new(_serviceProvider);
-        _logger = Substitute.For<ILogger<AvmDocumentationGetCommand>>();
-        _avmDocsService = Substitute.For<IAvmDocsService>();
-        _command = new(_logger, _avmDocsService);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("get", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.NotEmpty(_command.Id);
-        Assert.NotEmpty(_command.Title);
-        Assert.False(_command.Metadata.Destructive);
-        Assert.True(_command.Metadata.ReadOnly);
+        Assert.Equal("get", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.NotEmpty(Command.Id);
+        Assert.NotEmpty(Command.Title);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
     }
 
     [Fact]
     public async Task ExecuteAsync_ValidInput_ReturnsDocumentation()
     {
-        _avmDocsService.GetDocumentationAsync("avm-res-storage-storageaccount", "0.4.0", Arg.Any<CancellationToken>())
+        Service.GetDocumentationAsync("avm-res-storage-storageaccount", "0.4.0", Arg.Any<CancellationToken>())
             .Returns("# Azure Storage Account Module\n\nThis module creates a storage account.");
 
-        var args = _commandDefinition.Parse(["--module-name", "avm-res-storage-storageaccount", "--module-version", "0.4.0"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--module-name", "avm-res-storage-storageaccount",
+            "--module-version", "0.4.0");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -63,8 +41,7 @@ public class AvmDocumentationGetCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingModuleName_ReturnsValidationError()
     {
-        var args = _commandDefinition.Parse(["--module-version", "0.4.0"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--module-version", "0.4.0");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
     }
@@ -72,8 +49,7 @@ public class AvmDocumentationGetCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingModuleVersion_ReturnsValidationError()
     {
-        var args = _commandDefinition.Parse(["--module-name", "avm-res-storage-storageaccount"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--module-name", "avm-res-storage-storageaccount");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
     }
@@ -81,11 +57,10 @@ public class AvmDocumentationGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ServiceThrows_HandlesException()
     {
-        _avmDocsService.GetDocumentationAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        Service.GetDocumentationAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Module not found"));
 
-        var args = _commandDefinition.Parse(["--module-name", "nonexistent", "--module-version", "1.0.0"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--module-name", "nonexistent", "--module-version", "1.0.0");
 
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
     }
@@ -93,13 +68,12 @@ public class AvmDocumentationGetCommandTests
     [Fact]
     public async Task ExecuteAsync_VerifiesServiceCalled()
     {
-        _avmDocsService.GetDocumentationAsync("test-module", "1.0.0", Arg.Any<CancellationToken>())
+        Service.GetDocumentationAsync("test-module", "1.0.0", Arg.Any<CancellationToken>())
             .Returns("# Test Module");
 
-        var args = _commandDefinition.Parse(["--module-name", "test-module", "--module-version", "1.0.0"]);
-        await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        await ExecuteCommandAsync("--module-name", "test-module", "--module-version", "1.0.0");
 
-        await _avmDocsService.Received(1).GetDocumentationAsync("test-module", "1.0.0", Arg.Any<CancellationToken>());
+        await Service.Received(1).GetDocumentationAsync("test-module", "1.0.0", Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -111,12 +85,11 @@ public class AvmDocumentationGetCommandTests
     {
         if (shouldSucceed)
         {
-            _avmDocsService.GetDocumentationAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            Service.GetDocumentationAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns("# Module docs");
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         if (shouldSucceed)
         {
@@ -131,19 +104,15 @@ public class AvmDocumentationGetCommandTests
     [Fact]
     public async Task ExecuteAsync_DeserializationValidation()
     {
-        _avmDocsService.GetDocumentationAsync("avm-res-storage-storageaccount", "0.4.0", Arg.Any<CancellationToken>())
+        Service.GetDocumentationAsync("avm-res-storage-storageaccount", "0.4.0", Arg.Any<CancellationToken>())
             .Returns("# Azure Storage Account Module\n\nThis module creates a storage account.");
 
-        var args = _commandDefinition.Parse(["--module-name", "avm-res-storage-storageaccount", "--module-version", "0.4.0"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--module-name", "avm-res-storage-storageaccount",
+            "--module-version", "0.4.0");
 
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureTerraformJsonContext.Default.AvmDocumentationResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureTerraformJsonContext.Default.AvmDocumentationResult);
-
-        Assert.NotNull(result);
         Assert.Equal("avm-res-storage-storageaccount", result.ModuleName);
         Assert.Equal("0.4.0", result.ModuleVersion);
         Assert.Contains("Azure Storage Account Module", result.Documentation);
@@ -152,12 +121,12 @@ public class AvmDocumentationGetCommandTests
     [Fact]
     public void BindOptions_BindsOptionsCorrectly()
     {
-        var args = _commandDefinition.Parse(["--module-name", "avm-res-storage-storageaccount", "--module-version", "0.4.0"]);
+        var args = CommandDefinition.Parse(["--module-name", "avm-res-storage-storageaccount", "--module-version", "0.4.0"]);
 
         Assert.NotNull(args);
         Assert.Empty(args.Errors);
 
-        var command = _command.GetCommand();
+        var command = Command.GetCommand();
         var options = command.Options;
 
         Assert.Contains(options, o => o.Name == "--module-name");

--- a/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AvmModuleListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AvmModuleListCommandTests.cs
@@ -1,51 +1,29 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureTerraform.Commands;
 using Azure.Mcp.Tools.AzureTerraform.Models;
 using Azure.Mcp.Tools.AzureTerraform.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureTerraform.UnitTests;
 
-public class AvmModuleListCommandTests
+public class AvmModuleListCommandTests : CommandUnitTestsBase<AvmModuleListCommand, IAvmDocsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<AvmModuleListCommand> _logger;
-    private readonly IAvmDocsService _avmDocsService;
-    private readonly CommandContext _context;
-    private readonly AvmModuleListCommand _command;
-    private readonly Command _commandDefinition;
-
-    public AvmModuleListCommandTests()
-    {
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-        _context = new(_serviceProvider);
-        _logger = Substitute.For<ILogger<AvmModuleListCommand>>();
-        _avmDocsService = Substitute.For<IAvmDocsService>();
-        _command = new(_logger, _avmDocsService);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("list", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.NotEmpty(_command.Id);
-        Assert.NotEmpty(_command.Title);
-        Assert.False(_command.Metadata.Destructive);
-        Assert.True(_command.Metadata.ReadOnly);
-        Assert.True(_command.Metadata.Idempotent);
+        Assert.Equal("list", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.NotEmpty(Command.Id);
+        Assert.NotEmpty(Command.Title);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
+        Assert.True(Command.Metadata.Idempotent);
     }
 
     [Fact]
@@ -69,11 +47,10 @@ public class AvmModuleListCommandTests
             }
         };
 
-        _avmDocsService.ListModulesAsync(Arg.Any<CancellationToken>())
+        Service.ListModulesAsync(Arg.Any<CancellationToken>())
             .Returns(expectedModules);
 
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -82,11 +59,10 @@ public class AvmModuleListCommandTests
     [Fact]
     public async Task ExecuteAsync_ServiceThrows_HandlesException()
     {
-        _avmDocsService.ListModulesAsync(Arg.Any<CancellationToken>())
+        Service.ListModulesAsync(Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("Network error"));
 
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
     }
@@ -97,12 +73,11 @@ public class AvmModuleListCommandTests
     {
         if (shouldSucceed)
         {
-            _avmDocsService.ListModulesAsync(Arg.Any<CancellationToken>())
+            Service.ListModulesAsync(Arg.Any<CancellationToken>())
                 .Returns(new List<AvmModule>());
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         if (shouldSucceed)
         {
@@ -128,19 +103,13 @@ public class AvmModuleListCommandTests
             }
         };
 
-        _avmDocsService.ListModulesAsync(Arg.Any<CancellationToken>())
+        Service.ListModulesAsync(Arg.Any<CancellationToken>())
             .Returns(expectedModules);
 
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureTerraformJsonContext.Default.AvmModuleListResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureTerraformJsonContext.Default.AvmModuleListResult);
-
-        Assert.NotNull(result);
         Assert.NotNull(result.Modules);
         Assert.Single(result.Modules);
         Assert.Equal("avm-res-storage-storageaccount", result.Modules[0].ModuleName);
@@ -149,7 +118,7 @@ public class AvmModuleListCommandTests
     [Fact]
     public void BindOptions_BindsOptionsCorrectly()
     {
-        var args = _commandDefinition.Parse([]);
+        var args = CommandDefinition.Parse([]);
 
         Assert.NotNull(args);
         Assert.Empty(args.Errors);

--- a/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AvmVersionListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AvmVersionListCommandTests.cs
@@ -1,50 +1,28 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureTerraform.Commands;
 using Azure.Mcp.Tools.AzureTerraform.Models;
 using Azure.Mcp.Tools.AzureTerraform.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureTerraform.UnitTests;
 
-public class AvmVersionListCommandTests
+public class AvmVersionListCommandTests : CommandUnitTestsBase<AvmVersionListCommand, IAvmDocsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<AvmVersionListCommand> _logger;
-    private readonly IAvmDocsService _avmDocsService;
-    private readonly CommandContext _context;
-    private readonly AvmVersionListCommand _command;
-    private readonly Command _commandDefinition;
-
-    public AvmVersionListCommandTests()
-    {
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-        _context = new(_serviceProvider);
-        _logger = Substitute.For<ILogger<AvmVersionListCommand>>();
-        _avmDocsService = Substitute.For<IAvmDocsService>();
-        _command = new(_logger, _avmDocsService);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("versions", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.NotEmpty(_command.Id);
-        Assert.NotEmpty(_command.Title);
-        Assert.False(_command.Metadata.Destructive);
-        Assert.True(_command.Metadata.ReadOnly);
+        Assert.Equal("versions", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.NotEmpty(Command.Id);
+        Assert.NotEmpty(Command.Title);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
     }
 
     [Fact]
@@ -56,11 +34,10 @@ public class AvmVersionListCommandTests
             new() { TagName = "0.3.0", CreatedAt = "2024-10-01T00:00:00Z", TarballUrl = "https://api.github.com/repos/Azure/terraform-azurerm-avm-res-storage-storageaccount/tarball/v0.3.0" }
         };
 
-        _avmDocsService.GetVersionsAsync("avm-res-storage-storageaccount", Arg.Any<CancellationToken>())
+        Service.GetVersionsAsync("avm-res-storage-storageaccount", Arg.Any<CancellationToken>())
             .Returns(expectedVersions);
 
-        var args = _commandDefinition.Parse(["--module-name", "avm-res-storage-storageaccount"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--module-name", "avm-res-storage-storageaccount");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -69,8 +46,7 @@ public class AvmVersionListCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingModuleName_ReturnsValidationError()
     {
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
     }
@@ -78,11 +54,10 @@ public class AvmVersionListCommandTests
     [Fact]
     public async Task ExecuteAsync_ServiceThrows_HandlesException()
     {
-        _avmDocsService.GetVersionsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        Service.GetVersionsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Module not found"));
 
-        var args = _commandDefinition.Parse(["--module-name", "nonexistent-module"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--module-name", "nonexistent-module");
 
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
     }
@@ -94,12 +69,11 @@ public class AvmVersionListCommandTests
     {
         if (shouldSucceed)
         {
-            _avmDocsService.GetVersionsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-                .Returns(new List<AvmVersion>());
+            Service.GetVersionsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns([]);
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         if (shouldSucceed)
         {
@@ -119,19 +93,13 @@ public class AvmVersionListCommandTests
             new() { TagName = "0.4.0", CreatedAt = "2024-12-01T00:00:00Z", TarballUrl = "https://api.github.com/repos/Azure/terraform-azurerm-avm-res-storage-storageaccount/tarball/v0.4.0" }
         };
 
-        _avmDocsService.GetVersionsAsync("avm-res-storage-storageaccount", Arg.Any<CancellationToken>())
+        Service.GetVersionsAsync("avm-res-storage-storageaccount", Arg.Any<CancellationToken>())
             .Returns(expectedVersions);
 
-        var args = _commandDefinition.Parse(["--module-name", "avm-res-storage-storageaccount"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--module-name", "avm-res-storage-storageaccount");
 
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureTerraformJsonContext.Default.AvmVersionListResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureTerraformJsonContext.Default.AvmVersionListResult);
-
-        Assert.NotNull(result);
         Assert.Equal("avm-res-storage-storageaccount", result.ModuleName);
         Assert.NotNull(result.Versions);
         Assert.Single(result.Versions);
@@ -141,13 +109,12 @@ public class AvmVersionListCommandTests
     [Fact]
     public void BindOptions_BindsOptionsCorrectly()
     {
-        var args = _commandDefinition.Parse(["--module-name", "avm-res-storage-storageaccount"]);
+        var args = CommandDefinition.Parse(["--module-name", "avm-res-storage-storageaccount"]);
 
         Assert.NotNull(args);
         Assert.Empty(args.Errors);
 
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         Assert.Contains(options, o => o.Name == "--module-name");
     }

--- a/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AzApiDocsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AzApiDocsGetCommandTests.cs
@@ -1,56 +1,40 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureTerraform.Commands;
 using Azure.Mcp.Tools.AzureTerraform.Models;
 using Azure.Mcp.Tools.AzureTerraform.Services;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureTerraform.UnitTests;
 
-public class AzApiDocsGetCommandTests
+public class AzApiDocsGetCommandTests : CommandUnitTestsBase<AzApiDocsGetCommand, IAzApiDocsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<AzApiDocsGetCommand> _logger;
-    private readonly IAzApiDocsService _docsService;
     private readonly IAzApiExamplesService _examplesService;
-    private readonly CommandContext _context;
-    private readonly AzApiDocsGetCommand _command;
-    private readonly Command _commandDefinition;
 
     public AzApiDocsGetCommandTests()
     {
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _context = new(_serviceProvider);
-        _logger = Substitute.For<ILogger<AzApiDocsGetCommand>>();
-        _docsService = Substitute.For<IAzApiDocsService>();
         _examplesService = Substitute.For<IAzApiExamplesService>();
-        _command = new(_logger, _docsService, _examplesService);
-        _commandDefinition = _command.GetCommand();
+        Services.AddSingleton(_examplesService);
     }
 
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("get", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.NotEmpty(_command.Id);
-        Assert.NotEmpty(_command.Title);
-        Assert.False(_command.Metadata.Destructive);
-        Assert.True(_command.Metadata.ReadOnly);
-        Assert.True(_command.Metadata.Idempotent);
-        Assert.False(_command.Metadata.LocalRequired);
-        Assert.False(_command.Metadata.Secret);
+        Assert.Equal("get", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.NotEmpty(Command.Id);
+        Assert.NotEmpty(Command.Title);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
+        Assert.True(Command.Metadata.Idempotent);
+        Assert.False(Command.Metadata.LocalRequired);
+        Assert.False(Command.Metadata.Secret);
     }
 
     [Fact]
@@ -66,14 +50,13 @@ public class AzApiDocsGetCommandTests
             Summary = "AzAPI resource schema for Microsoft.Compute/virtualMachines@2024-03-01"
         };
 
-        _docsService.GetDocumentation("Microsoft.Compute/virtualMachines", null)
+        Service.GetDocumentation("Microsoft.Compute/virtualMachines", null)
             .Returns(expectedResult);
 
         _examplesService.GetExamplesAsync("Microsoft.Compute/virtualMachines", Arg.Any<CancellationToken>())
-            .Returns(new List<AzApiExample>());
+            .Returns([]);
 
-        var args = _commandDefinition.Parse(["--resource-type", "Microsoft.Compute/virtualMachines"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-type", "Microsoft.Compute/virtualMachines");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -90,20 +73,18 @@ public class AzApiDocsGetCommandTests
             Summary = "AzAPI resource schema"
         };
 
-        _docsService.GetDocumentation("Microsoft.Storage/storageAccounts", "2023-01-01")
+        Service.GetDocumentation("Microsoft.Storage/storageAccounts", "2023-01-01")
             .Returns(expectedResult);
 
         _examplesService.GetExamplesAsync("Microsoft.Storage/storageAccounts", Arg.Any<CancellationToken>())
-            .Returns(new List<AzApiExample>());
+            .Returns([]);
 
-        var args = _commandDefinition.Parse([
+        var response = await ExecuteCommandAsync(
             "--resource-type", "Microsoft.Storage/storageAccounts",
-            "--api-version", "2023-01-01"
-        ]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--api-version", "2023-01-01");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        _docsService.Received(1).GetDocumentation("Microsoft.Storage/storageAccounts", "2023-01-01");
+        Service.Received(1).GetDocumentation("Microsoft.Storage/storageAccounts", "2023-01-01");
     }
 
     [Fact]
@@ -127,14 +108,13 @@ public class AzApiDocsGetCommandTests
             }
         };
 
-        _docsService.GetDocumentation("Microsoft.Compute/virtualMachines", null)
+        Service.GetDocumentation("Microsoft.Compute/virtualMachines", null)
             .Returns(expectedResult);
 
         _examplesService.GetExamplesAsync("Microsoft.Compute/virtualMachines", Arg.Any<CancellationToken>())
             .Returns(examples);
 
-        var args = _commandDefinition.Parse(["--resource-type", "Microsoft.Compute/virtualMachines"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-type", "Microsoft.Compute/virtualMachines");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -143,8 +123,7 @@ public class AzApiDocsGetCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingResourceType_ReturnsValidationError()
     {
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
     }
@@ -152,11 +131,10 @@ public class AzApiDocsGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ServiceThrows_HandlesException()
     {
-        _docsService.GetDocumentation(Arg.Any<string>(), Arg.Any<string?>())
+        Service.GetDocumentation(Arg.Any<string>(), Arg.Any<string?>())
             .Throws(new InvalidDataException("Resource type not found."));
 
-        var args = _commandDefinition.Parse(["--resource-type", "Microsoft.Fake/nonexistent"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-type", "Microsoft.Fake/nonexistent");
 
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
     }
@@ -169,14 +147,13 @@ public class AzApiDocsGetCommandTests
     {
         if (shouldSucceed)
         {
-            _docsService.GetDocumentation(Arg.Any<string>(), Arg.Any<string?>())
+            Service.GetDocumentation(Arg.Any<string>(), Arg.Any<string?>())
                 .Returns(new AzApiDocsResult { ResourceType = "Microsoft.Compute/virtualMachines", ApiVersion = "2024-03-01", Schema = "...", Summary = "..." });
             _examplesService.GetExamplesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-                .Returns(new List<AzApiExample>());
+                .Returns([]);
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         if (shouldSucceed)
         {
@@ -201,20 +178,15 @@ public class AzApiDocsGetCommandTests
             Summary = "AzAPI resource schema for Microsoft.Compute/virtualMachines@2024-03-01"
         };
 
-        _docsService.GetDocumentation("Microsoft.Compute/virtualMachines", null)
+        Service.GetDocumentation("Microsoft.Compute/virtualMachines", null)
             .Returns(expectedResult);
 
         _examplesService.GetExamplesAsync("Microsoft.Compute/virtualMachines", Arg.Any<CancellationToken>())
-            .Returns(new List<AzApiExample>());
+            .Returns([]);
 
-        var args = _commandDefinition.Parse(["--resource-type", "Microsoft.Compute/virtualMachines"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-type", "Microsoft.Compute/virtualMachines");
 
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureTerraformJsonContext.Default.AzApiDocsResult);
+        var result = ValidateAndDeserializeResponse(response, AzureTerraformJsonContext.Default.AzApiDocsResult);
 
         Assert.NotNull(result);
         Assert.Equal("Microsoft.Compute/virtualMachines", result.ResourceType);
@@ -225,13 +197,12 @@ public class AzApiDocsGetCommandTests
     [Fact]
     public void BindOptions_BindsOptionsCorrectly()
     {
-        var args = _commandDefinition.Parse(["--resource-type", "Microsoft.Compute/virtualMachines", "--api-version", "2024-03-01"]);
+        var args = CommandDefinition.Parse(["--resource-type", "Microsoft.Compute/virtualMachines", "--api-version", "2024-03-01"]);
 
         Assert.NotNull(args);
         Assert.Empty(args.Errors);
 
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         Assert.Contains(options, o => o.Name == "--resource-type");
         Assert.Contains(options, o => o.Name == "--api-version");

--- a/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AztfexportQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AztfexportQueryCommandTests.cs
@@ -1,46 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureTerraform.Commands;
 using Azure.Mcp.Tools.AzureTerraform.Models;
 using Azure.Mcp.Tools.AzureTerraform.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureTerraform.UnitTests;
 
-public class AztfexportQueryCommandTests
+public class AztfexportQueryCommandTests : CommandUnitTestsBase<AztfexportQueryCommand, IAztfexportService>
 {
-    private readonly ILogger<AztfexportQueryCommand> _logger;
-    private readonly IAztfexportService _aztfexportService;
-    private readonly CommandContext _context;
-    private readonly AztfexportQueryCommand _command;
-    private readonly Command _commandDefinition;
-
-    public AztfexportQueryCommandTests()
-    {
-        var collection = new ServiceCollection();
-        var serviceProvider = collection.BuildServiceProvider();
-        _context = new(serviceProvider);
-        _logger = Substitute.For<ILogger<AztfexportQueryCommand>>();
-        _aztfexportService = Substitute.For<IAztfexportService>();
-        _command = new(_logger, _aztfexportService);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("query", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.True(_command.Metadata.LocalRequired);
+        Assert.Equal("query", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.True(Command.Metadata.LocalRequired);
     }
 
     [Fact]
@@ -55,13 +34,11 @@ public class AztfexportQueryCommandTests
             Description = $"Export Azure resources by query: {query}"
         };
 
-        _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-        _aztfexportService.GenerateQueryCommand(
-            query, null, "azurerm", null, false, 10, true)
+        Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        Service.GenerateQueryCommand(query, null, "azurerm", null, false, 10, true)
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--query", query]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--query", query);
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -70,10 +47,9 @@ public class AztfexportQueryCommandTests
     [Fact]
     public async Task ExecuteAsync_AztfexportNotAvailable_ReturnsInstallationHelp()
     {
-        _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(false);
+        Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(false);
 
-        var args = _commandDefinition.Parse(["--query", "type =~ 'Microsoft.Storage/storageAccounts'"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--query", "type =~ 'Microsoft.Storage/storageAccounts'");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -82,8 +58,7 @@ public class AztfexportQueryCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingQuery_ReturnsValidationError()
     {
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
     }
@@ -91,11 +66,10 @@ public class AztfexportQueryCommandTests
     [Fact]
     public async Task ExecuteAsync_ServiceThrows_HandlesException()
     {
-        _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>())
+        Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Test error"));
 
-        var args = _commandDefinition.Parse(["--query", "type =~ 'Microsoft.Storage/storageAccounts'"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--query", "type =~ 'Microsoft.Storage/storageAccounts'");
 
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
     }
@@ -107,15 +81,14 @@ public class AztfexportQueryCommandTests
     {
         if (shouldSucceed)
         {
-            _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-            _aztfexportService.GenerateQueryCommand(
+            Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+            Service.GenerateQueryCommand(
                 Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(),
                 Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>())
                 .Returns(new AztfexportCommandResult { AztfexportFound = true, Command = "aztfexport", Args = [], Description = "test" });
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         if (shouldSucceed)
         {
@@ -139,22 +112,16 @@ public class AztfexportQueryCommandTests
             Description = $"Export Azure resources by query: {query}"
         };
 
-        _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-        _aztfexportService.GenerateQueryCommand(
+        Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        Service.GenerateQueryCommand(
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(),
             Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>())
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--query", query]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--query", query);
 
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureTerraformJsonContext.Default.AztfexportCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureTerraformJsonContext.Default.AztfexportCommandResult);
-
-        Assert.NotNull(result);
         Assert.True(result.AztfexportFound);
         Assert.Equal("aztfexport", result.Command);
         Assert.NotNull(result.Args);
@@ -163,7 +130,7 @@ public class AztfexportQueryCommandTests
     [Fact]
     public void BindOptions_BindsOptionsCorrectly()
     {
-        var args = _commandDefinition.Parse([
+        var args = CommandDefinition.Parse([
             "--query", "type =~ 'Microsoft.Storage/storageAccounts'",
             "--output-folder", "./output",
             "--provider", "azapi",
@@ -173,8 +140,7 @@ public class AztfexportQueryCommandTests
         Assert.NotNull(args);
         Assert.Empty(args.Errors);
 
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         Assert.Contains(options, o => o.Name == "--query");
         Assert.Contains(options, o => o.Name == "--output-folder");

--- a/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AztfexportResourceCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AztfexportResourceCommandTests.cs
@@ -1,48 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureTerraform.Commands;
 using Azure.Mcp.Tools.AzureTerraform.Models;
 using Azure.Mcp.Tools.AzureTerraform.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureTerraform.UnitTests;
 
-public class AztfexportResourceCommandTests
+public class AztfexportResourceCommandTests : CommandUnitTestsBase<AztfexportResourceCommand, IAztfexportService>
 {
-    private readonly ILogger<AztfexportResourceCommand> _logger;
-    private readonly IAztfexportService _aztfexportService;
-    private readonly CommandContext _context;
-    private readonly AztfexportResourceCommand _command;
-    private readonly Command _commandDefinition;
-
-    public AztfexportResourceCommandTests()
-    {
-        var collection = new ServiceCollection();
-        var serviceProvider = collection.BuildServiceProvider();
-        _context = new(serviceProvider);
-        _logger = Substitute.For<ILogger<AztfexportResourceCommand>>();
-        _aztfexportService = Substitute.For<IAztfexportService>();
-        _command = new(_logger, _aztfexportService);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("resource", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.NotEmpty(_command.Id);
-        Assert.True(_command.Metadata.LocalRequired);
-        Assert.True(_command.Metadata.ReadOnly);
+        Assert.Equal("resource", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.NotEmpty(Command.Id);
+        Assert.True(Command.Metadata.LocalRequired);
+        Assert.True(Command.Metadata.ReadOnly);
     }
 
     [Fact]
@@ -57,13 +36,11 @@ public class AztfexportResourceCommandTests
             Description = $"Export Azure resource: {resourceId}"
         };
 
-        _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-        _aztfexportService.GenerateResourceCommand(
-            resourceId, null, "azurerm", null, false, 10, true)
+        Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        Service.GenerateResourceCommand(resourceId, null, "azurerm", null, false, 10, true)
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--resource-id", resourceId]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-id", resourceId);
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -72,10 +49,9 @@ public class AztfexportResourceCommandTests
     [Fact]
     public async Task ExecuteAsync_AztfexportNotAvailable_ReturnsInstallationHelp()
     {
-        _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(false);
+        Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(false);
 
-        var args = _commandDefinition.Parse(["--resource-id", "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-id", "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -84,8 +60,7 @@ public class AztfexportResourceCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingResourceId_ReturnsValidationError()
     {
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
     }
@@ -93,11 +68,10 @@ public class AztfexportResourceCommandTests
     [Fact]
     public async Task ExecuteAsync_ServiceThrows_HandlesException()
     {
-        _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>())
+        Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Test error"));
 
-        var args = _commandDefinition.Parse(["--resource-id", "/subscriptions/sub/rg/providers/Microsoft.Storage/storageAccounts/sa"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-id", "/subscriptions/sub/rg/providers/Microsoft.Storage/storageAccounts/sa");
 
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
     }
@@ -109,15 +83,14 @@ public class AztfexportResourceCommandTests
     {
         if (shouldSucceed)
         {
-            _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-            _aztfexportService.GenerateResourceCommand(
+            Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+            Service.GenerateResourceCommand(
                 Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(),
                 Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>())
                 .Returns(new AztfexportCommandResult { AztfexportFound = true, Command = "aztfexport", Args = [], Description = "test" });
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         if (shouldSucceed)
         {
@@ -141,22 +114,16 @@ public class AztfexportResourceCommandTests
             Description = $"Export Azure resource: {resourceId}"
         };
 
-        _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-        _aztfexportService.GenerateResourceCommand(
+        Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        Service.GenerateResourceCommand(
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(),
             Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>())
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--resource-id", resourceId]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-id", resourceId);
 
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureTerraformJsonContext.Default.AztfexportCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureTerraformJsonContext.Default.AztfexportCommandResult);
-
-        Assert.NotNull(result);
         Assert.True(result.AztfexportFound);
         Assert.Equal("aztfexport", result.Command);
         Assert.NotNull(result.Args);
@@ -165,7 +132,7 @@ public class AztfexportResourceCommandTests
     [Fact]
     public void BindOptions_BindsOptionsCorrectly()
     {
-        var args = _commandDefinition.Parse([
+        var args = CommandDefinition.Parse([
             "--resource-id", "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa",
             "--output-folder", "./output",
             "--provider", "azapi"
@@ -174,8 +141,7 @@ public class AztfexportResourceCommandTests
         Assert.NotNull(args);
         Assert.Empty(args.Errors);
 
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         Assert.Contains(options, o => o.Name == "--resource-id");
         Assert.Contains(options, o => o.Name == "--output-folder");

--- a/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AztfexportResourceGroupCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AztfexportResourceGroupCommandTests.cs
@@ -1,46 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureTerraform.Commands;
 using Azure.Mcp.Tools.AzureTerraform.Models;
 using Azure.Mcp.Tools.AzureTerraform.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureTerraform.UnitTests;
 
-public class AztfexportResourceGroupCommandTests
+public class AztfexportResourceGroupCommandTests : CommandUnitTestsBase<AztfexportResourceGroupCommand, IAztfexportService>
 {
-    private readonly ILogger<AztfexportResourceGroupCommand> _logger;
-    private readonly IAztfexportService _aztfexportService;
-    private readonly CommandContext _context;
-    private readonly AztfexportResourceGroupCommand _command;
-    private readonly Command _commandDefinition;
-
-    public AztfexportResourceGroupCommandTests()
-    {
-        var collection = new ServiceCollection();
-        var serviceProvider = collection.BuildServiceProvider();
-        _context = new(serviceProvider);
-        _logger = Substitute.For<ILogger<AztfexportResourceGroupCommand>>();
-        _aztfexportService = Substitute.For<IAztfexportService>();
-        _command = new(_logger, _aztfexportService);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("resourcegroup", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.True(_command.Metadata.LocalRequired);
+        Assert.Equal("resourcegroup", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.True(Command.Metadata.LocalRequired);
     }
 
     [Fact]
@@ -54,13 +33,12 @@ public class AztfexportResourceGroupCommandTests
             Description = "Export Azure resource group: my-rg"
         };
 
-        _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-        _aztfexportService.GenerateResourceGroupCommand(
+        Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        Service.GenerateResourceGroupCommand(
             "my-rg", null, "azurerm", null, false, 10, true)
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--resource-group", "my-rg"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-group", "my-rg");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -69,10 +47,9 @@ public class AztfexportResourceGroupCommandTests
     [Fact]
     public async Task ExecuteAsync_AztfexportNotAvailable_ReturnsInstallationHelp()
     {
-        _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(false);
+        Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(false);
 
-        var args = _commandDefinition.Parse(["--resource-group", "my-rg"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-group", "my-rg");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -81,8 +58,7 @@ public class AztfexportResourceGroupCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingResourceGroup_ReturnsValidationError()
     {
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
     }
@@ -90,11 +66,10 @@ public class AztfexportResourceGroupCommandTests
     [Fact]
     public async Task ExecuteAsync_ServiceThrows_HandlesException()
     {
-        _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>())
+        Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Test error"));
 
-        var args = _commandDefinition.Parse(["--resource-group", "my-rg"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-group", "my-rg");
 
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
     }
@@ -106,15 +81,14 @@ public class AztfexportResourceGroupCommandTests
     {
         if (shouldSucceed)
         {
-            _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-            _aztfexportService.GenerateResourceGroupCommand(
+            Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+            Service.GenerateResourceGroupCommand(
                 Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(),
                 Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>())
                 .Returns(new AztfexportCommandResult { AztfexportFound = true, Command = "aztfexport", Args = [], Description = "test" });
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         if (shouldSucceed)
         {
@@ -137,22 +111,16 @@ public class AztfexportResourceGroupCommandTests
             Description = "Export Azure resource group: my-rg"
         };
 
-        _aztfexportService.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-        _aztfexportService.GenerateResourceGroupCommand(
+        Service.IsAztfexportAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        Service.GenerateResourceGroupCommand(
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(),
             Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>())
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--resource-group", "my-rg"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-group", "my-rg");
 
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureTerraformJsonContext.Default.AztfexportCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureTerraformJsonContext.Default.AztfexportCommandResult);
-
-        Assert.NotNull(result);
         Assert.True(result.AztfexportFound);
         Assert.Equal("aztfexport", result.Command);
         Assert.NotNull(result.Args);
@@ -161,7 +129,7 @@ public class AztfexportResourceGroupCommandTests
     [Fact]
     public void BindOptions_BindsOptionsCorrectly()
     {
-        var args = _commandDefinition.Parse([
+        var args = CommandDefinition.Parse([
             "--resource-group", "my-rg",
             "--output-folder", "./output",
             "--provider", "azapi"
@@ -170,8 +138,7 @@ public class AztfexportResourceGroupCommandTests
         Assert.NotNull(args);
         Assert.Empty(args.Errors);
 
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         Assert.Contains(options, o => o.Name == "--resource-group");
         Assert.Contains(options, o => o.Name == "--output-folder");

--- a/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AzureRMDocsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/AzureRMDocsGetCommandTests.cs
@@ -1,52 +1,29 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureTerraform.Commands;
 using Azure.Mcp.Tools.AzureTerraform.Models;
 using Azure.Mcp.Tools.AzureTerraform.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureTerraform.UnitTests;
 
-public class AzureRMDocsGetCommandTests
+public class AzureRMDocsGetCommandTests : CommandUnitTestsBase<AzureRMDocsGetCommand, IAzureRMDocsService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<AzureRMDocsGetCommand> _logger;
-    private readonly IAzureRMDocsService _docsService;
-    private readonly CommandContext _context;
-    private readonly AzureRMDocsGetCommand _command;
-    private readonly Command _commandDefinition;
-
-    public AzureRMDocsGetCommandTests()
-    {
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _context = new(_serviceProvider);
-        _logger = Substitute.For<ILogger<AzureRMDocsGetCommand>>();
-        _docsService = Substitute.For<IAzureRMDocsService>();
-        _command = new(_logger, _docsService);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("get", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.NotEmpty(_command.Id);
-        Assert.NotEmpty(_command.Title);
-        Assert.False(_command.Metadata.Destructive);
-        Assert.True(_command.Metadata.ReadOnly);
-        Assert.True(_command.Metadata.Idempotent);
+        Assert.Equal("get", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.NotEmpty(Command.Id);
+        Assert.NotEmpty(Command.Title);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
+        Assert.True(Command.Metadata.Idempotent);
     }
 
     [Fact]
@@ -69,7 +46,7 @@ public class AzureRMDocsGetCommandTests
             Notes = ["Some note"]
         };
 
-        _docsService.GetDocumentationAsync(
+        Service.GetDocumentationAsync(
             "azurerm_resource_group",
             "resource",
             null,
@@ -77,8 +54,7 @@ public class AzureRMDocsGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--resource-type", "azurerm_resource_group"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-type", "azurerm_resource_group");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -87,8 +63,7 @@ public class AzureRMDocsGetCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingResourceType_ReturnsValidationError()
     {
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
     }
@@ -96,7 +71,7 @@ public class AzureRMDocsGetCommandTests
     [Fact]
     public async Task ExecuteAsync_ServiceThrows_HandlesException()
     {
-        _docsService.GetDocumentationAsync(
+        Service.GetDocumentationAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
@@ -104,8 +79,7 @@ public class AzureRMDocsGetCommandTests
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("Network error"));
 
-        var args = _commandDefinition.Parse(["--resource-type", "azurerm_resource_group"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-type", "azurerm_resource_group");
 
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
     }
@@ -113,7 +87,7 @@ public class AzureRMDocsGetCommandTests
     [Fact]
     public async Task ExecuteAsync_WithDocType_PassesDocType()
     {
-        _docsService.GetDocumentationAsync(
+        Service.GetDocumentationAsync(
             "azurerm_resource_group",
             "data-source",
             null,
@@ -121,11 +95,10 @@ public class AzureRMDocsGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(new AzureRMDocsResult { ResourceType = "azurerm_resource_group" });
 
-        var args = _commandDefinition.Parse(["--resource-type", "azurerm_resource_group", "--doc-type", "data-source"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-type", "azurerm_resource_group", "--doc-type", "data-source");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _docsService.Received(1).GetDocumentationAsync(
+        await Service.Received(1).GetDocumentationAsync(
             "azurerm_resource_group",
             "data-source",
             null,
@@ -136,7 +109,7 @@ public class AzureRMDocsGetCommandTests
     [Fact]
     public async Task ExecuteAsync_WithArgumentFilter_PassesArgumentName()
     {
-        _docsService.GetDocumentationAsync(
+        Service.GetDocumentationAsync(
             "azurerm_resource_group",
             "resource",
             "name",
@@ -144,11 +117,10 @@ public class AzureRMDocsGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(new AzureRMDocsResult { ResourceType = "azurerm_resource_group" });
 
-        var args = _commandDefinition.Parse(["--resource-type", "azurerm_resource_group", "--argument", "name"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-type", "azurerm_resource_group", "--argument", "name");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await _docsService.Received(1).GetDocumentationAsync(
+        await Service.Received(1).GetDocumentationAsync(
             "azurerm_resource_group",
             "resource",
             "name",
@@ -164,13 +136,12 @@ public class AzureRMDocsGetCommandTests
     {
         if (shouldSucceed)
         {
-            _docsService.GetDocumentationAsync(
+            Service.GetDocumentationAsync(
                 Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new AzureRMDocsResult { ResourceType = "azurerm_resource_group" });
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         if (shouldSucceed)
         {
@@ -202,7 +173,7 @@ public class AzureRMDocsGetCommandTests
             Notes = ["Some note"]
         };
 
-        _docsService.GetDocumentationAsync(
+        Service.GetDocumentationAsync(
             "azurerm_resource_group",
             "resource",
             null,
@@ -210,16 +181,10 @@ public class AzureRMDocsGetCommandTests
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--resource-type", "azurerm_resource_group"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--resource-type", "azurerm_resource_group");
 
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureTerraformJsonContext.Default.AzureRMDocsResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureTerraformJsonContext.Default.AzureRMDocsResult);
-
-        Assert.NotNull(result);
         Assert.Equal("azurerm_resource_group", result.ResourceType);
         Assert.Equal("Manages a Resource Group.", result.Summary);
         Assert.NotNull(result.Arguments);
@@ -230,7 +195,7 @@ public class AzureRMDocsGetCommandTests
     [Fact]
     public void BindOptions_BindsOptionsCorrectly()
     {
-        var args = _commandDefinition.Parse([
+        var args = CommandDefinition.Parse([
             "--resource-type", "azurerm_resource_group",
             "--doc-type", "data-source",
             "--argument", "name",
@@ -240,8 +205,7 @@ public class AzureRMDocsGetCommandTests
         Assert.NotNull(args);
         Assert.Empty(args.Errors);
 
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         Assert.Contains(options, o => o.Name == "--resource-type");
         Assert.Contains(options, o => o.Name == "--doc-type");

--- a/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/Conftest/ConftestPlanValidationCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/Conftest/ConftestPlanValidationCommandTests.cs
@@ -1,48 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureTerraform.Commands;
 using Azure.Mcp.Tools.AzureTerraform.Models;
 using Azure.Mcp.Tools.AzureTerraform.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
-namespace Azure.Mcp.Tools.AzureTerraform.UnitTests;
+namespace Azure.Mcp.Tools.AzureTerraform.UnitTests.Conftest;
 
-public class ConftestPlanValidationCommandTests
+public class ConftestPlanValidationCommandTests : CommandUnitTestsBase<ConftestPlanValidationCommand, IConftestService>
 {
-    private readonly ILogger<ConftestPlanValidationCommand> _logger;
-    private readonly IConftestService _conftestService;
-    private readonly CommandContext _context;
-    private readonly ConftestPlanValidationCommand _command;
-    private readonly Command _commandDefinition;
-
-    public ConftestPlanValidationCommandTests()
-    {
-        var collection = new ServiceCollection();
-        var serviceProvider = collection.BuildServiceProvider();
-        _context = new(serviceProvider);
-        _logger = Substitute.For<ILogger<ConftestPlanValidationCommand>>();
-        _conftestService = Substitute.For<IConftestService>();
-        _command = new(_logger, _conftestService);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("plan", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.NotEmpty(_command.Id);
-        Assert.True(_command.Metadata.LocalRequired);
-        Assert.True(_command.Metadata.ReadOnly);
+        Assert.Equal("plan", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.NotEmpty(Command.Id);
+        Assert.True(Command.Metadata.LocalRequired);
+        Assert.True(Command.Metadata.ReadOnly);
     }
 
     [Fact]
@@ -57,13 +36,12 @@ public class ConftestPlanValidationCommandTests
             Description = $"Validate Terraform plan in: {planFolder}"
         };
 
-        _conftestService.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-        _conftestService.GeneratePlanValidationCommand(
+        Service.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        Service.GeneratePlanValidationCommand(
             planFolder, "all", null, null)
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--plan-folder", planFolder]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--plan-folder", planFolder);
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -72,10 +50,9 @@ public class ConftestPlanValidationCommandTests
     [Fact]
     public async Task ExecuteAsync_ConftestNotAvailable_ReturnsInstallationHelp()
     {
-        _conftestService.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(false);
+        Service.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(false);
 
-        var args = _commandDefinition.Parse(["--plan-folder", "/home/user/project"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--plan-folder", "/home/user/project");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -84,8 +61,7 @@ public class ConftestPlanValidationCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingPlanFolder_ReturnsValidationError()
     {
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
     }
@@ -103,13 +79,15 @@ public class ConftestPlanValidationCommandTests
             PolicySet = "avmsec"
         };
 
-        _conftestService.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-        _conftestService.GeneratePlanValidationCommand(
+        Service.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        Service.GeneratePlanValidationCommand(
             planFolder, "avmsec", "high", null)
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--plan-folder", planFolder, "--policy-set", "avmsec", "--severity-filter", "high"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--plan-folder", planFolder,
+            "--policy-set", "avmsec",
+            "--severity-filter", "high");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -118,11 +96,10 @@ public class ConftestPlanValidationCommandTests
     [Fact]
     public async Task ExecuteAsync_ServiceThrows_HandlesException()
     {
-        _conftestService.IsConftestAvailableAsync(Arg.Any<CancellationToken>())
+        Service.IsConftestAvailableAsync(Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Test error"));
 
-        var args = _commandDefinition.Parse(["--plan-folder", "/home/user/project"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--plan-folder", "/home/user/project");
 
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
     }
@@ -135,14 +112,13 @@ public class ConftestPlanValidationCommandTests
     {
         if (shouldSucceed)
         {
-            _conftestService.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-            _conftestService.GeneratePlanValidationCommand(
+            Service.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+            Service.GeneratePlanValidationCommand(
                 Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>())
                 .Returns(new ConftestCommandResult { ConftestFound = true, Command = "conftest", Args = [], Description = "test" });
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         if (shouldSucceed)
         {
@@ -167,21 +143,15 @@ public class ConftestPlanValidationCommandTests
             PolicySet = "all"
         };
 
-        _conftestService.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-        _conftestService.GeneratePlanValidationCommand(
+        Service.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        Service.GeneratePlanValidationCommand(
             planFolder, "all", null, null)
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--plan-folder", planFolder]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--plan-folder", planFolder);
 
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureTerraformJsonContext.Default.ConftestCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureTerraformJsonContext.Default.ConftestCommandResult);
-
-        Assert.NotNull(result);
         Assert.True(result.ConftestFound);
         Assert.Equal("conftest", result.Command);
         Assert.NotNull(result.Args);
@@ -190,7 +160,7 @@ public class ConftestPlanValidationCommandTests
     [Fact]
     public void BindOptions_BindsOptionsCorrectly()
     {
-        var args = _commandDefinition.Parse([
+        var args = CommandDefinition.Parse([
             "--plan-folder", "/home/user/project",
             "--policy-set", "avmsec",
             "--severity-filter", "high"
@@ -199,8 +169,7 @@ public class ConftestPlanValidationCommandTests
         Assert.NotNull(args);
         Assert.Empty(args.Errors);
 
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         Assert.Contains(options, o => o.Name == "--plan-folder");
         Assert.Contains(options, o => o.Name == "--policy-set");

--- a/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/Conftest/ConftestWorkspaceValidationCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.UnitTests/Conftest/ConftestWorkspaceValidationCommandTests.cs
@@ -1,48 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.AzureTerraform.Commands;
 using Azure.Mcp.Tools.AzureTerraform.Models;
 using Azure.Mcp.Tools.AzureTerraform.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
-namespace Azure.Mcp.Tools.AzureTerraform.UnitTests;
+namespace Azure.Mcp.Tools.AzureTerraform.UnitTests.Conftest;
 
-public class ConftestWorkspaceValidationCommandTests
+public class ConftestWorkspaceValidationCommandTests : CommandUnitTestsBase<ConftestWorkspaceValidationCommand, IConftestService>
 {
-    private readonly ILogger<ConftestWorkspaceValidationCommand> _logger;
-    private readonly IConftestService _conftestService;
-    private readonly CommandContext _context;
-    private readonly ConftestWorkspaceValidationCommand _command;
-    private readonly Command _commandDefinition;
-
-    public ConftestWorkspaceValidationCommandTests()
-    {
-        var collection = new ServiceCollection();
-        var serviceProvider = collection.BuildServiceProvider();
-        _context = new(serviceProvider);
-        _logger = Substitute.For<ILogger<ConftestWorkspaceValidationCommand>>();
-        _conftestService = Substitute.For<IConftestService>();
-        _command = new(_logger, _conftestService);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("workspace", _command.Name);
-        Assert.NotEmpty(_command.Description);
-        Assert.NotEmpty(_command.Id);
-        Assert.True(_command.Metadata.LocalRequired);
-        Assert.True(_command.Metadata.ReadOnly);
+        Assert.Equal("workspace", Command.Name);
+        Assert.NotEmpty(Command.Description);
+        Assert.NotEmpty(Command.Id);
+        Assert.True(Command.Metadata.LocalRequired);
+        Assert.True(Command.Metadata.ReadOnly);
     }
 
     [Fact]
@@ -57,13 +36,12 @@ public class ConftestWorkspaceValidationCommandTests
             Description = $"Validate Terraform workspace: {workspaceFolder}"
         };
 
-        _conftestService.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-        _conftestService.GenerateWorkspaceValidationCommand(
+        Service.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        Service.GenerateWorkspaceValidationCommand(
             workspaceFolder, "all", null, null)
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--workspace-folder", workspaceFolder]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--workspace-folder", workspaceFolder);
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -72,10 +50,9 @@ public class ConftestWorkspaceValidationCommandTests
     [Fact]
     public async Task ExecuteAsync_ConftestNotAvailable_ReturnsInstallationHelp()
     {
-        _conftestService.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(false);
+        Service.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(false);
 
-        var args = _commandDefinition.Parse(["--workspace-folder", "/home/user/project"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--workspace-folder", "/home/user/project");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -84,8 +61,7 @@ public class ConftestWorkspaceValidationCommandTests
     [Fact]
     public async Task ExecuteAsync_MissingWorkspaceFolder_ReturnsValidationError()
     {
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
     }
@@ -103,13 +79,13 @@ public class ConftestWorkspaceValidationCommandTests
             PolicySet = "avmsec"
         };
 
-        _conftestService.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-        _conftestService.GenerateWorkspaceValidationCommand(
-            workspaceFolder, "avmsec", null, null)
+        Service.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        Service.GenerateWorkspaceValidationCommand(workspaceFolder, "avmsec", null, null)
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--workspace-folder", workspaceFolder, "--policy-set", "avmsec"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--workspace-folder", workspaceFolder,
+            "--policy-set", "avmsec");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
@@ -118,11 +94,10 @@ public class ConftestWorkspaceValidationCommandTests
     [Fact]
     public async Task ExecuteAsync_ServiceThrows_HandlesException()
     {
-        _conftestService.IsConftestAvailableAsync(Arg.Any<CancellationToken>())
+        Service.IsConftestAvailableAsync(Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Test error"));
 
-        var args = _commandDefinition.Parse(["--workspace-folder", "/home/user/project"]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--workspace-folder", "/home/user/project");
 
         Assert.NotEqual(HttpStatusCode.OK, response.Status);
     }
@@ -135,14 +110,13 @@ public class ConftestWorkspaceValidationCommandTests
     {
         if (shouldSucceed)
         {
-            _conftestService.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-            _conftestService.GenerateWorkspaceValidationCommand(
+            Service.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+            Service.GenerateWorkspaceValidationCommand(
                 Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>())
                 .Returns(new ConftestCommandResult { ConftestFound = true, Command = "conftest", Args = [], Description = "test" });
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         if (shouldSucceed)
         {
@@ -167,21 +141,14 @@ public class ConftestWorkspaceValidationCommandTests
             PolicySet = "all"
         };
 
-        _conftestService.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
-        _conftestService.GenerateWorkspaceValidationCommand(
-            workspaceFolder, "all", null, null)
+        Service.IsConftestAvailableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        Service.GenerateWorkspaceValidationCommand(workspaceFolder, "all", null, null)
             .Returns(expectedResult);
 
-        var args = _commandDefinition.Parse(["--workspace-folder", workspaceFolder]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--workspace-folder", workspaceFolder);
 
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureTerraformJsonContext.Default.ConftestCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, AzureTerraformJsonContext.Default.ConftestCommandResult);
-
-        Assert.NotNull(result);
         Assert.True(result.ConftestFound);
         Assert.Equal("conftest", result.Command);
         Assert.NotNull(result.Args);
@@ -190,7 +157,7 @@ public class ConftestWorkspaceValidationCommandTests
     [Fact]
     public void BindOptions_BindsOptionsCorrectly()
     {
-        var args = _commandDefinition.Parse([
+        var args = CommandDefinition.Parse([
             "--workspace-folder", "/home/user/project",
             "--policy-set", "avmsec",
             "--severity-filter", "high"
@@ -199,8 +166,7 @@ public class ConftestWorkspaceValidationCommandTests
         Assert.NotNull(args);
         Assert.Empty(args.Errors);
 
-        var command = _command.GetCommand();
-        var options = command.Options;
+        var options = CommandDefinition.Options;
 
         Assert.Contains(options, o => o.Name == "--workspace-folder");
         Assert.Contains(options, o => o.Name == "--policy-set");

--- a/tools/Azure.Mcp.Tools.AzureTerraformBestPractices/tests/Azure.Mcp.Tools.AzureTerraformBestPractices.UnitTests/AzureTerraformBestPracticesGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraformBestPractices/tests/Azure.Mcp.Tools.AzureTerraformBestPractices.UnitTests/AzureTerraformBestPracticesGetCommandTests.cs
@@ -1,47 +1,22 @@
-using System.CommandLine;
-using System.Text.Json;
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Azure.Mcp.Tools.AzureTerraformBestPractices.Commands;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
-using NSubstitute;
+using Microsoft.Mcp.Tests.Client;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AzureTerraformBestPractices.UnitTests;
 
-public class AzureTerraformBestPracticesGetCommandTests
+public class AzureTerraformBestPracticesGetCommandTests : CommandUnitTestsBase<AzureTerraformBestPracticesGetCommand, object>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<AzureTerraformBestPracticesGetCommand> _logger;
-    private readonly CommandContext _context;
-    private readonly AzureTerraformBestPracticesGetCommand _command;
-    private readonly Command _commandDefinition;
-
-    public AzureTerraformBestPracticesGetCommandTests()
-    {
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-
-        _context = new(_serviceProvider);
-        _logger = Substitute.For<ILogger<AzureTerraformBestPracticesGetCommand>>();
-        _command = new(_logger);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public async Task ExecuteAsync_ReturnsAzureTerraformBestPractices()
     {
-        var args = _commandDefinition.Parse([]);
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync([]);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, AzureTerraformBestPracticesJsonContext.Default.ListString);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<string[]>(json);
-
-        Assert.NotNull(result);
         Assert.Contains("winget install Hashicorp.Terraform", result[0]);
         Assert.Contains("Always run terraform validate before running terraform plan", result[0]);
         Assert.Contains("terraform apply -auto-approve", result[0]);

--- a/tools/Azure.Mcp.Tools.CloudArchitect/tests/Azure.Mcp.Tools.CloudArchitect.UnitTests/Azure.Mcp.Tools.CloudArchitect.UnitTests.csproj
+++ b/tools/Azure.Mcp.Tools.CloudArchitect/tests/Azure.Mcp.Tools.CloudArchitect.UnitTests/Azure.Mcp.Tools.CloudArchitect.UnitTests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Azure.Mcp.Tools.CloudArchitect.csproj" />
     <ProjectReference Include="..\..\..\..\core\Azure.Mcp.Core\src\Azure.Mcp.Core.csproj" />
+    <ProjectReference Include="..\..\..\..\core\Azure.Mcp.Core\tests\Azure.Mcp.Tests\Azure.Mcp.Tests.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/tools/Azure.Mcp.Tools.CloudArchitect/tests/Azure.Mcp.Tools.CloudArchitect.UnitTests/Design/DesignCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.CloudArchitect/tests/Azure.Mcp.Tools.CloudArchitect.UnitTests/Design/DesignCommandTests.cs
@@ -3,61 +3,39 @@
 
 using System.Net;
 using System.Reflection;
-using System.Text;
-using System.Text.Json;
 using Azure.Mcp.Tools.CloudArchitect.Commands.Design;
 using Azure.Mcp.Tools.CloudArchitect.Options;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 
 namespace Azure.Mcp.Tools.CloudArchitect.UnitTests.Design;
 
-public class DesignCommandTests
+public class DesignCommandTests : CommandUnitTestsBase<DesignCommand, object>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<DesignCommand> _logger;
-    private readonly DesignCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public DesignCommandTests()
-    {
-        _logger = Substitute.For<ILogger<DesignCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("design", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("design", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
 
         // Check that the description contains the expected content from the actual implementation
-        Assert.Contains("Recommends architecture design for cloud services/apps/solutions", command.Description);
-        Assert.Contains("file storage, banking, video streaming, e-commerce, SaaS", command.Description);
-        Assert.Contains("Ask about user role, business goals, etc (1-2 questions at a time)", command.Description);
-        Assert.Contains("Track confidence returned by service and update requirements", command.Description);
-        Assert.Contains("confidence >= 0.7", command.Description);
-        Assert.Contains("Present architecture with table format, visual organization, ASCII diagrams", command.Description);
-        Assert.Contains("Follow Azure Well-Architected Framework principles", command.Description);
-        Assert.Contains("infrastructure, platform, application, data, security, operations", command.Description);
-        Assert.Contains("State tracks components, requirements by category, and confidence factors", command.Description);
-        Assert.Contains("Be conservative with suggestions", command.Description);
+        Assert.Contains("Recommends architecture design for cloud services/apps/solutions", CommandDefinition.Description);
+        Assert.Contains("file storage, banking, video streaming, e-commerce, SaaS", CommandDefinition.Description);
+        Assert.Contains("Ask about user role, business goals, etc (1-2 questions at a time)", CommandDefinition.Description);
+        Assert.Contains("Track confidence returned by service and update requirements", CommandDefinition.Description);
+        Assert.Contains("confidence >= 0.7", CommandDefinition.Description);
+        Assert.Contains("Present architecture with table format, visual organization, ASCII diagrams", CommandDefinition.Description);
+        Assert.Contains("Follow Azure Well-Architected Framework principles", CommandDefinition.Description);
+        Assert.Contains("infrastructure, platform, application, data, security, operations", CommandDefinition.Description);
+        Assert.Contains("State tracks components, requirements by category, and confidence factors", CommandDefinition.Description);
+        Assert.Contains("Be conservative with suggestions", CommandDefinition.Description);
     }
 
     [Fact]
     public void Command_HasCorrectOptions()
     {
-        var command = _command.GetCommand();
-
         // Check that the command has the expected options
-        var optionNames = command.Options.Select(o => o.Name).ToList();
+        var optionNames = CommandDefinition.Options.Select(o => o.Name).ToList();
 
         Assert.Contains("--question", optionNames);
         Assert.Contains("--question-number", optionNames);
@@ -80,29 +58,12 @@ public class DesignCommandTests
     [InlineData("--question \"App type?\" --question-number 1 --total-questions 5")]
     public async Task ExecuteAsync_ReturnsArchitectureDesignText(string args)
     {
-        // Arrange
-        var parseResult = _commandDefinition.Parse(args);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-        Assert.Empty(response.Message);
+        var responseObject = ValidateAndDeserializeResponse(response, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
 
-        // Verify that results contain the architecture design response structure
-        using var stream = new MemoryStream();
-        using var writer = new Utf8JsonWriter(stream);
-        response.Results.Write(writer);
-        writer.Flush();
-
-        var serializedResult = Encoding.UTF8.GetString(stream.ToArray());
-
-
-        var responseObject = JsonSerializer.Deserialize(serializedResult, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
-
-        Assert.NotNull(responseObject);
         Assert.NotEmpty(responseObject.DesignArchitecture);
         Assert.NotNull(responseObject.ResponseObject);
 
@@ -113,31 +74,18 @@ public class DesignCommandTests
     [Fact]
     public async Task ExecuteAsync_WithAllOptionsSet()
     {
-        // Arrange
-        var args = new[]
-        {
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(
             "--question", "What is your application type?",
             "--question-number", "1",
             "--total-questions", "5",
             "--answer", "Web application",
             "--next-question-needed", "true",
-            "--confidence-score", "0.8",
-        };
-
-        var parseResult = _commandDefinition.Parse(args);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+            "--confidence-score", "0.8");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-        Assert.Empty(response.Message);
+        var responseObject = ValidateAndDeserializeResponse(response, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
 
-        // Verify the command executed successfully regardless of the input options
-        string serializedResult = SerializeResponseResult(response.Results);
-        var responseObject = JsonSerializer.Deserialize(serializedResult, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
-        Assert.NotNull(responseObject);
         Assert.NotEmpty(responseObject.DesignArchitecture);
         Assert.NotNull(responseObject.ResponseObject);
         Assert.Equal("What is your application type?", responseObject.ResponseObject.DisplayText);
@@ -152,22 +100,12 @@ public class DesignCommandTests
     [InlineData("Mixed \"quotes\" and 'apostrophes'", "Mixed \"quotes\" and 'apostrophes'")]
     public async Task ExecuteAsync_HandlesQuotesAndEscapingProperly(string questionWithQuotes, string expectedQuestion)
     {
-        // Arrange
-        var args = new[] { "--question", questionWithQuotes };
-        var parseResult = _commandDefinition.Parse(args);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync("--question", questionWithQuotes);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-        Assert.Empty(response.Message);
+        var responseObject = ValidateAndDeserializeResponse(response, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
 
-        // Verify that the command executed successfully with the quoted input
-        string serializedResult = SerializeResponseResult(response.Results);
-        var responseObject = JsonSerializer.Deserialize(serializedResult, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
-        Assert.NotNull(responseObject);
         Assert.NotEmpty(responseObject.DesignArchitecture);
         Assert.NotNull(responseObject.ResponseObject);
 
@@ -189,13 +127,17 @@ public class DesignCommandTests
             "--question-number", "2",
             "--total-questions", "10"
         };
-        var parseResult = _commandDefinition.Parse(args);
+        var parseResult = CommandDefinition.Parse(args);
 
         // Ensure there were no parse/validation errors
-        Assert.True(!parseResult.Errors.Any(), string.Join("; ", parseResult.Errors.Select(e => e.Message)));
+        Assert.False(parseResult.Errors.Any());
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--question", complexQuestion,
+            "--answer", complexAnswer,
+            "--question-number", "2",
+            "--total-questions", "10");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -213,46 +155,28 @@ public class DesignCommandTests
     [Fact]
     public void Metadata_IsConfiguredCorrectly()
     {
-        // Arrange & Act
-        var metadata = _command.Metadata;
-
-        // Assert
-        Assert.False(metadata.Destructive);
-        Assert.True(metadata.ReadOnly);
+        Assert.False(Command.Metadata.Destructive);
+        Assert.True(Command.Metadata.ReadOnly);
     }
 
     [Fact]
     public void Properties_AreConfiguredCorrectly()
     {
-        // Arrange & Act
-        var name = _command.Name;
-        var title = _command.Title;
-        var description = _command.Description;
-
-        // Assert
-        Assert.Equal("design", name);
-        Assert.Equal("Design Azure cloud architectures through guided questions", title);
-        Assert.NotEmpty(description);
-        Assert.Contains("Recommends architecture design for cloud services/apps/solutions", description);
+        Assert.Equal("design", Command.Name);
+        Assert.Equal("Design Azure cloud architectures through guided questions", Command.Title);
+        Assert.NotEmpty(Command.Description);
+        Assert.Contains("Recommends architecture design for cloud services/apps/solutions", Command.Description);
     }
 
     [Fact]
     public async Task ExecuteAsync_LoadsEmbeddedResourceText()
     {
-        // Arrange
-        var args = new[] { "--question", "Test question" };
-        var parseResult = _commandDefinition.Parse(args);
-
-        // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync("--question", "Test question");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var responseObject = ValidateAndDeserializeResponse(response, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
 
-        string serializedResult = SerializeResponseResult(response.Results!);
-        var responseObject = JsonSerializer.Deserialize(serializedResult, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
-
-        Assert.NotNull(responseObject);
         Assert.NotEmpty(responseObject.DesignArchitecture);
         // The embedded resource should contain Azure architecture guidance
         Assert.Contains("Azure", responseObject.DesignArchitecture);
@@ -263,21 +187,14 @@ public class DesignCommandTests
     {
         // Arrange - Create a simple JSON state object
         var stateJson = "{\"architectureComponents\":[],\"architectureTiers\":{\"infrastructure\":[],\"platform\":[],\"application\":[],\"data\":[],\"security\":[],\"operations\":[]},\"requirements\":{\"explicit\":[],\"implicit\":[],\"assumed\":[]},\"confidenceFactors\":{\"explicitRequirementsCoverage\":0.5,\"implicitRequirementsCertainty\":0.7,\"assumptionRisk\":0.3}}";
-        var args = new[] { "--state", stateJson };
-        var parseResult = _commandDefinition.Parse(args);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--state", stateJson);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-        Assert.Empty(response.Message);
-
         // Verify the command executed successfully with state option
-        string serializedResult = SerializeResponseResult(response.Results);
-        var responseObject = JsonSerializer.Deserialize(serializedResult, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
-        Assert.NotNull(responseObject);
+        var responseObject = ValidateAndDeserializeResponse(response, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
+
         Assert.NotEmpty(responseObject.DesignArchitecture);
         Assert.NotNull(responseObject.ResponseObject);
         Assert.NotNull(responseObject.ResponseObject.State);
@@ -297,18 +214,14 @@ public class DesignCommandTests
             "--confidence-score", "0.9",
         };
 
-        var parseResult = _commandDefinition.Parse(args);
+        var parseResult = CommandDefinition.Parse(args);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-        Assert.Empty(response.Message);
-
         // Verify all options were parsed correctly
-        var command = _command.GetCommand();
+        var command = Command.GetCommand();
         var questionValue = parseResult.GetValue((Option<string>)command.Options.First(o => o.Name == "--question"));
         var questionNumberValue = parseResult.GetValue((Option<int>)command.Options.First(o => o.Name == "--question-number"));
         var totalQuestionsValue = parseResult.GetValue((Option<int>)command.Options.First(o => o.Name == "--total-questions"));
@@ -324,24 +237,14 @@ public class DesignCommandTests
         Assert.Equal(0.9, confidenceScoreValue);
 
         // Verify the response structure
-        string serializedResult = SerializeResponseResult(response.Results);
-        var responseObject = JsonSerializer.Deserialize(serializedResult, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
-        Assert.NotNull(responseObject);
+        var responseObject = ValidateAndDeserializeResponse(response, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
+
         Assert.NotEmpty(responseObject.DesignArchitecture);
         Assert.NotNull(responseObject.ResponseObject);
         Assert.Equal(questionValue, responseObject.ResponseObject.DisplayText);
         Assert.Equal(questionNumberValue, responseObject.ResponseObject.QuestionNumber);
         Assert.Equal(totalQuestionsValue, responseObject.ResponseObject.TotalQuestions);
         Assert.Equal(nextQuestionNeededValue, responseObject.ResponseObject.NextQuestionNeeded);
-    }
-
-    private static string SerializeResponseResult(ResponseResult responseResult)
-    {
-        using var stream = new MemoryStream();
-        using var writer = new Utf8JsonWriter(stream);
-        responseResult.Write(writer);
-        writer.Flush();
-        return Encoding.UTF8.GetString(stream.ToArray());
     }
 
     #region Validation Tests
@@ -353,11 +256,8 @@ public class DesignCommandTests
     [InlineData(-1.0)]
     public void Parse_InvalidConfidenceScore_ReturnsError(double invalidScore)
     {
-        // Arrange
-        var args = new[] { "--confidence-score", invalidScore.ToString() };
-
-        // Act
-        var parseResult = _commandDefinition.Parse(args);
+        // Arrange & Act
+        var parseResult = CommandDefinition.Parse(["--confidence-score", invalidScore.ToString()]);
 
         // Assert
         Assert.NotEmpty(parseResult.Errors);
@@ -372,11 +272,8 @@ public class DesignCommandTests
     [InlineData(0.9)]
     public void Parse_ValidConfidenceScore_NoErrors(double validScore)
     {
-        // Arrange
-        var args = new[] { "--confidence-score", validScore.ToString() };
-
-        // Act
-        var parseResult = _commandDefinition.Parse(args);
+        // Arrange & Act
+        var parseResult = CommandDefinition.Parse(["--confidence-score", validScore.ToString()]);
 
         // Assert
         Assert.Empty(parseResult.Errors);
@@ -388,11 +285,8 @@ public class DesignCommandTests
     [InlineData(-100)]
     public void Parse_NegativeQuestionNumber_ReturnsError(int invalidQuestionNumber)
     {
-        // Arrange
-        var args = new[] { "--question-number", invalidQuestionNumber.ToString() };
-
-        // Act
-        var parseResult = _commandDefinition.Parse(args);
+        // Arrange & Act
+        var parseResult = CommandDefinition.Parse(["--question-number", invalidQuestionNumber.ToString()]);
 
         // Assert
         Assert.NotEmpty(parseResult.Errors);
@@ -406,11 +300,8 @@ public class DesignCommandTests
     [InlineData(100)]
     public void Parse_ValidQuestionNumber_NoErrors(int validQuestionNumber)
     {
-        // Arrange
-        var args = new[] { "--question-number", validQuestionNumber.ToString() };
-
-        // Act
-        var parseResult = _commandDefinition.Parse(args);
+        // Arrange & Act
+        var parseResult = CommandDefinition.Parse(["--question-number", validQuestionNumber.ToString()]);
 
         // Assert
         Assert.Empty(parseResult.Errors);
@@ -422,11 +313,8 @@ public class DesignCommandTests
     [InlineData(-100)]
     public void Parse_NegativeTotalQuestions_ReturnsError(int invalidTotalQuestions)
     {
-        // Arrange
-        var args = new[] { "--total-questions", invalidTotalQuestions.ToString() };
-
-        // Act
-        var parseResult = _commandDefinition.Parse(args);
+        // Arrange & Act
+        var parseResult = CommandDefinition.Parse(["--total-questions", invalidTotalQuestions.ToString()]);
 
         // Assert
         Assert.NotEmpty(parseResult.Errors);
@@ -440,11 +328,8 @@ public class DesignCommandTests
     [InlineData(100)]
     public void Parse_ValidTotalQuestions_NoErrors(int validTotalQuestions)
     {
-        // Arrange
-        var args = new[] { "--total-questions", validTotalQuestions.ToString() };
-
-        // Act
-        var parseResult = _commandDefinition.Parse(args);
+        // Arrange & Act
+        var parseResult = CommandDefinition.Parse(["--total-questions", validTotalQuestions.ToString()]);
 
         // Assert
         Assert.Empty(parseResult.Errors);
@@ -457,15 +342,11 @@ public class DesignCommandTests
     [InlineData(0, 5)] // Zero is valid for question number
     public void Parse_QuestionNumberWithinTotalQuestions_NoErrors(int questionNumber, int totalQuestions)
     {
-        // Arrange
-        var args = new[]
-        {
+        // Arrange & Act
+        var parseResult = CommandDefinition.Parse([
             "--question-number", questionNumber.ToString(),
             "--total-questions", totalQuestions.ToString()
-        };
-
-        // Act
-        var parseResult = _commandDefinition.Parse(args);
+        ]);
 
         // Assert
         Assert.Empty(parseResult.Errors);
@@ -474,15 +355,11 @@ public class DesignCommandTests
     [Fact]
     public void Parse_MultipleValidationErrors_ReturnsFirstError()
     {
-        // Arrange - Set both invalid confidence score and negative question number
-        var args = new[]
-        {
+        // Arrange & Act - Set both invalid confidence score and negative question number
+        var parseResult = CommandDefinition.Parse([
             "--confidence-score", "1.5",
             "--question-number", "-1"
-        };
-
-        // Act
-        var parseResult = _commandDefinition.Parse(args);
+        ]);
 
         // Assert
         Assert.NotEmpty(parseResult.Errors);
@@ -549,25 +426,15 @@ public class DesignCommandTests
                         }
                         """;
 
-        var args = new[]
-        {
+        // Act
+        var response = await ExecuteCommandAsync(
             "--state", stateJson,
             "--question", "What is your primary business goal?",
-            "--confidence-score", "0.5"
-        };
-
-        // Act
-        var parseResult = _commandDefinition.Parse(args);
-        var result = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+            "--confidence-score", "0.5");
 
         // Assert
-        Assert.Empty(parseResult.Errors);
-        Assert.Equal(HttpStatusCode.OK, _context.Response.Status);
+        var responseObject = ValidateAndDeserializeResponse(response, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
 
-        // Verify that the state was parsed correctly by checking the response
-        string serializedResult = SerializeResponseResult(_context.Response.Results!);
-        var responseObject = JsonSerializer.Deserialize(serializedResult, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
-        Assert.NotNull(responseObject);
         Assert.NotNull(responseObject.ResponseObject.State);
         Assert.Empty(responseObject.ResponseObject.State.ArchitectureComponents);
         Assert.NotNull(responseObject.ResponseObject.State.Requirements);
@@ -596,19 +463,12 @@ public class DesignCommandTests
     [Fact]
     public async Task ExecuteAsync_WithEmptyState_CreatesDefaultState()
     {
-        // Arrange
-        var args = new[] { "--state", "" };
-        var parseResult = _commandDefinition.Parse(args);
-
-        // Act
-        var result = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync("--state", "");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, _context.Response.Status);
+        var responseObject = ValidateAndDeserializeResponse(response, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
 
-        string serializedResult = SerializeResponseResult(_context.Response.Results!);
-        var responseObject = JsonSerializer.Deserialize(serializedResult, CloudArchitectJsonContext.Default.CloudArchitectDesignResponse);
-        Assert.NotNull(responseObject);
         Assert.NotNull(responseObject.ResponseObject.State);
         Assert.Empty(responseObject.ResponseObject.State.ArchitectureComponents);
         Assert.NotNull(responseObject.ResponseObject.State.Requirements);
@@ -619,17 +479,13 @@ public class DesignCommandTests
     public void BindOptions_WithInvalidStateJson_ThrowsException()
     {
         // Arrange
-        var invalidStateJson = "{ invalid json }";
-        var args = new[] { "--state", invalidStateJson };
-        var parseResult = _commandDefinition.Parse(args);
-
+        var parseResult = CommandDefinition.Parse(["--state", "{ invalid json }"]);
 
         // Act & Assert
         var exception = Assert.Throws<TargetInvocationException>(() =>
         {
             // Access the protected BindOptions method via reflection to test state deserialization
-            var command = _command.GetCommand();
-            var stateOption = command.Options.First(o => o.Name == "--state");
+            var stateOption = CommandDefinition.Options.First(o => o.Name == "--state");
             var stateValue = parseResult.GetValue((Option<string>)stateOption);
 
             // Manually call the state deserialization that happens in BindOptions

--- a/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/Architecture/DiagramGenerateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/Architecture/DiagramGenerateCommandTests.cs
@@ -5,36 +5,20 @@ using System.Net;
 using System.Text.Json;
 using Azure.Mcp.Tools.Deploy.Commands.Architecture;
 using Azure.Mcp.Tools.Deploy.Options;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
-using NSubstitute;
+using Microsoft.Mcp.Tests.Client;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Deploy.UnitTests.Commands.Architecture;
 
 
-public class DiagramGenerateCommandTests
+public class DiagramGenerateCommandTests : CommandUnitTestsBase<DiagramGenerateCommand, object>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<DiagramGenerateCommand> _logger;
-
-    public DiagramGenerateCommandTests()
-    {
-        _logger = Substitute.For<ILogger<DiagramGenerateCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-    }
-
-
     [Fact]
     public async Task GenerateArchitectureDiagram_ShouldReturnNoServiceDetected()
     {
-        var command = new DiagramGenerateCommand(_logger);
-        var args = command.GetCommand().Parse(["--raw-mcp-tool-input", "{\"projectName\": \"test\",\"services\": []}"]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--raw-mcp-tool-input", "{\"projectName\": \"test\",\"services\": []}");
+
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.Contains("No service detected", response.Message);
@@ -43,10 +27,8 @@ public class DiagramGenerateCommandTests
     [Fact]
     public async Task GenerateArchitectureDiagram_InvalidJsonInput()
     {
-        var command = new DiagramGenerateCommand(_logger);
-        var args = command.GetCommand().Parse(["--raw-mcp-tool-input", "test"]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--raw-mcp-tool-input", "test");
+
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("invalid JSON literal", response.Message);
@@ -55,7 +37,6 @@ public class DiagramGenerateCommandTests
     [Fact]
     public async Task GenerateArchitectureDiagram_ShouldReturnEncryptedDiagramUrl()
     {
-        var command = new DiagramGenerateCommand(_logger);
         var appTopology = new AppTopology()
         {
             WorkspaceFolder = "testWorkspace",
@@ -125,9 +106,8 @@ public class DiagramGenerateCommandTests
             ]
         };
 
-        var args = command.GetCommand().Parse(["--raw-mcp-tool-input", JsonSerializer.Serialize(appTopology)]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--raw-mcp-tool-input", JsonSerializer.Serialize(appTopology));
+
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.OK, response.Status);
         // Extract the URL from the response message

--- a/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/Infrastructure/RulesGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/Infrastructure/RulesGetCommandTests.cs
@@ -1,49 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using Azure.Mcp.Tools.Deploy.Commands.Infrastructure;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
-using NSubstitute;
+using Microsoft.Mcp.Tests.Client;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Deploy.UnitTests.Commands.Infrastructure;
 
 
-public class RulesGetCommandTests
+public class RulesGetCommandTests : CommandUnitTestsBase<RulesGetCommand, object>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<RulesGetCommand> _logger;
-    private readonly Command _commandDefinition;
-    private readonly CommandContext _context;
-    private readonly RulesGetCommand _command;
-
-    public RulesGetCommandTests()
-    {
-        _logger = Substitute.For<ILogger<RulesGetCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-        _context = new(_serviceProvider);
-        _command = new(_logger);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public async Task Should_get_infrastructure_code_rules()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--deployment-tool", "azd",
             "--iac-type", "bicep",
-            "--resource-types", "appservice, azurestorage"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-types", "appservice, azurestorage");
 
         // assert
         Assert.NotNull(result);
@@ -55,15 +30,11 @@ public class RulesGetCommandTests
     [Fact]
     public async Task Should_get_infrastructure_rules_for_terraform()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--deployment-tool", "azd",
             "--iac-type", "terraform",
-            "--resource-types", "containerapp, azurecosmosdb"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-types", "containerapp, azurecosmosdb");
 
         // assert
         Assert.NotNull(result);
@@ -75,15 +46,11 @@ public class RulesGetCommandTests
     [Fact]
     public async Task Should_get_infrastructure_rules_for_function_app()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--deployment-tool", "azd",
             "--iac-type", "bicep",
-            "--resource-types", "function"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-types", "function");
 
         // assert
         Assert.NotNull(result);
@@ -96,15 +63,11 @@ public class RulesGetCommandTests
     [Fact]
     public async Task Should_get_infrastructure_rules_for_container_app()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--deployment-tool", "azd",
             "--iac-type", "bicep",
-            "--resource-types", "containerapp"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-types", "containerapp");
 
         // assert
         Assert.NotNull(result);
@@ -117,15 +80,11 @@ public class RulesGetCommandTests
     [Fact]
     public async Task Should_get_infrastructure_rules_for_azcli_deployment_tool()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--deployment-tool", "AzCli",
             "--iac-type", "",
-            "--resource-types", "aks"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-types", "aks");
 
         // assert
         Assert.NotNull(result);
@@ -137,15 +96,11 @@ public class RulesGetCommandTests
     [Fact]
     public async Task Should_default_to_bicep_for_azd_when_iac_type_is_empty()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--deployment-tool", "azd",
             "--iac-type", "",
-            "--resource-types", "appservice"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-types", "appservice");
 
         // assert
         Assert.NotNull(result);
@@ -160,15 +115,11 @@ public class RulesGetCommandTests
     [Fact]
     public async Task Should_include_necessary_tools_in_response()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--deployment-tool", "azd",
             "--iac-type", "terraform",
-            "--resource-types", "containerapp"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-types", "containerapp");
 
         // assert
         Assert.NotNull(result);
@@ -183,15 +134,11 @@ public class RulesGetCommandTests
     [Fact]
     public async Task Should_handle_multiple_resource_types()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--deployment-tool", "azd",
             "--iac-type", "bicep",
-            "--resource-types", "appservice,containerapp,function"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-types", "appservice,containerapp,function");
 
         // assert
         Assert.NotNull(result);
@@ -206,15 +153,11 @@ public class RulesGetCommandTests
     [Fact]
     public async Task Should_handle_azcli_terraform_all_resource_types()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--deployment-tool", "AzCli",
             "--iac-type", "terraform",
-            "--resource-types", "appservice,containerapp,function,aks,azuredatabaseforpostgresql,azuredatabaseformysql,azuresqldatabase,azurecosmosdb,azurestorageaccount,azurekeyvault"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-types", "appservice,containerapp,function,aks,azuredatabaseforpostgresql,azuredatabaseformysql,azuresqldatabase,azurecosmosdb,azurestorageaccount,azurekeyvault");
 
         // assert
         Assert.NotNull(result);

--- a/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/Pipeline/GuidanceGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/Pipeline/GuidanceGetCommandTests.cs
@@ -1,47 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using Azure.Mcp.Tools.Deploy.Commands.Pipeline;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
-using NSubstitute;
+using Microsoft.Mcp.Tests.Client;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Deploy.UnitTests.Commands.Pipeline;
 
 
-public class GuidanceGetCommandTests
+public class GuidanceGetCommandTests : CommandUnitTestsBase<GuidanceGetCommand, object>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<GuidanceGetCommand> _logger;
-    private readonly Command _commandDefinition;
-    private readonly CommandContext _context;
-    private readonly GuidanceGetCommand _command;
-
-    public GuidanceGetCommandTests()
-    {
-        _logger = Substitute.For<ILogger<GuidanceGetCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-        _context = new(_serviceProvider);
-        _command = new(_logger);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public async Task Should_generate_pipeline()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
-            "--subscription", "test-subscription-id"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        // arrange & act
+        var result = await ExecuteCommandAsync("--subscription", "test-subscription-id");
 
         // assert
         Assert.NotNull(result);
@@ -56,16 +30,12 @@ public class GuidanceGetCommandTests
     [Fact]
     public async Task Should_generate_pipeline_with_github_actions()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--subscription", "test-subscription-id",
             "--is-azd-project", "false",
             "--pipeline-platform", "github-actions",
-            "--deploy-option", "deploy-only",
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--deploy-option", "deploy-only");
 
         // assert
         Assert.NotNull(result);
@@ -80,16 +50,12 @@ public class GuidanceGetCommandTests
     [Fact]
     public async Task Should_generate_pipeline_with_azure_devops()
     {
-        // arrange - not providing is-azd-project should default to false
-        var args = _commandDefinition.Parse([
+        // arrange & act - not providing is-azd-project should default to false
+        var result = await ExecuteCommandAsync(
             "--subscription", "test-subscription-id",
             "--is-azd-project", "false",
             "--pipeline-platform", "azure-devops",
-            "--deploy-option", "deploy-only",
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--deploy-option", "deploy-only");
 
         // assert
         Assert.NotNull(result);
@@ -104,15 +70,11 @@ public class GuidanceGetCommandTests
     [Fact]
     public async Task Should_generate_pipeline_with_provision_and_deploy()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--subscription", "test-subscription-id",
             "--is-azd-project", "false",
-            "--deploy-option", "provision-and-deploy",
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--deploy-option", "provision-and-deploy");
 
         // assert
         Assert.NotNull(result);

--- a/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/Plan/GetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.UnitTests/Commands/Plan/GetCommandTests.cs
@@ -1,51 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
 using Azure.Mcp.Tools.Deploy.Commands.Plan;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
-using NSubstitute;
+using Microsoft.Mcp.Tests.Client;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Deploy.UnitTests.Commands.Plan;
 
 
-public class GetCommandTests
+public class GetCommandTests : CommandUnitTestsBase<GetCommand, object>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly ILogger<GetCommand> _logger;
-    private readonly Command _commandDefinition;
-    private readonly CommandContext _context;
-    private readonly GetCommand _command;
-
-    public GetCommandTests()
-    {
-        _logger = Substitute.For<ILogger<GetCommand>>();
-
-        var collection = new ServiceCollection();
-        _serviceProvider = collection.BuildServiceProvider();
-        _context = new(_serviceProvider);
-        _command = new(_logger);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public async Task GetPlan_Should_Return_Expected_Result()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--workspace-folder", "C:/",
             "--project-name", "django",
             "--target-app-service", "ContainerApp",
             "--provisioning-tool", "AZD",
-            "--iac-options", "bicep"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--iac-options", "bicep");
 
         // assert
         Assert.NotNull(result);
@@ -58,17 +33,12 @@ public class GetCommandTests
     [Fact]
     public async Task Should_get_plan_with_default_iac_options()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--workspace-folder", "C:/test",
             "--project-name", "myapp",
             "--target-app-service", "WebApp",
-            "--provisioning-tool", "azd"
-            // No iac-options provided - should default to "bicep"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--provisioning-tool", "azd");
 
         // assert
         Assert.NotNull(result);
@@ -81,16 +51,12 @@ public class GetCommandTests
     [Fact]
     public async Task Should_get_plan_for_kubernetes()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--workspace-folder", "C:/k8s-project",
             "--project-name", "k8s-app",
             "--target-app-service", "AKS",
-            "--provisioning-tool", "azcli"
-        ]);
-
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--provisioning-tool", "azcli");
 
         // assert
         Assert.NotNull(result);
@@ -106,15 +72,12 @@ public class GetCommandTests
     [Fact]
     public async Task Should_get_plan_with_default_target_service()
     {
-        // arrange
-        var args = _commandDefinition.Parse([
+        // arrange & act
+        var result = await ExecuteCommandAsync(
             "--workspace-folder", "C:/",
             "--project-name", "default-app",
             "--target-app-service", "unknown-service", // This should default to Container Apps
-            "--provisioning-tool", "AZD"
-        ]);
-        // act
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--provisioning-tool", "AZD");
 
         // assert
         Assert.NotNull(result);
@@ -127,16 +90,14 @@ public class GetCommandTests
     [Fact]
     public async Task Should_get_deploy_only_plan()
     {
-        var args = _commandDefinition.Parse([
+        var result = await ExecuteCommandAsync(
             "--workspace-folder", "C:/",
             "--project-name", "default-app",
             "--target-app-service", "ContainerApp",
             "--provisioning-tool", "AzCli",
             "--deploy-option", "deploy-only",
             "--source-type", "from-azure",
-            "--resource-group", "DefaultRG"
-        ]);
-        var result = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+            "--resource-group", "DefaultRG");
 
         // assert
         Assert.NotNull(result);

--- a/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Subscription/SubscriptionListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Subscription/SubscriptionListCommandTests.cs
@@ -1,54 +1,37 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.EventGrid.Commands;
 using Azure.Mcp.Tools.EventGrid.Commands.Subscription;
 using Azure.Mcp.Tools.EventGrid.Services;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.EventGrid.UnitTests.Subscription;
 
-public class SubscriptionListCommandTests
+public class SubscriptionListCommandTests : CommandUnitTestsBase<SubscriptionListCommand, IEventGridService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IEventGridService _eventGridService;
     private readonly ISubscriptionService _subscriptionService;
-    private readonly ILogger<SubscriptionListCommand> _logger;
-    private readonly SubscriptionListCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
 
     public SubscriptionListCommandTests()
     {
-        _eventGridService = Substitute.For<IEventGridService>();
         _subscriptionService = Substitute.For<ISubscriptionService>();
-        _logger = Substitute.For<ILogger<SubscriptionListCommand>>();
 
-        var collection = new ServiceCollection()
-            .AddSingleton(_eventGridService)
-            .AddSingleton(_subscriptionService);
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _eventGridService, _subscriptionService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
+        Services.AddSingleton(_subscriptionService);
     }
 
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
-        Assert.Equal("list", command.Name);
-        Assert.NotNull(command.Description);
-        Assert.NotEmpty(command.Description);
+        Assert.Equal("list", CommandDefinition.Name);
+        Assert.NotNull(CommandDefinition.Description);
+        Assert.NotEmpty(CommandDefinition.Description);
     }
 
     [Fact]
@@ -62,25 +45,17 @@ public class SubscriptionListCommandTests
             new("subscription2", "Microsoft.EventGrid/eventSubscriptions", "StorageQueue", "https://storage.queue.core.windows.net/myqueue", "Succeeded", null, null, 10, 720, "2023-01-03T00:00:00Z", "2023-01-04T00:00:00Z")
         };
 
-        _eventGridService.GetSubscriptionsAsync(Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedSubscriptions));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription]);
+        Service.GetSubscriptionsAsync(Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(expectedSubscriptions);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, EventGridJsonContext.Default.SubscriptionListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-        var result = JsonSerializer.Deserialize(json, EventGridJsonContext.Default.SubscriptionListCommandResult);
-
-        Assert.NotNull(result);
-        Assert.NotNull(result!.Subscriptions);
-        Assert.Equal(expectedSubscriptions.Count, result.Subscriptions!.Count);
+        Assert.NotNull(result.Subscriptions);
+        Assert.Equal(expectedSubscriptions.Count, result.Subscriptions.Count);
         Assert.Equal(expectedSubscriptions.Select(s => s.Name), result.Subscriptions.Select(s => s.Name));
     }
 
@@ -96,23 +71,19 @@ public class SubscriptionListCommandTests
             new("filtered-subscription", "Microsoft.EventGrid/eventSubscriptions", "WebHook", "https://example.com/webhook", "Succeeded", null, null, 30, 1440, "2023-01-01T00:00:00Z", "2023-01-02T00:00:00Z")
         };
 
-        _eventGridService.GetSubscriptionsAsync(Arg.Is(subscription), Arg.Is(resourceGroup), Arg.Is(topicName), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedSubscriptions));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--resource-group", resourceGroup, "--topic", topicName]);
+        Service.GetSubscriptionsAsync(Arg.Is(subscription), Arg.Is(resourceGroup), Arg.Is(topicName), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(expectedSubscriptions);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(
+            "--subscription", subscription,
+            "--resource-group", resourceGroup,
+            "--topic", topicName);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, EventGridJsonContext.Default.SubscriptionListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, EventGridJsonContext.Default.SubscriptionListCommandResult);
-
-        Assert.NotNull(result);
-        Assert.NotNull(result!.Subscriptions);
+        Assert.NotNull(result.Subscriptions);
         Assert.Single(result.Subscriptions);
         Assert.Equal("filtered-subscription", result.Subscriptions.First().Name);
     }
@@ -123,22 +94,15 @@ public class SubscriptionListCommandTests
         // Arrange
         var subscription = "sub123";
 
-        _eventGridService.GetSubscriptionsAsync(Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetSubscriptionsAsync(Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var args = _commandDefinition.Parse(["--subscription", subscription]);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, EventGridJsonContext.Default.SubscriptionListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, EventGridJsonContext.Default.SubscriptionListCommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Subscriptions);
     }
 
@@ -153,23 +117,16 @@ public class SubscriptionListCommandTests
             new("location-filtered-subscription", "Microsoft.EventGrid/eventSubscriptions", "WebHook", "https://example.com/webhook", "Succeeded", null, null, 30, 1440, "2023-01-01T00:00:00Z", "2023-01-02T00:00:00Z")
         };
 
-        _eventGridService.GetSubscriptionsAsync(Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Is(location), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(expectedSubscriptions));
-
-        var args = _commandDefinition.Parse(["--subscription", subscription, "--location", location]);
+        Service.GetSubscriptionsAsync(Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Is(location), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(expectedSubscriptions);
 
         // Act
-        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", subscription, "--location", location);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, EventGridJsonContext.Default.SubscriptionListCommandResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, EventGridJsonContext.Default.SubscriptionListCommandResult);
-
-        Assert.NotNull(result);
-        Assert.NotNull(result!.Subscriptions);
+        Assert.NotNull(result.Subscriptions);
         Assert.Single(result.Subscriptions);
         Assert.Equal("location-filtered-subscription", result.Subscriptions.First().Name);
     }
@@ -178,13 +135,11 @@ public class SubscriptionListCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _eventGridService.GetSubscriptionsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<Models.EventGridSubscriptionInfo>>(new Exception("Test error")));
-
-        var parseResult = _commandDefinition.Parse(["--subscription", "sub"]);
+        Service.GetSubscriptionsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--subscription", "sub");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -205,7 +160,7 @@ public class SubscriptionListCommandTests
         // Arrange
         if (shouldSucceed)
         {
-            _eventGridService.GetSubscriptionsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Service.GetSubscriptionsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
                 .Returns(
                 [
                     new("subscription1", "Microsoft.EventGrid/eventSubscriptions", "WebHook", "https://example.com/webhook1", "Succeeded", null, null, 30, 1440, "2023-01-01T00:00:00Z", "2023-01-02T00:00:00Z")
@@ -216,10 +171,8 @@ public class SubscriptionListCommandTests
                 .Returns([]);
         }
 
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);

--- a/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.UnitTests/AzqrCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.UnitTests/AzqrCommandTests.cs
@@ -7,35 +7,26 @@ using System.Runtime.InteropServices;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.Extension.Commands;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Services.ProcessExecution;
 using Microsoft.Mcp.Core.Services.Time;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Extension.UnitTests;
 
-public sealed class AzqrCommandTests
+public sealed class AzqrCommandTests : CommandUnitTestsBase<AzqrCommand, IExternalProcessService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IExternalProcessService _processService;
     private readonly ISubscriptionService _subscriptionService;
     private readonly IDateTimeProvider _dateTimeProvider;
-    private readonly ILogger<AzqrCommand> _logger;
 
     public AzqrCommandTests()
     {
-        _processService = Substitute.For<IExternalProcessService>();
         _subscriptionService = Substitute.For<ISubscriptionService>();
         _dateTimeProvider = Substitute.For<IDateTimeProvider>();
-        _logger = Substitute.For<ILogger<AzqrCommand>>();
 
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_processService);
-        collection.AddSingleton(_subscriptionService);
-        collection.AddSingleton(_dateTimeProvider);
-        _serviceProvider = collection.BuildServiceProvider();
+        Services.AddSingleton(_subscriptionService);
+        Services.AddSingleton(_dateTimeProvider);
     }
 
     [Fact]
@@ -45,11 +36,7 @@ public sealed class AzqrCommandTests
         var fixedDateTime = new DateTime(2024, 1, 15, 10, 30, 45, DateTimeKind.Utc);
         _dateTimeProvider.UtcNow.Returns(fixedDateTime);
 
-        var command = new AzqrCommand(_logger, _subscriptionService, _dateTimeProvider, _processService);
-
         var mockSubscriptionId = "12345678-1234-1234-1234-123456789012";
-        var args = command.GetCommand().Parse($"--subscription {mockSubscriptionId}");
-        var context = new CommandContext(_serviceProvider);
 
         var expectedOutput = "Scan completed successfully";
         var reportFilePath = Path.Combine(Path.GetTempPath(), $"azqr-report-{mockSubscriptionId}-{fixedDateTime:yyyyMMdd-HHmmss}");
@@ -70,7 +57,7 @@ public sealed class AzqrCommandTests
         var originalAzqrPath = field?.GetValue(null);
         field?.SetValue(null, tempAzqrPath);
 
-        _processService.ExecuteAsync(
+        Service.ExecuteAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<IDictionary<string, string>?>(),
@@ -81,13 +68,13 @@ public sealed class AzqrCommandTests
         try
         {
             // Act
-            var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+            var response = await ExecuteCommandAsync("--subscription", mockSubscriptionId);
 
             // Assert
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.OK, response.Status);
             Assert.Equal("azqr report generated successfully.", response.Message);
-            await _processService.Received().ExecuteAsync(
+            await Service.Received().ExecuteAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<IDictionary<string, string>?>(),
@@ -115,14 +102,8 @@ public sealed class AzqrCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsBadRequest_WhenMissingSubscriptionArgument()
     {
-        // Arrange
-        var command = new AzqrCommand(_logger, _subscriptionService, _dateTimeProvider, _processService);
-
-        var args = command.GetCommand().Parse(""); // No subscription specified
-        var context = new CommandContext(_serviceProvider);
-
-        // Act
-        var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
+        // Arrange & Act
+        var response = await ExecuteCommandAsync("");
 
         // Assert
         Assert.NotNull(response);

--- a/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.UnitTests/CliGenerateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.UnitTests/CliGenerateCommandTests.cs
@@ -3,47 +3,22 @@
 
 using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.Extension.Commands;
 using Azure.Mcp.Tools.Extension.Services;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Extension.UnitTests;
 
-public sealed class CliGenerateCommandTests
+public sealed class CliGenerateCommandTests : CommandUnitTestsBase<CliGenerateCommand, ICliGenerateService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IHttpClientFactory _httpClientFactory;
-    private readonly ICliGenerateService _cliGenerateService;
-    private readonly ILogger<CliGenerateCommand> _logger;
-    private readonly CliGenerateCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public CliGenerateCommandTests()
-    {
-        _httpClientFactory = Substitute.For<IHttpClientFactory>();
-        _cliGenerateService = Substitute.For<ICliGenerateService>();
-        _logger = Substitute.For<ILogger<CliGenerateCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_httpClientFactory);
-        collection.AddSingleton(_cliGenerateService);
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _cliGenerateService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
+        var command = Command.GetCommand();
         Assert.Equal("generate", command.Name);
         Assert.NotNull(command.Description);
         Assert.NotEmpty(command.Description);
@@ -60,18 +35,15 @@ public sealed class CliGenerateCommandTests
         // Arrange
         if (shouldSucceed)
         {
-            _cliGenerateService.GenerateAzureCLICommandAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            Service.GenerateAzureCLICommandAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent("Command")
-                }));
+                });
         }
 
-        // Build args from a single string in tests using the test-only splitter
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal([shouldSucceed ? 200 : 400], [(int)response.Status]);
@@ -90,25 +62,18 @@ public sealed class CliGenerateCommandTests
     public async Task ExecuteAsync_DeserializationValidation()
     {
         // Arrange
-        _cliGenerateService.GenerateAzureCLICommandAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        Service.GenerateAzureCLICommandAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent("Command")
-            }));
-
-        var parseResult = _commandDefinition.Parse("--intent mock_intent --cli-type az");
+            });
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--intent", "mock_intent", "--cli-type", "az");
 
         // Assert
-        Assert.Equal([200], [(int)response.Status]);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ExtensionJsonContext.Default.CliGenerateResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ExtensionJsonContext.Default.CliGenerateResult);
-
-        Assert.NotNull(result);
         Assert.Equal("az", result.CliType);
         Assert.Equal("Command", result.Command);
     }
@@ -117,12 +82,10 @@ public sealed class CliGenerateCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _cliGenerateService.GenerateAzureCLICommandAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test error"));
-
-        var parseResult = _commandDefinition.Parse("--intent mock_intent --cli-type az");
+        Service.GenerateAzureCLICommandAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--intent", "mock_intent", "--cli-type", "az");
 
         // Assert
         Assert.Equal([500], [(int)response.Status]);

--- a/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.UnitTests/CliInstallCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.UnitTests/CliInstallCommandTests.cs
@@ -3,47 +3,22 @@
 
 using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.Extension.Commands;
 using Azure.Mcp.Tools.Extension.Services;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Extension.UnitTests;
 
-public sealed class CliInstallCommandTests
+public sealed class CliInstallCommandTests : CommandUnitTestsBase<CliInstallCommand, ICliInstallService>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IHttpClientFactory _httpClientFactory;
-    private readonly ICliInstallService _cliInstallService;
-    private readonly ILogger<CliInstallCommand> _logger;
-    private readonly CliInstallCommand _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public CliInstallCommandTests()
-    {
-        _httpClientFactory = Substitute.For<IHttpClientFactory>();
-        _cliInstallService = Substitute.For<ICliInstallService>();
-        _logger = Substitute.For<ILogger<CliInstallCommand>>();
-
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_httpClientFactory);
-        collection.AddSingleton(_cliInstallService);
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger, _cliInstallService);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
+        var command = Command.GetCommand();
         Assert.Equal("install", command.Name);
         Assert.NotNull(command.Description);
         Assert.NotEmpty(command.Description);
@@ -60,18 +35,15 @@ public sealed class CliInstallCommandTests
         // Arrange
         if (shouldSucceed)
         {
-            _cliInstallService.GetCliInstallInstructions(Arg.Any<string>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            Service.GetCliInstallInstructions(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent("Instructions")
-                }));
+                });
         }
 
-        // Build args from a single string in tests using the test-only splitter
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal([shouldSucceed ? 200 : 400], [(int)response.Status]);
@@ -86,25 +58,18 @@ public sealed class CliInstallCommandTests
     public async Task ExecuteAsync_DeserializationValidation()
     {
         // Arrange
-        _cliInstallService.GetCliInstallInstructions(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        Service.GetCliInstallInstructions(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent("Instructions")
-            }));
-
-        var parseResult = _commandDefinition.Parse("--cli-type az");
+            });
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--cli-type", "az");
 
         // Assert
-        Assert.Equal([200], [(int)response.Status]);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ExtensionJsonContext.Default.CliInstallResult);
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, ExtensionJsonContext.Default.CliInstallResult);
-
-        Assert.NotNull(result);
         Assert.Equal("az", result.CliType);
         Assert.Equal("Instructions", result.InstallationInstructions);
     }
@@ -113,12 +78,10 @@ public sealed class CliInstallCommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _cliInstallService.GetCliInstallInstructions(Arg.Any<string>(), Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test error"));
-
-        var parseResult = _commandDefinition.Parse("--cli-type az");
+        Service.GetCliInstallInstructions(Arg.Any<string>(), Arg.Any<CancellationToken>()).ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+        var response = await ExecuteCommandAsync("--cli-type", "az");
 
         // Assert
         Assert.Equal([500], [(int)response.Status]);

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Secret/SecretGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.UnitTests/Secret/SecretGetCommandTests.cs
@@ -1,16 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CommandLine;
 using System.Net;
-using System.Text.Json;
 using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Secret;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Secrets;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/TableSchemaCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/TableSchemaCommandTests.cs
@@ -4,10 +4,7 @@
 using System.Net;
 using Azure.Mcp.Tools.Kusto.Commands;
 using Azure.Mcp.Tools.Kusto.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;

--- a/tools/Azure.Mcp.Tools.WellArchitectedFramework/tests/Azure.Mcp.Tools.WellArchitectedFramework.UnitTests/Commands/ServiceGuide/ServiceGuideGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.WellArchitectedFramework/tests/Azure.Mcp.Tools.WellArchitectedFramework.UnitTests/Commands/ServiceGuide/ServiceGuideGetCommandTests.cs
@@ -14,12 +14,9 @@ namespace Azure.Mcp.Tools.WellArchitectedFramework.UnitTests.Commands.ServiceGui
 
 public class ServiceGuideGetCommandTests : CommandUnitTestsBase<ServiceGuideGetCommand, IServiceGuideService>
 {
-    public ServiceGuideGetCommandTests() : base(services =>
+    public ServiceGuideGetCommandTests()
     {
-        // Register the real ServiceGuideService to test the actual logic, not a mock
-        services.AddSingleton<IServiceGuideService, ServiceGuideService>();
-    })
-    {
+        Services.AddSingleton<IServiceGuideService, ServiceGuideService>();
     }
 
 


### PR DESCRIPTION
## What does this PR do?

Migrates Command unit tests to use `CommandUnitTestBase`. Adds new helper method to `CommandUnitTestBase` that performs common validation when a tool call was expected to succeed with a response value.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
