### PR TITLE
Optimize: Redirect CLI log output from stdout to stderr (Optimizes Token usage for Agents).

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1777452002350.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1777452002350.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed CLI mode log messages being written to stdout instead of stderr. Log output now goes exclusively to stderr, ensuring agents and pipelines consuming stdout receive clean JSON only. Use `2>&1` to see logs alongside output, or `2>file.log` to capture them separately."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -36,6 +36,23 @@ azmcp storage account list --learn
 
 The output is a JSON `CommandResponse` containing a list of `CommandInfo` objects with the command name, description, full CLI path, and all supported options. This is equivalent to the `learn` parameter supported by the Azure MCP server tools in namespace mode.
 
+### CLI Logging
+
+In CLI mode, all `azmcp` commands write only JSON to **stdout**. Informational and diagnostic log messages are written to **stderr**. This means AI agents and tools consuming stdout receive clean JSON without log noise.
+
+To see logs while running a CLI command:
+
+```powershell
+# Show logs in terminal alongside JSON output (PowerShell / bash)
+azmcp storage account list --subscription <sub> 2>&1
+
+# Capture JSON silently, discard logs (PowerShell)
+$json = azmcp storage account list --subscription <sub> 2>$null
+
+# Write logs to a file while JSON goes to stdout
+azmcp storage account list --subscription <sub> 2>azmcp.log
+```
+
 ## Available Commands
 
 ### Server Operations

--- a/servers/Azure.Mcp.Server/src/Program.cs
+++ b/servers/Azure.Mcp.Server/src/Program.cs
@@ -56,7 +56,7 @@ internal class Program
 
             services.AddLogging(builder =>
             {
-                builder.AddConsole();
+                builder.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
                 builder.SetMinimumLevel(LogLevel.Information);
             });
 


### PR DESCRIPTION
In CLI mode, azmcp was writing informational log messages (Azure SDK HTTP pipeline traces, etc.) to stdout alongside the JSON response. This inflated token consumption for AI agents and pipelines parsing stdout — benchmarks showed up to ~44.5% of stdout bytes were log noise, not JSON.

The issue was AddConsole() in Program.cs defaults LogToStandardErrorThreshold to LogLevel.None, routing all log levels to stdout.

This PR sets LogToStandardErrorThreshold = LogLevel.Trace so every log level routes exclusively to stderr. Stdout now contains only the JSON CommandResponse.

Impact:

No behavior change for interactive terminal users (stderr is visible by default)
AI agents and pipelines consuming stdout receive clean JSON only    
