### PR TITLE
Refactor remaining Azure commands to the CommandMetadata attribute

### DIFF
--- a/core/Azure.Mcp.Core/src/Areas/Group/Commands/GroupListCommand.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Group/Commands/GroupListCommand.cs
@@ -7,38 +7,28 @@ using Azure.Mcp.Core.Services.Azure.ResourceGroup;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Command;
-using Microsoft.Mcp.Core.Models.Option;
 using Microsoft.Mcp.Core.Models.ResourceGroup;
 
 namespace Azure.Mcp.Core.Areas.Group.Commands;
 
+[CommandMetadata(
+    Id = "a0049f31-9a32-4b5e-91ec-e7b074fc7246",
+    Name = "list",
+    Title = "List Resource Groups",
+    Description = """
+        List all resource groups in a subscription. This command retrieves all resource groups available
+        in the specified subscription. Results include resource group names and IDs,
+        returned as a JSON array.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    LocalRequired = false,
+    Secret = false)]
 public sealed class GroupListCommand(ILogger<GroupListCommand> logger) : SubscriptionCommand<BaseGroupOptions>()
 {
-    private const string CommandTitle = "List Resource Groups";
     private readonly ILogger<GroupListCommand> _logger = logger;
-
-    public override string Id => "a0049f31-9a32-4b5e-91ec-e7b074fc7246";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        $"""
-        List all resource groups in a subscription. This command retrieves all resource groups available
-        in the specified {OptionDefinitions.Common.SubscriptionName}. Results include resource group names and IDs,
-        returned as a JSON array.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/core/Azure.Mcp.Core/src/Areas/Group/Commands/ResourceListCommand.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Group/Commands/ResourceListCommand.cs
@@ -13,35 +13,26 @@ using Microsoft.Mcp.Core.Models.Resource;
 
 namespace Azure.Mcp.Core.Areas.Group.Commands;
 
+[CommandMetadata(
+    Id = "b1c2d3e4-f5a6-7890-abcd-ef1234567890",
+    Name = "list",
+    Title = "List Resources in Resource Group",
+    Description = """
+        List all resources in a resource group. This command retrieves all resources available
+        in the specified resource group within the given subscription. Results include resource
+        names, IDs, types, and locations. The command returns a JSON object with a `resources`
+        array containing these entries.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    LocalRequired = false,
+    Secret = false)]
 public sealed class ResourceListCommand(ILogger<ResourceListCommand> logger, IResourceGroupService resourceGroupService) : SubscriptionCommand<ResourceListOptions>()
 {
-    private const string CommandTitle = "List Resources in Resource Group";
     private readonly ILogger<ResourceListCommand> _logger = logger;
     private readonly IResourceGroupService _resourceGroupService = resourceGroupService;
-
-    public override string Id => "b1c2d3e4-f5a6-7890-abcd-ef1234567890";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        $"""
-        List all resources in a resource group. This command retrieves all resources available
-        in the specified {OptionDefinitions.Common.ResourceGroupName} within the given
-        {OptionDefinitions.Common.SubscriptionName}. Results include resource names, IDs, types,
-        and locations. The command returns a JSON object with a `resources` array containing these entries.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/core/Azure.Mcp.Core/src/Areas/Subscription/Commands/SubscriptionListCommand.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Subscription/Commands/SubscriptionListCommand.cs
@@ -11,32 +11,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Core.Areas.Subscription.Commands;
 
+[CommandMetadata(
+    Id = "72bbe80e-ca42-4a43-8f02-45495bca1179",
+    Name = "list",
+    Title = "List Azure Subscriptions",
+    Description = "List all Azure subscriptions for the current account. Returns subscriptionId, displayName, state, tenantId, and isDefault for each subscription. The isDefault field indicates the user's default subscription as resolved from the Azure CLI profile (configured via 'az account set') or, if not set there, from the AZURE_SUBSCRIPTION_ID environment variable. When the user has not specified a subscription, prefer the subscription where isDefault is true. If no default can be determined from either source and multiple subscriptions exist, ask the user which subscription to use.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    LocalRequired = false,
+    Secret = false)]
 public sealed class SubscriptionListCommand(ILogger<SubscriptionListCommand> logger) : GlobalCommand<SubscriptionListOptions>()
 {
-    private const string CommandTitle = "List Azure Subscriptions";
     private readonly ILogger<SubscriptionListCommand> _logger = logger;
-
-    public override string Id => "72bbe80e-ca42-4a43-8f02-45495bca1179";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        "List all Azure subscriptions for the current account. Returns subscriptionId, displayName, state, tenantId, and isDefault for each subscription. " +
-        "The isDefault field indicates the user's default subscription as resolved from the Azure CLI profile (configured via 'az account set') or, if not set there, from the AZURE_SUBSCRIPTION_ID environment variable. " +
-        "When the user has not specified a subscription, prefer the subscription where isDefault is true. " +
-        "If no default can be determined from either source and multiple subscriptions exist, ask the user which subscription to use.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/PluginTelemetryCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/PluginTelemetryCommand.cs
@@ -24,39 +24,30 @@ namespace Microsoft.Mcp.Core.Areas.Server.Commands;
 /// This command is hidden from the main tool list and intended for programmatic use only.
 /// </summary>
 [HiddenCommand]
+[CommandMetadata(
+    Id = "b3e7c1a2-4f85-4d9e-a6c3-8f2b1e0d7a94",
+    Name = "plugin-telemetry",
+    Title = "Plugin Telemetry",
+    Description = """
+        Publish plugin-related telemetry events from agent hooks.
+        Accepts command-line options such as '--timestamp', '--event-type', '--session-id', '--client-type', '--client-name', 
+        '--plugin-name', '--plugin-version', '--skill-name', '--skill-version', '--tool-name', and '--file-reference'. 
+        Use this command from agent hooks in clients like VS Code, Claude Desktop, or Copilot CLI to emit usage metrics.
+        """,
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    LocalRequired = false,
+    Secret = false)]
 public sealed class PluginTelemetryCommand(
     IPluginFileReferenceAllowlistProvider fileReferenceAllowlistProvider,
     IPluginSkillNameAllowlistProvider skillNameAllowlistProvider,
     IServiceProvider serviceProvider) : BaseCommand<PluginTelemetryOptions>
 {
-    private const string CommandTitle = "Plugin Telemetry";
     private readonly IPluginFileReferenceAllowlistProvider _fileReferenceAllowlistProvider = fileReferenceAllowlistProvider;
     private readonly IPluginSkillNameAllowlistProvider _skillNameAllowlistProvider = skillNameAllowlistProvider;
     private readonly IServiceProvider _serviceProvider = serviceProvider;
-
-    public override string Id => "b3e7c1a2-4f85-4d9e-a6c3-8f2b1e0d7a94";
-
-    public override string Name => "plugin-telemetry";
-
-    public override string Description =>
-        """
-        Publish plugin-related telemetry events from agent hooks.
-        Accepts command-line options such as '--timestamp', '--event-type', '--session-id', '--client-type', '--client-name', 
-        '--plugin-name', '--plugin-version', '--skill-name', '--skill-version', '--tool-name', and '--file-reference'. 
-        Use this command from agent hooks in clients like VS Code, Claude Desktop, or Copilot CLI to emit usage metrics.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     /// <summary>
     /// Gets or sets the service configuration action.

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceInfoCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceInfoCommand.cs
@@ -14,30 +14,23 @@ namespace Microsoft.Mcp.Core.Areas.Server.Commands;
 /// Command that provides basic server information.
 /// </summary>
 [HiddenCommand]
+[CommandMetadata(
+    Id = "add0f6fe-258c-45c4-af74-0c165d4913cb",
+    Name = "info",
+    Title = "Server information.",
+    Description = "Displays running MCP server information.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    LocalRequired = false,
+    Secret = false)]
 public sealed class ServiceInfoCommand(IOptions<McpServerConfiguration> serverOptions, ILogger<ServiceInfoCommand> logger) : BaseCommand<EmptyOptions>
 {
     private static readonly EmptyOptions EmptyOptions = new();
 
     private readonly IOptions<McpServerConfiguration> _serverOptions = serverOptions;
     private readonly ILogger<ServiceInfoCommand> _logger = logger;
-
-    public override string Id => "add0f6fe-258c-45c4-af74-0c165d4913cb";
-
-    public override string Name => "info";
-
-    public override string Description => "Displays running MCP server information.";
-
-    public override string Title => "Server information.";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceStartCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceStartCommand.cs
@@ -41,9 +41,15 @@ namespace Microsoft.Mcp.Core.Areas.Server.Commands;
 /// This command is hidden from the main command list.
 /// </summary>
 [HiddenCommand]
+[CommandMetadata(
+    Id = "9953ff62-e3d7-4bdf-9b70-d569e54e3df1",
+    Name = "start",
+    Title = "Start MCP Server",
+    Description = "Starts Azure MCP Server.",
+    Destructive = false,
+    ReadOnly = true)]
 public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
 {
-    private const string CommandTitle = "Start MCP Server";
     private static readonly string[] StdioHostBuilderArgs =
     [
         $"--contentRoot={AppContext.BaseDirectory}",
@@ -55,31 +61,9 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
         ContentRootPath = AppContext.BaseDirectory
     };
 
-    /// <summary>
-    /// Gets the name of the command.
-    /// </summary>
-    public override string Name => "start";
-
-    /// <summary>
-    /// Gets the description of the command.
-    /// </summary>
-    public override string Description => "Starts Azure MCP Server.";
-
-    /// <summary>
-    /// Gets the title of the command.
-    /// </summary>
-    public override string Title => CommandTitle;
-
-    /// <summary>
-    /// Gets the metadata for this command.
-    /// </summary>
-    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
-
     public static Action<IServiceCollection> ConfigureServices { get; set; } = _ => { };
 
     public static Func<IServiceProvider, Task> InitializeServicesAsync { get; set; } = _ => Task.CompletedTask;
-
-    public override string Id => "9953ff62-e3d7-4bdf-9b70-d569e54e3df1";
 
     /// <summary>
     /// Registers command options for the service start command.

--- a/core/Microsoft.Mcp.Core/src/Areas/Tools/Commands/ToolsListCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Tools/Commands/ToolsListCommand.cs
@@ -12,32 +12,23 @@ using Microsoft.Mcp.Core.Models.Option;
 namespace Microsoft.Mcp.Core.Areas.Tools.Commands;
 
 [HiddenCommand]
-public sealed class ToolsListCommand(ILogger<ToolsListCommand> logger) : BaseCommand<ToolsListOptions>
-{
-    private const string CommandTitle = "List Available Tools";
-
-    public override string Id => "63de05a7-047d-4f8a-86ea-cebd64527e2b";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "63de05a7-047d-4f8a-86ea-cebd64527e2b",
+    Name = "list",
+    Title = "List Available Tools",
+    Description = """
         List all available commands and their tools in a hierarchical structure. This command returns detailed information
         about each command, including its name, description, full command path, available subcommands, and all supported
         arguments. Use --name-only to return only tool names, and --namespace to filter by specific namespaces.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    LocalRequired = false,
+    Secret = false)]
+public sealed class ToolsListCommand(ILogger<ToolsListCommand> logger) : BaseCommand<ToolsListOptions>
+{
 
     protected override void RegisterOptions(Command command)
     {

--- a/servers/Azure.Mcp.Server/docs/new-command.md
+++ b/servers/Azure.Mcp.Server/docs/new-command.md
@@ -730,35 +730,26 @@ using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Extensions;
 using Microsoft.Mcp.Core.Models.Command;
 
-public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Command> logger)
-    : Base{Toolset}Command<{Resource}{Operation}Options>
-{
-    private const string CommandTitle = "Human Readable Title";
-    private readonly ILogger<{Resource}{Operation}Command> _logger = logger;
-
-    public override string Id => "<GUID>"
-
-    public override string Name => "operation";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "<GUID>",
+    Name = "operation",
+    Title = "Human Readable Title",
+    Description = """
         Detailed description of what the command does.
         Returns description of return format.
           Required options:
         - list required options
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,    // Set to true for tools that modify resources
-        OpenWorld = true,       // Set to false for tools whose domain of interaction is closed and well-defined
-        Idempotent = true,      // Set to false for tools that are not idempotent
-        ReadOnly = true,        // Set to false for tools that modify resources
-        Secret = false,         // Set to true for tools that may return sensitive information
-        LocalRequired = false   // Set to true for tools requiring local execution/resources
-    };
+        """,
+    Destructive = false,    // Set to true for tools that modify resources
+    OpenWorld = true,       // Set to false for tools whose domain of interaction is closed and well-defined
+    Idempotent = true,      // Set to false for tools that are not idempotent
+    ReadOnly = true,        // Set to false for tools that modify resources
+    Secret = false,         // Set to true for tools that may return sensitive information
+    LocalRequired = false)] // Set to true for tools requiring local execution/resources
+public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Command> logger)
+    : Base{Toolset}Command<{Resource}{Operation}Options>
+{
+    private readonly ILogger<{Resource}{Operation}Command> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Acr/src/Commands/Registry/RegistryListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Acr/src/Commands/Registry/RegistryListCommand.cs
@@ -9,34 +9,25 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Acr.Commands.Registry;
 
-public sealed class RegistryListCommand(ILogger<RegistryListCommand> logger, IAcrService acrService) : BaseAcrCommand<RegistryListOptions>
-{
-    private const string CommandTitle = "List Container Registries";
-    private readonly ILogger<RegistryListCommand> _logger = logger;
-    private readonly IAcrService _acrService = acrService;
-
-    public override string Id => "796f8778-2fa7-4343-87ad-06bdcf6b296c";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        $"""
+[CommandMetadata(
+    Id = "796f8778-2fa7-4343-87ad-06bdcf6b296c",
+    Name = "list",
+    Title = "List Container Registries",
+    Description = """
         List Azure Container Registries in a subscription. Optionally filter by resource group. Each registry result
         includes: name, location, loginServer, skuName, skuTier. If no registries are found the tool returns null results
         (consistent with other list commands).
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class RegistryListCommand(ILogger<RegistryListCommand> logger, IAcrService acrService) : BaseAcrCommand<RegistryListOptions>
+{
+    private readonly ILogger<RegistryListCommand> _logger = logger;
+    private readonly IAcrService _acrService = acrService;
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Acr/src/Commands/Registry/RegistryRepositoryListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Acr/src/Commands/Registry/RegistryRepositoryListCommand.cs
@@ -11,33 +11,25 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Acr.Commands.Registry;
 
+[CommandMetadata(
+    Id = "adc6eb20-ad98-4624-954d-61581f6fbca9",
+    Name = "list",
+    Title = "List Container Registry Repositories",
+    Description = """
+        List repositories in Azure Container Registries. By default, lists repositories for all registries in the subscription.
+        You can narrow the scope using --resource-group and/or --registry to list repositories for a specific registry only.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class RegistryRepositoryListCommand(ILogger<RegistryRepositoryListCommand> logger, IAcrService acrService)
     : BaseAcrCommand<RegistryRepositoryListOptions>
 {
-    private const string CommandTitle = "List Container Registry Repositories";
     private readonly ILogger<RegistryRepositoryListCommand> _logger = logger;
     private readonly IAcrService _acrService = acrService;
-    public override string Id => "adc6eb20-ad98-4624-954d-61581f6fbca9";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
-        List repositories in Azure Container Registries. By default, lists repositories for all registries in the subscription.
-        You can narrow the scope using --resource-group and/or --registry to list repositories for a specific registry only.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Advisor/src/Commands/Recommendation/RecommendationListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Commands/Recommendation/RecommendationListCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Net;
@@ -10,32 +10,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Advisor.Commands.Recommendation;
 
+[CommandMetadata(
+    Id = "e3f09221-523a-4107-a715-823cebd97902",
+    Name = "list",
+    Title = "List Advisor Recommendations",
+    Description = "List Azure advisor recommendations in a subscription.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class RecommendationListCommand(ILogger<RecommendationListCommand> logger, IAdvisorService advisorService)
     : BaseAdvisorCommand<RecommendationListOptions>(logger)
 {
     private readonly IAdvisorService _advisorService = advisorService;
-    private const string CommandTitle = "List Advisor Recommendations";
-
-    public override string Id => "e3f09221-523a-4107-a715-823cebd97902";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
-        List Azure advisor recommendations in a subscription.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Aks/src/Commands/Cluster/ClusterGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Aks/src/Commands/Cluster/ClusterGetCommand.cs
@@ -12,30 +12,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Aks.Commands.Cluster;
 
+[CommandMetadata(
+    Id = "34e0d3d3-cbc5-4df8-8244-1439b97f3de5",
+    Name = "get",
+    Title = "Get Azure Kubernetes Service (AKS) Cluster Details",
+    Description = "List/enumerate all AKS (Azure Kubernetes Service) clusters in a subscription. Get/retrieve/show the details of a specific cluster if a name is provided.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ClusterGetCommand(ILogger<ClusterGetCommand> logger, IAksService aksService) : BaseAksCommand<ClusterGetOptions>
 {
-    private const string CommandTitle = "Get Azure Kubernetes Service (AKS) Cluster Details";
     private readonly ILogger<ClusterGetCommand> _logger = logger;
     private readonly IAksService _aksService = aksService;
-
-    public override string Id => "34e0d3d3-cbc5-4df8-8244-1439b97f3de5";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        "List/enumerate all AKS (Azure Kubernetes Service) clusters in a subscription. Get/retrieve/show the details of a specific cluster if a name is provided.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Aks/src/Commands/Nodepool/NodepoolGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Aks/src/Commands/Nodepool/NodepoolGetCommand.cs
@@ -12,30 +12,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Aks.Commands.Nodepool;
 
+[CommandMetadata(
+    Id = "9abb0904-2ffc-4aab-b4ea-fc454b6351b1",
+    Name = "get",
+    Title = "Get Azure Kubernetes Service (AKS) Node Pool Details",
+    Description = "List/enumerate all AKS (Azure Kubernetes Service) node pools in a cluster. Get/retrieve/show the details of a specific node pool if a name is provided.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class NodepoolGetCommand(ILogger<NodepoolGetCommand> logger, IAksService aksService) : BaseAksCommand<NodepoolGetOptions>
 {
-    private const string CommandTitle = "Get Azure Kubernetes Service (AKS) Node Pool Details";
     private readonly ILogger<NodepoolGetCommand> _logger = logger;
     private readonly IAksService _aksService = aksService;
-
-    public override string Id => "9abb0904-2ffc-4aab-b4ea-fc454b6351b1";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        "List/enumerate all AKS (Azure Kubernetes Service) node pools in a cluster. Get/retrieve/show the details of a specific node pool if a name is provided.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/Account/AccountListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/Account/AccountListCommand.cs
@@ -11,33 +11,24 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AppConfig.Commands.Account;
 
-public sealed class AccountListCommand(ILogger<AccountListCommand> logger, IAppConfigService appConfigService) : SubscriptionCommand<AccountListOptions>()
-{
-    private const string CommandTitle = "List App Configuration Stores";
-    private readonly ILogger<AccountListCommand> _logger = logger;
-    private readonly IAppConfigService _appConfigService = appConfigService;
-
-    public override string Id => "e403c988-b57b-4ac1-afb7-25ba3fdd6e6a";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "e403c988-b57b-4ac1-afb7-25ba3fdd6e6a",
+    Name = "list",
+    Title = "List App Configuration Stores",
+    Description = """
         List all App Configuration stores in a subscription. This command retrieves and displays all App Configuration
         stores available in the specified subscription. Results include store names returned as a JSON array.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class AccountListCommand(ILogger<AccountListCommand> logger, IAppConfigService appConfigService) : SubscriptionCommand<AccountListOptions>()
+{
+    private readonly ILogger<AccountListCommand> _logger = logger;
+    private readonly IAppConfigService _appConfigService = appConfigService;
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueDeleteCommand.cs
@@ -9,35 +9,26 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AppConfig.Commands.KeyValue;
 
-public sealed class KeyValueDeleteCommand(ILogger<KeyValueDeleteCommand> logger, IAppConfigService appConfigService)
-    : BaseKeyValueCommand<KeyValueDeleteOptions>()
-{
-    private const string CommandTitle = "Delete App Configuration Key-Value Setting";
-    private readonly ILogger<KeyValueDeleteCommand> _logger = logger;
-    private readonly IAppConfigService _appConfigService = appConfigService;
-
-    public override string Id => "f885a499-82ec-4897-a788-fb6b4615ab06";
-
-    public override string Name => "delete";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "f885a499-82ec-4897-a788-fb6b4615ab06",
+    Name = "delete",
+    Title = "Delete App Configuration Key-Value Setting",
+    Description = """
         Delete a key-value pair from an App Configuration store. This command removes the specified key-value pair from the store.
         If a label is specified, only the labeled version is deleted. If no label is specified, the key-value with the matching
         key and the default label will be deleted.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class KeyValueDeleteCommand(ILogger<KeyValueDeleteCommand> logger, IAppConfigService appConfigService)
+    : BaseKeyValueCommand<KeyValueDeleteOptions>()
+{
+    private readonly ILogger<KeyValueDeleteCommand> _logger = logger;
+    private readonly IAppConfigService _appConfigService = appConfigService;
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueGetCommand.cs
@@ -13,36 +13,27 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AppConfig.Commands.KeyValue;
 
-public sealed class KeyValueGetCommand(ILogger<KeyValueGetCommand> logger, IAppConfigService appConfigService)
-    : BaseAppConfigCommand<KeyValueGetOptions>()
-{
-    private const string CommandTitle = "Gets App Configuration Key-Value Settings";
-    private readonly ILogger<KeyValueGetCommand> _logger = logger;
-    private readonly IAppConfigService _appConfigService = appConfigService;
-
-    public override string Id => "abc28800-ae4a-4369-9ec0-2653a578e82a";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "abc28800-ae4a-4369-9ec0-2653a578e82a",
+    Name = "get",
+    Title = "Gets App Configuration Key-Value Settings",
+    Description = """
         Gets key-values in an App Configuration store. This command can either retrieve a specific key-value by its key
         and optional label, or list key-values if no key is provided. Listing key-values can optionally be filtered by a
         key filter and label filter. Each key-value includes its key, value, label, content type, ETag, last modified time,
         and lock status.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class KeyValueGetCommand(ILogger<KeyValueGetCommand> logger, IAppConfigService appConfigService)
+    : BaseAppConfigCommand<KeyValueGetOptions>()
+{
+    private readonly ILogger<KeyValueGetCommand> _logger = logger;
+    private readonly IAppConfigService _appConfigService = appConfigService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueSetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueSetCommand.cs
@@ -11,36 +11,28 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AppConfig.Commands.KeyValue;
 
+[CommandMetadata(
+    Id = "a89086eb-acf4-4168-9d32-de5cd7384030",
+    Name = "set",
+    Title = "Set App Configuration Key-Value Setting",
+    Description = """
+        Set a key-value setting in an App Configuration store. This command creates or updates a key-value setting
+        with the specified value. You must specify an account name, key, and value. Optionally, you can specify a
+        label otherwise the default label will be used. You can also specify a content type to indicate how the value
+        should be interpreted. You can add tags in the format 'key=value' to associate metadata with the setting.
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class KeyValueSetCommand(ILogger<KeyValueSetCommand> logger, IAppConfigService appConfigService)
     : BaseKeyValueCommand<KeyValueSetOptions>()
 {
     private const string CommandTitle = "Set App Configuration Key-Value Setting";
     private readonly ILogger<KeyValueSetCommand> _logger = logger;
     private readonly IAppConfigService _appConfigService = appConfigService;
-
-    public override string Id => "a89086eb-acf4-4168-9d32-de5cd7384030";
-
-    public override string Name => "set";
-
-    public override string Description =>
-        """
-        Set a key-value setting in an App Configuration store. This command creates or updates a key-value setting
-        with the specified value. You must specify an account name, key, and value. Optionally, you can specify a
-        label otherwise the default label will be used. You can also specify a content type to indicate how the value
-        should be interpreted. You can add tags in the format 'key=value' to associate metadata with the setting.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/Lock/KeyValueLockSetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/Lock/KeyValueLockSetCommand.cs
@@ -11,37 +11,28 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AppConfig.Commands.KeyValue.Lock;
 
-public sealed class KeyValueLockSetCommand(ILogger<KeyValueLockSetCommand> logger, IAppConfigService appConfigService)
-    : BaseKeyValueCommand<KeyValueLockSetOptions>()
-{
-    private const string CommandTitle = "Sets the lock state of an App Configuration Key-Value Setting";
-    private readonly ILogger<KeyValueLockSetCommand> _logger = logger;
-    private readonly IAppConfigService _appConfigService = appConfigService;
-
-    public override string Id => "b48fd781-d74a-4dfd-a29c-421ded9a6ce9";
-
-    public override string Name => "set";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "b48fd781-d74a-4dfd-a29c-421ded9a6ce9",
+    Name = "set",
+    Title = "Sets the lock state of an App Configuration Key-Value Setting",
+    Description = """
         Sets the lock state of a key-value in an App Configuration store. This command can lock and unlock key-values.
         Locking sets a key-value to read-only mode, preventing any modifications to its value. Unlocking removes the
         read-only mode from a key-value setting, allowing modifications to its value. You must specify an account name
         and key. Optionally, you can specify a label to lock or unlock a specific labeled version of the key-value.
         Default is unlocking the key-value.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class KeyValueLockSetCommand(ILogger<KeyValueLockSetCommand> logger, IAppConfigService appConfigService)
+    : BaseKeyValueCommand<KeyValueLockSetOptions>()
+{
+    private readonly ILogger<KeyValueLockSetCommand> _logger = logger;
+    private readonly IAppConfigService _appConfigService = appConfigService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AppLens/src/Commands/Resource/ResourceDiagnoseCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Commands/Resource/ResourceDiagnoseCommand.cs
@@ -17,33 +17,22 @@ namespace Azure.Mcp.Tools.AppLens.Commands.Resource;
 /// Subscription, resource group, and resource type are optional - the service uses
 /// Azure Resource Graph to discover the resource by name when they are not provided.
 /// </summary>
+[CommandMetadata(
+    Id = "92fb5b7d-f1d7-4834-a61a-e170ad8594ac",
+    Name = "diagnose",
+    Title = "Diagnose Azure Resource Issues",
+    Description = "Get diagnostic help from App Lens for Azure application and service issues to identify what's wrong with a service. Ask questions about performance, slowness, failures, errors, application state, availability to receive expert analysis and solutions which can help when performing diagnostics and to address issues about performance and failures. Returns analysis, insights, and recommended solutions. Always use this tool before manually checking metrics or logs when users report performance or functionality issues. Only the resource name and question are required - subscription, resource group, and resource type are optional and used to narrow down results when multiple resources share the same name.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ResourceDiagnoseCommand(ILogger<ResourceDiagnoseCommand> logger, IAppLensService appLensService)
     : GlobalCommand<ResourceDiagnoseOptions>
 {
-    private const string CommandTitle = "Diagnose Azure Resource Issues";
     private readonly ILogger<ResourceDiagnoseCommand> _logger = logger;
     private readonly IAppLensService _appLensService = appLensService;
-
-    public override string Id => "92fb5b7d-f1d7-4834-a61a-e170ad8594ac";
-
-    public override string Name => "diagnose";
-
-    public override string Description =>
-    "Get diagnostic help from App Lens for Azure application and service issues to identify what's wrong with a service. Ask questions about performance, slowness, failures, errors, application state, availability to receive expert analysis and solutions which can help when performing diagnostics and to address issues about performance and failures. " +
-    "Returns analysis, insights, and recommended solutions. " +
-    "Always use this tool before manually checking metrics or logs when users report performance or functionality issues. " +
-    "Only the resource name and question are required - subscription, resource group, and resource type are optional and used to narrow down results when multiple resources share the same name.";
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/Database/DatabaseAddCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/Database/DatabaseAddCommand.cs
@@ -12,35 +12,26 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AppService.Commands.Database;
 
-public sealed class DatabaseAddCommand(ILogger<DatabaseAddCommand> logger, IAppServiceService appServiceService)
-    : BaseAppServiceCommand<DatabaseAddOptions>(resourceGroupRequired: true, appRequired: true)
-{
-    private const string CommandTitle = "Add Database to App Service";
-    private readonly ILogger<DatabaseAddCommand> _logger = logger;
-    private readonly IAppServiceService _appServiceService = appServiceService;
-
-    public override string Id => "14be1264-82c8-4a4c-8271-7cfe1fbebbc8";
-
-    public override string Name => "add";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "14be1264-82c8-4a4c-8271-7cfe1fbebbc8",
+    Name = "add",
+    Title = "Add Database to App Service",
+    Description = """
         Add a database connection for an App Service using connection string for an existing database. This command configures database connection
         settings for the specified App Service, allowing it to connect to a database server name. You must specify the App Service name, database name,
         database type, database server name, connection string, resource group name and subscription.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = true,
-        ReadOnly = false,
-        Secret = false,
-        LocalRequired = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = true,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class DatabaseAddCommand(ILogger<DatabaseAddCommand> logger, IAppServiceService appServiceService)
+    : BaseAppServiceCommand<DatabaseAddOptions>(resourceGroupRequired: true, appRequired: true)
+{
+    private readonly ILogger<DatabaseAddCommand> _logger = logger;
+    private readonly IAppServiceService _appServiceService = appServiceService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Deployment/DeploymentGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Deployment/DeploymentGetCommand.cs
@@ -12,34 +12,27 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AppService.Commands.Webapp.Deployment;
 
-public sealed class DeploymentGetCommand(ILogger<DeploymentGetCommand> logger)
-    : BaseAppServiceCommand<DeploymentGetOptions>(resourceGroupRequired: true, appRequired: true)
-{
-    private const string CommandTitle = "Gets Azure App Service Web App Deployment Details";
-    private readonly ILogger<DeploymentGetCommand> _logger = logger;
-    public override string Id => "17c59409-5382-4419-aef4-0058ffe2c6ec";
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "17c59409-5382-4419-aef4-0058ffe2c6ec",
+    Name = "get",
+    Title = "Gets Azure App Service Web App Deployment Details",
+    Description = """
         Retrieves detailed information about Azure App Service web app deployments, including deployment name,
         if deployment is actively happening, when the deployment started and ended, who authored and deployed the
         deployment, and the type of deployment. If a specific deployment ID is not provided, the command will return
         details for all deployments in the web app. You can specify a deployment ID to get details for a specific
         deployment.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        Secret = false,
-        LocalRequired = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class DeploymentGetCommand(ILogger<DeploymentGetCommand> logger)
+    : BaseAppServiceCommand<DeploymentGetOptions>(resourceGroupRequired: true, appRequired: true)
+{
+    private readonly ILogger<DeploymentGetCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Diagnostic/DetectorDiagnoseCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Diagnostic/DetectorDiagnoseCommand.cs
@@ -13,33 +13,26 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AppService.Commands.Webapp.Diagnostic;
 
-public sealed class DetectorDiagnoseCommand(ILogger<DetectorDiagnoseCommand> logger)
-    : BaseAppServiceCommand<DetectorDiagnoseOptions>(resourceGroupRequired: true, appRequired: true)
-{
-    private const string CommandTitle = "Diagnose an App Service Web App";
-    private readonly ILogger<DetectorDiagnoseCommand> _logger = logger;
-    public override string Id => "a8aa0966-4c0c-4e22-8854-cced583f0fb2";
-    public override string Name => "diagnose";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "a8aa0966-4c0c-4e22-8854-cced583f0fb2",
+    Name = "diagnose",
+    Title = "Diagnose an App Service Web App",
+    Description = """
         Runs a specific diagnostic detector on an App Service Web App to troubleshoot issues with performance, availability,
         configuration, or errors. Returns detailed analysis results including insights and recommendations. Use this to investigate
         why a web app is slow, failing, restarting, or unhealthy. Requires a detector ID from 'azmcp appservice webapp diagnostic list'.
         Supports optional time range filtering for historical analysis.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        Secret = false,
-        LocalRequired = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class DetectorDiagnoseCommand(ILogger<DetectorDiagnoseCommand> logger)
+    : BaseAppServiceCommand<DetectorDiagnoseOptions>(resourceGroupRequired: true, appRequired: true)
+{
+    private readonly ILogger<DetectorDiagnoseCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Diagnostic/DetectorListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Diagnostic/DetectorListCommand.cs
@@ -10,33 +10,26 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AppService.Commands.Webapp.Diagnostic;
 
-public sealed class DetectorListCommand(ILogger<DetectorListCommand> logger)
-    : BaseAppServiceCommand<BaseAppServiceOptions>(resourceGroupRequired: true, appRequired: true)
-{
-    private const string CommandTitle = "List the Diagnostic Detectors for an App Service Web App";
-    private readonly ILogger<DetectorListCommand> _logger = logger;
-    public override string Id => "7807fdb6-4b92-4361-8042-be61dd342e17";
-    public override string Name => "list";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "7807fdb6-4b92-4361-8042-be61dd342e17",
+    Name = "list",
+    Title = "List the Diagnostic Detectors for an App Service Web App",
+    Description = """
         Lists all available diagnostic detectors for an App Service Web App. Use this to discover which diagnostics
         are available before running a specific detector. Returns the detector ID, name, type, description, category,
         and analysis types for each detector. Useful for troubleshooting app service issues, checking available
         health checks, and finding the right detector for performance, availability, or configuration analysis.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        Secret = false,
-        LocalRequired = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class DetectorListCommand(ILogger<DetectorListCommand> logger)
+    : BaseAppServiceCommand<BaseAppServiceOptions>(resourceGroupRequired: true, appRequired: true)
+{
+    private readonly ILogger<DetectorListCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command) => base.RegisterOptions(command);
 

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Settings/AppSettingsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Settings/AppSettingsGetCommand.cs
@@ -9,32 +9,25 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AppService.Commands.Webapp.Settings;
 
+[CommandMetadata(
+    Id = "825ef21f-392f-4cd4-8272-7e7dce12e293",
+    Name = "get-appsettings",
+    Title = "Gets Azure App Service Web App Application Settings",
+    Description = """
+        Retrieves the application settings for an App Service web app, returning key-value pairs that represent the
+        setting. Application settings may contain sensitive information.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = true,
+    LocalRequired = false)]
 public sealed class AppSettingsGetCommand(ILogger<AppSettingsGetCommand> logger, IAppServiceService appServiceService)
     : BaseAppServiceCommand<BaseAppServiceOptions>(resourceGroupRequired: true, appRequired: true)
 {
-    private const string CommandTitle = "Gets Azure App Service Web App Application Settings";
     private readonly ILogger<AppSettingsGetCommand> _logger = logger;
     private readonly IAppServiceService _appServiceService = appServiceService;
-    public override string Id => "825ef21f-392f-4cd4-8272-7e7dce12e293";
-    public override string Name => "get-appsettings";
-
-    public override string Description =>
-        """
-        Retrieves the application settings for an App Service web app, returning key-value pairs that represent the
-        setting. Application settings may contain sensitive information.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        Secret = true,
-        LocalRequired = false
-    };
 
     protected override void RegisterOptions(Command command) => base.RegisterOptions(command);
 

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Settings/AppSettingsUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Settings/AppSettingsUpdateCommand.cs
@@ -11,39 +11,32 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AppService.Commands.Webapp.Settings;
 
-public sealed class AppSettingsUpdateCommand(ILogger<AppSettingsUpdateCommand> logger, IAppServiceService appServiceService)
-    : BaseAppServiceCommand<AppSettingsUpdateOptions>(resourceGroupRequired: true, appRequired: true)
-{
-    private const string CommandTitle = "Updates Azure App Service Web App Application Settings";
-    private readonly ILogger<AppSettingsUpdateCommand> _logger = logger;
-    private readonly IAppServiceService _appServiceService = appServiceService;
-    public override string Id => "08ca52a3-f766-4c62-9597-702f629efaf6";
-    public override string Name => "update-appsettings";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "08ca52a3-f766-4c62-9597-702f629efaf6",
+    Name = "update-appsettings",
+    Title = "Updates Azure App Service Web App Application Settings",
+    Description = """
         Updates the application setting for an App Service web app. Three types of updating are available:
-        
+
         - Add: adds a new application setting with the specified name and value. If the application setting already exists, the operation will fail and return an error message.
         - Set: sets the value of an application setting. If the application setting does not exist, this is equivalent to add. If the application setting already exists, the value will be overwritten.
         - Delete: deletes an application setting with the specified name. If the application setting does not exist, nothing happens.
 
         For add and set update types, both the application setting name and value are required. For delete update type, only the application setting name is required.
-        """;
-
-    public override string Title => CommandTitle;
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class AppSettingsUpdateCommand(ILogger<AppSettingsUpdateCommand> logger, IAppServiceService appServiceService)
+    : BaseAppServiceCommand<AppSettingsUpdateOptions>(resourceGroupRequired: true, appRequired: true)
+{
+    private readonly ILogger<AppSettingsUpdateCommand> _logger = logger;
+    private readonly IAppServiceService _appServiceService = appServiceService;
 
     private static readonly HashSet<string> ValidUpdateTypes = ["add", "set", "delete"];
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        Secret = false,
-        LocalRequired = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/WebappGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/WebappGetCommand.cs
@@ -12,34 +12,27 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AppService.Commands.Webapp;
 
-public sealed class WebappGetCommand(ILogger<WebappGetCommand> logger, IAppServiceService appServiceService)
-    : BaseAppServiceCommand<BaseAppServiceOptions>(resourceGroupRequired: false)
-{
-    private const string CommandTitle = "Gets Azure App Service Web App Details";
-    private readonly ILogger<WebappGetCommand> _logger = logger;
-    private readonly IAppServiceService _appServiceService = appServiceService;
-    public override string Id => "4412f1af-16e7-46db-8305-33e3d7ae06de";
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "4412f1af-16e7-46db-8305-33e3d7ae06de",
+    Name = "get",
+    Title = "Gets Azure App Service Web App Details",
+    Description = """
         Retrieves detailed information about Azure App Service web apps, including app name, resource group, location,
         state, hostnames, etc. If a specific app name is not provided, the command will return details for all web apps
         in a subscription or resource group in a subscription. You can specify the app name, resource group name, and
         subscription to get details for a specific web app.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        Secret = false,
-        LocalRequired = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class WebappGetCommand(ILogger<WebappGetCommand> logger, IAppServiceService appServiceService)
+    : BaseAppServiceCommand<BaseAppServiceOptions>(resourceGroupRequired: false)
+{
+    private readonly ILogger<WebappGetCommand> _logger = logger;
+    private readonly IAppServiceService _appServiceService = appServiceService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/src/Commands/Recommendation/RecommendationListCommand.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/src/Commands/Recommendation/RecommendationListCommand.cs
@@ -14,25 +14,24 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ApplicationInsights.Commands.Recommendation;
 
-public sealed class RecommendationListCommand(ILogger<RecommendationListCommand> logger, IApplicationInsightsService applicationInsightsService) : SubscriptionCommand<RecommendationListOptions>()
-{
-    private const string CommandTitle = "List Application Insights Recommendations";
-    private readonly ILogger<RecommendationListCommand> _logger = logger;
-    private readonly IApplicationInsightsService _applicationInsightsService = applicationInsightsService;
-
-    public override string Id => "8d259f21-43b3-4962-bec8-de616b8b5f0d";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "8d259f21-43b3-4962-bec8-de616b8b5f0d",
+    Name = "list",
+    Title = "List Application Insights Recommendations",
+    Description = """
         List Application Insights Code Optimization Recommendations in a subscription. Optionally filter by resource group when --resource-group is provided.
         Returns the code optimization recommendations based on the profiler data.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new() { Destructive = false, Idempotent = true, LocalRequired = false, OpenWorld = false, Secret = false, ReadOnly = true };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class RecommendationListCommand(ILogger<RecommendationListCommand> logger, IApplicationInsightsService applicationInsightsService) : SubscriptionCommand<RecommendationListOptions>()
+{
+    private readonly ILogger<RecommendationListCommand> _logger = logger;
+    private readonly IApplicationInsightsService _applicationInsightsService = applicationInsightsService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
@@ -13,33 +13,24 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Authorization.Commands;
 
-public sealed class RoleAssignmentListCommand(ILogger<RoleAssignmentListCommand> logger, IAuthorizationService authorizationService) : SubscriptionCommand<RoleAssignmentListOptions>
-{
-    private const string _commandTitle = "List Role Assignments";
-    private readonly ILogger<RoleAssignmentListCommand> _logger = logger;
-    private readonly IAuthorizationService _authorizationService = authorizationService;
-
-    public override string Id => "1dfbef45-4014-4575-a9ba-2242bc792e54";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "1dfbef45-4014-4575-a9ba-2242bc792e54",
+    Name = "list",
+    Title = "List Role Assignments",
+    Description = """
         List role assignments. This command retrieves and displays all Azure RBAC role assignments
         in the specified scope. Results include role definition IDs and principal IDs, returned as a JSON array.
-        """;
-
-    public override string Title => _commandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class RoleAssignmentListCommand(ILogger<RoleAssignmentListCommand> logger, IAuthorizationService authorizationService) : SubscriptionCommand<RoleAssignmentListOptions>
+{
+    private readonly ILogger<RoleAssignmentListCommand> _logger = logger;
+    private readonly IAuthorizationService _authorizationService = authorizationService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/docs/new-tools.md
+++ b/tools/Azure.Mcp.Tools.AzureBackup/docs/new-tools.md
@@ -141,28 +141,23 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureBackup.Commands.Vault;
 
+[CommandMetadata(
+    Id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    Name = "delete",
+    Title = "Delete Backup Vault",
+    Description = "Deletes a backup vault (RSV or DPP).",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    LocalRequired = false,
+    Secret = false)]
 public sealed class VaultDeleteCommand(
     ILogger<VaultDeleteCommand> logger,
     IAzureBackupService azureBackupService) : BaseAzureBackupCommand<VaultDeleteOptions>()
 {
-    private const string CommandTitle = "Delete Backup Vault";
     private readonly ILogger<VaultDeleteCommand> _logger = logger;
     private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    // Generate a new GUID for the command ID
-    public override string Id => "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
-    public override string Name => "delete";
-    public override string Description => "Deletes a backup vault (RSV or DPP).";
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(
         CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Backup/BackupStatusCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Backup/BackupStatusCommand.cs
@@ -15,23 +15,26 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AzureBackup.Commands.Backup;
 
-public sealed class BackupStatusCommand(ILogger<BackupStatusCommand> logger, IAzureBackupService azureBackupService) : SubscriptionCommand<BackupStatusOptions>()
-{
-    private const string CommandTitle = "Check Backup Status";
-    private readonly ILogger<BackupStatusCommand> _logger = logger;
-    private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "f5612c55-054d-4fd8-964c-952e8e6b87f8";
-    public override string Name => "status";
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "f5612c55-054d-4fd8-964c-952e8e6b87f8",
+    Name = "status",
+    Title = "Check Backup Status",
+    Description = """
         Checks the backup status of an Azure resource and returns whether it is protected,
         along with vault and policy details. Use this to verify if a VM, disk, storage account,
         or other datasource is currently backed up. Requires the datasource ARM resource ID
         and the Azure region (location) where the resource exists.
-        """;
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new() { Destructive = false, Idempotent = true, OpenWorld = false, ReadOnly = true, LocalRequired = false, Secret = false };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class BackupStatusCommand(ILogger<BackupStatusCommand> logger, IAzureBackupService azureBackupService) : SubscriptionCommand<BackupStatusOptions>()
+{
+    private readonly ILogger<BackupStatusCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/DisasterRecovery/DisasterRecoveryEnableCrrCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/DisasterRecovery/DisasterRecoveryEnableCrrCommand.cs
@@ -13,17 +13,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AzureBackup.Commands.DisasterRecovery;
 
+[CommandMetadata(
+    Id = "917b66e5-483f-43ac-9620-9403e1689dbe",
+    Name = "enable-crr",
+    Title = "Enable Cross-Region Restore",
+    Description = "Enables Cross-Region Restore on a GRS-enabled vault.",
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class DisasterRecoveryEnableCrrCommand(ILogger<DisasterRecoveryEnableCrrCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<BaseAzureBackupOptions>()
 {
-    private const string CommandTitle = "Enable Cross-Region Restore";
     private readonly ILogger<DisasterRecoveryEnableCrrCommand> _logger = logger;
     private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "917b66e5-483f-43ac-9620-9403e1689dbe";
-    public override string Name => "enable-crr";
-    public override string Description => "Enables Cross-Region Restore on a GRS-enabled vault.";
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new() { Destructive = true, Idempotent = true, OpenWorld = false, ReadOnly = false, LocalRequired = false, Secret = false };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceFindUnprotectedCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceFindUnprotectedCommand.cs
@@ -14,29 +14,24 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AzureBackup.Commands.Governance;
 
-public sealed class GovernanceFindUnprotectedCommand(ILogger<GovernanceFindUnprotectedCommand> logger, IAzureBackupService azureBackupService) : SubscriptionCommand<GovernanceFindUnprotectedOptions>()
-{
-    private const string CommandTitle = "Find Unprotected Resources";
-    private readonly ILogger<GovernanceFindUnprotectedCommand> _logger = logger;
-    private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "73b050ca-2e20-448c-a76c-08e8cd5bbe25";
-    public override string Name => "find-unprotected";
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "73b050ca-2e20-448c-a76c-08e8cd5bbe25",
+    Name = "find-unprotected",
+    Title = "Find Unprotected Resources",
+    Description = """
         Scans the subscription to find Azure resources that are not currently protected by any
         backup policy. Optionally filter by resource type, resource group, or tags.
-        """;
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class GovernanceFindUnprotectedCommand(ILogger<GovernanceFindUnprotectedCommand> logger, IAzureBackupService azureBackupService) : SubscriptionCommand<GovernanceFindUnprotectedOptions>()
+{
+    private readonly ILogger<GovernanceFindUnprotectedCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceImmutabilityCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceImmutabilityCommand.cs
@@ -14,29 +14,24 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AzureBackup.Commands.Governance;
 
-public sealed class GovernanceImmutabilityCommand(ILogger<GovernanceImmutabilityCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<GovernanceImmutabilityOptions>()
-{
-    private const string CommandTitle = "Configure Vault Immutability";
-    private readonly ILogger<GovernanceImmutabilityCommand> _logger = logger;
-    private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "a0ac7596-9a80-4b53-b459-06f27598a2e2";
-    public override string Name => "immutability";
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "a0ac7596-9a80-4b53-b459-06f27598a2e2",
+    Name = "immutability",
+    Title = "Configure Vault Immutability",
+    Description = """
         Configures the immutability state for a backup vault. States include 'Disabled', 'Enabled',
         or 'Locked'. Warning: 'Locked' state is irreversible.
-        """;
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class GovernanceImmutabilityCommand(ILogger<GovernanceImmutabilityCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<GovernanceImmutabilityOptions>()
+{
+    private readonly ILogger<GovernanceImmutabilityCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceSoftDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceSoftDeleteCommand.cs
@@ -13,29 +13,24 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AzureBackup.Commands.Governance;
 
-public sealed class GovernanceSoftDeleteCommand(ILogger<GovernanceSoftDeleteCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<GovernanceSoftDeleteOptions>()
-{
-    private const string CommandTitle = "Configure Soft Delete";
-    private readonly ILogger<GovernanceSoftDeleteCommand> _logger = logger;
-    private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "b3f1ea2d-5535-4155-849c-61f2fc49f1d9";
-    public override string Name => "soft-delete";
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "b3f1ea2d-5535-4155-849c-61f2fc49f1d9",
+    Name = "soft-delete",
+    Title = "Configure Soft Delete",
+    Description = """
         Configures the soft delete settings for a backup vault. Set the state to 'AlwaysOn', 'On',
         or 'Off', and optionally specify the retention period in days (14-180).
-        """;
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class GovernanceSoftDeleteCommand(ILogger<GovernanceSoftDeleteCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<GovernanceSoftDeleteOptions>()
+{
+    private readonly ILogger<GovernanceSoftDeleteCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Job/JobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Job/JobGetCommand.cs
@@ -18,30 +18,25 @@ namespace Azure.Mcp.Tools.AzureBackup.Commands.Job;
 /// Consolidated job command: when --job is supplied returns a single job's details;
 /// otherwise lists all jobs in the vault.
 /// </summary>
-public sealed class JobGetCommand(ILogger<JobGetCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<JobGetOptions>()
-{
-    private const string CommandTitle = "Get Backup Job";
-    private readonly ILogger<JobGetCommand> _logger = logger;
-    private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "f1291650-8ff2-413c-8001-e4b33f157a3b";
-    public override string Name => "get";
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "f1291650-8ff2-413c-8001-e4b33f157a3b",
+    Name = "get",
+    Title = "Get Backup Job",
+    Description = """
         Retrieves backup job information. When --job is specified, returns detailed information
         about a single job including operation type, status, start/end times, error codes, and
         datasource details. When omitted, lists all backup jobs in the vault.
-        """;
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class JobGetCommand(ILogger<JobGetCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<JobGetOptions>()
+{
+    private readonly ILogger<JobGetCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyCreateCommand.cs
@@ -14,17 +14,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AzureBackup.Commands.Policy;
 
+[CommandMetadata(
+    Id = "bc5e600b-c414-4bce-8b7d-a6021cfd3d23",
+    Name = "create",
+    Title = "Create Backup Policy",
+    Description = "Creates a backup policy for a specified workload type with schedule and retention rules.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class PolicyCreateCommand(ILogger<PolicyCreateCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<PolicyCreateOptions>()
 {
-    private const string CommandTitle = "Create Backup Policy";
     private readonly ILogger<PolicyCreateCommand> _logger = logger;
     private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "bc5e600b-c414-4bce-8b7d-a6021cfd3d23";
-    public override string Name => "create";
-    public override string Description => "Creates a backup policy for a specified workload type with schedule and retention rules.";
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new() { Destructive = true, Idempotent = false, OpenWorld = false, ReadOnly = false, LocalRequired = false, Secret = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyGetCommand.cs
@@ -18,30 +18,25 @@ namespace Azure.Mcp.Tools.AzureBackup.Commands.Policy;
 /// Consolidated policy command: when --policy is supplied returns a single policy's details;
 /// otherwise lists all policies in the vault.
 /// </summary>
-public sealed class PolicyGetCommand(ILogger<PolicyGetCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<PolicyGetOptions>()
-{
-    private const string CommandTitle = "Get Backup Policy";
-    private readonly ILogger<PolicyGetCommand> _logger = logger;
-    private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "5f7ef3ae-72f3-4fe8-bd1e-ea56e4db86df";
-    public override string Name => "get";
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "5f7ef3ae-72f3-4fe8-bd1e-ea56e4db86df",
+    Name = "get",
+    Title = "Get Backup Policy",
+    Description = """
         Retrieves backup policy information. When --policy is specified, returns detailed
         information about a single policy including datasource types and protected items count.
         When omitted, lists all backup policies configured in the vault.
-        """;
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class PolicyGetCommand(ILogger<PolicyGetCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<PolicyGetOptions>()
+{
+    private readonly ILogger<PolicyGetCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectableItem/ProtectableItemListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectableItem/ProtectableItemListCommand.cs
@@ -12,32 +12,27 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureBackup.Commands.ProtectableItem;
 
-public sealed class ProtectableItemListCommand(ILogger<ProtectableItemListCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<ProtectableItemListOptions>()
-{
-    private const string CommandTitle = "List Protectable Items";
-    private readonly ILogger<ProtectableItemListCommand> _logger = logger;
-    private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "9f6b0a1e-1c2d-4e5f-8a9b-7c6d5e4f3a21";
-    public override string Name => "list";
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "9f6b0a1e-1c2d-4e5f-8a9b-7c6d5e4f3a21",
+    Name = "list",
+    Title = "List Protectable Items",
+    Description = """
         Lists items that can be backed up (protectable items) in a Recovery Services vault,
         such as SQL databases and SAP HANA databases discovered on registered VMs.
         Use this to find databases and workloads available for backup protection.
         Only supported for RSV vaults; DPP datasources are protected by ARM resource ID directly.
         Filter results by --workload-type (e.g., SQL, SAPHana) or --container.
-        """;
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ProtectableItemListCommand(ILogger<ProtectableItemListCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<ProtectableItemListOptions>()
+{
+    private readonly ILogger<ProtectableItemListCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemGetCommand.cs
@@ -17,32 +17,27 @@ namespace Azure.Mcp.Tools.AzureBackup.Commands.ProtectedItem;
 /// Consolidated protected item command: when --protected-item is supplied returns a single
 /// item's details; otherwise lists all protected items in the vault.
 /// </summary>
-public sealed class ProtectedItemGetCommand(ILogger<ProtectedItemGetCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<BaseProtectedItemOptions>()
-{
-    private const string CommandTitle = "Get Protected Item";
-    private readonly ILogger<ProtectedItemGetCommand> _logger = logger;
-    private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "bc985e4f-8945-447a-9aba-ef13df309001";
-    public override string Name => "get";
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "bc985e4f-8945-447a-9aba-ef13df309001",
+    Name = "get",
+    Title = "Get Protected Item",
+    Description = """
         Retrieves protected item information. When --protected-item is specified, returns
         detailed information about a single backup instance including protection status,
         datasource details, policy assignment, and last backup time. Specify --container
         for RSV workload items. When --protected-item is omitted, lists all protected items
         (backup instances) in the vault.
-        """;
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ProtectedItemGetCommand(ILogger<ProtectedItemGetCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<BaseProtectedItemOptions>()
+{
+    private readonly ILogger<ProtectedItemGetCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemProtectCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemProtectCommand.cs
@@ -14,16 +14,11 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AzureBackup.Commands.ProtectedItem;
 
-public sealed class ProtectedItemProtectCommand(ILogger<ProtectedItemProtectCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<ProtectedItemProtectOptions>()
-{
-    private const string CommandTitle = "Protect Resource";
-    private readonly ILogger<ProtectedItemProtectCommand> _logger = logger;
-    private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "7a6fc193-ca3c-4309-97c5-ee1e7fe90e69";
-    public override string Name => "protect";
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "7a6fc193-ca3c-4309-97c5-ee1e7fe90e69",
+    Name = "protect",
+    Title = "Protect Resource",
+    Description = """
         Enables or configures backup protection for an Azure resource by creating a
         protected item or backup instance. Protects VMs, disks, file shares, SQL databases,
         SAP HANA databases, and other supported datasources.
@@ -32,17 +27,17 @@ public sealed class ProtectedItemProtectCommand(ILogger<ProtectedItemProtectComm
         as --datasource-id (e.g., 'SAPHanaDatabase;instance;dbname'), and specify --container.
         Requires a backup policy name via --policy. The operation is asynchronous;
         use 'azurebackup job get' to monitor the protection job progress.
-        """;
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ProtectedItemProtectCommand(ILogger<ProtectedItemProtectCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<ProtectedItemProtectOptions>()
+{
+    private readonly ILogger<ProtectedItemProtectCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemUndeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemUndeleteCommand.cs
@@ -14,33 +14,28 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AzureBackup.Commands.ProtectedItem;
 
-public sealed class ProtectedItemUndeleteCommand(ILogger<ProtectedItemUndeleteCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<ProtectedItemUndeleteOptions>()
-{
-    private const string CommandTitle = "Undelete Protected Item";
-    private readonly ILogger<ProtectedItemUndeleteCommand> _logger = logger;
-    private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "d8e3a1b7-5c42-4f9e-b6d1-7a2e9c3f4b58";
-    public override string Name => "undelete";
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "d8e3a1b7-5c42-4f9e-b6d1-7a2e9c3f4b58",
+    Name = "undelete",
+    Title = "Undelete Protected Item",
+    Description = """
         Undeletes or restores a soft-deleted backup item to an active protection state.
         Use this when a backup or protected item was accidentally deleted and needs to be recovered.
         For RSV vaults: pass the datasource ARM resource ID as --datasource-id.
         For DPP vaults: pass the datasource ARM resource ID as --datasource-id.
         Optionally specify --container for RSV workload items (SQL/HANA).
         The operation is asynchronous; use 'azurebackup job get' to monitor progress.
-        """;
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ProtectedItemUndeleteCommand(ILogger<ProtectedItemUndeleteCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<ProtectedItemUndeleteOptions>()
+{
+    private readonly ILogger<ProtectedItemUndeleteCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/RecoveryPoint/RecoveryPointGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/RecoveryPoint/RecoveryPointGetCommand.cs
@@ -18,30 +18,25 @@ namespace Azure.Mcp.Tools.AzureBackup.Commands.RecoveryPoint;
 /// Consolidated recovery point command: when --recovery-point is supplied returns a single
 /// recovery point's details; otherwise lists all recovery points for the protected item.
 /// </summary>
-public sealed class RecoveryPointGetCommand(ILogger<RecoveryPointGetCommand> logger, IAzureBackupService azureBackupService) : BaseProtectedItemCommand<RecoveryPointGetOptions>()
-{
-    private const string CommandTitle = "Get Recovery Point";
-    private readonly ILogger<RecoveryPointGetCommand> _logger = logger;
-    private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "e930bbb6-b495-454b-bae4-46b9da14eb1c";
-    public override string Name => "get";
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "e930bbb6-b495-454b-bae4-46b9da14eb1c",
+    Name = "get",
+    Title = "Get Recovery Point",
+    Description = """
         Retrieves recovery point information for a protected item. When --recovery-point is
         specified, returns detailed information about a single recovery point including time
         and type. When omitted, lists all available recovery points for the protected item.
-        """;
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class RecoveryPointGetCommand(ILogger<RecoveryPointGetCommand> logger, IAzureBackupService azureBackupService) : BaseProtectedItemCommand<RecoveryPointGetOptions>()
+{
+    private readonly ILogger<RecoveryPointGetCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultCreateCommand.cs
@@ -14,33 +14,28 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AzureBackup.Commands.Vault;
 
-public sealed class VaultCreateCommand(ILogger<VaultCreateCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<VaultCreateOptions>()
-{
-    private const string CommandTitle = "Create Backup Vault";
-    private readonly ILogger<VaultCreateCommand> _logger = logger;
-    private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "1dccdb24-d81c-4bde-9437-577a7bd0cf09";
-    public override string Name => "create";
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "1dccdb24-d81c-4bde-9437-577a7bd0cf09",
+    Name = "create",
+    Title = "Create Backup Vault",
+    Description = """
         Creates a new backup vault. Specify --vault-type as 'rsv' for a Recovery Services vault
         or 'dpp' for a Backup vault (Data Protection). For DPP vaults a System-Assigned
         Managed Identity is enabled by default so the vault can authenticate to protected
         datasources (storage accounts, disks, PG Flex, etc.) - change later with
         'azurebackup vault update --identity-type ...' if needed. Returns the created
         vault details.
-        """;
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class VaultCreateCommand(ILogger<VaultCreateCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<VaultCreateOptions>()
+{
+    private readonly ILogger<VaultCreateCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultGetCommand.cs
@@ -18,32 +18,27 @@ namespace Azure.Mcp.Tools.AzureBackup.Commands.Vault;
 /// Consolidated vault command: when --vault is supplied returns a single vault's details;
 /// otherwise lists all vaults in the subscription (optionally filtered by --vault-type).
 /// </summary>
-public sealed class VaultGetCommand(ILogger<VaultGetCommand> logger, IAzureBackupService azureBackupService) : SubscriptionCommand<BaseAzureBackupOptions>()
-{
-    private const string CommandTitle = "Get Backup Vault";
-    private readonly ILogger<VaultGetCommand> _logger = logger;
-    private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "4a1084d5-50d9-489f-9e4c-acc594441b1f";
-    public override string Name => "get";
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "4a1084d5-50d9-489f-9e4c-acc594441b1f",
+    Name = "get",
+    Title = "Get Backup Vault",
+    Description = """
         Retrieves backup vault information. When --vault and --resource-group are specified,
         returns detailed information about a single vault including type, location, SKU, and
         storage redundancy. When omitted, lists all backup vaults (RSV and Backup vaults) in
         the subscription. Optionally filter by --vault-type ('rsv' or 'dpp') and/or
         --resource-group to narrow the listing results.
-        """;
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class VaultGetCommand(ILogger<VaultGetCommand> logger, IAzureBackupService azureBackupService) : SubscriptionCommand<BaseAzureBackupOptions>()
+{
+    private readonly ILogger<VaultGetCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultUpdateCommand.cs
@@ -14,17 +14,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AzureBackup.Commands.Vault;
 
+[CommandMetadata(
+    Id = "da7f163e-471c-4d7d-ae00-d41f5f4b939e",
+    Name = "update",
+    Title = "Update Backup Vault",
+    Description = "Updates vault-level settings including storage redundancy, soft delete, immutability, and managed identity.",
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class VaultUpdateCommand(ILogger<VaultUpdateCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<VaultUpdateOptions>()
 {
-    private const string CommandTitle = "Update Backup Vault";
     private readonly ILogger<VaultUpdateCommand> _logger = logger;
     private readonly IAzureBackupService _azureBackupService = azureBackupService;
-
-    public override string Id => "da7f163e-471c-4d7d-ae00-d41f5f4b939e";
-    public override string Name => "update";
-    public override string Description => "Updates vault-level settings including storage redundancy, soft delete, immutability, and managed identity.";
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new() { Destructive = true, Idempotent = true, OpenWorld = false, ReadOnly = false, LocalRequired = false, Secret = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureBestPractices/src/Commands/AIAppBestPracticesCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBestPractices/src/Commands/AIAppBestPracticesCommand.cs
@@ -10,9 +10,24 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureBestPractices.Commands;
 
+[CommandMetadata(
+    Id = "6c29659e-406d-4b9b-8150-e3d4fd7ba31c",
+    Name = "ai_app",
+    Title = "Get AI App Best Practices",
+    Description = """
+        Returns best practices and code generation guidance for building AI applications in Azure.
+        Use this command when you need recommendations on how to write code for AI agents, chatbots, workflows, or any AI / LLM features.
+        This command also provides guidance for code generation on Microsoft Foundry for application development.
+        When the request involves code generation of AI components or AI applications in any capacity, use this command instead of calling the general code generation best practices command.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class AIAppBestPracticesCommand(ILogger<AIAppBestPracticesCommand> logger) : BaseCommand<EmptyOptions>
 {
-    private const string CommandTitle = "Get AI App Best Practices";
     private readonly ILogger<AIAppBestPracticesCommand> _logger = logger;
     private static readonly string s_bestPracticesText = LoadBestPracticesText();
 
@@ -35,28 +50,6 @@ public sealed class AIAppBestPracticesCommand(ILogger<AIAppBestPracticesCommand>
         string resourceName = EmbeddedResourceHelper.FindEmbeddedResource(assembly, fileName);
         return EmbeddedResourceHelper.ReadEmbeddedResource(assembly, resourceName);
     }
-
-    public override string Id => "6c29659e-406d-4b9b-8150-e3d4fd7ba31c";
-
-    public override string Name => "ai_app";
-
-    public override string Description =>
-        @"Returns best practices and code generation guidance for building AI applications in Azure. 
-        Use this command when you need recommendations on how to write code for AI agents, chatbots, workflows, or any AI / LLM features.
-        This command also provides guidance for code generation on Microsoft Foundry for application development. 
-        When the request involves code generation of AI components or AI applications in any capacity, use this command instead of calling the general code generation best practices command.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override EmptyOptions BindOptions(ParseResult parseResult) => new();
 

--- a/tools/Azure.Mcp.Tools.AzureBestPractices/src/Commands/BestPracticesCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBestPractices/src/Commands/BestPracticesCommand.cs
@@ -13,36 +13,29 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureBestPractices.Commands;
 
-public sealed class BestPracticesCommand(ILogger<BestPracticesCommand> logger) : BaseCommand<BestPracticesOptions>
-{
-    private const string CommandTitle = "Get Azure Best Practices";
-    private readonly ILogger<BestPracticesCommand> _logger = logger;
-    private static readonly Dictionary<string, string> s_bestPracticesCache = new();
-
-    public override string Id => "ff12e8fb-f7ce-446a-884b-996dac118b83";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        @"This tool returns a list of best practices for code generation, operations and deployment
+[CommandMetadata(
+    Id = "ff12e8fb-f7ce-446a-884b-996dac118b83",
+    Name = "get",
+    Title = "Get Azure Best Practices",
+    Description = """
+        This tool returns a list of best practices for code generation, operations and deployment
         when working with Azure services. It should be called for any code generation, deployment or
         operations involving Azure, Azure Functions, Azure Kubernetes Service (AKS), Azure Container
         Apps (ACA), Bicep, Terraform, Azure Cache, Redis, CosmosDB, Entra, Azure Active Directory,
         Azure App Services, or any other Azure technology or programming language. Only call this function
         when you are confident the user is discussing Azure. If this tool needs to be categorized,
-        it belongs to the Azure Best Practices category.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        it belongs to the Azure Best Practices category.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class BestPracticesCommand(ILogger<BestPracticesCommand> logger) : BaseCommand<BestPracticesOptions>
+{
+    private readonly ILogger<BestPracticesCommand> _logger = logger;
+    private static readonly Dictionary<string, string> s_bestPracticesCache = new();
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureIsv/src/Commands/Datadog/MonitoredResourcesListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureIsv/src/Commands/Datadog/MonitoredResourcesListCommand.cs
@@ -13,35 +13,26 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AzureIsv.Commands.Datadog;
 
-public sealed class MonitoredResourcesListCommand(ILogger<MonitoredResourcesListCommand> logger, IDatadogService datadogService) : SubscriptionCommand<MonitoredResourcesListOptions>
-{
-    private const string _commandTitle = "List Monitored Resources in a Datadog Monitor";
-    private readonly ILogger<MonitoredResourcesListCommand> _logger = logger;
-    private readonly IDatadogService _datadogService = datadogService;
-
-    public override string Id => "bbd026b6-df96-4c52-8b72-13734984a600";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "bbd026b6-df96-4c52-8b72-13734984a600",
+    Name = "list",
+    Title = "List Monitored Resources in a Datadog Monitor",
+    Description = """
         List monitored resources in Datadog for a datadog resource taken as input from the user.
         This command retrieves all monitored azure resources available.
         Requires `datadog-resource`, `resource-group` and `subscription`.
         Result is a list of monitored resources as a JSON array.
-        """;
-
-    public override string Title => _commandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class MonitoredResourcesListCommand(ILogger<MonitoredResourcesListCommand> logger, IDatadogService datadogService) : SubscriptionCommand<MonitoredResourcesListOptions>
+{
+    private readonly ILogger<MonitoredResourcesListCommand> _logger = logger;
+    private readonly IDatadogService _datadogService = datadogService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureMigrate/src/Commands/PlatformLandingZone/GetGuidanceCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/src/Commands/PlatformLandingZone/GetGuidanceCommand.cs
@@ -14,25 +14,15 @@ namespace Azure.Mcp.Tools.AzureMigrate.Commands.PlatformLandingZone;
 /// <summary>
 /// Command to get platform landing zone modification guidance and recommendations.
 /// </summary>
-public sealed class GetGuidanceCommand(ILogger<GetGuidanceCommand> logger, IPlatformLandingZoneGuidanceService guidanceService)
-    : BaseAzureMigrateCommand<GetGuidanceOptions>()
-{
-    private readonly IPlatformLandingZoneGuidanceService _guidanceService = guidanceService;
-    private const string CommandTitle = "Get Platform Landing Zone Modification Guidance";
-
-    /// <inheritdoc/>
-    public override string Id => "d4e8c9b2-5f3a-4d1c-8b7e-2a9f1c6d5e4b";
-
-    /// <inheritdoc/>
-    public override string Name => "getguidance";
-
-    /// <inheritdoc/>
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "d4e8c9b2-5f3a-4d1c-8b7e-2a9f1c6d5e4b",
+    Name = "getguidance",
+    Title = "Get Platform Landing Zone Modification Guidance",
+    Description = """
         Get how-to guidance for modifying, configuring, or customizing an existing Platform Landing Zone.
         Use this tool when user asks "how do I", "show me how to", "get guidance for", or asks about 
         disabling, enabling, turning off, changing, or modifying Landing Zone settings.
-        
+
         **Use this tool for questions about:**
         - How to turn off or disable Bastion, DDoS, DNS, gateways, Defender, or monitoring
         - How to change IP addresses, CIDR ranges, network topology, or regions
@@ -40,7 +30,7 @@ public sealed class GetGuidanceCommand(ILogger<GetGuidanceCommand> logger, IPlat
         - How to change resource naming patterns or conventions
         - Finding or searching for specific policies within a Landing Zone
         - Listing all available policies by archetype
-        
+
         **Available scenarios:**
         - bastion: Turn off Bastion host
         - ddos: Enable or disable DDoS protection plan
@@ -57,25 +47,31 @@ public sealed class GetGuidanceCommand(ILogger<GetGuidanceCommand> logger, IPlat
         - defender: Turn off Defender Plans
         - zero-trust: Implement Zero Trust Networking
         - slz: Implement Sovereign Landing Zone controls
-        
+
         **For policy searches:**
         - Use policy-name to search for a specific policy
         - Use list-policies=true to list ALL policies by archetype
-        """;
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = true,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = true)]
+public sealed class GetGuidanceCommand(ILogger<GetGuidanceCommand> logger, IPlatformLandingZoneGuidanceService guidanceService)
+    : BaseAzureMigrateCommand<GetGuidanceOptions>()
+{
+    private readonly IPlatformLandingZoneGuidanceService _guidanceService = guidanceService;
 
     /// <inheritdoc/>
-    public override string Title => CommandTitle;
 
     /// <inheritdoc/>
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = true,
-        ReadOnly = false,
-        LocalRequired = true,
-        Secret = false
-    };
+
+    /// <inheritdoc/>
+
+    /// <inheritdoc/>
+
+    /// <inheritdoc/>
 
     /// <inheritdoc/>
     protected override void RegisterOptions(Command command)

--- a/tools/Azure.Mcp.Tools.AzureMigrate/src/Commands/PlatformLandingZone/RequestCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/src/Commands/PlatformLandingZone/RequestCommand.cs
@@ -17,25 +17,11 @@ namespace Azure.Mcp.Tools.AzureMigrate.Commands.PlatformLandingZone;
 /// <summary>
 /// Command to generate and download platform landing zone configurations, update parameters, check existing platform landing zones, and view status.
 /// </summary>
-public sealed class RequestCommand(ILogger<RequestCommand> logger, IPlatformLandingZoneService platformLandingZoneService, AzureMigrateProjectHelper azureMigrateProjectHelper)
-    : SubscriptionCommand<RequestOptions>()
-{
-    private readonly IPlatformLandingZoneService _platformLandingZoneService = platformLandingZoneService;
-    private readonly AzureMigrateProjectHelper _azureMigrateProjectHelper = azureMigrateProjectHelper;
-    private const string CommandTitle = "Platform Landing Zone Management";
-
-    /// <inheritdoc/>
-    public override string Id => "a7f3b8c1-9e2d-4f6a-8b3c-5d1e7f9a2c4b";
-
-    /// <inheritdoc/>
-    public override string Name => "request";
-
-    /// <inheritdoc/>
-    public override string Title => CommandTitle;
-
-    /// <inheritdoc/>
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "a7f3b8c1-9e2d-4f6a-8b3c-5d1e7f9a2c4b",
+    Name = "request",
+    Title = "Platform Landing Zone Management",
+    Description = """
         Generate and download platform landing zone configurations for Azure Migrate projects.
         Updates parameters, check existing landing zones, and view parameters status.
 
@@ -78,18 +64,28 @@ public sealed class RequestCommand(ILogger<RequestCommand> logger, IPlatformLand
 
         **IMPORTANT:** When using 'update', collect ALL parameters from the user in ONE call.
         Show them the defaults and ask which ones they want to change.
-        """;
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = true)]
+public sealed class RequestCommand(ILogger<RequestCommand> logger, IPlatformLandingZoneService platformLandingZoneService, AzureMigrateProjectHelper azureMigrateProjectHelper)
+    : SubscriptionCommand<RequestOptions>()
+{
+    private readonly IPlatformLandingZoneService _platformLandingZoneService = platformLandingZoneService;
+    private readonly AzureMigrateProjectHelper _azureMigrateProjectHelper = azureMigrateProjectHelper;
 
     /// <inheritdoc/>
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        ReadOnly = false,
-        LocalRequired = true,
-        Idempotent = true,
-        OpenWorld = false,
-        Secret = false
-    };
+
+    /// <inheritdoc/>
+
+    /// <inheritdoc/>
+
+    /// <inheritdoc/>
+
+    /// <inheritdoc/>
 
     /// <inheritdoc/>
     protected override void RegisterOptions(Command command)

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AvmDocumentationGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AvmDocumentationGetCommand.cs
@@ -11,36 +11,28 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureTerraform.Commands;
 
+[CommandMetadata(
+    Id = "e5f6a7b8-c9d0-1234-ef01-456789012cde",
+    Name = "get",
+    Title = "Get AVM Module Documentation",
+    Description = """
+        Retrieves the documentation (README.md) for a specific version of an Azure Verified Module (AVM).
+        Returns the full module documentation including usage examples, input variables,
+        output values, and resource descriptions. Use --module-name and --module-version
+        to specify the module and version (e.g., --module-name avm-res-storage-storageaccount --module-version 0.4.0).
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = true,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class AvmDocumentationGetCommand(
     ILogger<AvmDocumentationGetCommand> logger,
     IAvmDocsService avmDocsService) : BaseCommand<AvmDocumentationOptions>
 {
     private readonly ILogger<AvmDocumentationGetCommand> _logger = logger;
     private readonly IAvmDocsService _avmDocsService = avmDocsService;
-
-    public override string Id => "e5f6a7b8-c9d0-1234-ef01-456789012cde";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
-        Retrieves the documentation (README.md) for a specific version of an Azure Verified Module (AVM).
-        Returns the full module documentation including usage examples, input variables,
-        output values, and resource descriptions. Use --module-name and --module-version
-        to specify the module and version (e.g., --module-name avm-res-storage-storageaccount --module-version 0.4.0).
-        """;
-
-    public override string Title => "Get AVM Module Documentation";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = true,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AvmModuleListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AvmModuleListCommand.cs
@@ -11,35 +11,27 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureTerraform.Commands;
 
+[CommandMetadata(
+    Id = "c3d4e5f6-a7b8-9012-cdef-234567890abc",
+    Name = "list",
+    Title = "List AVM Modules",
+    Description = """
+        Retrieves all available Azure Verified Modules (AVM) for Terraform.
+        Returns a list of modules with their name, description, source reference, and repository URL.
+        The source field can be used directly in Terraform module blocks.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = true,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class AvmModuleListCommand(
     ILogger<AvmModuleListCommand> logger,
     IAvmDocsService avmDocsService) : BaseCommand<AvmModuleListOptions>
 {
     private readonly ILogger<AvmModuleListCommand> _logger = logger;
     private readonly IAvmDocsService _avmDocsService = avmDocsService;
-
-    public override string Id => "c3d4e5f6-a7b8-9012-cdef-234567890abc";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
-        Retrieves all available Azure Verified Modules (AVM) for Terraform.
-        Returns a list of modules with their name, description, source reference, and repository URL.
-        The source field can be used directly in Terraform module blocks.
-        """;
-
-    public override string Title => "List AVM Modules";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = true,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override AvmModuleListOptions BindOptions(ParseResult parseResult) => new();
 

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AvmVersionListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AvmVersionListCommand.cs
@@ -11,36 +11,28 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureTerraform.Commands;
 
+[CommandMetadata(
+    Id = "d4e5f6a7-b8c9-0123-def0-345678901bcd",
+    Name = "versions",
+    Title = "List AVM Module Versions",
+    Description = """
+        Retrieves all available versions of a specified Azure Verified Module (AVM).
+        Returns version tags with creation dates, sorted from newest to oldest.
+        The first version in the list is the latest. Use --module-name to specify
+        the module (e.g., avm-res-storage-storageaccount).
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = true,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class AvmVersionListCommand(
     ILogger<AvmVersionListCommand> logger,
     IAvmDocsService avmDocsService) : BaseCommand<AvmVersionOptions>
 {
     private readonly ILogger<AvmVersionListCommand> _logger = logger;
     private readonly IAvmDocsService _avmDocsService = avmDocsService;
-
-    public override string Id => "d4e5f6a7-b8c9-0123-def0-345678901bcd";
-
-    public override string Name => "versions";
-
-    public override string Description =>
-        """
-        Retrieves all available versions of a specified Azure Verified Module (AVM).
-        Returns version tags with creation dates, sorted from newest to oldest.
-        The first version in the list is the latest. Use --module-name to specify
-        the module (e.g., avm-res-storage-storageaccount).
-        """;
-
-    public override string Title => "List AVM Module Versions";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = true,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AzApiDocsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AzApiDocsGetCommand.cs
@@ -11,6 +11,25 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureTerraform.Commands;
 
+[CommandMetadata(
+    Id = "f6a7b8c9-d0e1-2345-bcde-678901234ef0",
+    Name = "get",
+    Title = "Get AzAPI Provider Documentation",
+    Description = """
+        Retrieves AzAPI Terraform provider documentation and schema for a specified Azure resource type.
+        Returns the resource schema in HCL format suitable for azapi_resource blocks, including property
+        definitions with types and requirements, parent resource information, and Terraform usage examples.
+        Use --resource-type to specify the Azure resource type in ARM format
+        (e.g., Microsoft.Compute/virtualMachines, Microsoft.Storage/storageAccounts).
+        Optionally specify --api-version to target a specific API version.
+        This tool reuses Azure Bicep type definitions to generate accurate AzAPI schemas.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = true,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class AzApiDocsGetCommand(
     ILogger<AzApiDocsGetCommand> logger,
     IAzApiDocsService docsService,
@@ -19,33 +38,6 @@ public sealed class AzApiDocsGetCommand(
     private readonly ILogger<AzApiDocsGetCommand> _logger = logger;
     private readonly IAzApiDocsService _docsService = docsService;
     private readonly IAzApiExamplesService _examplesService = examplesService;
-
-    public override string Id => "f6a7b8c9-d0e1-2345-bcde-678901234ef0";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
-        Retrieves AzAPI Terraform provider documentation and schema for a specified Azure resource type.
-        Returns the resource schema in HCL format suitable for azapi_resource blocks, including property
-        definitions with types and requirements, parent resource information, and Terraform usage examples.
-        Use --resource-type to specify the Azure resource type in ARM format
-        (e.g., Microsoft.Compute/virtualMachines, Microsoft.Storage/storageAccounts).
-        Optionally specify --api-version to target a specific API version.
-        This tool reuses Azure Bicep type definitions to generate accurate AzAPI schemas.
-        """;
-
-    public override string Title => "Get AzAPI Provider Documentation";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = true,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AztfexportQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AztfexportQueryCommand.cs
@@ -11,38 +11,30 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureTerraform.Commands;
 
-public sealed class AztfexportQueryCommand(
-    ILogger<AztfexportQueryCommand> logger,
-    IAztfexportService aztfexportService) : BaseCommand<AztfexportQueryOptions>
-{
-    private readonly ILogger<AztfexportQueryCommand> _logger = logger;
-    private readonly IAztfexportService _aztfexportService = aztfexportService;
-
-    public override string Id => "b8c9d0e1-f2a3-4567-1234-789012345f01";
-
-    public override string Name => "query";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "b8c9d0e1-f2a3-4567-1234-789012345f01",
+    Name = "query",
+    Title = "Export Azure Resources by Query to Terraform",
+    Description = """
         Generates an aztfexport command to export Azure resources matching an Azure Resource Graph query
         to Terraform configuration. Returns the command and arguments for the agent to execute locally.
         Specify --query with a KQL WHERE clause for Azure Resource Graph (e.g., "type =~ 'Microsoft.Storage/storageAccounts'").
         Optionally configure the Terraform provider (azurerm or azapi), naming pattern, output folder,
         parallelism, and whether to include role assignments.
         If aztfexport is not installed locally, returns installation instructions instead.
-        """;
-
-    public override string Title => "Export Azure Resources by Query to Terraform";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = true,
-        ReadOnly = true,
-        LocalRequired = true,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = true,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = true)]
+public sealed class AztfexportQueryCommand(
+    ILogger<AztfexportQueryCommand> logger,
+    IAztfexportService aztfexportService) : BaseCommand<AztfexportQueryOptions>
+{
+    private readonly ILogger<AztfexportQueryCommand> _logger = logger;
+    private readonly IAztfexportService _aztfexportService = aztfexportService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AztfexportResourceCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AztfexportResourceCommand.cs
@@ -11,37 +11,29 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureTerraform.Commands;
 
+[CommandMetadata(
+    Id = "f6a7b8c9-d0e1-2345-f012-567890123def",
+    Name = "resource",
+    Title = "Export Azure Resource to Terraform",
+    Description = """
+        Generates an aztfexport command to export a single Azure resource to Terraform configuration.
+        Returns the command and arguments for the agent to execute locally.
+        Specify --resource-id with the full Azure resource ID. Optionally configure the Terraform provider
+        (azurerm or azapi), custom resource name, output folder, parallelism, and whether to include role assignments.
+        If aztfexport is not installed locally, returns installation instructions instead.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = true,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = true)]
 public sealed class AztfexportResourceCommand(
     ILogger<AztfexportResourceCommand> logger,
     IAztfexportService aztfexportService) : BaseCommand<AztfexportResourceOptions>
 {
     private readonly ILogger<AztfexportResourceCommand> _logger = logger;
     private readonly IAztfexportService _aztfexportService = aztfexportService;
-
-    public override string Id => "f6a7b8c9-d0e1-2345-f012-567890123def";
-
-    public override string Name => "resource";
-
-    public override string Description =>
-        """
-        Generates an aztfexport command to export a single Azure resource to Terraform configuration.
-        Returns the command and arguments for the agent to execute locally.
-        Specify --resource-id with the full Azure resource ID. Optionally configure the Terraform provider
-        (azurerm or azapi), custom resource name, output folder, parallelism, and whether to include role assignments.
-        If aztfexport is not installed locally, returns installation instructions instead.
-        """;
-
-    public override string Title => "Export Azure Resource to Terraform";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = true,
-        ReadOnly = true,
-        LocalRequired = true,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AztfexportResourceGroupCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AztfexportResourceGroupCommand.cs
@@ -11,37 +11,29 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureTerraform.Commands;
 
+[CommandMetadata(
+    Id = "a7b8c9d0-e1f2-3456-0123-678901234ef0",
+    Name = "resourcegroup",
+    Title = "Export Azure Resource Group to Terraform",
+    Description = """
+        Generates an aztfexport command to export an Azure resource group and all its resources to Terraform configuration.
+        Returns the command and arguments for the agent to execute locally.
+        Specify --resource-group with the name of the resource group. Optionally configure the Terraform provider
+        (azurerm or azapi), naming pattern, output folder, parallelism, and whether to include role assignments.
+        If aztfexport is not installed locally, returns installation instructions instead.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = true,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = true)]
 public sealed class AztfexportResourceGroupCommand(
     ILogger<AztfexportResourceGroupCommand> logger,
     IAztfexportService aztfexportService) : BaseCommand<AztfexportResourceGroupOptions>
 {
     private readonly ILogger<AztfexportResourceGroupCommand> _logger = logger;
     private readonly IAztfexportService _aztfexportService = aztfexportService;
-
-    public override string Id => "a7b8c9d0-e1f2-3456-0123-678901234ef0";
-
-    public override string Name => "resourcegroup";
-
-    public override string Description =>
-        """
-        Generates an aztfexport command to export an Azure resource group and all its resources to Terraform configuration.
-        Returns the command and arguments for the agent to execute locally.
-        Specify --resource-group with the name of the resource group. Optionally configure the Terraform provider
-        (azurerm or azapi), naming pattern, output folder, parallelism, and whether to include role assignments.
-        If aztfexport is not installed locally, returns installation instructions instead.
-        """;
-
-    public override string Title => "Export Azure Resource Group to Terraform";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = true,
-        ReadOnly = true,
-        LocalRequired = true,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AzureRMDocsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AzureRMDocsGetCommand.cs
@@ -11,37 +11,29 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureTerraform.Commands;
 
+[CommandMetadata(
+    Id = "d4e5f6a7-b8c9-0123-abcd-567890123def",
+    Name = "get",
+    Title = "Get AzureRM Provider Documentation",
+    Description = """
+        Retrieves comprehensive AzureRM Terraform provider documentation for a specified resource type.
+        Returns the resource summary, arguments with descriptions and requirements, attributes,
+        usage examples, and important notes. Use --resource-type to specify the resource
+        (e.g., azurerm_resource_group). Optionally filter by --doc-type (resource or data-source),
+        --argument, or --attribute.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = true,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class AzureRMDocsGetCommand(
     ILogger<AzureRMDocsGetCommand> logger,
     IAzureRMDocsService docsService) : BaseCommand<AzureRMDocsOptions>
 {
     private readonly ILogger<AzureRMDocsGetCommand> _logger = logger;
     private readonly IAzureRMDocsService _docsService = docsService;
-
-    public override string Id => "d4e5f6a7-b8c9-0123-abcd-567890123def";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
-        Retrieves comprehensive AzureRM Terraform provider documentation for a specified resource type.
-        Returns the resource summary, arguments with descriptions and requirements, attributes,
-        usage examples, and important notes. Use --resource-type to specify the resource
-        (e.g., azurerm_resource_group). Optionally filter by --doc-type (resource or data-source),
-        --argument, or --attribute.
-        """;
-
-    public override string Title => "Get AzureRM Provider Documentation";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = true,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/Conftest/ConftestPlanValidationCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/Conftest/ConftestPlanValidationCommand.cs
@@ -11,38 +11,30 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureTerraform.Commands;
 
-public sealed class ConftestPlanValidationCommand(
-    ILogger<ConftestPlanValidationCommand> logger,
-    IConftestService conftestService) : BaseCommand<ConftestPlanValidationOptions>
-{
-    private readonly ILogger<ConftestPlanValidationCommand> _logger = logger;
-    private readonly IConftestService _conftestService = conftestService;
-
-    public override string Id => "b2c3d4e5-f6a7-8901-bcde-f01234567890";
-
-    public override string Name => "plan";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "b2c3d4e5-f6a7-8901-bcde-f01234567890",
+    Name = "plan",
+    Title = "Validate Terraform Plan with Conftest",
+    Description = """
         Generates a conftest command to validate a Terraform plan JSON file against Azure policies.
         Returns the command and arguments for the agent to execute locally.
         Uses the Azure policy library (policy-library-avm) for validation with configurable policy sets.
         Specify --plan-folder with the path to the folder containing tfplan.json. Optionally configure the policy set
         ('all', 'Azure-Proactive-Resiliency-Library-v2', or 'avmsec'), severity filter (for avmsec), and custom policy paths.
         If conftest is not installed locally, returns installation instructions instead.
-        """;
-
-    public override string Title => "Validate Terraform Plan with Conftest";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = true,
-        ReadOnly = true,
-        LocalRequired = true,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = true,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = true)]
+public sealed class ConftestPlanValidationCommand(
+    ILogger<ConftestPlanValidationCommand> logger,
+    IConftestService conftestService) : BaseCommand<ConftestPlanValidationOptions>
+{
+    private readonly ILogger<ConftestPlanValidationCommand> _logger = logger;
+    private readonly IConftestService _conftestService = conftestService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/Conftest/ConftestWorkspaceValidationCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/Conftest/ConftestWorkspaceValidationCommand.cs
@@ -11,38 +11,30 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureTerraform.Commands;
 
-public sealed class ConftestWorkspaceValidationCommand(
-    ILogger<ConftestWorkspaceValidationCommand> logger,
-    IConftestService conftestService) : BaseCommand<ConftestWorkspaceValidationOptions>
-{
-    private readonly ILogger<ConftestWorkspaceValidationCommand> _logger = logger;
-    private readonly IConftestService _conftestService = conftestService;
-
-    public override string Id => "a1b2c3d4-e5f6-7890-abcd-ef0123456789";
-
-    public override string Name => "workspace";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "a1b2c3d4-e5f6-7890-abcd-ef0123456789",
+    Name = "workspace",
+    Title = "Validate Terraform Workspace with Conftest",
+    Description = """
         Generates a conftest command to validate Terraform .tf files in a workspace against Azure policies.
         Returns the command and arguments for the agent to execute locally.
         Uses the Azure policy library (policy-library-avm) for validation with configurable policy sets.
         Specify --workspace-folder with the path to the Terraform workspace. Optionally configure the policy set
         ('all', 'Azure-Proactive-Resiliency-Library-v2', or 'avmsec'), severity filter (for avmsec), and custom policy paths.
         If conftest is not installed locally, returns installation instructions instead.
-        """;
-
-    public override string Title => "Validate Terraform Workspace with Conftest";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = true,
-        ReadOnly = true,
-        LocalRequired = true,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = true,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = true)]
+public sealed class ConftestWorkspaceValidationCommand(
+    ILogger<ConftestWorkspaceValidationCommand> logger,
+    IConftestService conftestService) : BaseCommand<ConftestWorkspaceValidationOptions>
+{
+    private readonly ILogger<ConftestWorkspaceValidationCommand> _logger = logger;
+    private readonly IConftestService _conftestService = conftestService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.AzureTerraformBestPractices/src/Commands/AzureTerraformBestPracticesGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraformBestPractices/src/Commands/AzureTerraformBestPracticesGetCommand.cs
@@ -10,9 +10,23 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AzureTerraformBestPractices.Commands;
 
+[CommandMetadata(
+    Id = "5bd36575-6313-4bf4-aa26-a79fe0fa32a8",
+    Name = "get",
+    Title = "Get Terraform Best Practices for Azure",
+    Description = """
+        Returns Terraform best practices for Azure. Call this command and follow its guidance before
+        generating or suggesting any Terraform code specific to Azure. If this tool needs to be categorized, it belongs to
+        the Azure Best Practices category.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class AzureTerraformBestPracticesGetCommand(ILogger<AzureTerraformBestPracticesGetCommand> logger) : BaseCommand<EmptyOptions>
 {
-    private const string CommandTitle = "Get Terraform Best Practices for Azure";
     private readonly ILogger<AzureTerraformBestPracticesGetCommand> _logger = logger;
     private static readonly string s_bestPracticesText = LoadBestPracticesText();
 
@@ -24,27 +38,6 @@ public sealed class AzureTerraformBestPracticesGetCommand(ILogger<AzureTerraform
         string resourceName = EmbeddedResourceHelper.FindEmbeddedResource(assembly, "terraform-best-practices-for-azure.txt");
         return EmbeddedResourceHelper.ReadEmbeddedResource(assembly, resourceName);
     }
-
-    public override string Id => "5bd36575-6313-4bf4-aa26-a79fe0fa32a8";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        @"Returns Terraform best practices for Azure. Call this command and follow its guidance before
-        generating or suggesting any Terraform code specific to Azure. If this tool needs to be categorized, it belongs to
-        the Azure Best Practices category.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override EmptyOptions BindOptions(ParseResult parseResult) => new();
 

--- a/tools/Azure.Mcp.Tools.BicepSchema/src/Commands/BicepSchemaGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.BicepSchema/src/Commands/BicepSchemaGetCommand.cs
@@ -11,32 +11,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.BicepSchema.Commands
 {
+[CommandMetadata(
+    Id = "553c003a-7cdf-4382-b833-94fe8bbb7386",
+    Name = "get",
+    Title = "Get Bicep Schema for a resource",
+    Description = "Provides the Bicep schema definition of any Azure resource type (latest service version). Use this to get the schema needed to write Bicep IaC (infrasturcture as code) for Azure resources such as AI models, storage accounts, databases, virtual machines, app services, key vaults, and more. Do not use this tool for resource deployment, deployment guidelines, or getting best practices.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
     public sealed class BicepSchemaGetCommand(ILogger<BicepSchemaGetCommand> logger) : BaseBicepSchemaCommand<BicepSchemaOptions>
     {
-        private const string CommandTitle = "Get Bicep Schema for a resource";
 
         private readonly ILogger<BicepSchemaGetCommand> _logger = logger;
-
-        public override string Id => "553c003a-7cdf-4382-b833-94fe8bbb7386";
-
-        public override string Name => "get";
-
-        public override string Description =>
-       """
-        Provides the Bicep schema definition of any Azure resource type (latest service version). Use this to get the schema needed to write Bicep IaC (infrasturcture as code) for Azure resources such as AI models, storage accounts, databases, virtual machines, app services, key vaults, and more. Do not use this tool for resource deployment, deployment guidelines, or getting best practices.
-       """;
-
-        public override string Title => CommandTitle;
-
-        public override ToolMetadata Metadata => new()
-        {
-            Destructive = false,
-            Idempotent = true,
-            OpenWorld = false,
-            ReadOnly = true,
-            LocalRequired = false,
-            Secret = false
-        };
 
         private static readonly Lazy<IServiceProvider> s_serviceProvider;
 

--- a/tools/Azure.Mcp.Tools.BicepSchema/src/Commands/BicepSchemaGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.BicepSchema/src/Commands/BicepSchemaGetCommand.cs
@@ -11,17 +11,17 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.BicepSchema.Commands
 {
-[CommandMetadata(
-    Id = "553c003a-7cdf-4382-b833-94fe8bbb7386",
-    Name = "get",
-    Title = "Get Bicep Schema for a resource",
-    Description = "Provides the Bicep schema definition of any Azure resource type (latest service version). Use this to get the schema needed to write Bicep IaC (infrasturcture as code) for Azure resources such as AI models, storage accounts, databases, virtual machines, app services, key vaults, and more. Do not use this tool for resource deployment, deployment guidelines, or getting best practices.",
-    Destructive = false,
-    Idempotent = true,
-    OpenWorld = false,
-    ReadOnly = true,
-    Secret = false,
-    LocalRequired = false)]
+    [CommandMetadata(
+        Id = "553c003a-7cdf-4382-b833-94fe8bbb7386",
+        Name = "get",
+        Title = "Get Bicep Schema for a resource",
+        Description = "Provides the Bicep schema definition of any Azure resource type (latest service version). Use this to get the schema needed to write Bicep IaC (infrasturcture as code) for Azure resources such as AI models, storage accounts, databases, virtual machines, app services, key vaults, and more. Do not use this tool for resource deployment, deployment guidelines, or getting best practices.",
+        Destructive = false,
+        Idempotent = true,
+        OpenWorld = false,
+        ReadOnly = true,
+        Secret = false,
+        LocalRequired = false)]
     public sealed class BicepSchemaGetCommand(ILogger<BicepSchemaGetCommand> logger) : BaseBicepSchemaCommand<BicepSchemaOptions>
     {
 

--- a/tools/Azure.Mcp.Tools.CloudArchitect/src/Commands/Design/DesignCommand.cs
+++ b/tools/Azure.Mcp.Tools.CloudArchitect/src/Commands/Design/DesignCommand.cs
@@ -13,21 +13,11 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.CloudArchitect.Commands.Design;
 
-public sealed class DesignCommand(ILogger<DesignCommand> logger) : GlobalCommand<ArchitectureDesignToolOptions>
-{
-    private const string CommandTitle = "Design Azure cloud architectures through guided questions";
-    private readonly ILogger<DesignCommand> _logger = logger;
-
-    private static readonly string s_designArchitectureText = LoadArchitectureDesignText();
-
-    private static string GetArchitectureDesignText() => s_designArchitectureText;
-
-    public override string Id => "aa7c2a8b-c664-423b-8fb5-8edfbdadc783";
-
-    public override string Name => "design";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "aa7c2a8b-c664-423b-8fb5-8edfbdadc783",
+    Name = "design",
+    Title = "Design Azure cloud architectures through guided questions",
+    Description = """
         Recommends architecture design for cloud services/apps/solutions, such as: file storage, banking, video streaming, e-commerce, SaaS, and more. Use as follows:
         1. Ask about user role, business goals, etc (1-2 questions at a time).
         2. Track confidence returned by service and update requirements (explicit/implicit/assumed).
@@ -36,19 +26,20 @@ public sealed class DesignCommand(ILogger<DesignCommand> logger) : GlobalCommand
         5. Follow Azure Well-Architected Framework principles.
         6. Cover all tiers: infrastructure, platform, application, data, security, operations.
         7. Provide actionable advice and high-level overview. Note: State tracks components, requirements by category, and confidence factors. Be conservative with suggestions.
-        """;
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class DesignCommand(ILogger<DesignCommand> logger) : GlobalCommand<ArchitectureDesignToolOptions>
+{
+    private readonly ILogger<DesignCommand> _logger = logger;
 
-    public override string Title => CommandTitle;
+    private static readonly string s_designArchitectureText = LoadArchitectureDesignText();
 
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+    private static string GetArchitectureDesignText() => s_designArchitectureText;
 
     private static string LoadArchitectureDesignText()
     {

--- a/tools/Azure.Mcp.Tools.Communication/src/Commands/Email/EmailSendCommand.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Commands/Email/EmailSendCommand.cs
@@ -14,31 +14,21 @@ namespace Azure.Mcp.Tools.Communication.Commands.Email;
 /// <summary>
 /// Send an email message using Azure Communication Services.
 /// </summary>
+[CommandMetadata(
+    Id = "60f79b69-9e90-4f07-9bf4-bd4452f1143d",
+    Name = "send",
+    Title = "Send Email",
+    Description = "Send emails to one or multiple recipients to the given email-address. The emails can be plain text or HTML formatted. You can include a subject, custom sender name, CC and BCC recipients, and reply-to addresses.",
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = true,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class EmailSendCommand(ILogger<EmailSendCommand> logger, ICommunicationService communicationService) : BaseCommunicationCommand<EmailSendOptions>
 {
-    private const string CommandTitle = "Send Email";
     private readonly ILogger<EmailSendCommand> _logger = logger;
     private readonly ICommunicationService _communicationService = communicationService;
-
-    public override string Name => "send";
-    public override string Id => "60f79b69-9e90-4f07-9bf4-bd4452f1143d";
-
-    public override string Title => CommandTitle;
-
-    public override string Description =>
-        """
-        Send emails to one or multiple recipients to the given email-address. The emails can be plain text or HTML formatted. You can include a subject, custom sender name, CC and BCC recipients, and reply-to addresses.
-        """;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        ReadOnly = true,
-        OpenWorld = true,
-        Idempotent = false,
-        Secret = false,
-        LocalRequired = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Communication/src/Commands/Sms/SmsSendCommand.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Commands/Sms/SmsSendCommand.cs
@@ -12,32 +12,24 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Communication.Commands.Sms;
 
-public sealed class SmsSendCommand(ILogger<SmsSendCommand> logger, ICommunicationService communicationService) : BaseCommunicationCommand<SmsSendOptions>
-{
-    private const string CommandTitle = "Send SMS Message";
-    private readonly ILogger<SmsSendCommand> _logger = logger;
-    private readonly ICommunicationService _communicationService = communicationService;
-    public override string Id => "a0dc94f3-25ac-4971-a552-0d90fd57e902";
-
-    public override string Name => "send";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "a0dc94f3-25ac-4971-a552-0d90fd57e902",
+    Name = "send",
+    Title = "Send SMS Message",
+    Description = """
         Sends SMS messages to one or more recipients to the given phone-number. You can enable delivery reports and receipt tracking, broadcast SMS, and tag messages for easier tracking.
         Returns message IDs and delivery status for each sent message.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        ReadOnly = true,
-        OpenWorld = true,
-        Idempotent = false,
-        Secret = false,
-        LocalRequired = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = true,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class SmsSendCommand(ILogger<SmsSendCommand> logger, ICommunicationService communicationService) : BaseCommunicationCommand<SmsSendOptions>
+{
+    private readonly ILogger<SmsSendCommand> _logger = logger;
+    private readonly ICommunicationService _communicationService = communicationService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskCreateCommand.cs
@@ -17,44 +17,23 @@ namespace Azure.Mcp.Tools.Compute.Commands.Disk;
 /// <summary>
 /// Command to create an Azure managed disk.
 /// </summary>
+[CommandMetadata(
+    Id = "3f8a1b2c-5d6e-4a7b-8c9d-0e1f2a3b4c5d",
+    Name = "create",
+    Title = "Create Managed Disk",
+    Description = "Creates a new Azure managed disk in the specified resource group. Supports creating empty disks (specify --size-gb), disks from a source such as a snapshot, another managed disk, or a blob URI (specify --source), disks from a Shared Image Gallery image version (specify --gallery-image-reference), or disks ready for upload (specify --upload-type and --upload-size-bytes). If location is not specified, defaults to the resource group's location. Supports configuring disk size, storage SKU (e.g., Premium_LRS, Standard_LRS, UltraSSD_LRS), OS type, availability zone, hypervisor generation, tags, encryption settings, performance tier, shared disk, on-demand bursting, and IOPS/throughput limits for UltraSSD disks. Create a disk with network access policy DenyAll, AllowAll, or AllowPrivate and associate a disk access resource during creation.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class DiskCreateCommand(
     ILogger<DiskCreateCommand> logger)
     : BaseComputeCommand<DiskCreateOptions>(true)
 {
-    private const string CommandTitle = "Create Managed Disk";
-    private const string CommandDescription =
-        "Creates a new Azure managed disk in the specified resource group. "
-        + "Supports creating empty disks (specify --size-gb), disks from a source such as a snapshot, "
-        + "another managed disk, or a blob URI (specify --source), disks from a Shared Image Gallery "
-        + "image version (specify --gallery-image-reference), or disks ready for upload "
-        + "(specify --upload-type and --upload-size-bytes). "
-        + "If location is not specified, defaults to the resource group's location. "
-        + "Supports configuring disk size, storage SKU (e.g., Premium_LRS, Standard_LRS, UltraSSD_LRS), "
-        + "OS type, availability zone, hypervisor generation, tags, encryption settings, "
-        + "performance tier, shared disk, on-demand bursting, "
-        + "and IOPS/throughput limits for UltraSSD disks. "
-        + "Create a disk with network access policy DenyAll, AllowAll, or AllowPrivate "
-        + "and associate a disk access resource during creation.";
 
     private readonly ILogger<DiskCreateCommand> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-
-    public override string Id => "3f8a1b2c-5d6e-4a7b-8c9d-0e1f2a3b4c5d";
-
-    public override string Name => "create";
-
-    public override string Title => CommandTitle;
-
-    public override string Description => CommandDescription;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,
-        Destructive = true,
-        Idempotent = false,
-        ReadOnly = false,
-        Secret = false,
-        LocalRequired = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskDeleteCommand.cs
@@ -15,36 +15,23 @@ namespace Azure.Mcp.Tools.Compute.Commands.Disk;
 /// <summary>
 /// Command to delete an Azure managed disk.
 /// </summary>
+[CommandMetadata(
+    Id = "a7c3e9f1-4b82-4d5a-9e6c-1f3d8b2a7c4e",
+    Name = "delete",
+    Title = "Delete Managed Disk",
+    Description = "Deletes an Azure managed disk from the specified resource group. This is an idempotent operation that returns Deleted = true if the disk was successfully removed, or Deleted = false if the disk was not found. The disk must not be attached to a virtual machine; detach it first before deleting.",
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = true,
+    LocalRequired = false)]
 public sealed class DiskDeleteCommand(
     ILogger<DiskDeleteCommand> logger)
     : BaseComputeCommand<DiskDeleteOptions>(true)
 {
-    private const string CommandTitle = "Delete Managed Disk";
-    private const string CommandDescription =
-        "Deletes an Azure managed disk from the specified resource group. "
-        + "This is an idempotent operation that returns Deleted = true if the disk was successfully removed, "
-        + "or Deleted = false if the disk was not found. "
-        + "The disk must not be attached to a virtual machine; detach it first before deleting.";
 
     private readonly ILogger<DiskDeleteCommand> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-
-    public override string Id => "a7c3e9f1-4b82-4d5a-9e6c-1f3d8b2a7c4e";
-
-    public override string Name => "delete";
-
-    public override string Title => CommandTitle;
-
-    public override string Description => CommandDescription;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,
-        Destructive = true,
-        Idempotent = true,
-        ReadOnly = false,
-        Secret = true,
-        LocalRequired = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskGetCommand.cs
@@ -16,32 +16,23 @@ namespace Azure.Mcp.Tools.Compute.Commands.Disk;
 /// <summary>
 /// Command to get details of an Azure managed disk.
 /// </summary>
+[CommandMetadata(
+    Id = "01ab6f7e-2b27-4d6e-b0cc-b29043efac8e",
+    Name = "get",
+    Title = "Get Disk Details",
+    Description = "Lists available Azure managed disks or retrieves detailed information about a specific disk. Shows all disks in a subscription or resource group, including disk size, SKU, provisioning state, and OS type. Supports wildcard patterns in disk names (e.g., 'win_OsDisk*'). When disk name is provided without resource group, searches across the entire subscription. When resource group is specified, scopes the search to that resource group. Both parameters are optional.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class DiskGetCommand(
     ILogger<DiskGetCommand> logger)
     : BaseComputeCommand<DiskGetOptions>(false)
 {
-    private const string CommandTitle = "Get Disk Details";
-    private const string CommandDescription = "Lists available Azure managed disks or retrieves detailed information about a specific disk. Shows all disks in a subscription or resource group, including disk size, SKU, provisioning state, and OS type. Supports wildcard patterns in disk names (e.g., 'win_OsDisk*'). When disk name is provided without resource group, searches across the entire subscription. When resource group is specified, scopes the search to that resource group. Both parameters are optional.";
 
     private readonly ILogger<DiskGetCommand> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-
-    public override string Id => "01ab6f7e-2b27-4d6e-b0cc-b29043efac8e";
-
-    public override string Name => "get";
-
-    public override string Title => CommandTitle;
-
-    public override string Description => CommandDescription;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,
-        Destructive = false,
-        Idempotent = true,
-        ReadOnly = true,
-        Secret = false,
-        LocalRequired = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskUpdateCommand.cs
@@ -16,39 +16,23 @@ namespace Azure.Mcp.Tools.Compute.Commands.Disk;
 /// <summary>
 /// Command to update an Azure managed disk.
 /// </summary>
+[CommandMetadata(
+    Id = "4a9b2c3d-6e7f-5b8c-9d0e-1f2a3b4c5d6e",
+    Name = "update",
+    Title = "Update Managed Disk",
+    Description = "Updates or modifies properties of an existing Azure managed disk that was previously created. If resource group is not specified, the disk is located by name within the subscription. Supports changing disk size (can only increase), storage SKU, IOPS and throughput limits (UltraSSD only), max shares for shared disk attachments, on-demand bursting, tags, encryption settings, disk access, and performance tier. Modify the network access policy to DenyAll, AllowAll, or AllowPrivate on an existing disk. Only specified properties are updated; unspecified properties remain unchanged.",
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class DiskUpdateCommand(
     ILogger<DiskUpdateCommand> logger)
     : BaseComputeCommand<DiskUpdateOptions>(false)
 {
-    private const string CommandTitle = "Update Managed Disk";
-    private const string CommandDescription =
-        "Updates or modifies properties of an existing Azure managed disk that was previously created. "
-        + "If resource group is not specified, the disk is located by name within the subscription. "
-        + "Supports changing disk size (can only increase), storage SKU, IOPS and throughput limits (UltraSSD only), "
-        + "max shares for shared disk attachments, on-demand bursting, tags, "
-        + "encryption settings, disk access, and performance tier. "
-        + "Modify the network access policy to DenyAll, AllowAll, or AllowPrivate on an existing disk. "
-        + "Only specified properties are updated; unspecified properties remain unchanged.";
 
     private readonly ILogger<DiskUpdateCommand> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-
-    public override string Id => "4a9b2c3d-6e7f-5b8c-9d0e-1f2a3b4c5d6e";
-
-    public override string Name => "update";
-
-    public override string Title => CommandTitle;
-
-    public override string Description => CommandDescription;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,
-        Destructive = true,
-        Idempotent = true,
-        ReadOnly = false,
-        Secret = false,
-        LocalRequired = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmCreateCommand.cs
@@ -14,37 +14,28 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Compute.Commands.Vm;
 
-public sealed class VmCreateCommand(ILogger<VmCreateCommand> logger)
-    : BaseComputeCommand<VmCreateOptions>(true)
-{
-    private const string CommandTitle = "Create Virtual Machine";
-    private readonly ILogger<VmCreateCommand> _logger = logger;
-
-    public override string Id => "b765ab9c-788d-4422-80aa-54488f6be648";
-
-    public override string Name => "create";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "b765ab9c-788d-4422-80aa-54488f6be648",
+    Name = "create",
+    Title = "Create Virtual Machine",
+    Description = """
         Create, deploy, or provision a single Azure Virtual Machine (VM).
         Use this to launch a new Linux or Windows VM with SSH key or password authentication.
         Automatically creates networking resources (VNet, subnet, NSG, NIC, public IP) when not specified.
         Equivalent to 'az vm create'. Defaults to Standard_D2s_v5 size and Ubuntu 24.04 LTS if not specified.
         For Linux VMs with SSH, read the user's public key file (e.g., ~/.ssh/id_rsa.pub) and pass its content.
         Do not use this for creating Virtual Machine Scale Sets with multiple identical instances (use VMSS create instead).
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = true
-    };
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = true,
+    LocalRequired = false)]
+public sealed class VmCreateCommand(ILogger<VmCreateCommand> logger)
+    : BaseComputeCommand<VmCreateOptions>(true)
+{
+    private readonly ILogger<VmCreateCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmDeleteCommand.cs
@@ -12,18 +12,11 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Compute.Commands.Vm;
 
-public sealed class VmDeleteCommand(ILogger<VmDeleteCommand> logger)
-    : BaseComputeCommand<VmDeleteOptions>(true)
-{
-    private const string CommandTitle = "Delete Virtual Machine";
-    private readonly ILogger<VmDeleteCommand> _logger = logger;
-
-    public override string Id => "d4e2c8a1-6f3b-4d9e-b8c7-1a2e3f4d5e6f";
-
-    public override string Name => "delete";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "d4e2c8a1-6f3b-4d9e-b8c7-1a2e3f4d5e6f",
+    Name = "delete",
+    Title = "Delete Virtual Machine",
+    Description = """
         Delete, remove, or destroy an Azure Virtual Machine (VM).
         Use this to permanently remove a VM that is no longer needed.
         Equivalent to 'az vm delete'. This operation is irreversible and the VM data will be lost.
@@ -31,19 +24,17 @@ public sealed class VmDeleteCommand(ILogger<VmDeleteCommand> logger)
         (passes forceDeletion=true to the Azure API).
         Associated resources like disks, NICs, and public IPs are NOT automatically deleted.
         Do not use this to delete Virtual Machine Scale Sets (use VMSS delete instead).
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = true
-    };
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = true,
+    LocalRequired = false)]
+public sealed class VmDeleteCommand(ILogger<VmDeleteCommand> logger)
+    : BaseComputeCommand<VmDeleteOptions>(true)
+{
+    private readonly ILogger<VmDeleteCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmGetCommand.cs
@@ -13,33 +13,22 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Compute.Commands.Vm;
 
+[CommandMetadata(
+    Id = "c1a8b3e5-4f2d-4a6e-8c7b-9d2e3f4a5b6c",
+    Name = "get",
+    Title = "Get Virtual Machine(s)",
+    Description = "List or get Azure Virtual Machine (VM) configuration and properties in a resource group. By default, returns VM details including name, location, size, provisioning state, and OS type. When retrieving a specific VM with --vm-name and --instance-view, the response also includes power state (running/stopped/deallocated). Use this tool to retrieve VM configuration details.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class VmGetCommand(ILogger<VmGetCommand> logger, IComputeService computeService)
     : BaseComputeCommand<VmGetOptions>(false)
 {
-    private const string CommandTitle = "Get Virtual Machine(s)";
     private readonly ILogger<VmGetCommand> _logger = logger;
     private readonly IComputeService _computeService = computeService;
-
-    public override string Id => "c1a8b3e5-4f2d-4a6e-8c7b-9d2e3f4a5b6c";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
-        List or get Azure Virtual Machine (VM) configuration and properties in a resource group. By default, returns VM details including name, location, size, provisioning state, and OS type. When retrieving a specific VM with --vm-name and --instance-view, the response also includes power state (running/stopped/deallocated). Use this tool to retrieve VM configuration details.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmUpdateCommand.cs
@@ -13,35 +13,26 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Compute.Commands.Vm;
 
-public sealed class VmUpdateCommand(ILogger<VmUpdateCommand> logger)
-    : BaseComputeCommand<VmUpdateOptions>(true)
-{
-    private const string CommandTitle = "Update Virtual Machine";
-    private readonly ILogger<VmUpdateCommand> _logger = logger;
-
-    public override string Id => "f330138e-8048-4a4a-8170-d8b6f958eaa4";
-
-    public override string Name => "update";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "f330138e-8048-4a4a-8170-d8b6f958eaa4",
+    Name = "update",
+    Title = "Update Virtual Machine",
+    Description = """
         Update, modify, or reconfigure an existing Azure Virtual Machine (VM).
         Use this to resize a VM, update tags, configure boot diagnostics, or change user data.
         Equivalent to 'az vm update'. The VM may need to be deallocated before resizing to certain sizes.
         Do not use this to create a new VM (use VM create) or to update Virtual Machine Scale Sets (use VMSS update).
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class VmUpdateCommand(ILogger<VmUpdateCommand> logger)
+    : BaseComputeCommand<VmUpdateOptions>(true)
+{
+    private readonly ILogger<VmUpdateCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssCreateCommand.cs
@@ -14,36 +14,27 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Compute.Commands.Vmss;
 
-public sealed class VmssCreateCommand(ILogger<VmssCreateCommand> logger)
-    : BaseComputeCommand<VmssCreateOptions>(true)
-{
-    private const string CommandTitle = "Create Virtual Machine Scale Set";
-    private readonly ILogger<VmssCreateCommand> _logger = logger;
-
-    public override string Id => "c46a4bc5-cba6-4d99-991b-a9109fc689ad";
-
-    public override string Name => "create";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "c46a4bc5-cba6-4d99-991b-a9109fc689ad",
+    Name = "create",
+    Title = "Create Virtual Machine Scale Set",
+    Description = """
         Create, deploy, or provision an Azure Virtual Machine Scale Set (VMSS) for running multiple identical VM instances.
         Use this to deploy workloads that need horizontal scaling, load balancing, or high availability across instances.
         Equivalent to 'az vmss create'. Defaults to 2 instances, Standard_D2s_v5 size, and Ubuntu 24.04 LTS.
         For Linux VMSS with SSH, read the user's public key file (e.g., ~/.ssh/id_rsa.pub) and pass its content.
         Do not use this for creating a single standalone VM (use VM create instead).
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = true
-    };
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = true,
+    LocalRequired = false)]
+public sealed class VmssCreateCommand(ILogger<VmssCreateCommand> logger)
+    : BaseComputeCommand<VmssCreateOptions>(true)
+{
+    private readonly ILogger<VmssCreateCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssDeleteCommand.cs
@@ -12,37 +12,28 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Compute.Commands.Vmss;
 
-public sealed class VmssDeleteCommand(ILogger<VmssDeleteCommand> logger)
-    : BaseComputeCommand<VmssDeleteOptions>(true)
-{
-    private const string CommandTitle = "Delete Virtual Machine Scale Set";
-    private readonly ILogger<VmssDeleteCommand> _logger = logger;
-
-    public override string Id => "e5f3d9b2-7a4c-4e8f-c9d8-2b3f4a5e6d7c";
-
-    public override string Name => "delete";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "e5f3d9b2-7a4c-4e8f-c9d8-2b3f4a5e6d7c",
+    Name = "delete",
+    Title = "Delete Virtual Machine Scale Set",
+    Description = """
         Delete, remove, or destroy an Azure Virtual Machine Scale Set (VMSS) and all its VM instances.
         Use this to permanently remove a scale set that is no longer needed.
         Equivalent to 'az vmss delete'. This operation is irreversible and all VMSS instances will be lost.
         Use --force-deletion to force delete the VMSS even if it is in a running or failed state
         (passes forceDeletion=true to the Azure API).
         Do not use this to delete a single VM (use VM delete instead).
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = true
-    };
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = true,
+    LocalRequired = false)]
+public sealed class VmssDeleteCommand(ILogger<VmssDeleteCommand> logger)
+    : BaseComputeCommand<VmssDeleteOptions>(true)
+{
+    private readonly ILogger<VmssDeleteCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssGetCommand.cs
@@ -13,33 +13,22 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Compute.Commands.Vmss;
 
+[CommandMetadata(
+    Id = "a5e2f7i9-8j6h-8e0i-2g1f-3h6i7j8e9f0g",
+    Name = "get",
+    Title = "Get Virtual Machine Scale Set(s)",
+    Description = "List or get Azure Virtual Machine Scale Sets (VMSS) and their instances in a subscription or resource group. Returns scale set details including name, location, SKU, capacity, upgrade policy, and individual VM instance information.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class VmssGetCommand(ILogger<VmssGetCommand> logger, IComputeService computeService)
     : BaseComputeCommand<VmssGetOptions>(false)
 {
-    private const string CommandTitle = "Get Virtual Machine Scale Set(s)";
     private readonly ILogger<VmssGetCommand> _logger = logger;
     private readonly IComputeService _computeService = computeService;
-
-    public override string Id => "a5e2f7i9-8j6h-8e0i-2g1f-3h6i7j8e9f0g";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
-        List or get Azure Virtual Machine Scale Sets (VMSS) and their instances in a subscription or resource group. Returns scale set details including name, location, SKU, capacity, upgrade policy, and individual VM instance information.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssUpdateCommand.cs
@@ -13,35 +13,26 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Compute.Commands.Vmss;
 
-public sealed class VmssUpdateCommand(ILogger<VmssUpdateCommand> logger)
-    : BaseComputeCommand<VmssUpdateOptions>(true)
-{
-    private const string CommandTitle = "Update Virtual Machine Scale Set";
-    private readonly ILogger<VmssUpdateCommand> _logger = logger;
-
-    public override string Id => "aaa0ad51-3c16-4ec2-99e2-b24f28a1e7d0";
-
-    public override string Name => "update";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "aaa0ad51-3c16-4ec2-99e2-b24f28a1e7d0",
+    Name = "update",
+    Title = "Update Virtual Machine Scale Set",
+    Description = """
         Update, modify, or reconfigure an existing Azure Virtual Machine Scale Set (VMSS).
         Use this to scale instance count, resize VMs, change upgrade policy, or update tags on a scale set.
         Equivalent to 'az vmss update'. Changes may require 'update-instances' to roll out to existing VMs.
         Do not use this to create a new VMSS (use VMSS create) or to update a single VM (use VM update).
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class VmssUpdateCommand(ILogger<VmssUpdateCommand> logger)
+    : BaseComputeCommand<VmssUpdateOptions>(true)
+{
+    private readonly ILogger<VmssUpdateCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/Entries/LedgerEntryAppendCommand.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/Entries/LedgerEntryAppendCommand.cs
@@ -12,31 +12,22 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ConfidentialLedger.Commands.Entries;
 
+[CommandMetadata(
+    Id = "94fec47b-eb44-4d20-862f-24c284328956",
+    Name = "append",
+    Title = "Append Confidential Ledger Entry",
+    Description = "Appends a tamper-proof entry to a Confidential Ledger instance and returns the transaction identifier.",
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class LedgerEntryAppendCommand(IConfidentialLedgerService service, ILogger<LedgerEntryAppendCommand> logger)
     : BaseConfidentialLedgerCommand<AppendEntryOptions>
 {
-    private const string CommandTitle = "Append Confidential Ledger Entry";
     private readonly IConfidentialLedgerService _service = service;
     private readonly ILogger<LedgerEntryAppendCommand> _logger = logger;
-    public override string Id => "94fec47b-eb44-4d20-862f-24c284328956";
-
-    public override string Name => "append";
-
-    public override string Description =>
-        "Appends a tamper-proof entry to a Confidential Ledger instance and returns the transaction identifier.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        // Appending creates immutable data - not destructive but not idempotent.
-        OpenWorld = false,
-        Destructive = false,
-        Idempotent = false,
-        ReadOnly = false,
-        Secret = false,
-        LocalRequired = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/Entries/LedgerEntryGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Commands/Entries/LedgerEntryGetCommand.cs
@@ -12,30 +12,22 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ConfidentialLedger.Commands.Entries;
 
+[CommandMetadata(
+    Id = "f1281e49-6392-455d-8caf-eb58428e8f5e",
+    Name = "get",
+    Title = "Retrieve Confidential Ledger Entry",
+    Description = "Retrieves the Confidential Ledger entry and its recorded contents for the specified transaction ID, optionally scoped to a collection.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class LedgerEntryGetCommand(IConfidentialLedgerService service, ILogger<LedgerEntryGetCommand> logger)
     : BaseConfidentialLedgerCommand<GetEntryOptions>
 {
-    private const string CommandTitle = "Retrieve Confidential Ledger Entry";
     private readonly IConfidentialLedgerService _service = service;
     private readonly ILogger<LedgerEntryGetCommand> _logger = logger;
-    public override string Id => "f1281e49-6392-455d-8caf-eb58428e8f5e";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        "Retrieves the Confidential Ledger entry and its recorded contents for the specified transaction ID, optionally scoped to a collection.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,
-        Destructive = false,
-        Idempotent = true,
-        ReadOnly = true,
-        Secret = false,
-        LocalRequired = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ContainerApps/src/Commands/ContainerApp/ContainerAppListCommand.cs
+++ b/tools/Azure.Mcp.Tools.ContainerApps/src/Commands/ContainerApp/ContainerAppListCommand.cs
@@ -9,34 +9,25 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.ContainerApps.Commands.ContainerApp;
 
-public sealed class ContainerAppListCommand(ILogger<ContainerAppListCommand> logger, IContainerAppsService containerAppsService) : BaseContainerAppsCommand<ContainerAppListOptions>
-{
-    private const string CommandTitle = "List Container Apps";
-    private readonly ILogger<ContainerAppListCommand> _logger = logger;
-    private readonly IContainerAppsService _containerAppsService = containerAppsService;
-
-    public override string Id => "d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        $"""
+[CommandMetadata(
+    Id = "d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90",
+    Name = "list",
+    Title = "List Container Apps",
+    Description = """
         List Azure Container Apps in a subscription. Optionally filter by resource group. Each container app result
         includes: name, location, resourceGroup, managedEnvironmentId, provisioningState. If no container apps are
         found the tool returns an empty list of results (consistent with other list commands).
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ContainerAppListCommand(ILogger<ContainerAppListCommand> logger, IContainerAppsService containerAppsService) : BaseContainerAppsCommand<ContainerAppListOptions>
+{
+    private readonly ILogger<ContainerAppListCommand> _logger = logger;
+    private readonly IContainerAppsService _containerAppsService = containerAppsService;
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CosmosListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CosmosListCommand.cs
@@ -14,30 +14,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Cosmos.Commands;
 
+[CommandMetadata(
+    Id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    Name = "list",
+    Title = "List Cosmos DB Resources",
+    Description = "List Cosmos DB accounts, databases, or containers. Returns all accounts in the subscription by default. Specify --account to list databases in that account, or --account and --database to list containers in a specific database.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class CosmosListCommand(ILogger<CosmosListCommand> logger) : SubscriptionCommand<CosmosListOptions>()
 {
-    private const string CommandTitle = "List Cosmos DB Resources";
     private readonly ILogger<CosmosListCommand> _logger = logger;
-
-    public override string Id => "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        "List Cosmos DB accounts, databases, or containers. Returns all accounts in the subscription by default. " +
-        "Specify --account to list databases in that account, or --account and --database to list containers in a specific database.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ItemQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ItemQueryCommand.cs
@@ -12,29 +12,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Cosmos.Commands;
 
+[CommandMetadata(
+    Id = "5c19a92a-4e0c-44dc-b1e7-5560a0d277b5",
+    Name = "query",
+    Title = "Query Cosmos DB Container",
+    Description = "List items from a Cosmos DB container by specifying the account name, database name, and container name, optionally providing a custom SQL query to filter results.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ItemQueryCommand(ILogger<ItemQueryCommand> logger) : BaseContainerCommand<ItemQueryOptions>()
 {
-    private const string CommandTitle = "Query Cosmos DB Container";
     private readonly ILogger<ItemQueryCommand> _logger = logger;
     private const string DefaultQuery = "SELECT * FROM c";
-    public override string Id => "5c19a92a-4e0c-44dc-b1e7-5560a0d277b5";
-
-    public override string Name => "query";
-
-    public override string Description =>
-    "List items from a Cosmos DB container by specifying the account name, database name, and container name, optionally providing a custom SQL query to filter results.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Deploy/src/Commands/App/LogsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/src/Commands/App/LogsGetCommand.cs
@@ -12,29 +12,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Deploy.Commands.App;
 
+[CommandMetadata(
+    Id = "ce9d648d-7c76-48a0-8cba-b9b57c6fd00b",
+    Name = "get",
+    Title = "Get AZD deployed App Logs",
+    Description = "Shows application logs for Azure Developer CLI (azd) deployed applications from their associated Log Analytics workspace. Supports Container Apps, App Services, and Function Apps deployed via 'azd up'. Requires local workspace access to read the azure.yaml project file. Automatically discovers the correct Log Analytics workspace and resources based on azd environment configuration. Returns console log entries for checking deployment status or troubleshooting post-deployment issues.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = true)]
 public sealed class LogsGetCommand(ILogger<LogsGetCommand> logger, IDeployService deployService) : SubscriptionCommand<LogsGetOptions>()
 {
-    private const string CommandTitle = "Get AZD deployed App Logs";
     private readonly ILogger<LogsGetCommand> _logger = logger;
     private readonly IDeployService _deployService = deployService;
-    public override string Id => "ce9d648d-7c76-48a0-8cba-b9b57c6fd00b";
-
-    public override string Name => "get";
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = true,
-        Secret = false
-    };
-
-    public override string Description =>
-        """
-        Shows application logs for Azure Developer CLI (azd) deployed applications from their associated Log Analytics workspace. Supports Container Apps, App Services, and Function Apps deployed via 'azd up'. Requires local workspace access to read the azure.yaml project file. Automatically discovers the correct Log Analytics workspace and resources based on azd environment configuration. Returns console log entries for checking deployment status or troubleshooting post-deployment issues.
-        """;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Deploy/src/Commands/Architecture/DiagramGenerateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/src/Commands/Architecture/DiagramGenerateCommand.cs
@@ -14,29 +14,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Deploy.Commands.Architecture;
 
+[CommandMetadata(
+    Id = "34d7ec6a-e229-4775-8af3-85f81ae3e6d3",
+    Name = "generate",
+    Title = "Generate Architecture Diagram",
+    Description = "Generates a Mermaid architecture diagram showing recommended Azure services and their connections for an application. Input is a structured AppTopology JSON built by scanning the workspace: detect services, frameworks, ports, Docker settings, and dependencies from connection strings and environment variables. For .NET Aspire applications, check aspireManifest.json. Returns a Mermaid diagram string. Supported compute types include AppService, FunctionApp, ContainerApp, StaticWebApp, and AKS. Supported dependency types include SQL, Cosmos, Redis, Storage, ServiceBus, KeyVault, and other supported Azure services.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class DiagramGenerateCommand(ILogger<DiagramGenerateCommand> logger) : BaseCommand<DiagramGenerateOptions>
 {
-    private const string CommandTitle = "Generate Architecture Diagram";
     private readonly ILogger<DiagramGenerateCommand> _logger = logger;
-    public override string Id => "34d7ec6a-e229-4775-8af3-85f81ae3e6d3";
-
-    public override string Name => "generate";
-
-    public override string Description =>
-        """
-        Generates a Mermaid architecture diagram showing recommended Azure services and their connections for an application. Input is a structured AppTopology JSON built by scanning the workspace: detect services, frameworks, ports, Docker settings, and dependencies from connection strings and environment variables. For .NET Aspire applications, check aspireManifest.json. Returns a Mermaid diagram string. Supported compute types include AppService, FunctionApp, ContainerApp, StaticWebApp, and AKS. Supported dependency types include SQL, Cosmos, Redis, Storage, ServiceBus, KeyVault, and other supported Azure services.
-        """;
-
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Deploy/src/Commands/Infrastructure/RulesGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/src/Commands/Infrastructure/RulesGetCommand.cs
@@ -12,29 +12,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Deploy.Commands.Infrastructure;
 
+[CommandMetadata(
+    Id = "942b5c00-01dd-4ca0-9596-4cf650ff7934",
+    Name = "get",
+    Title = "Get IaC (Infrastructure as Code) Rules",
+    Description = "Retrieves curated IaC rules and best practices for creating Bicep or Terraform files compatible with Azure Developer CLI (azd) or Azure CLI deployments. Covers Azure resource configuration standards, naming requirements, and deployment tool constraints that differ from generic IaC guidance. Returns a formatted rules document. Specify deployment tool (AzCli or AZD), IaC type (bicep or terraform), and target resource types.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class RulesGetCommand(ILogger<RulesGetCommand> logger)
     : BaseCommand<RulesGetOptions>
 {
-    private const string CommandTitle = "Get IaC (Infrastructure as Code) Rules";
     private readonly ILogger<RulesGetCommand> _logger = logger;
-    public override string Id => "942b5c00-01dd-4ca0-9596-4cf650ff7934";
-
-    public override string Name => "get";
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
-
-    public override string Description =>
-        """
-        Retrieves curated IaC rules and best practices for creating Bicep or Terraform files compatible with Azure Developer CLI (azd) or Azure CLI deployments. Covers Azure resource configuration standards, naming requirements, and deployment tool constraints that differ from generic IaC guidance. Returns a formatted rules document. Specify deployment tool (AzCli or AZD), IaC type (bicep or terraform), and target resource types.
-        """;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Deploy/src/Commands/Pipeline/GuidanceGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/src/Commands/Pipeline/GuidanceGetCommand.cs
@@ -13,30 +13,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Deploy.Commands.Pipeline;
 
+[CommandMetadata(
+    Id = "8aec84f9-e884-4119-a386-53b7cfbe9e00",
+    Name = "get",
+    Title = "Get Azure Deployment CI/CD Pipeline Guidance",
+    Description = "Provides the recommended Azure-specific rules for generating CI/CD pipeline files (GitHub Actions or Azure DevOps) for deploying to Azure. Call this tool before writing pipeline/workflow YAML when the user asks to set up CI/CD pipelines or workflows. It returns current authentication patterns (e.g., OIDC with managed identity), multi-environment configuration, and deployment constraints that vary by platform and are not covered by general best practices. Determine the pipeline platform (github-actions or azure-devops) and deployment scope (deploy-only or provision-and-deploy) from project context before calling. Handles both azd-based and Azure CLI-based deployments.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class GuidanceGetCommand(ILogger<GuidanceGetCommand> logger)
     : SubscriptionCommand<GuidanceGetOptions>()
 {
-    private const string CommandTitle = "Get Azure Deployment CI/CD Pipeline Guidance";
     private readonly ILogger<GuidanceGetCommand> _logger = logger;
-    public override string Id => "8aec84f9-e884-4119-a386-53b7cfbe9e00";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
-        Provides the recommended Azure-specific rules for generating CI/CD pipeline files (GitHub Actions or Azure DevOps) for deploying to Azure. Call this tool before writing pipeline/workflow YAML when the user asks to set up CI/CD pipelines or workflows. It returns current authentication patterns (e.g., OIDC with managed identity), multi-environment configuration, and deployment constraints that vary by platform and are not covered by general best practices. Determine the pipeline platform (github-actions or azure-devops) and deployment scope (deploy-only or provision-and-deploy) from project context before calling. Handles both azd-based and Azure CLI-based deployments.
-        """;
-
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Deploy/src/Commands/Plan/GetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/src/Commands/Plan/GetCommand.cs
@@ -16,30 +16,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Deploy.Commands.Plan;
 
+[CommandMetadata(
+    Id = "92ca95b2-cde6-407c-ac67-9743db40dfc4",
+    Name = "get",
+    Title = "Generate Azure Deployment Plan",
+    Description = "Retrieves an Azure-specific deployment plan template for deploying an application to Azure using deployment options provided by the caller. Use this tool when the user wants a formatted, step-by-step deployment plan, including suggested Azure resources, infrastructure as code (IaC) templates, and deployment instructions, for a target Azure hosting service such as Container Apps, App Service, or AKS and a chosen provisioning tool such as Azure Developer CLI (azd) or Azure CLI with Bicep or Terraform. Before calling, determine the services, frameworks, and dependencies to deploy, select the appropriate Azure hosting service, provisioning tool, IaC type, and deployment option, and then pass those chosen values into this tool to generate the deployment plan.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class GetCommand(ILogger<GetCommand> logger)
     : BaseCommand<GetOptions>
 {
-    private const string CommandTitle = "Generate Azure Deployment Plan";
     private readonly ILogger<GetCommand> _logger = logger;
-    public override string Id => "92ca95b2-cde6-407c-ac67-9743db40dfc4";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
-        Retrieves an Azure-specific deployment plan template for deploying an application to Azure using deployment options provided by the caller. Use this tool when the user wants a formatted, step-by-step deployment plan, including suggested Azure resources, infrastructure as code (IaC) templates, and deployment instructions, for a target Azure hosting service such as Container Apps, App Service, or AKS and a chosen provisioning tool such as Azure Developer CLI (azd) or Azure CLI with Bicep or Terraform. Before calling, determine the services, frameworks, and dependencies to deploy, select the appropriate Azure hosting service, provisioning tool, IaC type, and deployment option, and then pass those chosen values into this tool to generate the deployment plan.
-        """;
-
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.DeviceRegistry/src/Commands/Namespace/NamespaceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.DeviceRegistry/src/Commands/Namespace/NamespaceListCommand.cs
@@ -13,34 +13,25 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.DeviceRegistry.Commands.Namespace;
 
-public sealed class NamespaceListCommand(ILogger<NamespaceListCommand> logger)
-    : BaseDeviceRegistryCommand<NamespaceListOptions>()
-{
-    private const string CommandTitle = "List Device Registry Namespaces";
-    private readonly ILogger<NamespaceListCommand> _logger = logger;
-
-    public override string Id => "9c42f93b-2d4e-4fb3-b98b-2ef119b46c94";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "9c42f93b-2d4e-4fb3-b98b-2ef119b46c94",
+    Name = "list",
+    Title = "List Device Registry Namespaces",
+    Description = """
         Lists Azure Device Registry namespaces in a subscription or resource group. Returns namespace details including
         name, location, provisioning state, and UUID. If a resource group is specified, only namespaces within that
         resource group are returned. Otherwise, all namespaces in the subscription are listed.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class NamespaceListCommand(ILogger<NamespaceListCommand> logger)
+    : BaseDeviceRegistryCommand<NamespaceListOptions>()
+{
+    private readonly ILogger<NamespaceListCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.EventGrid/src/Commands/Events/EventsPublishCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/src/Commands/Events/EventsPublishCommand.cs
@@ -12,33 +12,25 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventGrid.Commands.Events;
 
-public sealed class EventGridPublishCommand(ILogger<EventGridPublishCommand> logger, IEventGridService eventGridService) : BaseEventGridCommand<EventsPublishOptions>
-{
-    private const string CommandTitle = "Publish Events to Event Grid Topic";
-    private readonly ILogger<EventGridPublishCommand> _logger = logger;
-    private readonly IEventGridService _eventGridService = eventGridService;
-    public override string Id => "d5f216a4-c45e-4c29-a414-d3feaa5929e2";
-
-    public override string Name => "publish";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "d5f216a4-c45e-4c29-a414-d3feaa5929e2",
+    Name = "publish",
+    Title = "Publish Events to Event Grid Topic",
+    Description = """
         Publish custom events to Event Grid topics for event-driven architectures. This tool sends structured event data to 
         Event Grid topics with schema validation and delivery guarantees for downstream subscribers. Returns publish operation 
         status. Requires topic, data, and optional schema.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class EventGridPublishCommand(ILogger<EventGridPublishCommand> logger, IEventGridService eventGridService) : BaseEventGridCommand<EventsPublishOptions>
+{
+    private readonly ILogger<EventGridPublishCommand> _logger = logger;
+    private readonly IEventGridService _eventGridService = eventGridService;
 
     private static readonly string[] s_item = ["cloudevents", "eventgrid", "custom"];
 

--- a/tools/Azure.Mcp.Tools.EventGrid/src/Commands/Subscription/SubscriptionListCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/src/Commands/Subscription/SubscriptionListCommand.cs
@@ -12,32 +12,22 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventGrid.Commands.Subscription;
 
+[CommandMetadata(
+    Id = "716a33e5-755c-4168-87ed-8a4651476c6e",
+    Name = "list",
+    Title = "List Event Grid Subscriptions",
+    Description = "Show all available Event Grid subscriptions with optional topic filtering. This tool displays active event subscriptions including webhook endpoints, event filters, and delivery retry policies. Use this when you need to show, list, or get Event Grid subscriptions for topics. Requires either topic name OR subscription. If only topic is provided, searches all accessible subscriptions for a topic with that name. Resource group and location filters can be applied, but only when used with a subscription or topic.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SubscriptionListCommand(ILogger<SubscriptionListCommand> logger, IEventGridService eventGridService, ISubscriptionService subscriptionService) : GlobalCommand<SubscriptionListOptions>
 {
-    private const string CommandTitle = "List Event Grid Subscriptions";
     private readonly ILogger<SubscriptionListCommand> _logger = logger;
     private readonly IEventGridService _eventGridService = eventGridService;
     private readonly ISubscriptionService _subscriptionService = subscriptionService;
-    public override string Id => "716a33e5-755c-4168-87ed-8a4651476c6e";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
-        Show all available Event Grid subscriptions with optional topic filtering. This tool displays active event subscriptions including webhook endpoints, event filters, and delivery retry policies. Use this when you need to show, list, or get Event Grid subscriptions for topics. Requires either topic name OR subscription. If only topic is provided, searches all accessible subscriptions for a topic with that name. Resource group and location filters can be applied, but only when used with a subscription or topic.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.EventGrid/src/Commands/Topic/TopicListCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/src/Commands/Topic/TopicListCommand.cs
@@ -10,31 +10,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventGrid.Commands.Topic;
 
+[CommandMetadata(
+    Id = "42390294-2856-4980-a057-095c91355650",
+    Name = "list",
+    Title = "List Event Grid Topics",
+    Description = "List or show all Event Grid topics in a subscription, optionally filtered by resource group, returning endpoints, access keys, provisioning state, and subscription details for event publishing and management. A subscription or topic name is required.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class TopicListCommand(ILogger<TopicListCommand> logger, IEventGridService eventGridService) : BaseEventGridCommand<TopicListOptions>
 {
-    private const string CommandTitle = "List Event Grid Topics";
     private readonly ILogger<TopicListCommand> _logger = logger;
     private readonly IEventGridService _eventGridService = eventGridService;
-    public override string Id => "42390294-2856-4980-a057-095c91355650";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
-        List or show all Event Grid topics in a subscription, optionally filtered by resource group, returning endpoints, access keys, provisioning state, and subscription details for event publishing and management. A subscription or topic name is required.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupDeleteCommand.cs
@@ -12,37 +12,29 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.ConsumerGroup;
 
-public sealed class ConsumerGroupDeleteCommand(ILogger<ConsumerGroupDeleteCommand> logger, IEventHubsService service)
-    : BaseEventHubsCommand<ConsumerGroupDeleteOptions>
-{
-    private const string CommandTitle = "Delete Event Hubs Consumer Group";
-
-    private readonly IEventHubsService _service = service;
-    private readonly ILogger<ConsumerGroupDeleteCommand> _logger = logger;
-    public override string Id => "08980fd4-c7c2-41cd-a3c2-eda5303bd458";
-
-    public override string Name => "delete";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "08980fd4-c7c2-41cd-a3c2-eda5303bd458",
+    Name = "delete",
+    Title = "Delete Event Hubs Consumer Group",
+    Description = """
         Delete a Consumer Group. This tool will delete a pre-existing Consumer Group from the specified 
         Event Hub. This tool will remove existing configurations, and is considered to be destructive.
 
         The tool requires specifying the resource group, Namespace name, Event Hub name, and Consumer
         Group name to identify the Consumer Group to delete.
-        """;
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ConsumerGroupDeleteCommand(ILogger<ConsumerGroupDeleteCommand> logger, IEventHubsService service)
+    : BaseEventHubsCommand<ConsumerGroupDeleteOptions>
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,
-        Destructive = true,     // Deletes resources
-        Idempotent = true,      // Same parameters produce same results
-        ReadOnly = false,       // Modifies resources
-        Secret = false,         // Returns non-sensitive information
-        LocalRequired = false   // Pure cloud API calls
-    };
+    private readonly IEventHubsService _service = service;
+    private readonly ILogger<ConsumerGroupDeleteCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupGetCommand.cs
@@ -12,19 +12,11 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.ConsumerGroup;
 
-public sealed class ConsumerGroupGetCommand(ILogger<ConsumerGroupGetCommand> logger, IEventHubsService service)
-    : BaseEventHubsCommand<ConsumerGroupGetOptions>
-{
-    private const string CommandTitle = "Get Event Hubs Consumer Groups";
-
-    private readonly IEventHubsService _service = service;
-    private readonly ILogger<ConsumerGroupGetCommand> _logger = logger;
-    public override string Id => "604fda48-2438-419d-a819-5f9d2f3b21f8";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "604fda48-2438-419d-a819-5f9d2f3b21f8",
+    Name = "get",
+    Title = "Get Event Hubs Consumer Groups",
+    Description = """
         Get consumer groups from Azure Event Hub. This command can either:
 
         1) List all consumer groups in an Event Hub
@@ -33,19 +25,19 @@ public sealed class ConsumerGroupGetCommand(ILogger<ConsumerGroupGetCommand> log
         The EventHub, Namespace, and ResourceGroup parameters are required (for both get and list)
         The Consumer Group parameter is only required for getting a specific consumer-group
         When retrieving a single consumer group and when listing all available consumer groups, return all available metadata on the consumer group.
-        """;
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ConsumerGroupGetCommand(ILogger<ConsumerGroupGetCommand> logger, IEventHubsService service)
+    : BaseEventHubsCommand<ConsumerGroupGetOptions>
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,       // Queries Azure resources
-        Destructive = false,    // Read-only operation
-        Idempotent = true,      // Same parameters produce same results
-        ReadOnly = true,        // Only reads data
-        Secret = false,         // Returns non-sensitive information
-        LocalRequired = false   // Pure cloud API calls
-    };
+    private readonly IEventHubsService _service = service;
+    private readonly ILogger<ConsumerGroupGetCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/ConsumerGroup/ConsumerGroupUpdateCommand.cs
@@ -12,39 +12,31 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.ConsumerGroup;
 
-public sealed class ConsumerGroupUpdateCommand(ILogger<ConsumerGroupUpdateCommand> logger, IEventHubsService service)
-    : BaseEventHubsCommand<ConsumerGroupUpdateOptions>
-{
-    private const string CommandTitle = "Create or Update Event Hubs Consumer Group";
-
-    private readonly IEventHubsService _service = service;
-    private readonly ILogger<ConsumerGroupUpdateCommand> _logger = logger;
-    public override string Id => "859871ba-b8dc-439c-a607-11b0d89f5112";
-
-    public override string Name => "update";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "859871ba-b8dc-439c-a607-11b0d89f5112",
+    Name = "update",
+    Title = "Create or Update Event Hubs Consumer Group",
+    Description = """
         Create or Update a Consumer Group. This tool will either create a Consumer Group resource 
         or update a pre-existing Consumer Group resource within the specified Event Hub, depending 
         on whether or not the specified Consumer Group already exists. This tool may modify existing 
         configurations, and is considered to be destructive. 
-        
+
         The tool requires specifying the resource group, namespace name, event hub name, and consumer 
         group name. Optionally, you can provide user metadata for the consumer group.
-        """;
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ConsumerGroupUpdateCommand(ILogger<ConsumerGroupUpdateCommand> logger, IEventHubsService service)
+    : BaseEventHubsCommand<ConsumerGroupUpdateOptions>
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,
-        Destructive = true,     // Creates/modifies resources
-        Idempotent = true,      // Same parameters produce same results
-        ReadOnly = false,       // Modifies resources
-        Secret = false,         // Returns non-sensitive information
-        LocalRequired = false   // Pure cloud API calls
-    };
+    private readonly IEventHubsService _service = service;
+    private readonly ILogger<ConsumerGroupUpdateCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubDeleteCommand.cs
@@ -14,18 +14,11 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.EventHub;
 
-public sealed class EventHubDeleteCommand(ILogger<EventHubDeleteCommand> logger, IEventHubsService service)
-    : BaseEventHubsCommand<EventHubDeleteOptions>
-{
-    private const string CommandTitle = "Delete Event Hub";
-    private readonly IEventHubsService _service = service;
-    private readonly ILogger<EventHubDeleteCommand> _logger = logger;
-    public override string Id => "108ffeab-8d37-4c29-98c9-aa99eb8f61c7";
-
-    public override string Name => "delete";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "108ffeab-8d37-4c29-98c9-aa99eb8f61c7",
+    Name = "delete",
+    Title = "Delete Event Hub",
+    Description = """
         Delete an Event Hub from an Azure Event Hubs namespace. This operation permanently removes
         the specified Event Hub and all its data. This is a destructive operation.
 
@@ -33,19 +26,18 @@ public sealed class EventHubDeleteCommand(ILogger<EventHubDeleteCommand> logger,
         with Deleted = false. If the Event Hub is successfully deleted, Deleted = true is returned.
         Warning: This operation cannot be undone. All messages and consumer groups in the Event Hub
         will be permanently deleted.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,
-        Destructive = true,
-        Idempotent = true,
-        ReadOnly = false,
-        Secret = false,
-        LocalRequired = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class EventHubDeleteCommand(ILogger<EventHubDeleteCommand> logger, IEventHubsService service)
+    : BaseEventHubsCommand<EventHubDeleteOptions>
+{
+    private readonly IEventHubsService _service = service;
+    private readonly ILogger<EventHubDeleteCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubGetCommand.cs
@@ -14,38 +14,29 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.EventHub;
 
-public sealed class EventHubGetCommand(ILogger<EventHubGetCommand> logger, IEventHubsService service)
-    : BaseEventHubsCommand<EventHubGetOptions>
-{
-    private const string CommandTitle = "Get Event Hubs from Namespace";
-    private readonly IEventHubsService _service = service;
-    private readonly ILogger<EventHubGetCommand> _logger = logger;
-
-    public override string Id => "ab774777-76ac-4e24-ba19-da67254441a9";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "ab774777-76ac-4e24-ba19-da67254441a9",
+    Name = "get",
+    Title = "Get Event Hubs from Namespace",
+    Description = """
         Get Event Hubs from Azure namespace. This command can either:
         1. List all Event Hubs in a namespace
         2. Get a single Event Hub by name
 
         When retrieving a single Event Hub or listing multiple Event Hubs, detailed information including
         partition count, settings, and metadata is returned for all Event Hubs.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,
-        Destructive = false,
-        Idempotent = true,
-        ReadOnly = true,
-        Secret = false,
-        LocalRequired = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class EventHubGetCommand(ILogger<EventHubGetCommand> logger, IEventHubsService service)
+    : BaseEventHubsCommand<EventHubGetOptions>
+{
+    private readonly IEventHubsService _service = service;
+    private readonly ILogger<EventHubGetCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/EventHub/EventHubUpdateCommand.cs
@@ -14,18 +14,11 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.EventHub;
 
-public sealed class EventHubUpdateCommand(ILogger<EventHubUpdateCommand> logger, IEventHubsService service)
-    : BaseEventHubsCommand<EventHubUpdateOptions>
-{
-    private const string CommandTitle = "Create or Update Event Hub";
-    private readonly IEventHubsService _service = service;
-    private readonly ILogger<EventHubUpdateCommand> _logger = logger;
-    public override string Id => "1df73670-9de5-4d4b-bdd8-9d2d9e16f732";
-
-    public override string Name => "update";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "1df73670-9de5-4d4b-bdd8-9d2d9e16f732",
+    Name = "update",
+    Title = "Create or Update Event Hub",
+    Description = """
         Create or update an Event Hub within an Azure Event Hubs namespace. This command can either:
         1. Create a new Event Hub if it doesn't exist
         2. Update an existing Event Hub's configuration
@@ -33,22 +26,21 @@ public sealed class EventHubUpdateCommand(ILogger<EventHubUpdateCommand> logger,
         You can configure:
         - Partition count (number of partitions for parallel processing)
         - Message retention time (how long messages are retained in hours)
-        
+
         Note: Some properties like partition count cannot be changed after creation.
         This is a potentially long-running operation that waits for completion.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,
-        Destructive = true,
-        Idempotent = true,
-        ReadOnly = false,
-        Secret = false,
-        LocalRequired = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class EventHubUpdateCommand(ILogger<EventHubUpdateCommand> logger, IEventHubsService service)
+    : BaseEventHubsCommand<EventHubUpdateOptions>
+{
+    private readonly IEventHubsService _service = service;
+    private readonly ILogger<EventHubUpdateCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceDeleteCommand.cs
@@ -13,42 +13,33 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.Namespace;
 
-public sealed class NamespaceDeleteCommand(ILogger<NamespaceDeleteCommand> logger, IEventHubsService service)
-    : BaseEventHubsCommand<NamespaceDeleteOptions>
-{
-    private const string CommandTitle = "Delete Event Hubs Namespace";
-
-    private readonly IEventHubsService _service = service;
-    private readonly ILogger<NamespaceDeleteCommand> _logger = logger;
-
-    public override string Id => "187ffc25-1e32-4e39-a7d4-94859852ac50";
-
-    public override string Name => "delete";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "187ffc25-1e32-4e39-a7d4-94859852ac50",
+    Name = "delete",
+    Title = "Delete Event Hubs Namespace",
+    Description = """
         Delete Event Hubs namespace. This tool will delete a pre-existing Namespace from the 
         specified resource group. This tool will remove existing configurations, and is 
         considered to be destructive.
 
         WARNING: This operation is irreversible. All Event Hubs, Consumer Groups, and
         configurations within the namespace will be permanently deleted.
-        
+
         The namespace must exist in the specified resource group. If the namespace is not found,
         an error will be returned.
-        """;
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class NamespaceDeleteCommand(ILogger<NamespaceDeleteCommand> logger, IEventHubsService service)
+    : BaseEventHubsCommand<NamespaceDeleteOptions>
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,
-        Destructive = true,    // Permanently deletes resources
-        Idempotent = true,     // Deleting same resource multiple times has same effect
-        ReadOnly = false,      // Modifies cloud state
-        Secret = false,        // Returns non-sensitive information
-        LocalRequired = false  // Pure cloud API calls
-    };
+    private readonly IEventHubsService _service = service;
+    private readonly ILogger<NamespaceDeleteCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceGetCommand.cs
@@ -12,43 +12,34 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.Namespace;
 
-public sealed class NamespaceGetCommand(ILogger<NamespaceGetCommand> logger, IEventHubsService service)
-    : BaseEventHubsCommand<NamespaceGetOptions>
-{
-    private const string CommandTitle = "Get Event Hubs Namespaces";
-
-    private readonly IEventHubsService _service = service;
-    private readonly ILogger<NamespaceGetCommand> _logger = logger;
-
-    public override string Id => "71ec6c5b-b6e4-4c64-b31b-2d61dfad3b5c";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "71ec6c5b-b6e4-4c64-b31b-2d61dfad3b5c",
+    Name = "get",
+    Title = "Get Event Hubs Namespaces",
+    Description = """
         Get Event Hubs namespaces from Azure. This command supports three modes of operation:
         1. List all Event Hubs namespaces in a subscription 
         2. List all Event Hubs namespaces in a specific resource group 
         3. Get a single namespace by name 
-        
+
         When retrieving a single namespace, detailed information including SKU, settings, and metadata 
         is returned. When listing namespaces, the same detailed information is returned for all 
         namespaces in the specified scope.
-        
+
         The --resource-group parameter is optional for listing operations but required when getting a specific namespace.
-        """;
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class NamespaceGetCommand(ILogger<NamespaceGetCommand> logger, IEventHubsService service)
+    : BaseEventHubsCommand<NamespaceGetOptions>
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,
-        Destructive = false,   // Safe read-only operation
-        Idempotent = true,     // Same parameters produce same results
-        ReadOnly = true,       // Only reads data, no modifications
-        Secret = false,        // Returns non-sensitive information
-        LocalRequired = false  // Pure cloud API calls
-    };
+    private readonly IEventHubsService _service = service;
+    private readonly ILogger<NamespaceGetCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceUpdateCommand.cs
@@ -12,47 +12,38 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.Namespace;
 
-public sealed class NamespaceUpdateCommand(ILogger<NamespaceUpdateCommand> logger, IEventHubsService service)
-    : BaseEventHubsCommand<NamespaceUpdateOptions>
-{
-    private const string CommandTitle = "Create or Update Event Hubs Namespace";
-
-    private readonly IEventHubsService _service = service;
-    private readonly ILogger<NamespaceUpdateCommand> _logger = logger;
-
-    public override string Id => "225eb25d-52c5-4c3a-9eb4-066cf2b9da84";
-
-    public override string Name => "update";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "225eb25d-52c5-4c3a-9eb4-066cf2b9da84",
+    Name = "update",
+    Title = "Create or Update Event Hubs Namespace",
+    Description = """
         Create or Update a Namespace. This tool will either create a Namespace resource or 
         update a pre-existing Namespace resource within the specified resource group, depending on 
         whether or not the specified Namespace already exists. This tool may modify existing 
         configurations, and is considered to be destructive. This is a potentially long-running operation.
-        
+
         When updating an existing namespace, you only need to provide the properties you want to change.
         Unspecified properties will retain their existing values. At least one update property must be provided.
-        
+
         Common update scenarios:
         - Scale up/down by changing SKU tier or capacity
         - Enable/disable auto-inflate and set maximum throughput units
         - Enable/disable Kafka support
         - Modify tags for resource management
         - Enable/disable zone redundancy (Premium SKU only)
-        """;
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class NamespaceUpdateCommand(ILogger<NamespaceUpdateCommand> logger, IEventHubsService service)
+    : BaseEventHubsCommand<NamespaceUpdateOptions>
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,
-        Destructive = true,    // Modifies existing resources
-        Idempotent = true,     // Same parameters produce same results
-        ReadOnly = false,      // Modifies data
-        Secret = false,        // Returns non-sensitive information
-        LocalRequired = false  // Pure cloud API calls
-    };
+    private readonly IEventHubsService _service = service;
+    private readonly ILogger<NamespaceUpdateCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Extension/src/Commands/AzqrCommand.cs
+++ b/tools/Azure.Mcp.Tools.Extension/src/Commands/AzqrCommand.cs
@@ -16,35 +16,25 @@ using Microsoft.Mcp.Core.Services.Time;
 
 namespace Azure.Mcp.Tools.Extension.Commands;
 
+[CommandMetadata(
+    Id = "e7ef18a3-2730-4300-bad3-dc766f47dd2a",
+    Name = "azqr",
+    Title = "Azure Quick Review CLI Command",
+    Description = "Runs Azure Quick Review CLI (azqr) commands to generate compliance and security reports for Azure resources, identifying non-compliant configurations or areas for improvement. Requires a subscription id and optionally a resource group name. Returns the generated report file path. Note: azqr is different from Azure CLI (az).",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class AzqrCommand(ILogger<AzqrCommand> logger, ISubscriptionService subscriptionService, IDateTimeProvider dateTimeProvider, IExternalProcessService processService, int processTimeoutSeconds = 300) : SubscriptionCommand<AzqrOptions>()
 {
-    private const string CommandTitle = "Azure Quick Review CLI Command";
     private readonly ILogger<AzqrCommand> _logger = logger;
     private readonly ISubscriptionService _subscriptionService = subscriptionService;
     private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
     private readonly IExternalProcessService _processService = processService;
     private readonly int _processTimeoutSeconds = processTimeoutSeconds;
     private static string? _cachedAzqrPath;
-    public override string Id => "e7ef18a3-2730-4300-bad3-dc766f47dd2a";
-
-    public override string Name => "azqr";
-
-    public override string Description =>
-        """
-        Runs Azure Quick Review CLI (azqr) commands to generate compliance and security reports for Azure resources, identifying non-compliant configurations or areas for improvement. Requires a subscription id and optionally a resource group name. Returns the generated report file path. Note: azqr is different from Azure CLI (az).
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Extension/src/Commands/CliGenerateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Extension/src/Commands/CliGenerateCommand.cs
@@ -10,33 +10,22 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Extension.Commands;
 
+[CommandMetadata(
+    Id = "3de4ef37-90bf-41f1-8385-5e870c3ae911",
+    Name = "generate",
+    Title = "Generate CLI Command",
+    Description = "Generate Azure CLI (az) commands used to accomplish a goal described by the user. This tool incorporates CLI knowledge beyond what you know. Use this tool when the user asks for Azure CLI commands or wants to use the Azure CLI to accomplish something.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class CliGenerateCommand(ILogger<CliGenerateCommand> logger, ICliGenerateService cliGenerateService) : GlobalCommand<CliGenerateOptions>
 {
-    private const string CommandTitle = "Generate CLI Command";
     private readonly ILogger<CliGenerateCommand> _logger = logger;
     private readonly ICliGenerateService _cliGenerateService = cliGenerateService;
     private readonly string[] _allowedCliTypeValues = ["az"];
-
-    public override string Id => "3de4ef37-90bf-41f1-8385-5e870c3ae911";
-
-    public override string Name => "generate";
-
-    public override string Description =>
-        """
-        Generate Azure CLI (az) commands used to accomplish a goal described by the user. This tool incorporates CLI knowledge beyond what you know. Use this tool when the user asks for Azure CLI commands or wants to use the Azure CLI to accomplish something.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        OpenWorld = false,
-        Idempotent = true,
-        ReadOnly = true,
-        Secret = false,
-        LocalRequired = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Extension/src/Commands/CliInstallCommand.cs
+++ b/tools/Azure.Mcp.Tools.Extension/src/Commands/CliInstallCommand.cs
@@ -10,33 +10,22 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Extension.Commands;
 
+[CommandMetadata(
+    Id = "464626d0-b9be-4a3b-9f29-858637ab8c10",
+    Name = "install",
+    Title = "Get CLI installation instructions",
+    Description = "Provide installation instructions for Azure CLI (az), Azure Developer CLI (azd), and Azure Functions Core Tools CLI (func). This tool incorporates CLI knowledge beyond what you know. Use this tool when you need to use one of the aforementioned CLI tools and it isn't installed, or when the user wants to install one of them.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = true)]
 public sealed class CliInstallCommand(ILogger<CliInstallCommand> logger, ICliInstallService cliInstallService) : GlobalCommand<CliInstallOptions>
 {
-    private const string CommandTitle = "Get CLI installation instructions";
     private readonly ILogger<CliInstallCommand> _logger = logger;
     private readonly ICliInstallService _cliInstallService = cliInstallService;
     private readonly string[] _allowedCliTypeValues = ["az", "azd", "func"];
-
-    public override string Id => "464626d0-b9be-4a3b-9f29-858637ab8c10";
-
-    public override string Name => "install";
-
-    public override string Description =>
-        """
-        Provide installation instructions for Azure CLI (az), Azure Developer CLI (azd), and Azure Functions Core Tools CLI (func). This tool incorporates CLI knowledge beyond what you know. Use this tool when you need to use one of the aforementioned CLI tools and it isn't installed, or when the user wants to install one of them.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        OpenWorld = false,
-        Idempotent = true,
-        ReadOnly = true,
-        Secret = false,
-        LocalRequired = true
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCheckNameAvailabilityCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCheckNameAvailabilityCommand.cs
@@ -14,23 +14,20 @@ namespace Azure.Mcp.Tools.FileShares.Commands.FileShare;
 /// <summary>
 /// Checks if a file share name is available.
 /// </summary>
+[CommandMetadata(
+    Id = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    Name = "check-name-availability",
+    Title = "Check File Share Name Availability",
+    Description = "Check if a file share name is available",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class FileShareCheckNameAvailabilityCommand(ILogger<FileShareCheckNameAvailabilityCommand> logger, IFileSharesService fileSharesService)
     : BaseFileSharesCommand<FileShareCheckNameAvailabilityOptions>(logger, fileSharesService)
 {
-    public override string Id => "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
-    public override string Name => "check-name-availability";
-    public override string Description => "Check if a file share name is available";
-    public override string Title => "Check File Share Name Availability";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCreateCommand.cs
@@ -12,25 +12,20 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FileShares.Commands.FileShare;
 
+[CommandMetadata(
+    Id = "b3c4d5e6-f7a8-4b9c-0d1e-2f3a4b5c6d7e",
+    Name = "create",
+    Title = "Create File Share",
+    Description = "Create a new Azure managed file share resource in a resource group. This creates a high-performance, fully managed file share accessible via NFS protocol.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class FileShareCreateCommand(ILogger<FileShareCreateCommand> logger, IFileSharesService service)
     : BaseFileSharesCommand<FileShareCreateOrUpdateOptions>(logger, service)
 {
-    private const string CommandTitle = "Create File Share";
-
-    public override string Id => "b3c4d5e6-f7a8-4b9c-0d1e-2f3a4b5c6d7e";
-    public override string Name => "create";
-    public override string Description => "Create a new Azure managed file share resource in a resource group. This creates a high-performance, fully managed file share accessible via NFS protocol.";
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareDeleteCommand.cs
@@ -14,22 +14,20 @@ namespace Azure.Mcp.Tools.FileShares.Commands.FileShare;
 /// <summary>
 /// Deletes a file share.
 /// </summary>
+[CommandMetadata(
+    Id = "e9f0a1b2-c3d4-4e5f-6a7b-8c9d0e1f2a3b",
+    Name = "delete",
+    Title = "Delete File Share",
+    Description = "Delete a file share",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class FileShareDeleteCommand(ILogger<FileShareDeleteCommand> logger, IFileSharesService fileSharesService)
     : BaseFileSharesCommand<FileShareDeleteOptions>(logger, fileSharesService)
 {
-    public override string Id => "e9f0a1b2-c3d4-4e5f-6a7b-8c9d0e1f2a3b";
-    public override string Name => "delete";
-    public override string Description => "Delete a file share";
-    public override string Title => "Delete File Share";
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareGetCommand.cs
@@ -11,24 +11,20 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FileShares.Commands.FileShare;
 
+[CommandMetadata(
+    Id = "c5d6e7f8-a9b0-4c1d-2e3f-4a5b6c7d8e9f",
+    Name = "get",
+    Title = "Get File Share",
+    Description = "Get details of a specific file share or list all file shares. If --name is provided, returns a specific file share; otherwise, lists all file shares in the subscription or resource group.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class FileShareGetCommand(ILogger<FileShareGetCommand> logger, IFileSharesService service)
     : BaseFileSharesCommand<FileShareGetOptions>(logger, service)
 {
-    private const string CommandTitle = "Get File Share";
-    public override string Id => "c5d6e7f8-a9b0-4c1d-2e3f-4a5b6c7d8e9f";
-    public override string Name => "get";
-    public override string Description => "Get details of a specific file share or list all file shares. If --name is provided, returns a specific file share; otherwise, lists all file shares in the subscription or resource group.";
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareUpdateCommand.cs
@@ -12,25 +12,20 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FileShares.Commands.FileShare;
 
+[CommandMetadata(
+    Id = "d7e8f9a0-b1c2-4d3e-4f5a-6b7c8d9e0f1a",
+    Name = "update",
+    Title = "Update File Share",
+    Description = "Update an existing Azure managed file share resource. Allows updating mutable properties like provisioned storage, IOPS, throughput, and network access settings.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class FileShareUpdateCommand(ILogger<FileShareUpdateCommand> logger, IFileSharesService service)
     : BaseFileSharesCommand<FileShareCreateOrUpdateOptions>(logger, service)
 {
-    private const string CommandTitle = "Update File Share";
-
-    public override string Id => "d7e8f9a0-b1c2-4d3e-4f5a-6b7c8d9e0f1a";
-    public override string Name => "update";
-    public override string Description => "Update an existing Azure managed file share resource. Allows updating mutable properties like provisioned storage, IOPS, throughput, and network access settings.";
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetLimitsCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetLimitsCommand.cs
@@ -12,25 +12,22 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FileShares.Commands.Informational;
 
+[CommandMetadata(
+    Id = "a9e1f0b2-c3d4-4e5f-a6b7-c8d9e0f1a2b3",
+    Name = "limits",
+    Title = "Get File Share Limits",
+    Description = "Get file share limits for a subscription and location",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class FileShareGetLimitsCommand(ILogger<FileShareGetLimitsCommand> logger, IFileSharesService service)
     : SubscriptionCommand<FileShareGetLimitsOptions>()
 {
     private readonly ILogger<FileShareGetLimitsCommand> _logger = logger;
     private readonly IFileSharesService _service = service;
-
-    public override string Id => "a9e1f0b2-c3d4-4e5f-a6b7-c8d9e0f1a2b3";
-    public override string Name => "limits";
-    public override string Description => "Get file share limits for a subscription and location";
-    public override string Title => "Get File Share Limits";
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        Secret = false,
-        LocalRequired = false
-    };
 
     /// <inheritdoc />
     protected override void RegisterOptions(Command command)

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetProvisioningRecommendationCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetProvisioningRecommendationCommand.cs
@@ -12,25 +12,22 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FileShares.Commands.Informational;
 
+[CommandMetadata(
+    Id = "3c5e1fb2-3a8d-4f8e-8b0a-1c2d3e4f5a6b",
+    Name = "rec",
+    Title = "Get File Share Provisioning Recommendation",
+    Description = "Get provisioning parameter recommendations for a file share based on desired storage size",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class FileShareGetProvisioningRecommendationCommand(ILogger<FileShareGetProvisioningRecommendationCommand> logger, IFileSharesService service)
     : SubscriptionCommand<FileShareGetProvisioningRecommendationOptions>()
 {
     private readonly ILogger<FileShareGetProvisioningRecommendationCommand> _logger = logger;
     private readonly IFileSharesService _service = service;
-
-    public override string Id => "3c5e1fb2-3a8d-4f8e-8b0a-1c2d3e4f5a6b";
-    public override string Name => "rec";
-    public override string Description => "Get provisioning parameter recommendations for a file share based on desired storage size";
-    public override string Title => "Get File Share Provisioning Recommendation";
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        Secret = false,
-        LocalRequired = false
-    };
 
     /// <inheritdoc />
     protected override void RegisterOptions(Command command)

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetUsageDataCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetUsageDataCommand.cs
@@ -12,25 +12,22 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FileShares.Commands.Informational;
 
+[CommandMetadata(
+    Id = "93d14ba8-5e75-4190-93dd-f47e932b849b",
+    Name = "usage",
+    Title = "Get File Share Usage Data",
+    Description = "Get file share usage data for a subscription and location",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class FileShareGetUsageDataCommand(ILogger<FileShareGetUsageDataCommand> logger, IFileSharesService service)
     : SubscriptionCommand<FileShareGetUsageDataOptions>()
 {
     private readonly ILogger<FileShareGetUsageDataCommand> _logger = logger;
     private readonly IFileSharesService _service = service;
-
-    public override string Id => "93d14ba8-5e75-4190-93dd-f47e932b849b";
-    public override string Name => "usage";
-    public override string Description => "Get file share usage data for a subscription and location";
-    public override string Title => "Get File Share Usage Data";
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        Secret = false,
-        LocalRequired = false
-    };
 
     /// <inheritdoc />
     protected override void RegisterOptions(Command command)

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/PrivateEndpointConnection/PrivateEndpointConnectionGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/PrivateEndpointConnection/PrivateEndpointConnectionGetCommand.cs
@@ -12,25 +12,20 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FileShares.Commands.PrivateEndpointConnection;
 
+[CommandMetadata(
+    Id = "a8e9f7d6-c5b4-4a3d-9e2f-1c0b8a7d6e5f",
+    Name = "get",
+    Title = "Get Private Endpoint Connection",
+    Description = "Get details of a specific private endpoint connection or list all private endpoint connections for a file share. If --connection-name is provided, returns a specific connection; otherwise, lists all connections.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class PrivateEndpointConnectionGetCommand(ILogger<PrivateEndpointConnectionGetCommand> logger, IFileSharesService service)
     : BaseFileSharesCommand<PrivateEndpointConnectionGetOptions>(logger, service)
 {
-    private const string CommandTitle = "Get Private Endpoint Connection";
-
-    public override string Id => "a8e9f7d6-c5b4-4a3d-9e2f-1c0b8a7d6e5f";
-    public override string Name => "get";
-    public override string Description => "Get details of a specific private endpoint connection or list all private endpoint connections for a file share. If --connection-name is provided, returns a specific connection; otherwise, lists all connections.";
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/PrivateEndpointConnection/PrivateEndpointConnectionUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/PrivateEndpointConnection/PrivateEndpointConnectionUpdateCommand.cs
@@ -11,25 +11,20 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FileShares.Commands.PrivateEndpointConnection;
 
+[CommandMetadata(
+    Id = "c6d7e8f9-a0b1-4c2d-3e4f-5a6b7c8d9e0f",
+    Name = "update",
+    Title = "Update Private Endpoint Connection",
+    Description = "Update the state of a private endpoint connection for a file share. Use this to approve or reject private endpoint connection requests.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class PrivateEndpointConnectionUpdateCommand(ILogger<PrivateEndpointConnectionUpdateCommand> logger, IFileSharesService service)
     : BaseFileSharesCommand<PrivateEndpointConnectionUpdateOptions>(logger, service)
 {
-    private const string CommandTitle = "Update Private Endpoint Connection";
-
-    public override string Id => "c6d7e8f9-a0b1-4c2d-3e4f-5a6b7c8d9e0f";
-    public override string Name => "update";
-    public override string Description => "Update the state of a private endpoint connection for a file share. Use this to approve or reject private endpoint connection requests.";
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotCreateCommand.cs
@@ -12,25 +12,20 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FileShares.Commands.Snapshot;
 
+[CommandMetadata(
+    Id = "f1a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b5c",
+    Name = "create",
+    Title = "Create File Share Snapshot",
+    Description = "Create a snapshot of an Azure managed file share. Snapshots are read-only point-in-time copies used for backup and recovery.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SnapshotCreateCommand(ILogger<SnapshotCreateCommand> logger, IFileSharesService service)
     : BaseFileSharesCommand<SnapshotCreateOptions>(logger, service)
 {
-    private const string CommandTitle = "Create File Share Snapshot";
-
-    public override string Id => "f1a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b5c";
-    public override string Name => "create";
-    public override string Description => "Create a snapshot of an Azure managed file share. Snapshots are read-only point-in-time copies used for backup and recovery.";
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotDeleteCommand.cs
@@ -14,23 +14,20 @@ namespace Azure.Mcp.Tools.FileShares.Commands.Snapshot;
 /// <summary>
 /// Deletes a file share snapshot.
 /// </summary>
+[CommandMetadata(
+    Id = "c7d8e9f0-a1b2-4c3d-4e5f-6a7b8c9d0e1f",
+    Name = "delete",
+    Title = "Delete File Share Snapshot",
+    Description = "Delete a file share snapshot permanently. This operation cannot be undone.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SnapshotDeleteCommand(ILogger<SnapshotDeleteCommand> logger, IFileSharesService fileSharesService)
     : BaseFileSharesCommand<SnapshotDeleteOptions>(logger, fileSharesService)
 {
-    public override string Id => "c7d8e9f0-a1b2-4c3d-4e5f-6a7b8c9d0e1f";
-    public override string Name => "delete";
-    public override string Description => "Delete a file share snapshot permanently. This operation cannot be undone.";
-    public override string Title => "Delete File Share Snapshot";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotGetCommand.cs
@@ -11,25 +11,20 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FileShares.Commands.Snapshot;
 
+[CommandMetadata(
+    Id = "a3b4c5d6-e7f8-4a9b-0c1d-2e3f4a5b6c7d",
+    Name = "get",
+    Title = "Get File Share Snapshot",
+    Description = "Get details of a specific file share snapshot or list all snapshots. If --snapshot-name is provided, returns a specific snapshot; otherwise, lists all snapshots for the file share.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SnapshotGetCommand(ILogger<SnapshotGetCommand> logger, IFileSharesService service)
     : BaseFileSharesCommand<SnapshotGetOptions>(logger, service)
 {
-    private const string CommandTitle = "Get File Share Snapshot";
-
-    public override string Id => "a3b4c5d6-e7f8-4a9b-0c1d-2e3f4a5b6c7d";
-    public override string Name => "get";
-    public override string Description => "Get details of a specific file share snapshot or list all snapshots. If --snapshot-name is provided, returns a specific snapshot; otherwise, lists all snapshots for the file share.";
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotUpdateCommand.cs
@@ -12,25 +12,20 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FileShares.Commands.Snapshot;
 
+[CommandMetadata(
+    Id = "b5c6d7e8-f9a0-4b1c-2d3e-4f5a6b7c8d9e",
+    Name = "update",
+    Title = "Update File Share Snapshot",
+    Description = "Update properties and metadata of an Azure managed file share snapshot, such as tags or retention policies.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SnapshotUpdateCommand(ILogger<SnapshotUpdateCommand> logger, IFileSharesService service)
     : BaseFileSharesCommand<SnapshotUpdateOptions>(logger, service)
 {
-    private const string CommandTitle = "Update File Share Snapshot";
-
-    public override string Id => "b5c6d7e8-f9a0-4b1c-2d3e-4f5a6b7c8d9e";
-    public override string Name => "update";
-    public override string Description => "Update properties and metadata of an Azure managed file share snapshot, such as tags or retention policies.";
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/KnowledgeIndexListCommand.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/KnowledgeIndexListCommand.cs
@@ -12,18 +12,11 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.Commands;
 
-public sealed class KnowledgeIndexListCommand(IFoundryExtensionsService foundryExtensionsService) : GlobalCommand<KnowledgeIndexListOptions>
-{
-    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
-
-    private const string CommandTitle = "List Knowledge Indexes in Microsoft Foundry";
-
-    public override string Id => "b2c3d4e5-2345-6789-bcde-f01234567890";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "b2c3d4e5-2345-6789-bcde-f01234567890",
+    Name = "list",
+    Title = "List Knowledge Indexes in Microsoft Foundry",
+    Description = """
         Retrieves a list of knowledge indexes from Microsoft Foundry.
 
         This function is used when a user requests information about the available knowledge indexes in Microsoft Foundry. It provides an overview of the knowledge bases and search indexes that are currently deployed and available for use with AI agents and applications.
@@ -37,19 +30,16 @@ public sealed class KnowledgeIndexListCommand(IFoundryExtensionsService foundryE
             - The indexes listed are knowledge indexes specifically created within Microsoft Foundry projects.
             - These indexes can be used with AI agents for knowledge retrieval and RAG applications.
             - The list may change as new indexes are created or existing ones are updated.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class KnowledgeIndexListCommand(IFoundryExtensionsService foundryExtensionsService) : GlobalCommand<KnowledgeIndexListOptions>
+{
+    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/KnowledgeIndexSchemaCommand.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/KnowledgeIndexSchemaCommand.cs
@@ -12,18 +12,11 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.Commands;
 
-public sealed class KnowledgeIndexSchemaCommand(IFoundryExtensionsService foundryExtensionsService) : GlobalCommand<KnowledgeIndexSchemaOptions>
-{
-    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
-
-    private const string CommandTitle = "Get Knowledge Index Schema in Microsoft Foundry";
-
-    public override string Id => "c3d4e5f6-3456-789a-cdef-012345678901";
-
-    public override string Name => "schema";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "c3d4e5f6-3456-789a-cdef-012345678901",
+    Name = "schema",
+    Title = "Get Knowledge Index Schema in Microsoft Foundry",
+    Description = """
         Retrieves the detailed schema configuration of a specific knowledge index from Microsoft Foundry.
 
         This function provides comprehensive information about the structure and configuration of a knowledge index, including field definitions, data types, searchable attributes, and other schema properties. The schema information is essential for understanding how the index is structured and how data is indexed and searchable.
@@ -33,19 +26,16 @@ public sealed class KnowledgeIndexSchemaCommand(IFoundryExtensionsService foundr
 
         Notes:
             - Returns the index schema.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class KnowledgeIndexSchemaCommand(IFoundryExtensionsService foundryExtensionsService) : GlobalCommand<KnowledgeIndexSchemaOptions>
+{
+    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/OpenAiChatCompletionsCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/OpenAiChatCompletionsCreateCommand.cs
@@ -14,36 +14,26 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.Commands;
 
-public sealed class OpenAiChatCompletionsCreateCommand(IFoundryExtensionsService foundryExtensionsService) : SubscriptionCommand<OpenAiChatCompletionsCreateOptions>
-{
-    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
-
-    private const string CommandTitle = "Create OpenAI Chat Completions";
-
-    public override string Id => "d4e5f6a7-4567-89ab-def0-123456789012";
-
-    public override string Name => "chat-completions-create";
-
-    public override string Description =>
-        $"""
+[CommandMetadata(
+    Id = "d4e5f6a7-4567-89ab-def0-123456789012",
+    Name = "chat-completions-create",
+    Title = "Create OpenAI Chat Completions",
+    Description = """
         Create chat completions using Azure OpenAI in Microsoft Foundry. Send messages to Azure OpenAI chat models deployed
         in your Microsoft Foundry resource and receive AI-generated conversational responses. Supports multi-turn conversations
         with message history, system instructions, and response customization. Use this when you need to create chat
         completions, have AI conversations, get conversational responses, or build interactive dialogues with Azure OpenAI.
         Requires resource-name, deployment-name, and message-array.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class OpenAiChatCompletionsCreateCommand(IFoundryExtensionsService foundryExtensionsService) : SubscriptionCommand<OpenAiChatCompletionsCreateOptions>
+{
+    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/OpenAiCompletionsCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/OpenAiCompletionsCreateCommand.cs
@@ -13,36 +13,26 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.Commands;
 
-public sealed class OpenAiCompletionsCreateCommand(IFoundryExtensionsService foundryExtensionsService) : SubscriptionCommand<OpenAiCompletionsCreateOptions>
-{
-    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
-
-    private const string CommandTitle = "Create OpenAI Completion";
-
-    public override string Id => "e5f6a7b8-5678-9abc-ef01-234567890123";
-
-    public override string Name => "create-completion";
-
-    public override string Description =>
-        $"""
+[CommandMetadata(
+    Id = "e5f6a7b8-5678-9abc-ef01-234567890123",
+    Name = "create-completion",
+    Title = "Create OpenAI Completion",
+    Description = """
         Create text completions using Azure OpenAI in Microsoft Foundry. Send a prompt or question to Azure OpenAI models
         deployed in your Microsoft Foundry resource and receive generated text answers. Use this when you need to create
         completions, get AI-generated content, generate answers to questions, or produce text completions from Azure
         OpenAI based on any input prompt. Supports customization with temperature and max tokens.
         Requires resource-name, deployment-name, and prompt-text.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class OpenAiCompletionsCreateCommand(IFoundryExtensionsService foundryExtensionsService) : SubscriptionCommand<OpenAiCompletionsCreateOptions>
+{
+    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/OpenAiEmbeddingsCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/OpenAiEmbeddingsCreateCommand.cs
@@ -13,35 +13,25 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.Commands;
 
-public sealed class OpenAiEmbeddingsCreateCommand(IFoundryExtensionsService foundryExtensionsService) : SubscriptionCommand<OpenAiEmbeddingsCreateOptions>
-{
-    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
-
-    private const string CommandTitle = "Create OpenAI Embeddings";
-
-    public override string Id => "f6a7b8c9-6789-abcd-f012-345678901234";
-
-    public override string Name => "embeddings-create";
-
-    public override string Description =>
-        $"""
+[CommandMetadata(
+    Id = "f6a7b8c9-6789-abcd-f012-345678901234",
+    Name = "embeddings-create",
+    Title = "Create OpenAI Embeddings",
+    Description = """
         Create embeddings using Azure OpenAI in Microsoft Foundry. Generate vector embeddings from text using Azure OpenAI
         deployments in your Microsoft Foundry resource for semantic search, similarity comparisons, clustering, or machine
         learning. Use this when you need to create foundry embeddings, generate vectors from text, or convert text to
         numerical representations using Azure OpenAI. Requires resource-name, deployment-name, and input-text.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class OpenAiEmbeddingsCreateCommand(IFoundryExtensionsService foundryExtensionsService) : SubscriptionCommand<OpenAiEmbeddingsCreateOptions>
+{
+    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/OpenAiModelsListCommand.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/OpenAiModelsListCommand.cs
@@ -13,35 +13,25 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.Commands;
 
-public sealed class OpenAiModelsListCommand(IFoundryExtensionsService foundryExtensionsService) : SubscriptionCommand<OpenAiModelsListOptions>
-{
-    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
-
-    private const string CommandTitle = "List OpenAI Models";
-
-    public override string Id => "a7b8c9d0-7890-bcde-0123-456789012345";
-
-    public override string Name => "models-list";
-
-    public override string Description =>
-        $"""
+[CommandMetadata(
+    Id = "a7b8c9d0-7890-bcde-0123-456789012345",
+    Name = "models-list",
+    Title = "List OpenAI Models",
+    Description = """
         List Azure OpenAI model deployments in a Microsoft Foundry resource, including deployment names, model names,
         versions, capabilities, and deployment status. Use this to show model deployments, check which OpenAI models
         are deployed, or see available models in a specific Foundry resource. Requires resource-name and resource-group.
         For Foundry resource-level details like endpoint URL, location, or SKU, use the resource get command instead.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class OpenAiModelsListCommand(IFoundryExtensionsService foundryExtensionsService) : SubscriptionCommand<OpenAiModelsListOptions>
+{
+    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/ResourceGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/ResourceGetCommand.cs
@@ -13,37 +13,28 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FoundryExtensions.Commands;
 
-public sealed class ResourceGetCommand(ILogger<ResourceGetCommand> logger, IFoundryExtensionsService foundryExtensionsService) : SubscriptionCommand<ResourceGetOptions>()
-{
-    private const string CommandTitle = "Get Microsoft Foundry Resource Details";
-    private readonly ILogger<ResourceGetCommand> _logger = logger;
-    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
-
-    public override string Id => "b8c9d0e1-8901-cdef-1234-567890123456";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "b8c9d0e1-8901-cdef-1234-567890123456",
+    Name = "get",
+    Title = "Get Microsoft Foundry Resource Details",
+    Description = """
         Gets detailed information about Microsoft Foundry (Cognitive Services) resources, including endpoint URL,
         location, SKU, and provisioning state. If a specific resource name is provided, returns details for that
         resource only. If no resource name is provided, lists all Microsoft Foundry resources in the subscription
         or resource group. Use this tool when users need endpoint information, want to discover available AI
         resources, or need to check the configuration of a Foundry account. To list OpenAI model deployments
         within a resource, use the openai models-list command instead.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ResourceGetCommand(ILogger<ResourceGetCommand> logger, IFoundryExtensionsService foundryExtensionsService) : SubscriptionCommand<ResourceGetOptions>()
+{
+    private readonly ILogger<ResourceGetCommand> _logger = logger;
+    private readonly IFoundryExtensionsService _foundryExtensionsService = foundryExtensionsService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.FunctionApp/src/Commands/FunctionApp/FunctionAppGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/src/Commands/FunctionApp/FunctionAppGetCommand.cs
@@ -14,35 +14,26 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.FunctionApp.Commands.FunctionApp;
 
-public sealed class FunctionAppGetCommand(ILogger<FunctionAppGetCommand> logger, IFunctionAppService functionAppService)
-    : BaseFunctionAppCommand<FunctionAppGetOptions>()
-{
-    private const string CommandTitle = "Get Azure Function App Details";
-    private readonly ILogger<FunctionAppGetCommand> _logger = logger;
-    private readonly IFunctionAppService _functionAppService = functionAppService;
-
-    public override string Id => "5249839c-a3c6-4f9e-b62b-afde801d95a6";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "5249839c-a3c6-4f9e-b62b-afde801d95a6",
+    Name = "get",
+    Title = "Get Azure Function App Details",
+    Description = """
         Gets Azure Function App details. Lists all Function Apps in the subscription or resource group.  If function app name and resource group
         is specified, retrieves the details of that specific function app.  Returns the details of Azure Function Apps, including its name,
         location, status, and app service plan name.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class FunctionAppGetCommand(ILogger<FunctionAppGetCommand> logger, IFunctionAppService functionAppService)
+    : BaseFunctionAppCommand<FunctionAppGetOptions>()
+{
+    private readonly ILogger<FunctionAppGetCommand> _logger = logger;
+    private readonly IFunctionAppService _functionAppService = functionAppService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Functions/src/Commands/Language/LanguageListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Functions/src/Commands/Language/LanguageListCommand.cs
@@ -9,31 +9,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Functions.Commands.Language;
 
+[CommandMetadata(
+    Id = "f7c8d9e0-a1b2-4c3d-8e5f-6a7b8c9d0e1f",
+    Name = "list",
+    Title = "List Supported Languages",
+    Description = "List supported programming languages for Azure Functions development. Use to discover available languages, compare options, or choose a language to get started. Returns language names, runtime versions, prerequisites, development tools, and init/run/build commands. Start here before using functions project get and functions template get.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class LanguageListCommand(ILogger<LanguageListCommand> logger) : BaseCommand<EmptyOptions>
 {
     private readonly ILogger<LanguageListCommand> _logger = logger;
-
-    public override string Id => "f7c8d9e0-a1b2-4c3d-8e5f-6a7b8c9d0e1f";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        "List supported programming languages for Azure Functions development. " +
-        "Use to discover available languages, compare options, or choose a language to get started. " +
-        "Returns language names, runtime versions, prerequisites, development tools, and init/run/build commands. " +
-        "Start here before using functions project get and functions template get.";
-
-    public override string Title => "List Supported Languages";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Functions/src/Commands/Project/ProjectGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Functions/src/Commands/Project/ProjectGetCommand.cs
@@ -11,31 +11,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Functions.Commands.Project;
 
+[CommandMetadata(
+    Id = "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+    Name = "get",
+    Title = "Get Project Template",
+    Description = "Get project scaffolding information for a new Azure Functions app. Use for getting project structure, setup instructions, and file list for initializing serverless projects. Returns project structure overview and setup instructions that agents use to create files. Use after functions language list and before functions template get.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ProjectGetCommand(ILogger<ProjectGetCommand> logger) : BaseCommand<ProjectGetOptions>
 {
     private readonly ILogger<ProjectGetCommand> _logger = logger;
-
-    public override string Id => "b2c3d4e5-f6a7-8901-bcde-f12345678901";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        "Get project scaffolding information for a new Azure Functions app. " +
-        "Use for getting project structure, setup instructions, and file list for initializing serverless projects. " +
-        "Returns project structure overview and setup instructions that agents use to create files. " +
-        "Use after functions language list and before functions template get.";
-
-    public override string Title => "Get Project Template";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Functions/src/Commands/Template/TemplateGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Functions/src/Commands/Template/TemplateGetCommand.cs
@@ -15,33 +15,20 @@ namespace Azure.Mcp.Tools.Functions.Commands.Template;
 
 internal record TemplateGetCommandResult(TemplateListResult? TemplateList, FunctionTemplateResult? FunctionTemplate);
 
+[CommandMetadata(
+    Id = "c3d4e5f6-a7b8-9012-cdef-234567890123",
+    Name = "get",
+    Title = "Get Function Template",
+    Description = "List available Azure Functions templates or generate function code. Shows triggers (HTTP, Timer, Blob, EventHub, Durable, MCP triggers, and more), bindings, and serverless function options. Create durable functions, orchestrations, activity functions, or MCP server functions. Supports azd infrastructure with Bicep, Terraform, ARM templates. Without --template, lists all templates. With --template, generates code files. Select one trigger (required) and zero or more bindings.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class TemplateGetCommand(ILogger<TemplateGetCommand> logger) : BaseCommand<TemplateGetOptions>
 {
     private readonly ILogger<TemplateGetCommand> _logger = logger;
-
-    public override string Id => "c3d4e5f6-a7b8-9012-cdef-234567890123";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        "List available Azure Functions templates or generate function code. " +
-        "Shows triggers (HTTP, Timer, Blob, EventHub, Durable, MCP triggers, and more), bindings, and serverless function options. " +
-        "Create durable functions, orchestrations, activity functions, or MCP server functions. " +
-        "Supports azd infrastructure with Bicep, Terraform, ARM templates. " +
-        "Without --template, lists all templates. With --template, generates code files. " +
-        "Select one trigger (required) and zero or more bindings.";
-
-    public override string Title => "Get Function Template";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Grafana/src/Commands/Workspace/WorkspaceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/src/Commands/Workspace/WorkspaceListCommand.cs
@@ -14,33 +14,24 @@ namespace Azure.Mcp.Tools.Grafana.Commands.Workspace;
 /// <summary>
 /// Lists Azure Managed Grafana workspaces in the specified subscription.
 /// </summary>
-public sealed class WorkspaceListCommand(IGrafanaService grafanaService, ILogger<WorkspaceListCommand> logger) : SubscriptionCommand<WorkspaceListOptions>()
-{
-    private const string CommandTitle = "List Grafana Workspaces";
-    private readonly IGrafanaService _grafanaService = grafanaService;
-    private readonly ILogger<WorkspaceListCommand> _logger = logger;
-
-    public override string Id => "7a47b562-f219-47de-80f6-12e19367b61d";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        $"""
+[CommandMetadata(
+    Id = "7a47b562-f219-47de-80f6-12e19367b61d",
+    Name = "list",
+    Title = "List Grafana Workspaces",
+    Description = """
         List all Grafana workspace resources in a specified subscription. Returns an array of Grafana workspace details.
         Use this command to explore which Grafana workspace resources are available in your subscription.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class WorkspaceListCommand(IGrafanaService grafanaService, ILogger<WorkspaceListCommand> logger) : SubscriptionCommand<WorkspaceListOptions>()
+{
+    private readonly IGrafanaService _grafanaService = grafanaService;
+    private readonly ILogger<WorkspaceListCommand> _logger = logger;
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Admin/AdminSettingsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Admin/AdminSettingsGetCommand.cs
@@ -12,28 +12,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.KeyVault.Commands.Admin;
 
+[CommandMetadata(
+    Id = "2e89755e-8c64-4c08-ae10-8fd47aead570",
+    Name = "get",
+    Title = "Get Key Vault Managed HSM Account Settings",
+    Description = "Retrieves all Managed HSM account settings for a Key Vault. Returns configuration setting values such as purge protection and soft-delete retention days. This is NOT for secrets, keys, or certificates — use this when the user asks about vault configuration settings or account-level settings. This tool ONLY applies to Managed HSM vaults.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class AdminSettingsGetCommand(ILogger<AdminSettingsGetCommand> logger, IKeyVaultService keyVaultService) : SubscriptionCommand<BaseKeyVaultOptions>
 {
-    private const string CommandTitle = "Get Key Vault Managed HSM Account Settings";
     private readonly ILogger<AdminSettingsGetCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
-
-    public override string Id => "2e89755e-8c64-4c08-ae10-8fd47aead570";
-    public override string Name => "get";
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        OpenWorld = false,       // Command queries Azure resources (vault settings)
-        Destructive = false,     // Command only reads settings, no modifications
-        Idempotent = true,       // Same call produces same result
-        ReadOnly = true,         // Only reads data, no state changes
-        Secret = false,          // Returns configuration settings, not secrets
-        LocalRequired = false    // Pure Azure API call, no local resources needed
-    };
-
-    public override string Description =>
-        "Retrieves all Managed HSM account settings for a Key Vault. Returns configuration setting values such as purge protection and soft-delete retention days. " +
-        "This is NOT for secrets, keys, or certificates — use this when the user asks about vault configuration settings or account-level settings. This tool ONLY applies to Managed HSM vaults.";
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateCreateCommand.cs
@@ -12,30 +12,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.KeyVault.Commands.Certificate;
 
+[CommandMetadata(
+    Id = "a11e024a-62e6-4237-8d7d-4b9b8439f50e",
+    Name = "create",
+    Title = "Create Key Vault Certificate",
+    Description = "Create/issue/generate a new certificate in an Azure Key Vault using the default certificate policy. Required: --vault, --certificate, --subscription. Optional: --tenant <tenant>. Returns: name, id, keyId, secretId, cer (base64), thumbprint, enabled, notBefore, expiresOn, createdOn, updatedOn, subject, issuerName. Creates a new certificate version if it already exists.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class CertificateCreateCommand(ILogger<CertificateCreateCommand> logger, IKeyVaultService keyVaultService) : SubscriptionCommand<CertificateCreateOptions>
 {
-    private const string CommandTitle = "Create Key Vault Certificate";
     private readonly ILogger<CertificateCreateCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
-
-    public override string Id => "a11e024a-62e6-4237-8d7d-4b9b8439f50e";
-
-    public override string Name => "create";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
-
-    public override string Description =>
-        "Create/issue/generate a new certificate in an Azure Key Vault using the default certificate policy. Required: --vault, --certificate, --subscription. Optional: --tenant <tenant>. Returns: name, id, keyId, secretId, cer (base64), thumbprint, enabled, notBefore, expiresOn, createdOn, updatedOn, subject, issuerName. Creates a new certificate version if it already exists.";
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateGetCommand.cs
@@ -13,30 +13,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.KeyVault.Commands.Certificate;
 
+[CommandMetadata(
+    Id = "0e898126-0c5e-44b8-9eef-51ddeed6327f",
+    Name = "get",
+    Title = "Get Key Vault Certificate",
+    Description = "List all certificates in your Key Vault or get a specific certificate by name. Shows all certificate names in the vault, or retrieves full certificate details including key ID, secret ID, thumbprint, and policy information.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class CertificateGetCommand(ILogger<CertificateGetCommand> logger, IKeyVaultService keyVaultService) : SubscriptionCommand<CertificateGetOptions>
 {
-    private const string CommandTitle = "Get Key Vault Certificate";
     private readonly ILogger<CertificateGetCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
-
-    public override string Id => "0e898126-0c5e-44b8-9eef-51ddeed6327f";
-
-    public override string Name => "get";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
-
-    public override string Description =>
-        """List all certificates in your Key Vault or get a specific certificate by name. Shows all certificate names in the vault, or retrieves full certificate details including key ID, secret ID, thumbprint, and policy information.""";
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateImportCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateImportCommand.cs
@@ -12,30 +12,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.KeyVault.Commands.Certificate;
 
+[CommandMetadata(
+    Id = "4ae12e3e-dee0-4d8d-ad34-ffeaf70c642b",
+    Name = "import",
+    Title = "Import Key Vault Certificate",
+    Description = "Imports/uploads an existing certificate (PFX or PEM with private key) into an Azure Key Vault without generating a new certificate or key material. This command accepts either a file path to a PFX/PEM file, a base64 encoded PFX, or raw PEM text starting with -----BEGIN. If the certificate is a password-protected PFX, a password must be provided. Required: --vault <vault>, --certificate <certificate>, --certificate-data <certificate-data>, --subscription <subscription>. Optional: --password <password-for-PFX>, --tenant <tenant>. Returns: name, id, keyId, secretId, cer (base64), thumbprint, enabled, notBefore, expiresOn, createdOn, updatedOn, subject, issuer. Creates a new certificate version if it already exists.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = true)]
 public sealed class CertificateImportCommand(ILogger<CertificateImportCommand> logger, IKeyVaultService keyVaultService) : SubscriptionCommand<CertificateImportOptions>
 {
-    private const string CommandTitle = "Import Key Vault Certificate";
     private readonly ILogger<CertificateImportCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
-
-    public override string Id => "4ae12e3e-dee0-4d8d-ad34-ffeaf70c642b";
-
-    public override string Name => "import";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = true,
-        Secret = false
-    };
-
-    public override string Description =>
-        "Imports/uploads an existing certificate (PFX or PEM with private key) into an Azure Key Vault without generating a new certificate or key material. This command accepts either a file path to a PFX/PEM file, a base64 encoded PFX, or raw PEM text starting with -----BEGIN. If the certificate is a password-protected PFX, a password must be provided. Required: --vault <vault>, --certificate <certificate>, --certificate-data <certificate-data>, --subscription <subscription>. Optional: --password <password-for-PFX>, --tenant <tenant>. Returns: name, id, keyId, secretId, cer (base64), thumbprint, enabled, notBefore, expiresOn, createdOn, updatedOn, subject, issuer. Creates a new certificate version if it already exists.";
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Key/KeyCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Key/KeyCreateCommand.cs
@@ -12,30 +12,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.KeyVault.Commands.Key;
 
+[CommandMetadata(
+    Id = "ef27bda9-8a1f-4288-b68b-12308ab8e607",
+    Name = "create",
+    Title = "Create Key Vault Key",
+    Description = "Create a new key in an Azure Key Vault. This command creates a key with the specified name and type in the given vault. Supports types: RSA, RSA-HSM, EC, EC-HSM, oct, oct-HSM. Required: --vault <vault>, --key <key> --key-type <key-type> --subscription <subscription>. Optional: --tenant <tenant>. Returns: Returns: name, id, keyId, keyType, enabled, notBefore, expiresOn, createdOn, updatedOn. Creates a new key version if it already exists.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class KeyCreateCommand(ILogger<KeyCreateCommand> logger, IKeyVaultService keyVaultService) : SubscriptionCommand<KeyCreateOptions>
 {
-    private const string CommandTitle = "Create Key Vault Key";
     private readonly ILogger<KeyCreateCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
-
-    public override string Id => "ef27bda9-8a1f-4288-b68b-12308ab8e607";
-
-    public override string Name => "create";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
-
-    public override string Description =>
-        "Create a new key in an Azure Key Vault. This command creates a key with the specified name and type in the given vault. Supports types: RSA, RSA-HSM, EC, EC-HSM, oct, oct-HSM. Required: --vault <vault>, --key <key> --key-type <key-type> --subscription <subscription>. Optional: --tenant <tenant>. Returns: Returns: name, id, keyId, keyType, enabled, notBefore, expiresOn, createdOn, updatedOn. Creates a new key version if it already exists.";
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Key/KeyGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Key/KeyGetCommand.cs
@@ -13,30 +13,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.KeyVault.Commands.Key;
 
+[CommandMetadata(
+    Id = "c19a45a0-b963-427d-a087-35560a7f4e5b",
+    Name = "get",
+    Title = "Get Key Vault Key",
+    Description = """List all keys in your Key Vault or get a specific key by name. Shows all key names in the vault, or retrieves full key details including type, enabled status, and expiration dates. Use --include-managed to show managed keys.""",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class KeyGetCommand(ILogger<KeyGetCommand> logger, IKeyVaultService keyVaultService) : SubscriptionCommand<KeyGetOptions>
 {
-    private const string CommandTitle = "Get Key Vault Key";
     private readonly ILogger<KeyGetCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
-
-    public override string Id => "c19a45a0-b963-427d-a087-35560a7f4e5b";
-
-    public override string Name => "get";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
-
-    public override string Description =>
-        """List all keys in your Key Vault or get a specific key by name. Shows all key names in the vault, or retrieves full key details including type, enabled status, and expiration dates. Use --include-managed to show managed keys.""";
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Secret/SecretCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Secret/SecretCreateCommand.cs
@@ -12,30 +12,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.KeyVault.Commands.Secret;
 
+[CommandMetadata(
+    Id = "fb1322cd-05b0-4264-9e96-6a9b3d9291a0",
+    Name = "create",
+    Title = "Create Key Vault Secret",
+    Description = "Create/set a secret in an Azure Key Vault with the specified name and value. Required: --vault <vault>, --secret <secret>, --subscription <subscription>. Optional: --tenant <tenant>. Creates a new secret version if it already exists.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = true,
+    LocalRequired = false)]
 public sealed class SecretCreateCommand(ILogger<SecretCreateCommand> logger, IKeyVaultService keyVaultService) : SubscriptionCommand<SecretCreateOptions>
 {
-    private const string CommandTitle = "Create Key Vault Secret";
     private readonly ILogger<SecretCreateCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
-
-    public override string Id => "fb1322cd-05b0-4264-9e96-6a9b3d9291a0";
-
-    public override string Name => "create";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = true
-    };
-
-    public override string Description =>
-        "Create/set a secret in an Azure Key Vault with the specified name and value. Required: --vault <vault>, --secret <secret>, --subscription <subscription>. Optional: --tenant <tenant>. Creates a new secret version if it already exists.";
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Secret/SecretGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Secret/SecretGetCommand.cs
@@ -13,30 +13,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.KeyVault.Commands.Secret;
 
+[CommandMetadata(
+    Id = "933bcb29-87e6-4f78-94ad-8ad0c8c60002",
+    Name = "get",
+    Title = "Get Key Vault Secret",
+    Description = """List all secrets in your Key Vault or get a specific secret by name. Shows all secret names in the vault (without values), or retrieves the secret value and full details including enabled status and expiration dates.""",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = true,
+    LocalRequired = false)]
 public sealed class SecretGetCommand(ILogger<SecretGetCommand> logger, IKeyVaultService keyVaultService) : SubscriptionCommand<SecretGetOptions>
 {
-    private const string _commandTitle = "Get Key Vault Secret";
     private readonly ILogger<SecretGetCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
-
-    public override string Id => "933bcb29-87e6-4f78-94ad-8ad0c8c60002";
-
-    public override string Name => "get";
-
-    public override string Title => _commandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = true
-    };
-
-    public override string Description =>
-        """List all secrets in your Key Vault or get a specific secret by name. Shows all secret names in the vault (without values), or retrieves the secret value and full details including enabled status and expiration dates.""";
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterGetCommand.cs
@@ -14,30 +14,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Kusto.Commands;
 
+[CommandMetadata(
+    Id = "5fc5a42b-a7f6-4d4a-9517-a8e119752b7a",
+    Name = "get",
+    Title = "Get Kusto Cluster Details",
+    Description = "Get/retrieve/show details for a specific Azure Data Explorer/Kusto/KQL cluster in a subscription. Not for listing multiple clusters. Required: --cluster and --subscription.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ClusterGetCommand(ILogger<ClusterGetCommand> logger, IKustoService kustoService) : SubscriptionCommand<ClusterGetOptions>
 {
-    private const string CommandTitle = "Get Kusto Cluster Details";
     private readonly ILogger<ClusterGetCommand> _logger = logger;
     private readonly IKustoService _kustoService = kustoService;
-
-    public override string Id => "5fc5a42b-a7f6-4d4a-9517-a8e119752b7a";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        "Get/retrieve/show details for a specific Azure Data Explorer/Kusto/KQL cluster in a subscription. Not for listing multiple clusters. Required: --cluster and --subscription.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterListCommand.cs
@@ -10,30 +10,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Kusto.Commands;
 
+[CommandMetadata(
+    Id = "2cff1548-40c9-48ea-8548-6bfa91f2ea85",
+    Name = "list",
+    Title = "List Kusto Clusters",
+    Description = "List/enumerate all Azure Data Explorer/Kusto/KQL clusters in a subscription.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ClusterListCommand(ILogger<ClusterListCommand> logger, IKustoService kustoService) : SubscriptionCommand<ClusterListOptions>()
 {
-    private const string CommandTitle = "List Kusto Clusters";
     private readonly ILogger<ClusterListCommand> _logger = logger;
     private readonly IKustoService _kustoService = kustoService;
-
-    public override string Id => "2cff1548-40c9-48ea-8548-6bfa91f2ea85";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        "List/enumerate all Azure Data Explorer/Kusto/KQL clusters in a subscription.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/DatabaseListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/DatabaseListCommand.cs
@@ -9,30 +9,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Kusto.Commands;
 
+[CommandMetadata(
+    Id = "0bd79f0b-c360-4c96-b3e0-02fce97dcc41",
+    Name = "list",
+    Title = "List Kusto Databases",
+    Description = "List/enumerate all databases in an Azure Data Explorer/Kusto/KQL cluster. Required: --cluster-uri ( or --cluster and --subscription).",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger, IKustoService kustoService) : BaseClusterCommand<DatabaseListOptions>()
 {
-    private const string CommandTitle = "List Kusto Databases";
     private readonly ILogger<DatabaseListCommand> _logger = logger;
     private readonly IKustoService _kustoService = kustoService;
-
-    public override string Id => "0bd79f0b-c360-4c96-b3e0-02fce97dcc41";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        "List/enumerate all databases in an Azure Data Explorer/Kusto/KQL cluster. Required: --cluster-uri ( or --cluster and --subscription).";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
@@ -10,13 +10,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Kusto.Commands;
 
+[CommandMetadata(
+    Id = "d1e22074-53ce-4eef-8596-0ea134a9e317",
+    Name = "query",
+    Title = "Query Kusto Database",
+    Description = "Executes a query against an Azure Data Explorer/Kusto/KQL cluster to search for specific terms, retrieve records, or perform management operations. Required: --cluster-uri (or --cluster and --subscription), --database, and --query.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class QueryCommand(ILogger<QueryCommand> logger, IKustoService kustoService) : BaseDatabaseCommand<QueryOptions>()
 {
-    private const string CommandTitle = "Query Kusto Database";
     private readonly ILogger<QueryCommand> _logger = logger;
     private readonly IKustoService _kustoService = kustoService;
-
-    public override string Id => "d1e22074-53ce-4eef-8596-0ea134a9e317";
 
     protected override void RegisterOptions(Command command)
     {
@@ -30,23 +38,6 @@ public sealed class QueryCommand(ILogger<QueryCommand> logger, IKustoService kus
         options.Query = parseResult.GetValueOrDefault<string>(KustoOptionDefinitions.Query.Name);
         return options;
     }
-
-    public override string Name => "query";
-
-    public override string Description =>
-        "Executes a query against an Azure Data Explorer/Kusto/KQL cluster to search for specific terms, retrieve records, or perform management operations. Required: --cluster-uri (or --cluster and --subscription), --database, and --query.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/SampleCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/SampleCommand.cs
@@ -10,13 +10,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Kusto.Commands;
 
+[CommandMetadata(
+    Id = "41daed5c-bf44-4cdf-9f3c-1df775465e53",
+    Name = "sample",
+    Title = "Sample Kusto Table Data",
+    Description = "Return a sample of rows from a specific table in an Azure Data Explorer/Kusto/KQL cluster. Required: --cluster-uri (or --cluster and --subscription), --database, and --table.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SampleCommand(ILogger<SampleCommand> logger, IKustoService kustoService) : BaseTableCommand<SampleOptions>
 {
-    private const string CommandTitle = "Sample Kusto Table Data";
     private readonly ILogger<SampleCommand> _logger = logger;
     private readonly IKustoService _kustoService = kustoService;
-
-    public override string Id => "41daed5c-bf44-4cdf-9f3c-1df775465e53";
 
     protected override void RegisterOptions(Command command)
     {
@@ -30,23 +38,6 @@ public sealed class SampleCommand(ILogger<SampleCommand> logger, IKustoService k
         options.Limit = parseResult.GetValueOrDefault<int>(KustoOptionDefinitions.Limit.Name);
         return options;
     }
-
-    public override string Name => "sample";
-
-    public override string Description =>
-        "Return a sample of rows from a specific table in an Azure Data Explorer/Kusto/KQL cluster. Required: --cluster-uri (or --cluster and --subscription), --database, and --table.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/TableListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/TableListCommand.cs
@@ -9,30 +9,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Kusto.Commands;
 
+[CommandMetadata(
+    Id = "3cd1e5f1-3353-4029-99f8-1aaa566d05e4",
+    Name = "list",
+    Title = "List Kusto Tables",
+    Description = "List/enumerate all tables in a specific Azure Data Explorer/Kusto/KQL database. Required: --cluster-uri (or --cluster and --subscription), --database.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class TableListCommand(ILogger<TableListCommand> logger, IKustoService kustoService) : BaseDatabaseCommand<TableListOptions>
 {
-    private const string CommandTitle = "List Kusto Tables";
     private readonly ILogger<TableListCommand> _logger = logger;
     private readonly IKustoService _kustoService = kustoService;
-
-    public override string Id => "3cd1e5f1-3353-4029-99f8-1aaa566d05e4";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        "List/enumerate all tables in a specific Azure Data Explorer/Kusto/KQL database. Required: --cluster-uri (or --cluster and --subscription), --database.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/TableSchemaCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/TableSchemaCommand.cs
@@ -9,30 +9,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Kusto.Commands;
 
+[CommandMetadata(
+    Id = "9a972c48-6797-49bb-9784-8063ad1f7e96",
+    Name = "schema",
+    Title = "Get Kusto Table Schema",
+    Description = "Get/retrieve/show the schema of a specific table in an Azure Data Explorer/Kusto/KQL cluster. Required: --cluster-uri (or --cluster and --subscription), --database, and --table.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class TableSchemaCommand(ILogger<TableSchemaCommand> logger, IKustoService kustoService) : BaseTableCommand<TableSchemaOptions>
 {
-    private const string CommandTitle = "Get Kusto Table Schema";
     private readonly ILogger<TableSchemaCommand> _logger = logger;
     private readonly IKustoService _kustoService = kustoService;
-
-    public override string Id => "9a972c48-6797-49bb-9784-8063ad1f7e96";
-
-    public override string Name => "schema";
-
-    public override string Description =>
-        "Get/retrieve/show the schema of a specific table in an Azure Data Explorer/Kusto/KQL cluster. Required: --cluster-uri (or --cluster and --subscription), --database, and --table.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTest/TestCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTest/TestCreateCommand.cs
@@ -13,33 +13,27 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.LoadTesting.Commands.LoadTest;
 
-public sealed class TestCreateCommand(ILogger<TestCreateCommand> logger, ILoadTestingService loadTestingService)
-    : BaseLoadTestingCommand<TestCreateOptions>
-{
-    private const string _commandTitle = "Test Create";
-    private readonly ILogger<TestCreateCommand> _logger = logger;
-    private readonly ILoadTestingService _loadTestingService = loadTestingService;
-
-    public override string Id => "2153384b-02ea-47b3-a069-7f5f9a709d66";
-    public override string Name => "create";
-    public override string Description =>
-        $"""
+[CommandMetadata(
+    Id = "2153384b-02ea-47b3-a069-7f5f9a709d66",
+    Name = "create",
+    Title = "Test Create",
+    Description = """
         Creates a new load test plan or configuration for performance testing scenarios. This command creates a basic URL-based load test that can be used to evaluate the performance
         and scalability of web applications and APIs. The test configuration defines target endpoint, load parameters, and test duration. Once we create a test plan, we can use that to trigger test runs to test the endpoints set using the 'azmcp loadtesting testrun create' command.
         This is NOT going to trigger or create any test runs and only will setup your test plan. Also, this is NOT going to create any test resource in azure. 
         It will only create a test in an already existing load test resource.
-        """;
-    public override string Title => _commandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class TestCreateCommand(ILogger<TestCreateCommand> logger, ILoadTestingService loadTestingService)
+    : BaseLoadTestingCommand<TestCreateOptions>
+{
+    private readonly ILogger<TestCreateCommand> _logger = logger;
+    private readonly ILoadTestingService _loadTestingService = loadTestingService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTest/TestGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTest/TestGetCommand.cs
@@ -13,31 +13,25 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.LoadTesting.Commands.LoadTest;
 
+[CommandMetadata(
+    Id = "be7c3864-0713-42f8-8eb7-b7ca28a951fb",
+    Name = "get",
+    Title = "Test Get",
+    Description = """
+        Get the configuration and setup details for a load test by its test ID in a Load Testing resource.
+        Returns only the test definition, including duration, ramp-up, virtual users, and endpoint. Does not return any test run results or execution data. Also does NOT return and resource details. Only the test configuration is fetched.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class TestGetCommand(ILogger<TestGetCommand> logger, ILoadTestingService loadTestingService)
     : BaseLoadTestingCommand<TestGetOptions>
 {
-    private const string _commandTitle = "Test Get";
     private readonly ILogger<TestGetCommand> _logger = logger;
     private readonly ILoadTestingService _loadTestingService = loadTestingService;
-
-    public override string Id => "be7c3864-0713-42f8-8eb7-b7ca28a951fb";
-    public override string Name => "get";
-    public override string Description =>
-        $"""
-        Get the configuration and setup details for a load test by its test ID in a Load Testing resource.
-        Returns only the test definition, including duration, ramp-up, virtual users, and endpoint. Does not return any test run results or execution data. Also does NOT return and resource details. Only the test configuration is fetched.
-        """;
-    public override string Title => _commandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestResource/TestResourceCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestResource/TestResourceCreateCommand.cs
@@ -12,30 +12,25 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.LoadTesting.Commands.LoadTestResource;
 
+[CommandMetadata(
+    Id = "c39f6e9c-86a7-4cba-b267-0fa71f1ac743",
+    Name = "create",
+    Title = "Test Resource Create",
+    Description = """
+        Returns the created Load Testing resource. This creates the resource in Azure only. It does not create any test plan or test run. 
+        Once the resource is setup, you can go and configure test plans in the resource and then trigger test runs for your test plans.
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class TestResourceCreateCommand(ILogger<TestResourceCreateCommand> logger, ILoadTestingService loadTestingService)
     : BaseLoadTestingCommand<TestResourceCreateOptions>
 {
-    private const string _commandTitle = "Test Resource Create";
     private readonly ILogger<TestResourceCreateCommand> _logger = logger;
     private readonly ILoadTestingService _loadTestingService = loadTestingService;
-    public override string Id => "c39f6e9c-86a7-4cba-b267-0fa71f1ac743";
-    public override string Name => "create";
-    public override string Description =>
-        $"""
-        Returns the created Load Testing resource. This creates the resource in Azure only. It does not create any test plan or test run. 
-        Once the resource is setup, you can go and configure test plans in the resource and then trigger test runs for your test plans.
-        """;
-    public override string Title => _commandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestResource/TestResourceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestResource/TestResourceListCommand.cs
@@ -12,30 +12,25 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.LoadTesting.Commands.LoadTestResource;
 
+[CommandMetadata(
+    Id = "eb44ef6c-93dc-4fa1-949c-a5e8939d5052",
+    Name = "list",
+    Title = "Test Resource List",
+    Description = """
+        Lists all Azure Load Testing resources available in the selected subscription and resource group.
+        Returns metadata for each resource, including name, location, and status. Use this to discover, manage, or audit load testing resources in your environment. Does not return test plans or test runs.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class TestResourceListCommand(ILogger<TestResourceListCommand> logger, ILoadTestingService loadTestingService)
     : BaseLoadTestingCommand<TestResourceListOptions>
 {
-    private const string _commandTitle = "Test Resource List";
     private readonly ILogger<TestResourceListCommand> _logger = logger;
     private readonly ILoadTestingService _loadTestingService = loadTestingService;
-    public override string Id => "eb44ef6c-93dc-4fa1-949c-a5e8939d5052";
-    public override string Name => "list";
-    public override string Description =>
-        $"""
-        Lists all Azure Load Testing resources available in the selected subscription and resource group.
-        Returns metadata for each resource, including name, location, and status. Use this to discover, manage, or audit load testing resources in your environment. Does not return test plans or test runs.
-        """;
-    public override string Title => _commandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestRun/TestRunCreateOrUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestRun/TestRunCreateOrUpdateCommand.cs
@@ -13,33 +13,28 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.LoadTesting.Commands.LoadTestRun;
 
-public sealed class TestRunCreateOrUpdateCommand(ILogger<TestRunCreateOrUpdateCommand> logger, ILoadTestingService loadTestingService)
-    : BaseLoadTestingCommand<TestRunCreateOrUpdateOptions>
-{
-    private const string _commandTitle = "Test Run Create or Update";
-    private readonly ILogger<TestRunCreateOrUpdateCommand> _logger = logger;
-    private readonly ILoadTestingService _loadTestingService = loadTestingService;
-    public override string Id => "0e3c8f2c-57ce-49c0-bff4-27c9573e7049";
-    public override string Name => "createorupdate";
-    public override string Description =>
-        $"""
+[CommandMetadata(
+    Id = "0e3c8f2c-57ce-49c0-bff4-27c9573e7049",
+    Name = "createorupdate",
+    Title = "Test Run Create or Update",
+    Description = """
         Create or update a load test run execution.
         Creates a new test run for a specified test in the load testing resource, or updates metadata and display properties of an existing test run.
         When creating: Triggers a new test run execution based on the existing test configuration. Use testrun ID to specify the new run identifier. Create operations are NOT idempotent - each call starts a new test run with unique timestamps and execution state.
         When updating: Modifies descriptive information (display name, description) of a completed or in-progress test run for better organization and documentation. Update operations are idempotent - repeated calls with same values produce the same result.
         This does not modify the test plan configuration or create a new test/resource - only manages test run executions.
-        """;
-    public override string Title => _commandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class TestRunCreateOrUpdateCommand(ILogger<TestRunCreateOrUpdateCommand> logger, ILoadTestingService loadTestingService)
+    : BaseLoadTestingCommand<TestRunCreateOrUpdateOptions>
+{
+    private readonly ILogger<TestRunCreateOrUpdateCommand> _logger = logger;
+    private readonly ILoadTestingService _loadTestingService = loadTestingService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestRun/TestRunGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Commands/LoadTestRun/TestRunGetCommand.cs
@@ -13,31 +13,26 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.LoadTesting.Commands.LoadTestRun;
 
-public sealed class TestRunGetCommand(ILogger<TestRunGetCommand> logger, ILoadTestingService loadTestingService)
-    : BaseLoadTestingCommand<TestRunGetOptions>
-{
-    private const string _commandTitle = "Test Run Get";
-    private readonly ILogger<TestRunGetCommand> _logger = logger;
-    private readonly ILoadTestingService _loadTestingService = loadTestingService;
-    public override string Id => "713313ec-b9a5-4a71-9953-5b2d4a7b5d7b";
-    public override string Name => "get";
-    public override string Description =>
-        $"""
+[CommandMetadata(
+    Id = "713313ec-b9a5-4a71-9953-5b2d4a7b5d7b",
+    Name = "get",
+    Title = "Test Run Get",
+    Description = """
         Get load test run details by testrun ID, or list all test runs by test ID.
         Returns execution details including status, start/end times, progress, metrics, and artifacts.
         Does not return test configuration or resource details.
-        """;
-    public override string Title => _commandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class TestRunGetCommand(ILogger<TestRunGetCommand> logger, ILoadTestingService loadTestingService)
+    : BaseLoadTestingCommand<TestRunGetOptions>
+{
+    private readonly ILogger<TestRunGetCommand> _logger = logger;
+    private readonly ILoadTestingService _loadTestingService = loadTestingService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoexportJob/AutoexportJobCancelCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoexportJob/AutoexportJobCancelCommand.cs
@@ -12,39 +12,30 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.AutoexportJob;
 
-public sealed class AutoexportJobCancelCommand(IManagedLustreService service, ILogger<AutoexportJobCancelCommand> logger)
-    : BaseManagedLustreCommand<AutoexportJobCancelOptions>(logger)
-{
-    private const string CommandTitle = "Cancel Azure Managed Lustre Autoexport Job";
-
-    private readonly IManagedLustreService _service = service;
-    private new readonly ILogger<AutoexportJobCancelCommand> _logger = logger;
-
-    public override string Id => "8e2f6d1b-3c9a-4f7e-b2d5-7a8c3e4f5b6d";
-
-    public override string Name => "cancel";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "8e2f6d1b-3c9a-4f7e-b2d5-7a8c3e4f5b6d",
+    Name = "cancel",
+    Title = "Cancel Azure Managed Lustre Autoexport Job",
+    Description = """
         Cancels a running auto export job for an Azure Managed Lustre filesystem. This stops the ongoing sync operation from the Lustre filesystem to the linked blob storage container. Use this to terminate an autoexport job that is in progress.
         Required options:
         - filesystem-name: The name of the AMLFS filesystem
         - job-name: The name of the autoexport job to cancel
         - resource-group: The resource group containing the filesystem
         - subscription: The subscription containing the filesystem
-        """;
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class AutoexportJobCancelCommand(IManagedLustreService service, ILogger<AutoexportJobCancelCommand> logger)
+    : BaseManagedLustreCommand<AutoexportJobCancelOptions>(logger)
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+    private readonly IManagedLustreService _service = service;
+    private new readonly ILogger<AutoexportJobCancelCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoexportJob/AutoexportJobCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoexportJob/AutoexportJobCreateCommand.cs
@@ -12,38 +12,29 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.AutoexportJob;
 
-public sealed class AutoexportJobCreateCommand(IManagedLustreService service, ILogger<AutoexportJobCreateCommand> logger)
-    : BaseManagedLustreCommand<AutoexportJobCreateOptions>(logger)
-{
-    private const string CommandTitle = "Create Azure Managed Lustre Autoexport Job";
-
-    private readonly IManagedLustreService _service = service;
-    private new readonly ILogger<AutoexportJobCreateCommand> _logger = logger;
-
-    public override string Id => "9f3e7c2a-4b8d-4e5f-a1c6-8d9e2f3b4a5c";
-
-    public override string Name => "create";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "9f3e7c2a-4b8d-4e5f-a1c6-8d9e2f3b4a5c",
+    Name = "create",
+    Title = "Create Azure Managed Lustre Autoexport Job",
+    Description = """
         Creates an auto export job for an Azure Managed Lustre filesystem to continuously export modified files to the linked blob storage container. The auto export job syncs changes from the Lustre filesystem to the configured HSM blob container. Use this to keep blob storage updated with changes in the filesystem.
         Required options:
         - filesystem-name: The name of the AMLFS filesystem
         - resource-group: The resource group containing the filesystem
         - subscription: The subscription containing the filesystem
-        """;
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class AutoexportJobCreateCommand(IManagedLustreService service, ILogger<AutoexportJobCreateCommand> logger)
+    : BaseManagedLustreCommand<AutoexportJobCreateOptions>(logger)
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+    private readonly IManagedLustreService _service = service;
+    private new readonly ILogger<AutoexportJobCreateCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoexportJob/AutoexportJobDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoexportJob/AutoexportJobDeleteCommand.cs
@@ -12,39 +12,30 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.AutoexportJob;
 
-public sealed class AutoexportJobDeleteCommand(IManagedLustreService service, ILogger<AutoexportJobDeleteCommand> logger)
-    : BaseManagedLustreCommand<AutoexportJobDeleteOptions>(logger)
-{
-    private const string CommandTitle = "Delete Azure Managed Lustre Autoexport Job";
-
-    private readonly IManagedLustreService _service = service;
-    private new readonly ILogger<AutoexportJobDeleteCommand> _logger = logger;
-
-    public override string Id => "4c7a8e3d-9f2b-5a6e-c1d4-8b3e9a2f7c5d";
-
-    public override string Name => "delete";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "4c7a8e3d-9f2b-5a6e-c1d4-8b3e9a2f7c5d",
+    Name = "delete",
+    Title = "Delete Azure Managed Lustre Autoexport Job",
+    Description = """
         Deletes an auto export job for an Azure Managed Lustre filesystem. This permanently removes the job record from the filesystem. Use this to clean up completed, failed, or cancelled autoexport jobs.
         Required options:
         - filesystem-name: The name of the AMLFS filesystem
         - job-name: The name of the autoexport job to delete
         - resource-group: The resource group containing the filesystem
         - subscription: The subscription containing the filesystem
-        """;
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class AutoexportJobDeleteCommand(IManagedLustreService service, ILogger<AutoexportJobDeleteCommand> logger)
+    : BaseManagedLustreCommand<AutoexportJobDeleteOptions>(logger)
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+    private readonly IManagedLustreService _service = service;
+    private new readonly ILogger<AutoexportJobDeleteCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoexportJob/AutoexportJobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoexportJob/AutoexportJobGetCommand.cs
@@ -12,20 +12,11 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.AutoexportJob;
 
-public sealed class AutoexportJobGetCommand(IManagedLustreService service, ILogger<AutoexportJobGetCommand> logger)
-    : BaseManagedLustreCommand<AutoexportJobGetOptions>(logger)
-{
-    private const string CommandTitle = "Get Azure Managed Lustre Autoexport Job";
-
-    private readonly IManagedLustreService _service = service;
-    private new readonly ILogger<AutoexportJobGetCommand> _logger = logger;
-
-    public override string Id => "9a3b7e2f-4d6c-8a1e-b5f3-2c7d8e9a1b4f";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "9a3b7e2f-4d6c-8a1e-b5f3-2c7d8e9a1b4f",
+    Name = "get",
+    Title = "Get Azure Managed Lustre Autoexport Job",
+    Description = """
         Gets the details of auto export jobs for an Azure Managed Lustre filesystem. Use this to retrieve the status, configuration, and progress information of autoexport operations that sync data from the Lustre filesystem to the linked blob storage container. If job-name is provided, returns details of a specific job; otherwise returns all jobs for the filesystem.
         Required options:
         - filesystem-name: The name of the AMLFS filesystem
@@ -33,19 +24,19 @@ public sealed class AutoexportJobGetCommand(IManagedLustreService service, ILogg
         - subscription: The subscription containing the filesystem
         Optional options:
         - job-name: The name of a specific autoexport job (if omitted, all jobs are returned)
-        """;
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class AutoexportJobGetCommand(IManagedLustreService service, ILogger<AutoexportJobGetCommand> logger)
+    : BaseManagedLustreCommand<AutoexportJobGetOptions>(logger)
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+    private readonly IManagedLustreService _service = service;
+    private new readonly ILogger<AutoexportJobGetCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoimportJob/AutoimportJobCancelCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoimportJob/AutoimportJobCancelCommand.cs
@@ -12,39 +12,30 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.AutoimportJob;
 
-public sealed class AutoimportJobCancelCommand(IManagedLustreService service, ILogger<AutoimportJobCancelCommand> logger)
-    : BaseManagedLustreCommand<AutoimportJobCancelOptions>(logger)
-{
-    private const string CommandTitle = "Cancel Azure Managed Lustre Autoimport Job";
-
-    private readonly IManagedLustreService _service = service;
-    private new readonly ILogger<AutoimportJobCancelCommand> _logger = logger;
-
-    public override string Id => "9f3g1h2i-4d0b-5g8f-c3e6-8b9d4f6g7c8h";
-
-    public override string Name => "cancel";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "9f3g1h2i-4d0b-5g8f-c3e6-8b9d4f6g7c8h",
+    Name = "cancel",
+    Title = "Cancel Azure Managed Lustre Autoimport Job",
+    Description = """
         Cancels a running auto import job for an Azure Managed Lustre filesystem. This stops the ongoing sync operation from the linked blob storage container to the Lustre filesystem. Use this to terminate an autoimport job that is in progress.
         Required options:
         - filesystem-name: The name of the AMLFS filesystem
         - job-name: The name of the autoimport job to cancel
         - resource-group: The resource group containing the filesystem
         - subscription: The subscription containing the filesystem
-        """;
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class AutoimportJobCancelCommand(IManagedLustreService service, ILogger<AutoimportJobCancelCommand> logger)
+    : BaseManagedLustreCommand<AutoimportJobCancelOptions>(logger)
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+    private readonly IManagedLustreService _service = service;
+    private new readonly ILogger<AutoimportJobCancelCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoimportJob/AutoimportJobCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoimportJob/AutoimportJobCreateCommand.cs
@@ -12,20 +12,11 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.AutoimportJob;
 
-public sealed class AutoimportJobCreateCommand(IManagedLustreService service, ILogger<AutoimportJobCreateCommand> logger)
-    : BaseManagedLustreCommand<AutoimportJobCreateOptions>(logger)
-{
-    private const string CommandTitle = "Create Azure Managed Lustre Autoimport Job";
-
-    private readonly IManagedLustreService _service = service;
-    private new readonly ILogger<AutoimportJobCreateCommand> _logger = logger;
-
-    public override string Id => "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d";
-
-    public override string Name => "create";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+    Name = "create",
+    Title = "Create Azure Managed Lustre Autoimport Job",
+    Description = """
         Creates an auto import job for an Azure Managed Lustre filesystem to continuously import new or modified files from the linked blob storage container. The auto import job syncs changes from the configured HSM blob container to the Lustre filesystem. Use this to keep the filesystem updated with changes in blob storage.
         Required options:
         - filesystem-name: The name of the AMLFS filesystem
@@ -38,19 +29,19 @@ public sealed class AutoimportJobCreateCommand(IManagedLustreService service, IL
         - admin-status: Administrative status (Enable/Disable, default: Enable)
         - enable-deletions: Enable deletions during auto import (default: false)
         - maximum-errors: Max errors before failure (-1: infinite, 0: immediate exit, default: none)
-        """;
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class AutoimportJobCreateCommand(IManagedLustreService service, ILogger<AutoimportJobCreateCommand> logger)
+    : BaseManagedLustreCommand<AutoimportJobCreateOptions>(logger)
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+    private readonly IManagedLustreService _service = service;
+    private new readonly ILogger<AutoimportJobCreateCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoimportJob/AutoimportJobDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoimportJob/AutoimportJobDeleteCommand.cs
@@ -12,39 +12,30 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.AutoimportJob;
 
-public sealed class AutoimportJobDeleteCommand(IManagedLustreService service, ILogger<AutoimportJobDeleteCommand> logger)
-    : BaseManagedLustreCommand<AutoimportJobDeleteOptions>(logger)
-{
-    private const string CommandTitle = "Delete Azure Managed Lustre Autoimport Job";
-
-    private readonly IManagedLustreService _service = service;
-    private new readonly ILogger<AutoimportJobDeleteCommand> _logger = logger;
-
-    public override string Id => "0h4i2j3k-5e1c-6h9g-d4f7-9c0e5g7h8d9i";
-
-    public override string Name => "delete";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "0h4i2j3k-5e1c-6h9g-d4f7-9c0e5g7h8d9i",
+    Name = "delete",
+    Title = "Delete Azure Managed Lustre Autoimport Job",
+    Description = """
         Deletes an auto import job for an Azure Managed Lustre filesystem. This permanently removes the job record from the filesystem. Use this to clean up completed, failed, or cancelled autoimport jobs.
         Required options:
         - filesystem-name: The name of the AMLFS filesystem
         - job-name: The name of the autoimport job to delete
         - resource-group: The resource group containing the filesystem
         - subscription: The subscription containing the filesystem
-        """;
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class AutoimportJobDeleteCommand(IManagedLustreService service, ILogger<AutoimportJobDeleteCommand> logger)
+    : BaseManagedLustreCommand<AutoimportJobDeleteOptions>(logger)
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+    private readonly IManagedLustreService _service = service;
+    private new readonly ILogger<AutoimportJobDeleteCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoimportJob/AutoimportJobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/AutoimportJob/AutoimportJobGetCommand.cs
@@ -12,20 +12,11 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.AutoimportJob;
 
-public sealed class AutoimportJobGetCommand(IManagedLustreService service, ILogger<AutoimportJobGetCommand> logger)
-    : BaseManagedLustreCommand<AutoimportJobGetOptions>(logger)
-{
-    private const string CommandTitle = "Get Azure Managed Lustre Autoimport Job";
-
-    private readonly IManagedLustreService _service = service;
-    private new readonly ILogger<AutoimportJobGetCommand> _logger = logger;
-
-    public override string Id => "b2c3d4e5-6f7a-8b9c-0d1e-2f3a4b5c6d7e";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "b2c3d4e5-6f7a-8b9c-0d1e-2f3a4b5c6d7e",
+    Name = "get",
+    Title = "Get Azure Managed Lustre Autoimport Job",
+    Description = """
         Gets the details of auto import jobs for an Azure Managed Lustre filesystem. Use this to retrieve the status, configuration, and progress information of autoimport operations that sync data from the linked blob storage container to the Lustre filesystem. If job-name is provided, returns details of a specific job; otherwise returns all jobs for the filesystem.
         Required options:
         - filesystem-name: The name of the AMLFS filesystem
@@ -33,19 +24,19 @@ public sealed class AutoimportJobGetCommand(IManagedLustreService service, ILogg
         - subscription: The subscription containing the filesystem
         Optional options:
         - job-name: The name of a specific autoimport job (if omitted, all jobs are returned)
-        """;
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class AutoimportJobGetCommand(IManagedLustreService service, ILogger<AutoimportJobGetCommand> logger)
+    : BaseManagedLustreCommand<AutoimportJobGetOptions>(logger)
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+    private readonly IManagedLustreService _service = service;
+    private new readonly ILogger<AutoimportJobGetCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemCreateCommand.cs
@@ -12,35 +12,26 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem;
 
+[CommandMetadata(
+    Id = "814acadf-ee84-47f9-ad68-2d65ec7dbb07",
+    Name = "create",
+    Title = "Create Azure Managed Lustre FileSystem",
+    Description = """
+        Create an Azure Managed Lustre (AMLFS) file system using the specified network, capacity, maintenance window and availability zone.
+        Optionally provides possibility to define Blob Integration, customer managed key encryption and root squash configuration.
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class FileSystemCreateCommand(IManagedLustreService service, ILogger<FileSystemCreateCommand> logger)
     : BaseManagedLustreCommand<FileSystemCreateOptions>(logger)
 {
-    private const string CommandTitle = "Create Azure Managed Lustre FileSystem";
 
     private readonly IManagedLustreService _service = service;
     private new readonly ILogger<FileSystemCreateCommand> _logger = logger;
-
-    public override string Id => "814acadf-ee84-47f9-ad68-2d65ec7dbb07";
-
-    public override string Name => "create";
-
-    public override string Description =>
-        """
-        Create an Azure Managed Lustre (AMLFS) file system using the specified network, capacity, maintenance window and availability zone.
-        Optionally provides possibility to define Blob Integration, customer managed key encryption and root squash configuration.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {
@@ -97,7 +88,6 @@ public sealed class FileSystemCreateCommand(IManagedLustreService service, ILogg
         options.UserAssignedIdentityId = parseResult.GetValueOrDefault<string>(ManagedLustreOptionDefinitions.UserAssignedIdentityIdOption.Name);
         return options;
     }
-
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemListCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemListCommand.cs
@@ -11,33 +11,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem;
 
+[CommandMetadata(
+    Id = "723d9b34-9022-486e-83a7-f72d83bdafd2",
+    Name = "list",
+    Title = "List Azure Managed Lustre File Systems",
+    Description = "Lists Azure Managed Lustre (AMLFS) file systems in a subscription or optional resource group including provisioning state, MGS address, tier, capacity (TiB), blob integration container, and maintenance window details. Use to inventory Azure Managed Lustre filesystems and to check their properties.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class FileSystemListCommand(IManagedLustreService service, ILogger<FileSystemListCommand> logger)
     : BaseManagedLustreCommand<FileSystemListOptions>(logger)
 {
     private readonly IManagedLustreService _service = service;
-    private const string CommandTitle = "List Azure Managed Lustre File Systems";
-
-    public override string Id => "723d9b34-9022-486e-83a7-f72d83bdafd2";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
-        Lists Azure Managed Lustre (AMLFS) file systems in a subscription or optional resource group including provisioning state, MGS address, tier, capacity (TiB), blob integration container, and maintenance window details. Use to inventory Azure Managed Lustre filesystems and to check their properties.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
-
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/FileSystemUpdateCommand.cs
@@ -12,34 +12,23 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem;
 
+[CommandMetadata(
+    Id = "db1bdf99-ac8a-4920-ab2e-15048623b2dc",
+    Name = "update",
+    Title = "Update Azure Managed Lustre FileSystem",
+    Description = "Update maintenance window and/or root squash settings of an existing Azure Managed Lustre (AMLFS) file system. Provide either maintenance day and time or root squash fields (no-squash-nid-list, squash-uid, squash-gid). Root squash fields must be provided if root squash is not None. In case of maintenance window update, both maintenance day and maintenance time should be provided.",
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class FileSystemUpdateCommand(IManagedLustreService service, ILogger<FileSystemUpdateCommand> logger)
     : BaseManagedLustreCommand<FileSystemUpdateOptions>(logger)
 {
-    private const string CommandTitle = "Update Azure Managed Lustre FileSystem";
 
     private readonly IManagedLustreService _service = service;
     private new readonly ILogger<FileSystemUpdateCommand> _logger = logger;
-
-    public override string Id => "db1bdf99-ac8a-4920-ab2e-15048623b2dc";
-
-    public override string Name => "update";
-
-    public override string Description =>
-        """
-        Update maintenance window and/or root squash settings of an existing Azure Managed Lustre (AMLFS) file system. Provide either maintenance day and time or root squash fields (no-squash-nid-list, squash-uid, squash-gid). Root squash fields must be provided if root squash is not None. In case of maintenance window update, both maintenance day and maintenance time should be provided.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ImportJob/ImportJobCancelCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ImportJob/ImportJobCancelCommand.cs
@@ -12,37 +12,28 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ImportJob;
 
-public sealed class ImportJobCancelCommand(IManagedLustreService service, ILogger<ImportJobCancelCommand> logger)
-    : BaseManagedLustreCommand<ImportJobCancelOptions>(logger)
-{
-    private const string CommandTitle = "Cancel Azure Managed Lustre Import Job";
-
-    private readonly IManagedLustreService _service = service;
-    private new readonly ILogger<ImportJobCancelCommand> _logger = logger;
-
-    public override string Id => "d3h5e7g9-1f4a-6d8e-0g2c-4f6a8d0f2e4g";
-
-    public override string Name => "cancel";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "d3h5e7g9-1f4a-6d8e-0g2c-4f6a8d0f2e4g",
+    Name = "cancel",
+    Title = "Cancel Azure Managed Lustre Import Job",
+    Description = """
         Cancels a running import job for an Azure Managed Lustre filesystem. This stops the import operation and prevents further processing. The job cannot be resumed after cancellation.
         Required options:
         - filesystem-name: The name of the AMLFS filesystem
         - job-name: Name of the import job to cancel
-        """;
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ImportJobCancelCommand(IManagedLustreService service, ILogger<ImportJobCancelCommand> logger)
+    : BaseManagedLustreCommand<ImportJobCancelOptions>(logger)
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+    private readonly IManagedLustreService _service = service;
+    private new readonly ILogger<ImportJobCancelCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ImportJob/ImportJobCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ImportJob/ImportJobCreateCommand.cs
@@ -12,20 +12,11 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ImportJob;
 
-public sealed class ImportJobCreateCommand(IManagedLustreService service, ILogger<ImportJobCreateCommand> logger)
-    : BaseManagedLustreCommand<ImportJobCreateOptions>(logger)
-{
-    private const string CommandTitle = "Create Azure Managed Lustre Import Job";
-
-    private readonly IManagedLustreService _service = service;
-    private new readonly ILogger<ImportJobCreateCommand> _logger = logger;
-
-    public override string Id => "b1f3c5e7-9d2a-4b8f-6c3e-1a7b9d2f5e8c";
-
-    public override string Name => "create";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "b1f3c5e7-9d2a-4b8f-6c3e-1a7b9d2f5e8c",
+    Name = "create",
+    Title = "Create Azure Managed Lustre Import Job",
+    Description = """
         Creates a one-time import job for an Azure Managed Lustre filesystem to import files from the linked blob storage container. The import job performs a one-time sync of data from the configured HSM blob container to the Lustre filesystem. Use this to import specific prefixes or all data from blob storage into the filesystem at a point in time.
         Required options:
         - filesystem-name: The name of the AMLFS filesystem
@@ -34,19 +25,19 @@ public sealed class ImportJobCreateCommand(IManagedLustreService service, ILogge
         - conflict-resolution-mode: How to handle conflicting files (Fail, Skip, OverwriteIfDirty, OverwriteAlways, default: Fail)
         - import-prefixes: Blob prefixes to import (default: imports all data from root '/')
         - maximum-errors: Maximum errors allowed before job failure (-1: infinite, 0: fail on first error, default: use service default)
-        """;
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ImportJobCreateCommand(IManagedLustreService service, ILogger<ImportJobCreateCommand> logger)
+    : BaseManagedLustreCommand<ImportJobCreateOptions>(logger)
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+    private readonly IManagedLustreService _service = service;
+    private new readonly ILogger<ImportJobCreateCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ImportJob/ImportJobDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ImportJob/ImportJobDeleteCommand.cs
@@ -12,37 +12,28 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ImportJob;
 
-public sealed class ImportJobDeleteCommand(IManagedLustreService service, ILogger<ImportJobDeleteCommand> logger)
-    : BaseManagedLustreCommand<ImportJobDeleteOptions>(logger)
-{
-    private const string CommandTitle = "Delete Azure Managed Lustre Import Job";
-
-    private readonly IManagedLustreService _service = service;
-    private new readonly ILogger<ImportJobDeleteCommand> _logger = logger;
-
-    public override string Id => "e4i6f8h0-2g5b-7e9f-1h3d-5g7b9e1g3f5h";
-
-    public override string Name => "delete";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "e4i6f8h0-2g5b-7e9f-1h3d-5g7b9e1g3f5h",
+    Name = "delete",
+    Title = "Delete Azure Managed Lustre Import Job",
+    Description = """
         Deletes an import job for an Azure Managed Lustre filesystem. This removes the job record and history. The job must be completed or cancelled before it can be deleted.
         Required options:
         - filesystem-name: The name of the AMLFS filesystem
         - job-name: Name of the import job to delete
-        """;
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ImportJobDeleteCommand(IManagedLustreService service, ILogger<ImportJobDeleteCommand> logger)
+    : BaseManagedLustreCommand<ImportJobDeleteOptions>(logger)
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+    private readonly IManagedLustreService _service = service;
+    private new readonly ILogger<ImportJobDeleteCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ImportJob/ImportJobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ImportJob/ImportJobGetCommand.cs
@@ -12,38 +12,29 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ImportJob;
 
-public sealed class ImportJobGetCommand(IManagedLustreService service, ILogger<ImportJobGetCommand> logger)
-    : BaseManagedLustreCommand<ImportJobGetOptions>(logger)
-{
-    private const string CommandTitle = "Get Azure Managed Lustre Import Job";
-
-    private readonly IManagedLustreService _service = service;
-    private new readonly ILogger<ImportJobGetCommand> _logger = logger;
-
-    public override string Id => "c2g4d6f8-0e3a-5c7d-9f1b-3e5a7c9f1d3f";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "c2g4d6f8-0e3a-5c7d-9f1b-3e5a7c9f1d3f",
+    Name = "get",
+    Title = "Get Azure Managed Lustre Import Job",
+    Description = """
         Gets import job details or lists all import jobs for an Azure Managed Lustre filesystem. If job-name is provided, returns details for that specific job. If job-name is omitted, returns a list of all import jobs for the filesystem.
         Required options:
         - filesystem-name: The name of the AMLFS filesystem
         Optional options:
         - job-name: Name of specific import job to get (omit to list all jobs)
-        """;
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ImportJobGetCommand(IManagedLustreService service, ILogger<ImportJobGetCommand> logger)
+    : BaseManagedLustreCommand<ImportJobGetOptions>(logger)
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+    private readonly IManagedLustreService _service = service;
+    private new readonly ILogger<ImportJobGetCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/Sku/SkuGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/Sku/SkuGetCommand.cs
@@ -10,35 +10,24 @@ using Microsoft.Mcp.Core.Extensions;
 using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Models.Option;
 
-
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem;
 
+[CommandMetadata(
+    Id = "43f679ba-1b6e-4851-9315-f8ad16b789e5",
+    Name = "get",
+    Title = "Get AMLFS SKU information",
+    Description = "Retrieves the available Azure Managed Lustre SKU, including increments, bandwidth, scale targets and zonal support. If a location is specified, the results will be filtered to that location.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SkuGetCommand(IManagedLustreService service, ILogger<SkuGetCommand> logger)
     : BaseManagedLustreCommand<SkuGetOptions>(logger)
 {
-    private const string CommandTitle = "Get AMLFS SKU information";
 
     private readonly IManagedLustreService _service = service;
-
-    public override string Id => "43f679ba-1b6e-4851-9315-f8ad16b789e5";
-    public override string Name => "get";
-
-    public override string Description =>
-        """
-        Retrieves the available Azure Managed Lustre SKU, including increments, bandwidth, scale targets and zonal support. If a location is specified, the results will be filtered to that location.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/SubnetSize/SubnetSizeAskCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/SubnetSize/SubnetSizeAskCommand.cs
@@ -11,33 +11,22 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem;
 
+[CommandMetadata(
+    Id = "3d3f6f27-218b-4915-9c1e-243dd53b16da",
+    Name = "ask",
+    Title = "Calculate AMLFS Subnet Size required number of IP Addresses",
+    Description = "Calculates the required subnet size for an Azure Managed Lustre file system given a SKU and size. Use to plan network deployment for AMLFS. Returns the number of required IPs.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SubnetSizeAskCommand(IManagedLustreService service, ILogger<SubnetSizeAskCommand> logger)
     : BaseManagedLustreCommand<SubnetSizeAskOptions>(logger)
 {
-    private const string CommandTitle = "Calculate AMLFS Subnet Size required number of IP Addresses";
 
     private readonly IManagedLustreService _service = service;
-
-    public override string Id => "3d3f6f27-218b-4915-9c1e-243dd53b16da";
-
-    public override string Name => "ask";
-
-    public override string Description =>
-        """
-        Calculates the required subnet size for an Azure Managed Lustre file system given a SKU and size. Use to plan network deployment for AMLFS. Returns the number of required IPs.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     private static readonly string[] AllowedSkus = [
         "AMLFS-Durable-Premium-40",

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/SubnetSize/SubnetSizeValidateCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/SubnetSize/SubnetSizeValidateCommand.cs
@@ -11,31 +11,22 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem;
 
+[CommandMetadata(
+    Id = "b6317bba-e28c-445b-9133-9cfbfe677698",
+    Name = "validate",
+    Title = "Validate AMLFS subnet against SKU and size",
+    Description = "Validates that the provided subnet can host an Azure Managed Lustre filesystem for the given SKU and size.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SubnetSizeValidateCommand(IManagedLustreService service, ILogger<SubnetSizeValidateCommand> logger)
     : BaseManagedLustreCommand<SubnetSizeValidateOptions>(logger)
 {
-    private const string CommandTitle = "Validate AMLFS subnet against SKU and size";
 
     private readonly IManagedLustreService _service = service;
-
-    public override string Id => "b6317bba-e28c-445b-9133-9cfbfe677698";
-
-    public override string Name => "validate";
-
-    public override string Description =>
-        "Validates that the provided subnet can host an Azure Managed Lustre filesystem for the given SKU and size.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     private static readonly string[] AllowedSkus = [
         "AMLFS-Durable-Premium-40",

--- a/tools/Azure.Mcp.Tools.Marketplace/src/Commands/Product/ProductGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/src/Commands/Product/ProductGetCommand.cs
@@ -14,33 +14,24 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Marketplace.Commands.Product;
 
+[CommandMetadata(
+    Id = "729a12ee-9c63-4a31-b1b8-4a81ad093564",
+    Name = "get",
+    Title = "Get Marketplace Product",
+    Description = """
+        Retrieves detailed information about a specific Azure Marketplace product (offer) for a given subscription,
+        including available plans, pricing, and product metadata.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ProductGetCommand(ILogger<ProductGetCommand> logger, IMarketplaceService marketplaceService) : SubscriptionCommand<ProductGetOptions>
 {
-    private const string CommandTitle = "Get Marketplace Product";
     private readonly ILogger<ProductGetCommand> _logger = logger;
     private readonly IMarketplaceService _marketplaceService = marketplaceService;
-
-    public override string Id => "729a12ee-9c63-4a31-b1b8-4a81ad093564";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
-        Retrieves detailed information about a specific Azure Marketplace product (offer) for a given subscription,
-         including available plans, pricing, and product metadata.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Marketplace/src/Commands/Product/ProductListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/src/Commands/Product/ProductListCommand.cs
@@ -14,32 +14,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Marketplace.Commands.Product;
 
+[CommandMetadata(
+    Id = "0485e8f9-61bf-4baf-b914-7fa5530a6f78",
+    Name = "list",
+    Title = "List Marketplace Products",
+    Description = "Retrieves and lists all marketplace products (offers) available to a subscription in the Azure Marketplace. Use this tool to search, select, browse, or filter marketplace offers by product name, publisher, pricing, or metadata. Returns information for each product, including display name, publisher details, category, pricing data, and available plans.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ProductListCommand(ILogger<ProductListCommand> logger, IMarketplaceService marketplaceService) : SubscriptionCommand<ProductListOptions>
 {
-    private const string CommandTitle = "List Marketplace Products";
     private readonly ILogger<ProductListCommand> _logger = logger;
     private readonly IMarketplaceService _marketplaceService = marketplaceService;
-
-    public override string Id => "0485e8f9-61bf-4baf-b914-7fa5530a6f78";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
-        Retrieves and lists all marketplace products (offers) available to a subscription in the Azure Marketplace. Use this tool to search, select, browse, or filter marketplace offers by product name, publisher, pricing, or metadata. Returns information for each product, including display name, publisher details, category, pricing data, and available plans.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/ActivityLog/ActivityLogListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/ActivityLog/ActivityLogListCommand.cs
@@ -14,37 +14,28 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.ActivityLog;
 
-public sealed class ActivityLogListCommand(ILogger<ActivityLogListCommand> logger, IMonitorService monitorService)
-    : SubscriptionCommand<ActivityLogListOptions>
-{
-    private const string CommandTitle = "List Activity Logs";
-    private readonly ILogger<ActivityLogListCommand> _logger = logger;
-    private readonly IMonitorService _monitorService = monitorService;
-    internal record ActivityLogListCommandResult(List<ActivityLogEventData> ActivityLogs);
-
-    public override string Id => "ffc0ed72-0622-4a27-bfd8-6df9b83adce8";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "ffc0ed72-0622-4a27-bfd8-6df9b83adce8",
+    Name = "list",
+    Title = "List Activity Logs",
+    Description = """
         Always use this tool if user is asking for activity logs for a resource.
         Lists activity logs for the specified Azure resource over the given prior number of hours.
         This command retrieves activity logs to help understand resource deployment history, modification activities, and access patterns.
         Returns activity log events with details including timestamp, operation name, status, and caller information. should be called to help retrieve information about why a resource failed to deploy or may not be working.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        OpenWorld = false,
-        Idempotent = true,
-        ReadOnly = true,
-        Secret = false,
-        LocalRequired = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ActivityLogListCommand(ILogger<ActivityLogListCommand> logger, IMonitorService monitorService)
+    : SubscriptionCommand<ActivityLogListOptions>
+{
+    private readonly ILogger<ActivityLogListCommand> _logger = logger;
+    private readonly IMonitorService _monitorService = monitorService;
+    internal record ActivityLogListCommandResult(List<ActivityLogEventData> ActivityLogs);
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/HealthModels/Entity/EntityGetHealthCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/HealthModels/Entity/EntityGetHealthCommand.cs
@@ -10,39 +10,29 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.HealthModels.Entity;
 
+[CommandMetadata(
+    Id = "80b23546-a6ac-4f0c-ad70-f51d6dff5543",
+    Name = "get",
+    Title = "Get the health of an entity in a health model",
+    Description = """
+        Retrieve the health status of an entity for a given Azure Monitor Health Model. Use this tool ONLY when the user mentions a specific health model name and asks for health status, health events. This provides application-level health monitoring with custom health models, not basic Azure resource availability.
+        For basic Azure resource availability status, use Resource Health tool instead `azmcp_resourcehealth_availability-status_get`.  
+        For querying logs from a Log Analystics workspace, use `azmcp_monitor_workspace_log_query`.  
+        For querying logs of a specific Azure resource, use `azmcp_monitor_resource_log_query`. 
+        Required arguments:
+            - --entity: The entity to get health for
+            - --health-model: The health model name
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class EntityGetHealthCommand(ILogger<EntityGetHealthCommand> logger, IMonitorHealthModelService healthModelService) : BaseMonitorHealthModelsCommand<BaseMonitorHealthModelsOptions>
 {
-    private const string CommandTitle = "Get the health of an entity in a health model";
-    private const string CommandName = "get";
     private readonly ILogger<EntityGetHealthCommand> _logger = logger;
     private readonly IMonitorHealthModelService _healthModelService = healthModelService;
-
-    public override string Id => "80b23546-a6ac-4f0c-ad70-f51d6dff5543";
-
-    public override string Name => CommandName;
-
-    public override string Description =>
-    $"""
-    Retrieve the health status of an entity for a given Azure Monitor Health Model. Use this tool ONLY when the user mentions a specific health model name and asks for health status, health events. This provides application-level health monitoring with custom health models, not basic Azure resource availability.
-    For basic Azure resource availability status, use Resource Health tool instead `azmcp_resourcehealth_availability-status_get`.  
-    For querying logs from a Log Analystics workspace, use `azmcp_monitor_workspace_log_query`.  
-    For querying logs of a specific Azure resource, use `azmcp_monitor_resource_log_query`. 
-    Required arguments:
-        - {MonitorOptionDefinitions.Health.Entity.Name}: The entity to get health for
-        - {MonitorOptionDefinitions.Health.HealthModel.Name}: The health model name
-    """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/GetLearningResourceCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/GetLearningResourceCommand.cs
@@ -11,29 +11,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Monitor.Commands;
 
+[CommandMetadata(
+    Id = "2c9f3785-4b97-4dd6-8489-af515638f0d5",
+    Name = "get-learning-resource",
+    Title = "Get Azure Monitor Learning Resource",
+    Description = "List all available learning resources for Azure Monitor instrumentation or get the content of a specific resource by path. Returns all resource paths by default, or retrieves the full content when a path is specified. Note: For instrumenting an application, use orchestrator-start instead.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = true)]
 public sealed class GetLearningResourceCommand(ILogger<GetLearningResourceCommand> logger)
     : BaseCommand<GetLearningResourceOptions>
 {
     private readonly ILogger<GetLearningResourceCommand> _logger = logger;
-
-    public override string Id => "2c9f3785-4b97-4dd6-8489-af515638f0d5";
-
-    public override string Name => "get-learning-resource";
-
-    public override string Description =>
-        "List all available learning resources for Azure Monitor instrumentation or get the content of a specific resource by path. Returns all resource paths by default, or retrieves the full content when a path is specified. Note: For instrumenting an application, use orchestrator-start instead.";
-
-    public override string Title => "Get Azure Monitor Learning Resource";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = true,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/OrchestratorNextCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/OrchestratorNextCommand.cs
@@ -11,37 +11,32 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Monitor.Commands;
 
+[CommandMetadata(
+    Id = "dd7d9a59-fb6d-436a-9e08-8bbdf6d5f9d5",
+    Name = "orchestrator-next",
+    Title = "Get Next Azure Monitor Instrumentation Action",
+    Description = """
+        Get the next instrumentation action after completing the current one.
+        Call this ONLY after you have executed the EXACT instruction from the previous response.
+        DO NOT skip steps. DO NOT improvise. DO NOT add extra code or commands.
+
+        Expected workflow:
+        1. You received an action from orchestrator-start or orchestrator-next
+        2. You executed EXACTLY what the 'instruction' field told you to do
+        3. Now call this tool to get the next action
+
+        Returns: The next action to execute, or 'complete' status when all steps are done.
+        """,
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = true)]
 public sealed class OrchestratorNextCommand(ILogger<OrchestratorNextCommand> logger)
     : BaseCommand<OrchestratorNextOptions>
 {
     private readonly ILogger<OrchestratorNextCommand> _logger = logger;
-
-    public override string Id => "dd7d9a59-fb6d-436a-9e08-8bbdf6d5f9d5";
-
-    public override string Name => "orchestrator-next";
-
-    public override string Description => @"Get the next instrumentation action after completing the current one.
-Call this ONLY after you have executed the EXACT instruction from the previous response.
-DO NOT skip steps. DO NOT improvise. DO NOT add extra code or commands.
-
-Expected workflow:
-1. You received an action from orchestrator-start or orchestrator-next
-2. You executed EXACTLY what the 'instruction' field told you to do
-3. Now call this tool to get the next action
-
-Returns: The next action to execute, or 'complete' status when all steps are done.";
-
-    public override string Title => "Get Next Azure Monitor Instrumentation Action";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = true,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/OrchestratorStartCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/OrchestratorStartCommand.cs
@@ -11,29 +11,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Monitor.Commands;
 
+[CommandMetadata(
+    Id = "35f577d9-6378-4d34-b822-111ff6e8957c",
+    Name = "orchestrator-start",
+    Title = "Start Azure Monitor Instrumentation",
+    Description = "START HERE for Azure Monitor instrumentation. Analyzes workspace and returns the first action to execute. After executing the action, call orchestrator-next to continue. DO NOT improvise. Execute EXACTLY what the 'instruction' field tells you.",
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = true)]
 public sealed class OrchestratorStartCommand(ILogger<OrchestratorStartCommand> logger)
     : BaseCommand<OrchestratorStartOptions>
 {
     private readonly ILogger<OrchestratorStartCommand> _logger = logger;
-
-    public override string Id => "35f577d9-6378-4d34-b822-111ff6e8957c";
-
-    public override string Name => "orchestrator-start";
-
-    public override string Description =>
-        "START HERE for Azure Monitor instrumentation. Analyzes workspace and returns the first action to execute. After executing the action, call orchestrator-next to continue. DO NOT improvise. Execute EXACTLY what the 'instruction' field tells you.";
-
-    public override string Title => "Start Azure Monitor Instrumentation";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = true,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/SendBrownfieldAnalysisCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/SendBrownfieldAnalysisCommand.cs
@@ -13,31 +13,26 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Monitor.Commands;
 
+[CommandMetadata(
+    Id = "8f69c45b-7e4f-4ea7-9a7d-58fa7fc0897e",
+    Name = "send-brownfield-analysis",
+    Title = "Send Brownfield Analysis",
+    Description = """
+        Send brownfield code analysis findings after orchestrator-start returned status 'analysis_needed'.
+        You must have scanned the workspace source files and filled in the analysis template.
+        For sections that do not exist in the codebase, pass an empty/default object (e.g. found: false, hasCustomSampling: false) rather than null.
+        After this call succeeds, continue with orchestrator-next as usual.
+        """,
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = true)]
 public sealed class SendBrownfieldAnalysisCommand(ILogger<SendBrownfieldAnalysisCommand> logger)
     : BaseCommand<SendBrownfieldAnalysisOptions>
 {
     private readonly ILogger<SendBrownfieldAnalysisCommand> _logger = logger;
-
-    public override string Id => "8f69c45b-7e4f-4ea7-9a7d-58fa7fc0897e";
-
-    public override string Name => "send-brownfield-analysis";
-
-    public override string Description => @"Send brownfield code analysis findings after orchestrator-start returned status 'analysis_needed'.
-You must have scanned the workspace source files and filled in the analysis template.
-For sections that do not exist in the codebase, pass an empty/default object (e.g. found: false, hasCustomSampling: false) rather than null.
-After this call succeeds, continue with orchestrator-next as usual.";
-
-    public override string Title => "Send Brownfield Analysis";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = true,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/SendEnhancementSelectCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/SendEnhancementSelectCommand.cs
@@ -11,31 +11,26 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Monitor.Commands;
 
+[CommandMetadata(
+    Id = "8fd4eb5f-14d1-450f-982c-82d761f0f7d6",
+    Name = "send-enhancement-select",
+    Title = "Send Enhancement Selection",
+    Description = """
+        Submit the user's enhancement selection after orchestrator-start returned status 'enhancement_available'.
+        Present the enhancement options to the user first, then call this tool with their chosen option key(s).
+        Multiple enhancements can be selected by passing a comma-separated list (e.g. 'redis,processors').
+        After this call succeeds, continue with orchestrator-next as usual.
+        """,
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = true)]
 public sealed class SendEnhancementSelectCommand(ILogger<SendEnhancementSelectCommand> logger)
     : BaseCommand<SendEnhancementSelectOptions>
 {
     private readonly ILogger<SendEnhancementSelectCommand> _logger = logger;
-
-    public override string Id => "8fd4eb5f-14d1-450f-982c-82d761f0f7d6";
-
-    public override string Name => "send-enhancement-select";
-
-    public override string Description => @"Submit the user's enhancement selection after orchestrator-start returned status 'enhancement_available'.
-Present the enhancement options to the user first, then call this tool with their chosen option key(s).
-Multiple enhancements can be selected by passing a comma-separated list (e.g. 'redis,processors').
-After this call succeeds, continue with orchestrator-next as usual.";
-
-    public override string Title => "Send Enhancement Selection";
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = true,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Log/ResourceLogQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Log/ResourceLogQueryCommand.cs
@@ -11,40 +11,31 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.Log;
 
+[CommandMetadata(
+    Id = "02aaf533-0593-4e1d-bd87-f7c69d34c7ba",
+    Name = "query",
+    Title = "Query Logs for Azure Resource",
+    Description = """
+        Query diagnostic and activity logs for a SPECIFIC Azure resource in a Log Analytics workspace using Kusto Query Language (KQL). 
+        Use this tool when the user mentions a specific resource name or Resource ID in their request (e.g., "show logs for resource 'app-monitor'"). 
+        This tool filters logs to only show data from the specified resource.
+
+        When to use: User asks for logs from a specific resource by name or ID.
+        When NOT to use: User asks for general workspace-wide logs without mentioning a specific resource.
+
+        Required arguments: resource ID or resource name, table name, KQL query
+        Optional: hours, limit
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ResourceLogQueryCommand(ILogger<ResourceLogQueryCommand> logger, IMonitorService monitorService) : SubscriptionCommand<ResourceLogQueryOptions>()
 {
-    private const string CommandTitle = "Query Logs for Azure Resource";
     private readonly ILogger<ResourceLogQueryCommand> _logger = logger;
     private readonly IMonitorService _monitorService = monitorService;
-
-    public override string Id => "02aaf533-0593-4e1d-bd87-f7c69d34c7ba";
-
-    public override string Name => "query";
-
-    public override string Description =>
-    $"""
-    Query diagnostic and activity logs for a SPECIFIC Azure resource in a Log Analytics workspace using Kusto Query Language (KQL). 
-    Use this tool when the user mentions a specific resource name or Resource ID in their request (e.g., "show logs for resource 'app-monitor'"). 
-    This tool filters logs to only show data from the specified resource.
-    
-    When to use: User asks for logs from a specific resource by name or ID.
-    When NOT to use: User asks for general workspace-wide logs without mentioning a specific resource.
-
-    Required arguments: resource ID or resource name, table name, KQL query
-    Optional: {MonitorOptionDefinitions.HoursName}, {MonitorOptionDefinitions.LimitName}
-    """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Log/WorkspaceLogQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Log/WorkspaceLogQueryCommand.cs
@@ -10,41 +10,32 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.Log;
 
+[CommandMetadata(
+    Id = "3f513aea-b6fc-4ad0-8f7d-9fbaa1056ac6",
+    Name = "query",
+    Title = "Query Log Analytics Workspace",
+    Description = """
+        Query logs across an ENTIRE Log Analytics workspace using Kusto Query Language (KQL). 
+        Use this tool when the user wants to query all resources in a workspace or doesn't specify a particular resource name/ID (e.g., "show all errors in workspace", "query workspace logs", "what happened in my workspace").
+        This tool queries across all resources and tables in the workspace.
+
+        When to use: User asks for workspace-wide logs, all resources, or doesn't mention a specific resource.
+        When NOT to use: User mentions a specific resource name or Resource ID - use resource log query instead.
+
+        Requires workspace and resource group.
+        Optional: hours and limit.
+        query accepts KQL syntax.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class WorkspaceLogQueryCommand(ILogger<WorkspaceLogQueryCommand> logger, IMonitorService monitorService) : BaseWorkspaceMonitorCommand<WorkspaceLogQueryOptions>()
 {
-    private const string CommandTitle = "Query Log Analytics Workspace";
     private readonly ILogger<WorkspaceLogQueryCommand> _logger = logger;
     private readonly IMonitorService _monitorService = monitorService;
-
-    public override string Id => "3f513aea-b6fc-4ad0-8f7d-9fbaa1056ac6";
-
-    public override string Name => "query";
-
-    public override string Description =>
-    $"""
-    Query logs across an ENTIRE Log Analytics workspace using Kusto Query Language (KQL). 
-    Use this tool when the user wants to query all resources in a workspace or doesn't specify a particular resource name/ID (e.g., "show all errors in workspace", "query workspace logs", "what happened in my workspace").
-    This tool queries across all resources and tables in the workspace.
-    
-    When to use: User asks for workspace-wide logs, all resources, or doesn't mention a specific resource.
-    When NOT to use: User mentions a specific resource name or Resource ID - use resource log query instead.
-
-    Requires {WorkspaceOptionDefinitions.WorkspaceIdOrName} and resource group.
-    Optional: {MonitorOptionDefinitions.HoursName} and {MonitorOptionDefinitions.LimitName}.
-    {MonitorOptionDefinitions.QueryTextName} accepts KQL syntax.
-    """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Metrics/MetricsDefinitionsCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Metrics/MetricsDefinitionsCommand.cs
@@ -16,33 +16,22 @@ namespace Azure.Mcp.Tools.Monitor.Commands.Metrics;
 /// <summary>
 /// Command for listing Azure Monitor metric definitions
 /// </summary>
+[CommandMetadata(
+    Id = "d3bf37ed-5f2e-448d-a16e-73140ef908c2",
+    Name = "definitions",
+    Title = "List Azure Monitor Metric Definitions",
+    Description = "List available metric definitions for an Azure resource. Returns metadata about the metrics available for the resource.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class MetricsDefinitionsCommand(ILogger<MetricsDefinitionsCommand> logger, IMonitorMetricsService metricsService)
     : BaseMetricsCommand<MetricsDefinitionsOptions>
 {
-    private const string CommandTitle = "List Azure Monitor Metric Definitions";
     private readonly ILogger<MetricsDefinitionsCommand> _logger = logger;
     private readonly IMonitorMetricsService _metricsService = metricsService;
-
-    public override string Id => "d3bf37ed-5f2e-448d-a16e-73140ef908c2";
-
-    public override string Name => "definitions";
-
-    public override string Description =>
-        """
-        List available metric definitions for an Azure resource. Returns metadata about the metrics available for the resource.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Metrics/MetricsQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Metrics/MetricsQueryCommand.cs
@@ -16,33 +16,22 @@ namespace Azure.Mcp.Tools.Monitor.Commands.Metrics;
 /// <summary>
 /// Command for querying Azure Monitor metrics
 /// </summary>
+[CommandMetadata(
+    Id = "6e86ef31-04e1-4cec-8bda-5292d4bc3ad8",
+    Name = "query",
+    Title = "Query Azure Monitor Metrics",
+    Description = "Query Azure Monitor metrics for a resource. Returns time series data for the specified metrics.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class MetricsQueryCommand(ILogger<MetricsQueryCommand> logger, IMonitorMetricsService metricsService)
     : BaseMetricsCommand<MetricsQueryOptions>
 {
-    private const string CommandTitle = "Query Azure Monitor Metrics";
     private readonly ILogger<MetricsQueryCommand> _logger = logger;
     private readonly IMonitorMetricsService _metricsService = metricsService;
-
-    public override string Id => "6e86ef31-04e1-4cec-8bda-5292d4bc3ad8";
-
-    public override string Name => "query";
-
-    public override string Description =>
-        """
-        Query Azure Monitor metrics for a resource. Returns time series data for the specified metrics.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Table/TableListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Table/TableListCommand.cs
@@ -10,33 +10,24 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.Table;
 
+[CommandMetadata(
+    Id = "2b1ae0be-d6dd-4db9-9c58-fc4fcb3bf8e6",
+    Name = "list",
+    Title = "List Log Analytics Tables",
+    Description = """
+        List all tables in a Log Analytics workspace. Requires workspace.
+        Returns table names and schemas that can be used for constructing KQL queries.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class TableListCommand(ILogger<TableListCommand> logger, IMonitorService monitorService) : BaseWorkspaceMonitorCommand<TableListOptions>()
 {
-    private const string CommandTitle = "List Log Analytics Tables";
     private readonly ILogger<TableListCommand> _logger = logger;
     private readonly IMonitorService _monitorService = monitorService;
-
-    public override string Id => "2b1ae0be-d6dd-4db9-9c58-fc4fcb3bf8e6";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        $"""
-        List all tables in a Log Analytics workspace. Requires {WorkspaceOptionDefinitions.WorkspaceIdOrName}.
-        Returns table names and schemas that can be used for constructing KQL queries.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/TableType/TableTypeListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/TableType/TableTypeListCommand.cs
@@ -9,30 +9,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.TableType;
 
+[CommandMetadata(
+    Id = "17928c13-3907-428c-8232-74f7aec1d76d",
+    Name = "list",
+    Title = "List Log Analytics Table Types",
+    Description = "List available table types in a Log Analytics workspace. Returns table type names.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class TableTypeListCommand(ILogger<TableTypeListCommand> logger, IMonitorService monitorService) : BaseWorkspaceMonitorCommand<TableTypeListOptions>()
 {
-    private const string CommandTitle = "List Log Analytics Table Types";
     private readonly ILogger<TableTypeListCommand> _logger = logger;
     private readonly IMonitorService _monitorService = monitorService;
-
-    public override string Id => "17928c13-3907-428c-8232-74f7aec1d76d";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        "List available table types in a Log Analytics workspace. Returns table type names.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsCreateOrUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsCreateOrUpdateCommand.cs
@@ -14,35 +14,26 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.WebTests;
 
-public sealed class WebTestsCreateOrUpdateCommand(ILogger<WebTestsCreateOrUpdateCommand> logger, IMonitorWebTestService monitorWebTestService) : BaseMonitorWebTestsCommand<WebTestsCreateOrUpdateOptions>
-{
-    private const string CommandTitle = "Create or update a web test in Azure Monitor";
-
-    private readonly ILogger<WebTestsCreateOrUpdateCommand> _logger = logger;
-    private readonly IMonitorWebTestService _monitorWebTestService = monitorWebTestService;
-
-    public override string Id => "aa5a22bc-6a04-4bc0-a963-b6e462b5cdc4";
-
-    public override string Name => "createorupdate";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "aa5a22bc-6a04-4bc0-a963-b6e462b5cdc4",
+    Name = "createorupdate",
+    Title = "Create or update a web test in Azure Monitor",
+    Description = """
         Create or update a standard web test in Azure Monitor to monitor endpoint availability.
         Use this to set up new web tests or modify existing ones with monitoring configurations like URL, frequency, locations, and expected responses.
         Automatically creates a new test if it doesn't exist, or updates an existing test with new settings.
-        """;
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class WebTestsCreateOrUpdateCommand(ILogger<WebTestsCreateOrUpdateCommand> logger, IMonitorWebTestService monitorWebTestService) : BaseMonitorWebTestsCommand<WebTestsCreateOrUpdateOptions>
+{
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+    private readonly ILogger<WebTestsCreateOrUpdateCommand> _logger = logger;
+    private readonly IMonitorWebTestService _monitorWebTestService = monitorWebTestService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/WebTests/WebTestsGetCommand.cs
@@ -14,34 +14,25 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.WebTests;
 
-public sealed class WebTestsGetCommand(ILogger<WebTestsGetCommand> logger, IMonitorWebTestService monitorWebTestService) : BaseMonitorWebTestsCommand<WebTestsGetOptions>
-{
-    private const string CommandTitle = "Get or list web tests";
-    private readonly ILogger<WebTestsGetCommand> _logger = logger;
-    private readonly IMonitorWebTestService _monitorWebTestService = monitorWebTestService;
-
-    public override string Id => "c9897ba5-445c-43dc-9902-e8454dbdc243";
-
-    public override string Name => "get";
-
-    public override string Description =>
-         $"""
+[CommandMetadata(
+    Id = "c9897ba5-445c-43dc-9902-e8454dbdc243",
+    Name = "get",
+    Title = "Get or list web tests",
+    Description = """
         Gets details for a specific web test or lists all web tests.
         When --webtest-resource is provided, returns detailed information about a single web test.
         When --webtest-resource is omitted, returns a list of all web tests in the subscription (optionally filtered by resource group).
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class WebTestsGetCommand(ILogger<WebTestsGetCommand> logger, IMonitorWebTestService monitorWebTestService) : BaseMonitorWebTestsCommand<WebTestsGetOptions>
+{
+    private readonly ILogger<WebTestsGetCommand> _logger = logger;
+    private readonly IMonitorWebTestService _monitorWebTestService = monitorWebTestService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Workspace/WorkspaceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Workspace/WorkspaceListCommand.cs
@@ -11,34 +11,25 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.Workspace;
 
-public sealed class WorkspaceListCommand(ILogger<WorkspaceListCommand> logger, IMonitorService monitorService) : SubscriptionCommand<WorkspaceListOptions>()
-{
-    private const string CommandTitle = "List Log Analytics Workspaces";
-    private readonly ILogger<WorkspaceListCommand> _logger = logger;
-    private readonly IMonitorService _monitorService = monitorService;
-
-    public override string Id => "0c76b74e-14bf-4e0c-ab10-4bbeeb53347b";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "0c76b74e-14bf-4e0c-ab10-4bbeeb53347b",
+    Name = "list",
+    Title = "List Log Analytics Workspaces",
+    Description = """
         List Log Analytics workspaces in a subscription. This command retrieves all Log Analytics workspaces
         available in the specified Azure subscription, displaying their names, IDs, and other key properties.
         Use this command to identify workspaces before querying their logs or tables.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class WorkspaceListCommand(ILogger<WorkspaceListCommand> logger, IMonitorService monitorService) : SubscriptionCommand<WorkspaceListOptions>()
+{
+    private readonly ILogger<WorkspaceListCommand> _logger = logger;
+    private readonly IMonitorService _monitorService = monitorService;
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.MySql/src/Commands/Database/DatabaseQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Commands/Database/DatabaseQueryCommand.cs
@@ -11,28 +11,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.MySql.Commands.Database;
 
+[CommandMetadata(
+    Id = "b73afaa5-4c3f-41e8-9ef3-c54e75215a97",
+    Name = "query",
+    Title = "Query MySQL Database",
+    Description = "Executes a safe, read-only SQL SELECT query against a database on Azure Database for MySQL Flexible Server. Use this tool to explore or retrieve table data without modifying it. Rejects non-SELECT statements (INSERT/UPDATE/DELETE/REPLACE/MERGE/TRUNCATE/ALTER/CREATE/DROP), multi-statements, comments hiding writes, transaction control (BEGIN/COMMIT/ROLLBACK), INTO OUTFILE, and other destructive keywords. Only a single SELECT is executed to ensure data integrity. Best practices: List needed columns (avoid SELECT *), add WHERE filters, use LIMIT/OFFSET for paging, ORDER BY for deterministic results, and avoid unnecessary sensitive data. Example: SELECT id, name, status FROM customers WHERE status = 'Active' ORDER BY name LIMIT 50;",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class DatabaseQueryCommand(ILogger<DatabaseQueryCommand> logger, IMySqlService mysqlService) : BaseDatabaseCommand<DatabaseQueryOptions>(logger)
 {
-    private const string CommandTitle = "Query MySQL Database";
     private readonly IMySqlService _mysqlService = mysqlService;
-
-    public override string Id => "b73afaa5-4c3f-41e8-9ef3-c54e75215a97";
-
-    public override string Name => "query";
-
-    public override string Description => "Executes a safe, read-only SQL SELECT query against a database on Azure Database for MySQL Flexible Server. Use this tool to explore or retrieve table data without modifying it. Rejects non-SELECT statements (INSERT/UPDATE/DELETE/REPLACE/MERGE/TRUNCATE/ALTER/CREATE/DROP), multi-statements, comments hiding writes, transaction control (BEGIN/COMMIT/ROLLBACK), INTO OUTFILE, and other destructive keywords. Only a single SELECT is executed to ensure data integrity. Best practices: List needed columns (avoid SELECT *), add WHERE filters, use LIMIT/OFFSET for paging, ORDER BY for deterministic results, and avoid unnecessary sensitive data. Example: SELECT id, name, status FROM customers WHERE status = 'Active' ORDER BY name LIMIT 50;";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.MySql/src/Commands/MySqlListCommand.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Commands/MySqlListCommand.cs
@@ -10,18 +10,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.MySql.Commands;
 
+[CommandMetadata(
+    Id = "77e60b50-5c16-4879-96b1-6a40d9c08a37",
+    Name = "list",
+    Title = "List MySQL Resources",
+    Description = "List MySQL servers, databases, or tables in your subscription. Returns all servers by default. Specify --server to list databases on that server, or --server and --database to list tables in a specific database.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class MySqlListCommand(ILogger<MySqlListCommand> logger, IMySqlService mysqlService) : BaseMySqlCommand<MySqlDatabaseOptions>(logger)
 {
     private readonly IMySqlService _mysqlService = mysqlService;
-    public override string Id => "77e60b50-5c16-4879-96b1-6a40d9c08a37";
-
-    public override string Name => "list";
-
-    public override string Description => "List MySQL servers, databases, or tables in your subscription. Returns all servers by default. Specify --server to list databases on that server, or --server and --database to list tables in a specific database.";
-
-    public override string Title => "List MySQL Resources";
-
-    public override ToolMetadata Metadata => new() { Destructive = false, Idempotent = true, OpenWorld = false, ReadOnly = true, Secret = false, LocalRequired = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.MySql/src/Commands/Server/ServerConfigGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Commands/Server/ServerConfigGetCommand.cs
@@ -9,28 +9,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.MySql.Commands.Server;
 
+[CommandMetadata(
+    Id = "677cef4f-0eb1-4665-a3a2-89301a75c201",
+    Name = "get",
+    Title = "Get MySQL Server Configuration",
+    Description = "Retrieves comprehensive configuration details for the specified Azure Database for MySQL Flexible Server instance. This command provides insights into server settings, performance parameters, security configurations, and operational characteristics essential for database administration and optimization. Returns configuration data in JSON format including ServerName, Location, Version, SKU, StorageSizeGB, BackupRetentionDays, and GeoRedundantBackup properties.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServerConfigGetCommand(ILogger<ServerConfigGetCommand> logger, IMySqlService mysqlService) : BaseServerCommand<ServerConfigGetOptions>(logger)
 {
-    private const string CommandTitle = "Get MySQL Server Configuration";
     private readonly IMySqlService _mysqlService = mysqlService;
-
-    public override string Id => "677cef4f-0eb1-4665-a3a2-89301a75c201";
-
-    public override string Name => "get";
-
-    public override string Description => "Retrieves comprehensive configuration details for the specified Azure Database for MySQL Flexible Server instance. This command provides insights into server settings, performance parameters, security configurations, and operational characteristics essential for database administration and optimization. Returns configuration data in JSON format including ServerName, Location, Version, SKU, StorageSizeGB, BackupRetentionDays, and GeoRedundantBackup properties.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.MySql/src/Commands/Server/ServerParamGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Commands/Server/ServerParamGetCommand.cs
@@ -11,28 +11,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.MySql.Commands.Server;
 
+[CommandMetadata(
+    Id = "bae423b4-aee8-4f23-a104-e816727d183f",
+    Name = "get",
+    Title = "Get MySQL Server Parameter",
+    Description = "Retrieves the current value of a single server configuration parameter on an Azure Database for MySQL Flexible Server. Use to inspect a setting (e.g. max_connections, wait_timeout, slow_query_log) before changing it.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServerParamGetCommand(ILogger<ServerParamGetCommand> logger, IMySqlService mysqlService) : BaseServerCommand<ServerParamGetOptions>(logger)
 {
-    private const string CommandTitle = "Get MySQL Server Parameter";
     private readonly IMySqlService _mysqlService = mysqlService;
-
-    public override string Id => "bae423b4-aee8-4f23-a104-e816727d183f";
-
-    public override string Name => "get";
-
-    public override string Description => "Retrieves the current value of a single server configuration parameter on an Azure Database for MySQL Flexible Server. Use to inspect a setting (e.g. max_connections, wait_timeout, slow_query_log) before changing it.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.MySql/src/Commands/Server/ServerParamSetCommand.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Commands/Server/ServerParamSetCommand.cs
@@ -11,28 +11,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.MySql.Commands.Server;
 
+[CommandMetadata(
+    Id = "8d086e44-8c8a-4649-a282-38f775704595",
+    Name = "set",
+    Title = "Set MySQL Server Parameter",
+    Description = "Sets/updates a single MySQL server configuration setting/parameter.",
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServerParamSetCommand(ILogger<ServerParamSetCommand> logger, IMySqlService mysqlService) : BaseServerCommand<ServerParamSetOptions>(logger)
 {
-    private const string CommandTitle = "Set MySQL Server Parameter";
     private readonly IMySqlService _mysqlService = mysqlService;
-
-    public override string Id => "8d086e44-8c8a-4649-a282-38f775704595";
-
-    public override string Name => "set";
-
-    public override string Description => "Sets/updates a single MySQL server configuration setting/parameter.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.MySql/src/Commands/Table/TableSchemaGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Commands/Table/TableSchemaGetCommand.cs
@@ -12,28 +12,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.MySql.Commands.Table;
 
+[CommandMetadata(
+    Id = "1c8d2584-fa52-4641-85f9-fb67a8f5c7c9",
+    Name = "get",
+    Title = "Get MySQL Table Schema",
+    Description = "Retrieves detailed schema information for a specific table within an Azure Database for MySQL Flexible Server database. This command provides comprehensive metadata including column definitions, data types, constraints, indexes, and relationships, essential for understanding table structure and supporting application development.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class TableSchemaGetCommand(ILogger<TableSchemaGetCommand> logger, IMySqlService mysqlService) : BaseDatabaseCommand<TableSchemaGetOptions>(logger)
 {
-    private const string CommandTitle = "Get MySQL Table Schema";
     private readonly IMySqlService _mysqlService = mysqlService;
-
-    public override string Id => "1c8d2584-fa52-4641-85f9-fb67a8f5c7c9";
-
-    public override string Name => "get";
-
-    public override string Description => "Retrieves detailed schema information for a specific table within an Azure Database for MySQL Flexible Server database. This command provides comprehensive metadata including column definitions, data types, constraints, indexes, and relationships, essential for understanding table structure and supporting application development.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Policy/src/Commands/Assignment/PolicyAssignmentListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Policy/src/Commands/Assignment/PolicyAssignmentListCommand.cs
@@ -14,37 +14,28 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Policy.Commands.Assignment;
 
-public sealed class PolicyAssignmentListCommand(ILogger<PolicyAssignmentListCommand> logger, IPolicyService policyService)
-    : SubscriptionCommand<PolicyAssignmentListOptions>
-{
-    private const string CommandTitle = "List Policy Assignments";
-    private readonly ILogger<PolicyAssignmentListCommand> _logger = logger;
-    private readonly IPolicyService _policyService = policyService;
-
-    public override string Id => "b7c4d3e2-0f1a-4b8c-9d6e-5a7b8c9d0e1f";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "b7c4d3e2-0f1a-4b8c-9d6e-5a7b8c9d0e1f",
+    Name = "list",
+    Title = "List Policy Assignments",
+    Description = """
         List policy assignments in a subscription or scope. This command retrieves all Azure Policy
         assignments along with their complete policy definition details (rules, effects, parameters schema),
         enforcement modes, assignment parameters, and metadata. This enables agents to understand policy
         requirements and design compliant cloud services. You can optionally filter by scope to list
         assignments at a specific resource group, resource, or management group level.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class PolicyAssignmentListCommand(ILogger<PolicyAssignmentListCommand> logger, IPolicyService policyService)
+    : SubscriptionCommand<PolicyAssignmentListOptions>
+{
+    private readonly ILogger<PolicyAssignmentListCommand> _logger = logger;
+    private readonly IPolicyService _policyService = policyService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/BaseDatabaseCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/BaseDatabaseCommand.cs
@@ -13,12 +13,6 @@ public abstract class BaseDatabaseCommand<
     [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions>(ILogger<BasePostgresCommand<TOptions>> logger)
     : BaseServerCommand<TOptions>(logger) where TOptions : BasePostgresOptions, new()
 {
-
-    public override string Name => "database";
-
-    public override string Description =>
-        "Retrieves information about a PostgreSQL database.";
-
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/BaseServerCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/BaseServerCommand.cs
@@ -15,12 +15,6 @@ public abstract class BaseServerCommand<
     : BasePostgresCommand<TOptions>(logger) where TOptions : BasePostgresOptions, new()
 
 {
-
-    public override string Name => "server";
-
-    public override string Description =>
-        "Retrieves information about a PostgreSQL server.";
-
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Database/DatabaseQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Database/DatabaseQueryCommand.cs
@@ -12,28 +12,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Postgres.Commands.Database;
 
+[CommandMetadata(
+    Id = "81a28bca-014c-4738-9e1a-654d77cb2dd8",
+    Name = "query",
+    Title = "Query PostgreSQL Database",
+    Description = "Executes a SQL query on an Azure Database for PostgreSQL server to search for specific terms, retrieve records, or perform SELECT operations.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class DatabaseQueryCommand(IPostgresService postgresService, ILogger<DatabaseQueryCommand> logger) : BaseDatabaseCommand<DatabaseQueryOptions>(logger)
 {
     private readonly IPostgresService _postgresService = postgresService;
-    private const string CommandTitle = "Query PostgreSQL Database";
-
-    public override string Id => "81a28bca-014c-4738-9e1a-654d77cb2dd8";
-
-    public override string Name => "query";
-
-    public override string Description => "Executes a SQL query on an Azure Database for PostgreSQL server to search for specific terms, retrieve records, or perform SELECT operations.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/PostgresListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/PostgresListCommand.cs
@@ -11,18 +11,20 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Postgres.Commands;
 
+[CommandMetadata(
+    Id = "8a12c3f4-2e5d-4b3a-9f2c-5e6d7f8a9b0c",
+    Name = "list",
+    Title = "List PostgreSQL Resources",
+    Description = "List PostgreSQL servers, databases, or tables. Returns all servers in the subscription by default (optionally scoped to a --resource-group). Specify --server to list databases on that server, or --server and --database to list tables in a specific database. --user is required when --server is provided.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class PostgresListCommand(IPostgresService postgresService, ILogger<PostgresListCommand> logger) : BasePostgresCommand<BasePostgresOptions>(logger)
 {
     private readonly IPostgresService _postgresService = postgresService;
-    public override string Id => "8a12c3f4-2e5d-4b3a-9f2c-5e6d7f8a9b0c";
-
-    public override string Name => "list";
-
-    public override string Description => "List PostgreSQL servers, databases, or tables. Returns all servers in the subscription by default (optionally scoped to a --resource-group). Specify --server to list databases on that server, or --server and --database to list tables in a specific database. --user is required when --server is provided.";
-
-    public override string Title => "List PostgreSQL Resources";
-
-    public override ToolMetadata Metadata => new() { Destructive = false, Idempotent = true, OpenWorld = false, ReadOnly = true, Secret = false, LocalRequired = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerConfigGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerConfigGetCommand.cs
@@ -9,29 +9,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Postgres.Commands.Server;
 
+[CommandMetadata(
+    Id = "049a0d10-0a6e-4278-a0a3-15ce6b2e5ee1",
+    Name = "get",
+    Title = "Get PostgreSQL Server Configuration",
+    Description = "Retrieve the configuration of a PostgreSQL server.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServerConfigGetCommand(IPostgresService postgresService, ILogger<ServerConfigGetCommand> logger) : BaseServerCommand<ServerConfigGetOptions>(logger)
 {
     private readonly IPostgresService _postgresService = postgresService;
-    private const string CommandTitle = "Get PostgreSQL Server Configuration";
-
-    public override string Id => "049a0d10-0a6e-4278-a0a3-15ce6b2e5ee1";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        "Retrieve the configuration of a PostgreSQL server.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamGetCommand.cs
@@ -11,29 +11,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Postgres.Commands.Server;
 
+[CommandMetadata(
+    Id = "af3a581d-ab64-4939-9765-974815d9c7be",
+    Name = "get",
+    Title = "Get PostgreSQL Server Parameter",
+    Description = "Retrieves a specific parameter of a PostgreSQL server.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServerParamGetCommand(IPostgresService postgresService, ILogger<ServerParamGetCommand> logger) : BaseServerCommand<ServerParamGetOptions>(logger)
 {
     private readonly IPostgresService _postgresService = postgresService;
-    private const string CommandTitle = "Get PostgreSQL Server Parameter";
-
-    public override string Id => "af3a581d-ab64-4939-9765-974815d9c7be";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        "Retrieves a specific parameter of a PostgreSQL server.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamSetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamSetCommand.cs
@@ -12,29 +12,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Postgres.Commands.Server;
 
+[CommandMetadata(
+    Id = "2134621b-518f-48ac-a66a-82c40fcb58bb",
+    Name = "set",
+    Title = "Set PostgreSQL Server Parameter",
+    Description = "Configures PostgreSQL server settings including replication, connection limits, and other parameters.",
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServerParamSetCommand(IPostgresService postgresService, ILogger<ServerParamSetCommand> logger) : BaseServerCommand<ServerParamSetOptions>(logger)
 {
     private readonly IPostgresService _postgresService = postgresService;
-    private const string CommandTitle = "Set PostgreSQL Server Parameter";
-
-    public override string Id => "2134621b-518f-48ac-a66a-82c40fcb58bb";
-
-    public override string Name => "set";
-
-    public override string Description =>
-        "Configures PostgreSQL server settings including replication, connection limits, and other parameters.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Table/TableSchemaGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Table/TableSchemaGetCommand.cs
@@ -11,25 +11,20 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Postgres.Commands.Table;
 
+[CommandMetadata(
+    Id = "643a3497-44e1-4727-b3d6-c2e5dba6cab2",
+    Name = "get",
+    Title = "Get PostgreSQL Table Schema",
+    Description = "Retrieves the schema of a specified table in a PostgreSQL database.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class TableSchemaGetCommand(IPostgresService postgresService, ILogger<TableSchemaGetCommand> logger) : BaseDatabaseCommand<TableSchemaGetOptions>(logger)
 {
     private readonly IPostgresService _postgresService = postgresService;
-    private const string CommandTitle = "Get PostgreSQL Table Schema";
-
-    public override string Id => "643a3497-44e1-4727-b3d6-c2e5dba6cab2";
-    public override string Name => "get";
-    public override string Description => "Retrieves the schema of a specified table in a PostgreSQL database.";
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {
@@ -55,7 +50,6 @@ public sealed class TableSchemaGetCommand(IPostgresService postgresService, ILog
 
         try
         {
-
 
             List<string> schema = await _postgresService.GetTableSchemaAsync(
                 options.Subscription!,

--- a/tools/Azure.Mcp.Tools.Quota/src/Commands/Region/AvailabilityListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Commands/Region/AvailabilityListCommand.cs
@@ -13,31 +13,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Quota.Commands.Region;
 
+[CommandMetadata(
+    Id = "0b8902f5-3fd4-49d9-b73e-4cea88afdd62",
+    Name = "list",
+    Title = "Get available regions for Azure resource types",
+    Description = "Given a list of Azure resource types, this tool will return a list of regions where the resource types are available. Always get the user's subscription ID before calling this tool.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class AvailabilityListCommand(ILogger<AvailabilityListCommand> logger, IQuotaService quotaService) : SubscriptionCommand<AvailabilityListOptions>()
 {
-    private const string CommandTitle = "Get available regions for Azure resource types";
     private readonly ILogger<AvailabilityListCommand> _logger = logger;
     private readonly IQuotaService _quotaService = quotaService;
-
-    public override string Id => "0b8902f5-3fd4-49d9-b73e-4cea88afdd62";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
-        Given a list of Azure resource types, this tool will return a list of regions where the resource types are available. Always get the user's subscription ID before calling this tool.
-        """;
-
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Quota/src/Commands/Usage/CheckCommand.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Commands/Usage/CheckCommand.cs
@@ -14,31 +14,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Quota.Commands.Usage;
 
+[CommandMetadata(
+    Id = "81f64603-5a56-4f74-90f8-395da69a99d3",
+    Name = "check",
+    Title = "Check Azure resources usage and quota in a region",
+    Description = "This tool will check the usage and quota information for Azure resources in a region.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class CheckCommand(ILogger<CheckCommand> logger, IQuotaService quotaService) : SubscriptionCommand<CheckOptions>()
 {
-    private const string CommandTitle = "Check Azure resources usage and quota in a region";
     private readonly ILogger<CheckCommand> _logger = logger;
     private readonly IQuotaService _quotaService = quotaService;
-
-    public override string Id => "81f64603-5a56-4f74-90f8-395da69a99d3";
-
-    public override string Name => "check";
-
-    public override string Description =>
-        """
-        This tool will check the usage and quota information for Azure resources in a region.
-        """;
-
-    public override string Title => CommandTitle;
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceCreateCommand.cs
@@ -16,33 +16,22 @@ namespace Azure.Mcp.Tools.Redis.Commands;
 /// <summary>
 /// Creates a new Azure Managed Redis resource.
 /// </summary>
+[CommandMetadata(
+    Id = "750133dd-d57f-4ed4-9488-c1d406ad4a83",
+    Name = "create",
+    Title = "Create Redis Resource",
+    Description = "Create a new Azure Managed Redis resource in Azure. Use this command to provision a new Redis resource in your subscription.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ResourceCreateCommand(IRedisService redisService, ILogger<ResourceCreateCommand> logger)
     : SubscriptionCommand<ResourceCreateOptions>()
 {
-    private const string CommandTitle = "Create Redis Resource";
     private readonly IRedisService _redisService = redisService;
     private readonly ILogger<ResourceCreateCommand> _logger = logger;
-
-    public override string Id => "750133dd-d57f-4ed4-9488-c1d406ad4a83";
-
-    public override string Name => "create";
-
-    public override string Description =>
-       """
-       Create a new Azure Managed Redis resource in Azure. Use this command to provision a new Redis resource in your subscription.
-       """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceListCommand.cs
@@ -14,33 +14,22 @@ namespace Azure.Mcp.Tools.Redis.Commands;
 /// <summary>
 /// Lists Redis resources in a subscription. Returns details for all Azure Managed Redis, Azure Cache for Redis, and Azure Redis Enterprise resources.
 /// </summary>
+[CommandMetadata(
+    Id = "eded7479-4187-4742-957f-d7778e03a69d",
+    Name = "list",
+    Title = "List Redis Resources",
+    Description = "List/show all Redis resources in a subscription. Returns details of all Azure Managed Redis, Azure Cache for Redis, and Azure Redis Enterprise resources. Use this command to explore and view which Redis resources are available in your subscription.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ResourceListCommand(IRedisService redisService, ILogger<ResourceListCommand> logger)
     : SubscriptionCommand<ResourceListOptions>()
 {
-    private const string CommandTitle = "List Redis Resources";
     private readonly IRedisService _redisService = redisService;
     private readonly ILogger<ResourceListCommand> _logger = logger;
-
-    public override string Id => "eded7479-4187-4742-957f-d7778e03a69d";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        $"""
-        List/show all Redis resources in a subscription. Returns details of all Azure Managed Redis, Azure Cache for Redis, and Azure Redis Enterprise resources. Use this command to explore and view which Redis resources are available in your subscription.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.ResourceHealth/src/Commands/AvailabilityStatus/AvailabilityStatusGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/src/Commands/AvailabilityStatus/AvailabilityStatusGetCommand.cs
@@ -14,30 +14,22 @@ namespace Azure.Mcp.Tools.ResourceHealth.Commands.AvailabilityStatus;
 /// <summary>
 /// Gets or lists availability status information for Azure resources.
 /// </summary>
+[CommandMetadata(
+    Id = "3b388cc7-4b16-4919-9e90-f592247d9891",
+    Name = "get",
+    Title = "Get/List Resource Availability Status",
+    Description = "Get the Azure Resource Health availability status for a specific resource or all resources in a subscription or resource group. Use this tool when asked about the availability status, health status, or Resource Health of an Azure resource (e.g. virtual machine, storage account). Reports whether a resource is Available, Unavailable, Degraded, or Unknown, including the reason and details. This is the correct tool for questions like 'What is the availability status of VM X?' or 'Is resource Y healthy?'.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class AvailabilityStatusGetCommand(ILogger<AvailabilityStatusGetCommand> logger, IResourceHealthService resourceHealthService)
     : BaseResourceHealthCommand<AvailabilityStatusGetOptions>()
 {
-    private const string CommandTitle = "Get/List Resource Availability Status";
     private readonly ILogger<AvailabilityStatusGetCommand> _logger = logger;
     private readonly IResourceHealthService _resourceHealthService = resourceHealthService;
-
-    public override string Id => "3b388cc7-4b16-4919-9e90-f592247d9891";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        "Get the Azure Resource Health availability status for a specific resource or all resources in a subscription or resource group. Use this tool when asked about the availability status, health status, or Resource Health of an Azure resource (e.g. virtual machine, storage account). Reports whether a resource is Available, Unavailable, Degraded, or Unknown, including the reason and details. This is the correct tool for questions like 'What is the availability status of VM X?' or 'Is resource Y healthy?'.";
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ResourceHealth/src/Commands/ServiceHealthEvents/ServiceHealthEventsListCommand.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/src/Commands/ServiceHealthEvents/ServiceHealthEventsListCommand.cs
@@ -13,33 +13,22 @@ namespace Azure.Mcp.Tools.ResourceHealth.Commands.ServiceHealthEvents;
 /// <summary>
 /// Lists Azure service health events for a subscription, providing insights into ongoing or past service issues.
 /// </summary>
+[CommandMetadata(
+    Id = "c3211c73-af20-4d8d-bed2-4f181e0e4c92",
+    Name = "list",
+    Title = "List Service Health Events",
+    Description = "List Azure service health events to track service issues that occurred in recent timeframes (last 30 days, weeks, months). Query subscription for planned maintenance, past or ongoing service incidents, advisories, and security events. Provides detailed information about resource availability state, potential issues, and timestamps. Returns: trackingId, title, summary, eventType, status, startTime, endTime, impactedServices. Access Azure Service Health portal data programmatically.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServiceHealthEventsListCommand(ILogger<ServiceHealthEventsListCommand> logger, IResourceHealthService resourceHealthService)
     : BaseResourceHealthCommand<ServiceHealthEventsListOptions>()
 {
-    private const string CommandTitle = "List Service Health Events";
     private readonly ILogger<ServiceHealthEventsListCommand> _logger = logger;
     private readonly IResourceHealthService _resourceHealthService = resourceHealthService;
-
-    public override string Id => "c3211c73-af20-4d8d-bed2-4f181e0e4c92";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
-        List Azure service health events to track service issues that occurred in recent timeframes (last 30 days, weeks, months). Query subscription for planned maintenance, past or ongoing service incidents, advisories, and security events. Provides detailed information about resource availability state, potential issues, and timestamps. Returns: trackingId, title, summary, eventType, status, startTime, endTime, impactedServices. Access Azure Service Health portal data programmatically.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     private static readonly HashSet<string> validEventTypes = new(StringComparer.OrdinalIgnoreCase) { "ServiceIssue", "PlannedMaintenance", "HealthAdvisory", "Security" };
     private static readonly HashSet<string> validStatuses = new(StringComparer.OrdinalIgnoreCase) { "Active", "Resolved" };

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexGetCommand.cs
@@ -13,34 +13,25 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Search.Commands.Index;
 
-public sealed class IndexGetCommand(ILogger<IndexGetCommand> logger, ISearchService searchService) : GlobalCommand<IndexGetOptions>()
-{
-    private const string CommandTitle = "Get Azure AI Search (formerly known as \"Azure Cognitive Search\") Index Details";
-    private readonly ILogger<IndexGetCommand> _logger = logger;
-    private readonly ISearchService _searchService = searchService;
-
-    public override string Id => "471292d0-4f6d-49d8-bf29-cbcb7b27dedb";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "471292d0-4f6d-49d8-bf29-cbcb7b27dedb",
+    Name = "get",
+    Title = "Get Azure AI Search (formerly known as \"Azure Cognitive Search\") Index Details",
+    Description = """
         List/get/show Azure AI Search indexes in a Search service. Returns index properties such as fields,
         description, and more. If a specific index name is not provided, the command will return details for all
         indexes.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class IndexGetCommand(ILogger<IndexGetCommand> logger, ISearchService searchService) : GlobalCommand<IndexGetOptions>()
+{
+    private readonly ILogger<IndexGetCommand> _logger = logger;
+    private readonly ISearchService _searchService = searchService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexQueryCommand.cs
@@ -11,33 +11,24 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Search.Commands.Index;
 
-public sealed class IndexQueryCommand(ILogger<IndexQueryCommand> logger, ISearchService searchService) : GlobalCommand<IndexQueryOptions>()
-{
-    private const string CommandTitle = "Query an Azure AI Search (formerly known as \"Azure Cognitive Search\") Index";
-    private readonly ILogger<IndexQueryCommand> _logger = logger;
-    private readonly ISearchService _searchService = searchService;
-
-    public override string Id => "f1938a77-8d6c-49c7-b592-71b4f26508e7";
-
-    public override string Name => "query";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "f1938a77-8d6c-49c7-b592-71b4f26508e7",
+    Name = "query",
+    Title = "Query an Azure AI Search (formerly known as \"Azure Cognitive Search\") Index",
+    Description = """
         Queries/searches documents in an Azure AI Search index with a given query, returning the results of the
         query/search.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class IndexQueryCommand(ILogger<IndexQueryCommand> logger, ISearchService searchService) : GlobalCommand<IndexQueryOptions>()
+{
+    private readonly ILogger<IndexQueryCommand> _logger = logger;
+    private readonly ISearchService _searchService = searchService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseGetCommand.cs
@@ -12,37 +12,28 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Search.Commands.Knowledge;
 
-public sealed class KnowledgeBaseGetCommand(ILogger<KnowledgeBaseGetCommand> logger, ISearchService searchService) : GlobalCommand<KnowledgeBaseGetOptions>()
-{
-    private const string CommandTitle = "Get Azure AI Search Knowledge Base Details";
-    private readonly ILogger<KnowledgeBaseGetCommand> _logger = logger;
-    private readonly ISearchService _searchService = searchService;
-
-    public override string Id => "e0e7c288-8d16-4d11-811d-9236dc86d9a8";
-
-    public override string Name => "get";
-
-    public override string Title => CommandTitle;
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "e0e7c288-8d16-4d11-811d-9236dc86d9a8",
+    Name = "get",
+    Title = "Get Azure AI Search Knowledge Base Details",
+    Description = """
         Gets the details of Azure AI Search knowledge bases. Knowledge bases encapsulate retrieval and reasoning
         capabilities over one or more knowledge sources or indexes. If a specific knowledge base name is not provided,
         the command will return details for all knowledge bases within the specified service.
 
         Required arguments:
         - service
-        """;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        LocalRequired = false,
-        OpenWorld = false,
-        ReadOnly = true,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class KnowledgeBaseGetCommand(ILogger<KnowledgeBaseGetCommand> logger, ISearchService searchService) : GlobalCommand<KnowledgeBaseGetOptions>()
+{
+    private readonly ILogger<KnowledgeBaseGetCommand> _logger = logger;
+    private readonly ISearchService _searchService = searchService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseRetrieveCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseRetrieveCommand.cs
@@ -14,20 +14,11 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Search.Commands.Knowledge;
 
-public sealed class KnowledgeBaseRetrieveCommand(ILogger<KnowledgeBaseRetrieveCommand> logger, ISearchService searchService) : GlobalCommand<KnowledgeBaseRetrieveOptions>()
-{
-    private const string CommandTitle = "Execute retrieval using a knowledge base in Azure AI Search";
-    private readonly ILogger<KnowledgeBaseRetrieveCommand> _logger = logger;
-    private readonly ISearchService _searchService = searchService;
-
-    public override string Id => "dcd2952d-02af-4ffc-a7a2-3c6d04251f66";
-
-    public override string Name => "retrieve";
-
-    public override string Title => CommandTitle;
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "dcd2952d-02af-4ffc-a7a2-3c6d04251f66",
+    Name = "retrieve",
+    Title = "Execute retrieval using a knowledge base in Azure AI Search",
+    Description = """
         Execute a retrieval operation using a specific Azure AI Search knowledge base, effectively searching and querying the underlying
         data sources as needed to find relevant information. Provide either a --query for single-turn retrieval or one or more
         conversational --messages in role:content form (e.g. user:What policies apply?). Specifying both --query and --messages is not
@@ -36,17 +27,17 @@ public sealed class KnowledgeBaseRetrieveCommand(ILogger<KnowledgeBaseRetrieveCo
         Required arguments:
         - service
         - knowledge-base
-        """;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        LocalRequired = false,
-        ReadOnly = true,
-        OpenWorld = true, // possibly interacts with Web content and federated data sources
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = true,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class KnowledgeBaseRetrieveCommand(ILogger<KnowledgeBaseRetrieveCommand> logger, ISearchService searchService) : GlobalCommand<KnowledgeBaseRetrieveOptions>()
+{
+    private readonly ILogger<KnowledgeBaseRetrieveCommand> _logger = logger;
+    private readonly ISearchService _searchService = searchService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeSourceGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeSourceGetCommand.cs
@@ -12,20 +12,11 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Search.Commands.Knowledge;
 
-public sealed class KnowledgeSourceGetCommand(ILogger<KnowledgeSourceGetCommand> logger, ISearchService searchService) : GlobalCommand<KnowledgeSourceGetOptions>()
-{
-    private const string CommandTitle = "Get Azure AI Search Knowledge Source Details";
-    private readonly ILogger<KnowledgeSourceGetCommand> _logger = logger;
-    private readonly ISearchService _searchService = searchService;
-
-    public override string Id => "efc985cd-5381-4547-8ffb-89ffe992ea41";
-
-    public override string Name => "get";
-
-    public override string Title => CommandTitle;
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "efc985cd-5381-4547-8ffb-89ffe992ea41",
+    Name = "get",
+    Title = "Get Azure AI Search Knowledge Source Details",
+    Description = """
         Gets the details of Azure AI Search knowledge sources. A knowledge source may point directly at an
         existing Azure AI Search index, or may represent external data (e.g. a blob storage container) that has been
         indexed in Azure AI Search internally. These knowledge sources are used by knowledge bases during retrieval.
@@ -34,17 +25,17 @@ public sealed class KnowledgeSourceGetCommand(ILogger<KnowledgeSourceGetCommand>
 
         Required arguments:
         - service
-        """;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        LocalRequired = false,
-        OpenWorld = false,
-        ReadOnly = true,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class KnowledgeSourceGetCommand(ILogger<KnowledgeSourceGetCommand> logger, ISearchService searchService) : GlobalCommand<KnowledgeSourceGetOptions>()
+{
+    private readonly ILogger<KnowledgeSourceGetCommand> _logger = logger;
+    private readonly ISearchService _searchService = searchService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Service/ServiceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Service/ServiceListCommand.cs
@@ -10,32 +10,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Search.Commands.Service;
 
+[CommandMetadata(
+    Id = "b0684f8c-20de-4bc0-bbc3-982575c8441f",
+    Name = "list",
+    Title = "List Azure AI Search (formerly known as \"Azure Cognitive Search\") Services",
+    Description = "List/show Azure AI Search services in a subscription, returning details about each service.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServiceListCommand(ILogger<ServiceListCommand> logger, ISearchService searchService) : SubscriptionCommand<ServiceListOptions>()
 {
-    private const string CommandTitle = "List Azure AI Search (formerly known as \"Azure Cognitive Search\") Services";
     private readonly ILogger<ServiceListCommand> _logger = logger;
     private readonly ISearchService _searchService = searchService;
-
-    public override string Id => "b0684f8c-20de-4bc0-bbc3-982575c8441f";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
-        List/show Azure AI Search services in a subscription, returning details about each service.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Queue/QueueDetailsCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Queue/QueueDetailsCommand.cs
@@ -15,37 +15,28 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.ServiceBus.Commands.Queue;
 
-public sealed class QueueDetailsCommand(ILogger<QueueDetailsCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<BaseQueueOptions>
-{
-    private const string CommandTitle = "Get Service Bus Queue Details";
-    private readonly ILogger<QueueDetailsCommand> _logger = logger;
-    private readonly IServiceBusService _serviceBusService = serviceBusService;
-
-    public override string Id => "a02c58ce-e89f-4303-ac4a-c9dfb118e761";
-
-    public override string Name => "details";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "a02c58ce-e89f-4303-ac4a-c9dfb118e761",
+    Name = "details",
+    Title = "Get Service Bus Queue Details",
+    Description = """
         Get details about a Service Bus queue. Returns queue properties and runtime information. Properties returned include
         lock duration, max message size, queue size, creation date, status, current message counts, etc.
 
         Required arguments:
         - namespace: The fully qualified Service Bus namespace host name. (This is usually in the form <namespace>.servicebus.windows.net)
         - queue: Queue name to get details and runtime information for.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class QueueDetailsCommand(ILogger<QueueDetailsCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<BaseQueueOptions>
+{
+    private readonly ILogger<QueueDetailsCommand> _logger = logger;
+    private readonly IServiceBusService _serviceBusService = serviceBusService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Queue/QueuePeekCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Queue/QueuePeekCommand.cs
@@ -14,18 +14,11 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.ServiceBus.Commands.Queue;
 
-public sealed class QueuePeekCommand(ILogger<QueuePeekCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<QueuePeekOptions>
-{
-    private const string CommandTitle = "Peek Messages from Service Bus Queue";
-    private readonly ILogger<QueuePeekCommand> _logger = logger;
-    private readonly IServiceBusService _serviceBusService = serviceBusService;
-
-    public override string Id => "90c32c6c-0732-4079-b657-d5129293c67a";
-
-    public override string Name => "peek";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "90c32c6c-0732-4079-b657-d5129293c67a",
+    Name = "peek",
+    Title = "Peek Messages from Service Bus Queue",
+    Description = """
         Peek messages from a Service Bus queue without removing them.  Message browsing, or peeking, enables a
         Service Bus client to enumerate all messages in a queue, for diagnostic and debugging purposes.
         The peek operation returns active, locked, deferred, and scheduled messages in the queue.
@@ -35,19 +28,17 @@ public sealed class QueuePeekCommand(ILogger<QueuePeekCommand> logger, IServiceB
         Required arguments:
         - namespace: The fully qualified Service Bus namespace host name. (This is usually in the form <namespace>.servicebus.windows.net)
         - queue: Queue name to peek messages from
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class QueuePeekCommand(ILogger<QueuePeekCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<QueuePeekOptions>
+{
+    private readonly ILogger<QueuePeekCommand> _logger = logger;
+    private readonly IServiceBusService _serviceBusService = serviceBusService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/SubscriptionDetailsCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/SubscriptionDetailsCommand.cs
@@ -15,37 +15,28 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.ServiceBus.Commands.Topic;
 
-public sealed class SubscriptionDetailsCommand(ILogger<SubscriptionDetailsCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<SubscriptionDetailsOptions>
-{
-    private const string CommandTitle = "Get Service Bus Topic Subscription Details";
-    private readonly ILogger<SubscriptionDetailsCommand> _logger = logger;
-    private readonly IServiceBusService _serviceBusService = serviceBusService;
-
-    public override string Id => "578edf30-01f3-45da-b451-3932dcce7cc5";
-
-    public override string Name => "details";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "578edf30-01f3-45da-b451-3932dcce7cc5",
+    Name = "details",
+    Title = "Get Service Bus Topic Subscription Details",
+    Description = """
         Get details about a Service Bus subscription. Returns subscription runtime properties including message counts, delivery settings, and other metadata.
 
         Required arguments:
         - namespace: The fully qualified Service Bus namespace host name. (This is usually in the form <namespace>.servicebus.windows.net)
         - topic: Topic name containing the subscription
         - subscription-name: Name of the subscription to get details for
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class SubscriptionDetailsCommand(ILogger<SubscriptionDetailsCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<SubscriptionDetailsOptions>
+{
+    private readonly ILogger<SubscriptionDetailsCommand> _logger = logger;
+    private readonly IServiceBusService _serviceBusService = serviceBusService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/SubscriptionPeekCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/SubscriptionPeekCommand.cs
@@ -14,18 +14,11 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.ServiceBus.Commands.Topic;
 
-public sealed class SubscriptionPeekCommand(ILogger<SubscriptionPeekCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<SubscriptionPeekOptions>
-{
-    private const string CommandTitle = "Peek Messages from Service Bus Topic Subscription";
-    private readonly ILogger<SubscriptionPeekCommand> _logger = logger;
-    private readonly IServiceBusService _serviceBusService = serviceBusService;
-
-    public override string Id => "61d32f07-fad6-4e43-9f1e-f0937ce773b3";
-
-    public override string Name => "peek";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "61d32f07-fad6-4e43-9f1e-f0937ce773b3",
+    Name = "peek",
+    Title = "Peek Messages from Service Bus Topic Subscription",
+    Description = """
         Peek messages from a Service Bus subscription without removing them.  Message browsing, or peeking, enables a
         Service Bus client to enumerate all messages in a subscription, for diagnostic and debugging purposes.
         The peek operation returns active, locked, and deferred messages in the subscription.
@@ -36,19 +29,17 @@ public sealed class SubscriptionPeekCommand(ILogger<SubscriptionPeekCommand> log
         - namespace: The fully qualified Service Bus namespace host name. (This is usually in the form <namespace>.servicebus.windows.net)
         - topic: Topic name containing the subscription
         - subscription-name: Subscription name to peek messages from
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class SubscriptionPeekCommand(ILogger<SubscriptionPeekCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<SubscriptionPeekOptions>
+{
+    private readonly ILogger<SubscriptionPeekCommand> _logger = logger;
+    private readonly IServiceBusService _serviceBusService = serviceBusService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/TopicDetailsCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/TopicDetailsCommand.cs
@@ -15,34 +15,25 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.ServiceBus.Commands.Topic;
 
-public sealed class TopicDetailsCommand(ILogger<TopicDetailsCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<BaseTopicOptions>
-{
-    private const string CommandTitle = "Get Service Bus Topic Details";
-    private readonly ILogger<TopicDetailsCommand> _logger = logger;
-    private readonly IServiceBusService _serviceBusService = serviceBusService;
-
-    public override string Id => "c2487c40-58d0-40f7-98f1-105744865a11";
-
-    public override string Name => "details";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "c2487c40-58d0-40f7-98f1-105744865a11",
+    Name = "details",
+    Title = "Get Service Bus Topic Details",
+    Description = """
         Retrieves details about a Service Bus topic. Returns runtime information and topic properties including number of subscriptions, max message size, max topic size, number of scheduled messages, etc.
         Required arguments are namespace: The fully qualified Service Bus namespace host name (usually in the form <namespace>.servicebus.windows.net) and topic: Topic name to get information about.
         Do not use this to get details on Service Bus subscription- instead use servicebus_topic_subscription_details.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class TopicDetailsCommand(ILogger<TopicDetailsCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<BaseTopicOptions>
+{
+    private readonly ILogger<TopicDetailsCommand> _logger = logger;
+    private readonly IServiceBusService _serviceBusService = serviceBusService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ServiceFabric/src/Commands/ManagedCluster/ManagedClusterNodeGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceFabric/src/Commands/ManagedCluster/ManagedClusterNodeGetCommand.cs
@@ -13,31 +13,22 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ServiceFabric.Commands.ManagedCluster;
 
+[CommandMetadata(
+    Id = "a3f1b2c4-d5e6-47f8-9a0b-1c2d3e4f5a6b",
+    Name = "get",
+    Title = "Get Service Fabric Managed Cluster Nodes",
+    Description = "Get nodes for a Service Fabric managed cluster. Returns all nodes by default or a single node when a node name is specified. Includes name, node type, status, IP address, fault domain, upgrade domain, health state, and seed node status.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ManagedClusterNodeGetCommand(ILogger<ManagedClusterNodeGetCommand> logger, IServiceFabricService serviceFabricService)
     : BaseServiceFabricCommand<ManagedClusterNodeGetOptions>
 {
-    private const string CommandTitle = "Get Service Fabric Managed Cluster Nodes";
     private readonly ILogger<ManagedClusterNodeGetCommand> _logger = logger;
     private readonly IServiceFabricService _serviceFabricService = serviceFabricService;
-
-    public override string Id => "a3f1b2c4-d5e6-47f8-9a0b-1c2d3e4f5a6b";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        "Get nodes for a Service Fabric managed cluster. Returns all nodes by default or a single node when a node name is specified. Includes name, node type, status, IP address, fault domain, upgrade domain, health state, and seed node status.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.ServiceFabric/src/Commands/ManagedCluster/ManagedClusterNodeTypeRestartCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceFabric/src/Commands/ManagedCluster/ManagedClusterNodeTypeRestartCommand.cs
@@ -13,31 +13,22 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.ServiceFabric.Commands.ManagedCluster;
 
+[CommandMetadata(
+    Id = "b4f2c3d5-e6f7-48a9-8b1c-2d3e4f5a6b7c",
+    Name = "restart",
+    Title = "Restart Service Fabric Managed Cluster Nodes",
+    Description = "Restart nodes of a specific node type in a Service Fabric managed cluster. Requires the cluster name, node type, and list of node names to restart. Optionally specify the update type (Default or ByUpgradeDomain).",
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ManagedClusterNodeTypeRestartCommand(ILogger<ManagedClusterNodeTypeRestartCommand> logger, IServiceFabricService serviceFabricService)
     : BaseServiceFabricCommand<ManagedClusterNodeTypeRestartOptions>
 {
-    private const string CommandTitle = "Restart Service Fabric Managed Cluster Nodes";
     private readonly ILogger<ManagedClusterNodeTypeRestartCommand> _logger = logger;
     private readonly IServiceFabricService _serviceFabricService = serviceFabricService;
-
-    public override string Id => "b4f2c3d5-e6f7-48a9-8b1c-2d3e4f5a6b7c";
-
-    public override string Name => "restart";
-
-    public override string Description =>
-        "Restart nodes of a specific node type in a Service Fabric managed cluster. Requires the cluster name, node type, and list of node names to restart. Optionally specify the update type (Default or ByUpgradeDomain).";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.SignalR/src/Commands/Runtime/RuntimeGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.SignalR/src/Commands/Runtime/RuntimeGetCommand.cs
@@ -14,35 +14,26 @@ namespace Azure.Mcp.Tools.SignalR.Commands.Runtime;
 /// <summary>
 /// Shows details of an Azure SignalR Service.
 /// </summary>
-public sealed class RuntimeGetCommand(ILogger<RuntimeGetCommand> logger, ISignalRService signalRService)
-    : BaseSignalRCommand<RuntimeGetOptions>
-{
-    private const string CommandTitle = "Show Service Details";
-    private readonly ILogger<RuntimeGetCommand> _logger = logger;
-    private readonly ISignalRService _signalRService = signalRService;
-
-    public override string Id => "bb9035f6-f642-4ee0-83c8-87d6da8266b1";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "bb9035f6-f642-4ee0-83c8-87d6da8266b1",
+    Name = "get",
+    Title = "Show Service Details",
+    Description = """
         Gets or lists details of an Azure SignalR Runtimes. If a specific SignalR name is used, the details of that
         SignalR runtime will be retrieved. Otherwise, all SignalR Runtimes in the specified subscription or resource
         group will be retrieved. Returns runtime information including identity, network ACLs, upstream templates.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class RuntimeGetCommand(ILogger<RuntimeGetCommand> logger, ISignalRService signalRService)
+    : BaseSignalRCommand<RuntimeGetOptions>
+{
+    private readonly ILogger<RuntimeGetCommand> _logger = logger;
+    private readonly ISignalRService _signalRService = signalRService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Speech/src/Commands/Stt/SttRecognizeCommand.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Commands/Stt/SttRecognizeCommand.cs
@@ -13,37 +13,28 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Speech.Commands.Stt;
 
-public sealed class SttRecognizeCommand(ILogger<SttRecognizeCommand> logger, ISpeechService speechService) : BaseSpeechCommand<SttRecognizeOptions>()
-{
-    internal record SttRecognizeCommandResult(SpeechRecognitionResult Result);
-
-    private const string CommandTitle = "Recognize Speech from Audio File";
-    private readonly ILogger<SttRecognizeCommand> _logger = logger;
-    private readonly ISpeechService _speechService = speechService;
-
-    public override string Id => "c725eb52-ca2c-4fe4-9422-935e7557b701";
-
-    public override string Name => "recognize";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "c725eb52-ca2c-4fe4-9422-935e7557b701",
+    Name = "recognize",
+    Title = "Recognize Speech from Audio File",
+    Description = """
         Recognize speech from an audio file using Azure AI Services Speech. This command takes an audio file and converts it to text using advanced speech recognition capabilities.
         You must provide an Azure AI Services endpoint (e.g., https://your-service.cognitiveservices.azure.com/) and a path to the audio file.
         Supported audio formats include WAV, MP3, OPUS/OGG, FLAC, ALAW, MULAW, MP4, M4A, and AAC. Compressed formats require GStreamer to be installed on the system.
         Optional parameters include language specification, phrase hints for better accuracy, output format (simple or detailed), and profanity filtering.
-        """;
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = true)]
+public sealed class SttRecognizeCommand(ILogger<SttRecognizeCommand> logger, ISpeechService speechService) : BaseSpeechCommand<SttRecognizeOptions>()
+{
+    internal record SttRecognizeCommandResult(SpeechRecognitionResult Result);
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = true, // Requires local audio file access
-        Secret = false
-    };
+    private readonly ILogger<SttRecognizeCommand> _logger = logger;
+    private readonly ISpeechService _speechService = speechService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Speech/src/Commands/Tts/TtsSynthesizeCommand.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Commands/Tts/TtsSynthesizeCommand.cs
@@ -13,38 +13,29 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Speech.Commands.Tts;
 
-public sealed class TtsSynthesizeCommand(ILogger<TtsSynthesizeCommand> logger, ISpeechService speechService) : BaseSpeechCommand<TtsSynthesizeOptions>()
-{
-    internal record TtsSynthesizeCommandResult(SynthesisResult Result);
-
-    private const string CommandTitle = "Synthesize Speech from Text";
-    private static readonly HashSet<string> SupportedExtensions = [".wav", ".mp3", ".ogg", ".raw"];
-    private readonly ILogger<TtsSynthesizeCommand> _logger = logger;
-    private readonly ISpeechService _speechService = speechService;
-
-    public override string Name => "synthesize";
-
-    public override string Id => "d6f6687f-feee-4e15-9b98-71aea4076e04";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "d6f6687f-feee-4e15-9b98-71aea4076e04",
+    Name = "synthesize",
+    Title = "Synthesize Speech from Text",
+    Description = """
         Convert text to speech using Azure AI Services Speech. This command takes text input and generates an audio file using advanced neural text-to-speech capabilities.
         You must provide an Azure AI Services endpoint (e.g., https://your-service.cognitiveservices.azure.com/), the text to convert, and an output file path.
         Optional parameters include language specification (default: en-US), voice selection, audio output format (default: Riff24Khz16BitMonoPcm), and custom voice endpoint ID.
         The command supports a wide variety of output formats and neural voices for natural-sounding speech synthesis.
-        """;
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = true)]
+public sealed class TtsSynthesizeCommand(ILogger<TtsSynthesizeCommand> logger, ISpeechService speechService) : BaseSpeechCommand<TtsSynthesizeOptions>()
+{
+    internal record TtsSynthesizeCommandResult(SynthesisResult Result);
 
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = true, // Requires local file output
-        Secret = false
-    };
+    private static readonly HashSet<string> SupportedExtensions = [".wav", ".mp3", ".ogg", ".raw"];
+    private readonly ILogger<TtsSynthesizeCommand> _logger = logger;
+    private readonly ISpeechService _speechService = speechService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseCreateCommand.cs
@@ -13,34 +13,25 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Sql.Commands.Database;
 
+[CommandMetadata(
+    Id = "a4d9af17-fe8b-4df3-93be-23b69f0b5a0c",
+    Name = "create",
+    Title = "Create SQL Database",
+    Description = """
+        Create a new Azure SQL Database on an existing SQL Server. This command creates a database with configurable
+        performance tiers, size limits, and other settings. Equivalent to 'az sql db create'.
+        Returns the newly created database information including configuration details.
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class DatabaseCreateCommand(ISqlService sqlService, ILogger<DatabaseCreateCommand> logger)
     : BaseDatabaseCommand<DatabaseCreateOptions>(logger)
 {
     private readonly ISqlService _sqlService = sqlService;
-    private const string CommandTitle = "Create SQL Database";
-
-    public override string Id => "a4d9af17-fe8b-4df3-93be-23b69f0b5a0c";
-
-    public override string Name => "create";
-
-    public override string Description =>
-        """
-        Create a new Azure SQL Database on an existing SQL Server. This command creates a database with configurable
-        performance tiers, size limits, and other settings. Equivalent to 'az sql db create'.
-        Returns the newly created database information including configuration details.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseDeleteCommand.cs
@@ -10,32 +10,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Sql.Commands.Database;
 
+[CommandMetadata(
+    Id = "c4ef0375-0df9-445c-b8ae-2542e9612425",
+    Name = "delete",
+    Title = "Delete SQL Database",
+    Description = "Deletes a database from an Azure SQL Server.This idempotent operation removes the specified database from the server, returning Deleted = false if the database doesn't exist or Deleted = true if successfully removed.",
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class DatabaseDeleteCommand(ISqlService sqlService, ILogger<DatabaseDeleteCommand> logger)
     : BaseDatabaseCommand<DatabaseDeleteOptions>(logger)
 {
     private readonly ISqlService _sqlService = sqlService;
-    private const string CommandTitle = "Delete SQL Database";
-
-    public override string Id => "c4ef0375-0df9-445c-b8ae-2542e9612425";
-
-    public override string Name => "delete";
-
-    public override string Description =>
-        """
-		Deletes a database from an Azure SQL Server.This idempotent operation removes the specified database from the server, returning Deleted = false if the database doesn't exist or Deleted = true if successfully removed.
-		""";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseGetCommand.cs
@@ -14,36 +14,27 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Sql.Commands.Database;
 
-public sealed class DatabaseGetCommand(ISqlService sqlService, ILogger<DatabaseGetCommand> logger)
-    : BaseSqlCommand<DatabaseGetOptions>(logger)
-{
-    private readonly ISqlService _sqlService = sqlService;
-    private const string CommandTitle = "Get SQL Database";
-
-    public override string Id => "2c4e6a8b-1d3f-4e5a-b6c7-8d9e0f1a2b3c";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "2c4e6a8b-1d3f-4e5a-b6c7-8d9e0f1a2b3c",
+    Name = "get",
+    Title = "Get SQL Database",
+    Description = """
         Show, get, or list Azure SQL databases in a SQL Server. Shows details for a specific Azure SQL database
         by name, or lists all Azure SQL databases in the specified SQL Server. Use to show or retrieve Azure SQL
         database information. Equivalent to 'az sql db show' (show one Azure SQL database) or 'az sql db list'
         (list all Azure SQL databases in a server). Returns database information including configuration details
         and current status.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class DatabaseGetCommand(ISqlService sqlService, ILogger<DatabaseGetCommand> logger)
+    : BaseSqlCommand<DatabaseGetOptions>(logger)
+{
+    private readonly ISqlService _sqlService = sqlService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseRenameCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseRenameCommand.cs
@@ -13,34 +13,25 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Sql.Commands.Database;
 
+[CommandMetadata(
+    Id = "3bddfa1a-ab9d-44f0-830a-e56a159e5469",
+    Name = "rename",
+    Title = "Rename SQL Database",
+    Description = """
+        Rename an existing Azure SQL Database to a new name within the same SQL server. This command moves the
+        database resource to a new identifier while preserving configuration and data. Equivalent to
+        'az sql db rename'. Returns the updated database information using the new name.
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class DatabaseRenameCommand(ISqlService sqlService, ILogger<DatabaseRenameCommand> logger)
     : BaseDatabaseCommand<DatabaseRenameOptions>(logger)
 {
     private readonly ISqlService _sqlService = sqlService;
-    private const string CommandTitle = "Rename SQL Database";
-
-    public override string Id => "3bddfa1a-ab9d-44f0-830a-e56a159e5469";
-
-    public override string Name => "rename";
-
-    public override string Description =>
-        """
-        Rename an existing Azure SQL Database to a new name within the same SQL server. This command moves the
-        database resource to a new identifier while preserving configuration and data. Equivalent to
-        'az sql db rename'. Returns the updated database information using the new name.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseUpdateCommand.cs
@@ -13,35 +13,26 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Sql.Commands.Database;
 
-public sealed class DatabaseUpdateCommand(ISqlService sqlService, ILogger<DatabaseUpdateCommand> logger)
-    : BaseDatabaseCommand<DatabaseUpdateOptions>(logger)
-{
-    private readonly ISqlService _sqlService = sqlService;
-    private const string CommandTitle = "Update SQL Database";
-
-    public override string Id => "16f02fbf-6760-440a-bacc-925365b6de49";
-
-    public override string Name => "update";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "16f02fbf-6760-440a-bacc-925365b6de49",
+    Name = "update",
+    Title = "Update SQL Database",
+    Description = """
         Scale and configure Azure SQL Database performance settings.
         Update an existing database's SKU, compute tier, storage capacity,
         or redundancy options to meet changing performance requirements.
         Returns the updated database configuration including applied scaling changes.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class DatabaseUpdateCommand(ISqlService sqlService, ILogger<DatabaseUpdateCommand> logger)
+    : BaseDatabaseCommand<DatabaseUpdateOptions>(logger)
+{
+    private readonly ISqlService _sqlService = sqlService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/ElasticPool/ElasticPoolListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/ElasticPool/ElasticPoolListCommand.cs
@@ -11,37 +11,28 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Sql.Commands.ElasticPool;
 
-public sealed class ElasticPoolListCommand(ISqlService sqlService, ILogger<ElasticPoolListCommand> logger)
-    : BaseElasticPoolCommand<ElasticPoolListOptions>(logger)
-{
-    private readonly ISqlService _sqlService = sqlService;
-    private const string CommandTitle = "List SQL Elastic Pools";
-
-    public override string Id => "f980fda7-4bd6-4c24-b139-a091f088584f";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "f980fda7-4bd6-4c24-b139-a091f088584f",
+    Name = "list",
+    Title = "List SQL Elastic Pools",
+    Description = """
         Lists all SQL elastic pools in an Azure SQL Server with their SKU, capacity, state, and database limits.
         Use when you need to: view elastic pool inventory, check pool utilization, compare pool configurations,
         or find available pools for database placement.
         Requires: subscription ID, resource group name, server name.
         Returns: JSON array of elastic pools with complete configuration details.
         Equivalent to 'az sql elastic-pool list'.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ElasticPoolListCommand(ISqlService sqlService, ILogger<ElasticPoolListCommand> logger)
+    : BaseElasticPoolCommand<ElasticPoolListOptions>(logger)
+{
+    private readonly ISqlService _sqlService = sqlService;
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/EntraAdmin/EntraAdminListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/EntraAdmin/EntraAdminListCommand.cs
@@ -11,34 +11,25 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Sql.Commands.EntraAdmin;
 
+[CommandMetadata(
+    Id = "240aac03-0eb0-4cd3-91f8-475577289186",
+    Name = "list",
+    Title = "List SQL Server Entra ID Administrators",
+    Description = """
+        Gets a list of Microsoft Entra ID administrators for a SQL server. This command retrieves all
+        Entra ID administrators configured for the specified SQL server, including their display names, object IDs,
+        and tenant information. Returns an array of Entra ID administrator objects with their properties.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class EntraAdminListCommand(ISqlService sqlService, ILogger<EntraAdminListCommand> logger)
     : BaseSqlCommand<EntraAdminListOptions>(logger)
 {
     private readonly ISqlService _sqlService = sqlService;
-    private const string CommandTitle = "List SQL Server Entra ID Administrators";
-
-    public override string Id => "240aac03-0eb0-4cd3-91f8-475577289186";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
-        Gets a list of Microsoft Entra ID administrators for a SQL server. This command retrieves all
-        Entra ID administrators configured for the specified SQL server, including their display names, object IDs,
-        and tenant information. Returns an array of Entra ID administrator objects with their properties.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/FirewallRule/FirewallRuleCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/FirewallRule/FirewallRuleCreateCommand.cs
@@ -14,35 +14,26 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Sql.Commands.FirewallRule;
 
-public sealed class FirewallRuleCreateCommand(ISqlService sqlService, ILogger<FirewallRuleCreateCommand> logger)
-    : BaseSqlCommand<FirewallRuleCreateOptions>(logger)
-{
-    private readonly ISqlService _sqlService = sqlService;
-    private const string CommandTitle = "Create SQL Server Firewall Rule";
-
-    public override string Id => "37c43190-c3f5-4cd2-beda-3ecc2e3ec049";
-
-    public override string Name => "create";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "37c43190-c3f5-4cd2-beda-3ecc2e3ec049",
+    Name = "create",
+    Title = "Create SQL Server Firewall Rule",
+    Description = """
         Creates a firewall rule for a SQL server. Firewall rules control which IP addresses
         are allowed to connect to the SQL server. You can specify either a single IP address
         (by setting start and end IP to the same value) or a range of IP addresses. Returns
         the created firewall rule with its properties.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class FirewallRuleCreateCommand(ISqlService sqlService, ILogger<FirewallRuleCreateCommand> logger)
+    : BaseSqlCommand<FirewallRuleCreateOptions>(logger)
+{
+    private readonly ISqlService _sqlService = sqlService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/FirewallRule/FirewallRuleDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/FirewallRule/FirewallRuleDeleteCommand.cs
@@ -12,35 +12,26 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Sql.Commands.FirewallRule;
 
-public sealed class FirewallRuleDeleteCommand(ISqlService sqlService, ILogger<FirewallRuleDeleteCommand> logger)
-    : BaseSqlCommand<FirewallRuleDeleteOptions>(logger)
-{
-    private readonly ISqlService _sqlService = sqlService;
-    private const string CommandTitle = "Delete SQL Server Firewall Rule";
-
-    public override string Id => "f13fc5d2-7547-480b-a704-36120e2e9b92";
-
-    public override string Name => "delete";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "f13fc5d2-7547-480b-a704-36120e2e9b92",
+    Name = "delete",
+    Title = "Delete SQL Server Firewall Rule",
+    Description = """
         Deletes a firewall rule from a SQL server. This operation removes the specified
         firewall rule, potentially restricting access for the IP addresses that were
         previously allowed by this rule. The operation is idempotent - if the rule
         doesn't exist, no error is returned.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class FirewallRuleDeleteCommand(ISqlService sqlService, ILogger<FirewallRuleDeleteCommand> logger)
+    : BaseSqlCommand<FirewallRuleDeleteOptions>(logger)
+{
+    private readonly ISqlService _sqlService = sqlService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/FirewallRule/FirewallRuleListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/FirewallRule/FirewallRuleListCommand.cs
@@ -11,34 +11,25 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Sql.Commands.FirewallRule;
 
+[CommandMetadata(
+    Id = "1f55cab9-0bbb-499a-a9ac-1492f11c043a",
+    Name = "list",
+    Title = "List SQL Server Firewall Rules",
+    Description = """
+        Gets a list of firewall rules for a SQL server. This command retrieves all
+        firewall rules configured for the specified SQL server, including their IP address ranges
+        and rule names. Returns an array of firewall rule objects with their properties.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class FirewallRuleListCommand(ISqlService sqlService, ILogger<FirewallRuleListCommand> logger)
     : BaseSqlCommand<FirewallRuleListOptions>(logger)
 {
     private readonly ISqlService _sqlService = sqlService;
-    private const string CommandTitle = "List SQL Server Firewall Rules";
-
-    public override string Id => "1f55cab9-0bbb-499a-a9ac-1492f11c043a";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
-        Gets a list of firewall rules for a SQL server. This command retrieves all
-        firewall rules configured for the specified SQL server, including their IP address ranges
-        and rule names. Returns an array of firewall rule objects with their properties.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerCreateCommand.cs
@@ -13,35 +13,26 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Sql.Commands.Server;
 
-public sealed class ServerCreateCommand(ISqlService sqlService, ILogger<ServerCreateCommand> logger)
-    : BaseSqlCommand<ServerCreateOptions>(logger)
-{
-    private readonly ISqlService _sqlService = sqlService;
-    private const string CommandTitle = "Create SQL Server";
-
-    public override string Id => "43f5f55d-2f21-47ac-b7f3-53f5d51b5218";
-
-    public override string Name => "create";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "43f5f55d-2f21-47ac-b7f3-53f5d51b5218",
+    Name = "create",
+    Title = "Create SQL Server",
+    Description = """
         Creates a new Azure SQL server in the specified resource group and location.
         The server will be created with the specified administrator credentials and
         optional configuration settings. Returns the created server with its properties
         including the fully qualified domain name.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ServerCreateCommand(ISqlService sqlService, ILogger<ServerCreateCommand> logger)
+    : BaseSqlCommand<ServerCreateOptions>(logger)
+{
+    private readonly ISqlService _sqlService = sqlService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerDeleteCommand.cs
@@ -12,34 +12,25 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Sql.Commands.Server;
 
+[CommandMetadata(
+    Id = "381bd0ef-5bb4-45ed-ae51-d129dcc044b2",
+    Name = "delete",
+    Title = "Delete SQL Server",
+    Description = """
+        Remove the specified SQL server from your Azure subscription, including all associated databases.
+        This operation permanently deletes all server data and cannot be reversed.
+        Use --force to bypass confirmation.
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServerDeleteCommand(ISqlService sqlService, ILogger<ServerDeleteCommand> logger)
     : BaseSqlCommand<ServerDeleteOptions>(logger)
 {
     private readonly ISqlService _sqlService = sqlService;
-    private const string CommandTitle = "Delete SQL Server";
-
-    public override string Id => "381bd0ef-5bb4-45ed-ae51-d129dcc044b2";
-
-    public override string Name => "delete";
-
-    public override string Description =>
-        """
-        Remove the specified SQL server from your Azure subscription, including all associated databases.
-        This operation permanently deletes all server data and cannot be reversed.
-        Use --force to bypass confirmation.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerGetCommand.cs
@@ -14,37 +14,28 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Sql.Commands.Server;
 
-public sealed class ServerGetCommand(ISqlService sqlService, ILogger<ServerGetCommand> logger)
-    : SubscriptionCommand<ServerGetOptions>
-{
-    private const string CommandTitle = "Get SQL Server";
-    private readonly ISqlService _sqlService = sqlService;
-    private readonly ILogger<ServerGetCommand> _logger = logger;
-
-    public override string Id => "7f9a1c3e-5b7d-4a6c-8e0f-2b4d6a8c0e1f";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "7f9a1c3e-5b7d-4a6c-8e0f-2b4d6a8c0e1f",
+    Name = "get",
+    Title = "Get SQL Server",
+    Description = """
         Show, get, or list Azure SQL servers in a resource group. Shows details for a specific Azure SQL server
         by name, or lists all Azure SQL servers in the specified resource group. Use to show, display, or
         retrieve Azure SQL server information. Equivalent to 'az sql server show' (show one Azure SQL server) or
         'az sql server list' (list all Azure SQL servers in a resource group). Returns server information
         including configuration details and current state.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ServerGetCommand(ISqlService sqlService, ILogger<ServerGetCommand> logger)
+    : SubscriptionCommand<ServerGetOptions>
+{
+    private readonly ISqlService _sqlService = sqlService;
+    private readonly ILogger<ServerGetCommand> _logger = logger;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountCreateCommand.cs
@@ -15,33 +15,24 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Storage.Commands.Account;
 
-public sealed class AccountCreateCommand(ILogger<AccountCreateCommand> logger, IStorageService storageService) : SubscriptionCommand<AccountCreateOptions>()
-{
-    private const string CommandTitle = "Create Storage Account";
-    private readonly ILogger<AccountCreateCommand> _logger = logger;
-    private readonly IStorageService _storageService = storageService;
-
-    public override string Id => "a2cf843a-57f2-45ea-8078-59b0be0805e6";
-
-    public override string Name => "create";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "a2cf843a-57f2-45ea-8078-59b0be0805e6",
+    Name = "create",
+    Title = "Create Storage Account",
+    Description = """
         Creates an Azure Storage account in the specified resource group and location and returns the created storage account
         information including name, location, SKU, access settings, and configuration details.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class AccountCreateCommand(ILogger<AccountCreateCommand> logger, IStorageService storageService) : SubscriptionCommand<AccountCreateOptions>()
+{
+    private readonly ILogger<AccountCreateCommand> _logger = logger;
+    private readonly IStorageService _storageService = storageService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountGetCommand.cs
@@ -14,32 +14,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Storage.Commands.Account;
 
+[CommandMetadata(
+    Id = "eb2363f1-f21f-45fc-ad63-bacfbae8c45c",
+    Name = "get",
+    Title = "Get Storage Account Details",
+    Description = "Retrieves detailed information about Azure Storage accounts, including account name, location, SKU, kind, hierarchical namespace status, HTTPS-only settings, and blob public access configuration. If a specific account name is not provided, the command will return details for all accounts in a subscription.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class AccountGetCommand(ILogger<AccountGetCommand> logger, IStorageService storageService) : SubscriptionCommand<AccountGetOptions>()
 {
-    private const string CommandTitle = "Get Storage Account Details";
     private readonly ILogger<AccountGetCommand> _logger = logger;
     private readonly IStorageService _storageService = storageService;
-
-    public override string Id => "eb2363f1-f21f-45fc-ad63-bacfbae8c45c";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
-        Retrieves detailed information about Azure Storage accounts, including account name, location, SKU, kind, hierarchical namespace status, HTTPS-only settings, and blob public access configuration. If a specific account name is not provided, the command will return details for all accounts in a subscription.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobGetCommand.cs
@@ -14,40 +14,31 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Storage.Commands.Blob;
 
-public sealed class BlobGetCommand(ILogger<BlobGetCommand> logger, IStorageService storageService) : BaseContainerCommand<BlobGetOptions>()
-{
-    private const string CommandTitle = "Get Storage Blob Details";
-    private readonly ILogger<BlobGetCommand> _logger = logger;
-    private readonly IStorageService _storageService = storageService;
-
-    public override string Id => "d6bdc190-e68f-49af-82e7-9cf6ec9b8183";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "d6bdc190-e68f-49af-82e7-9cf6ec9b8183",
+    Name = "get",
+    Title = "Get Storage Blob Details",
+    Description = """
         List/get/show blobs in a blob container in Storage account. Use this tool to list the blobs in a container or
         get details for a specific blob. If no blob specified, lists all blobs present in the container, optionally
         filtering on a prefix. The prefix is ignored if a blob is specified.
 
         Required: --account, --container, --subscription
         Optional: --blob, --tenant, --prefix
-        
+
         Returns: blob name, size, lastModified, contentType, contentHash, metadata, and blob properties.
         Do not use this tool to list containers in the storage account.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class BlobGetCommand(ILogger<BlobGetCommand> logger, IStorageService storageService) : BaseContainerCommand<BlobGetOptions>()
+{
+    private readonly ILogger<BlobGetCommand> _logger = logger;
+    private readonly IStorageService _storageService = storageService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobUploadCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobUploadCommand.cs
@@ -11,33 +11,24 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Storage.Commands.Blob;
 
-public sealed class BlobUploadCommand(ILogger<BlobUploadCommand> logger, IStorageService storageService) : BaseBlobCommand<BlobUploadOptions>
-{
-    private const string CommandTitle = "Upload Local File to Blob";
-    private readonly ILogger<BlobUploadCommand> _logger = logger;
-    private readonly IStorageService _storageService = storageService;
-
-    public override string Id => "aafb82ac-e35a-4800-b362-c642a3ac1e17";
-
-    public override string Name => "upload";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "aafb82ac-e35a-4800-b362-c642a3ac1e17",
+    Name = "upload",
+    Title = "Upload Local File to Blob",
+    Description = """
         Uploads a local file to an Azure Storage blob, only if the blob does not exist, returning the last modified time,
         ETag, and content hash of the uploaded blob.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = true,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = true)]
+public sealed class BlobUploadCommand(ILogger<BlobUploadCommand> logger, IStorageService storageService) : BaseBlobCommand<BlobUploadOptions>
+{
+    private readonly ILogger<BlobUploadCommand> _logger = logger;
+    private readonly IStorageService _storageService = storageService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerCreateCommand.cs
@@ -10,38 +10,29 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Storage.Commands.Blob.Container;
 
-public sealed class ContainerCreateCommand(ILogger<ContainerCreateCommand> logger, IStorageService storageService) : BaseContainerCommand<ContainerCreateOptions>()
-{
-    private const string CommandTitle = "Create Storage Blob Container";
-    private readonly ILogger<ContainerCreateCommand> _logger = logger;
-    private readonly IStorageService _storageService = storageService;
-
-    public override string Id => "f5088334-e630-4df0-a5be-ac87787acad0";
-
-    public override string Name => "create";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "f5088334-e630-4df0-a5be-ac87787acad0",
+    Name = "create",
+    Title = "Create Storage Blob Container",
+    Description = """
         Create/provision a new Azure Storage blob container in a storage account.
-        
+
         Required: --account, --container, --subscription
         Optional: --tenant
-        
+
         Returns: container name, lastModified, eTag, leaseStatus, publicAccessLevel, hasImmutabilityPolicy, hasLegalHold.
         Creates a logical container for organizing blobs within a storage account.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ContainerCreateCommand(ILogger<ContainerCreateCommand> logger, IStorageService storageService) : BaseContainerCommand<ContainerCreateOptions>()
+{
+    private readonly ILogger<ContainerCreateCommand> _logger = logger;
+    private readonly IStorageService _storageService = storageService;
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerGetCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Options;
 using Azure.Mcp.Tools.Storage.Options.Blob.Container;
@@ -14,40 +13,31 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Storage.Commands.Blob.Container;
 
-public sealed class ContainerGetCommand(ILogger<ContainerGetCommand> logger, IStorageService storageService) : BaseStorageCommand<ContainerGetOptions>()
-{
-    private const string CommandTitle = "Get Storage Container Details";
-    private readonly ILogger<ContainerGetCommand> _logger = logger;
-    private readonly IStorageService _storageService = storageService;
-
-    public override string Id => "e96eb850-abb8-431d-bdc6-7ccd0a24838e";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "e96eb850-abb8-431d-bdc6-7ccd0a24838e",
+    Name = "get",
+    Title = "Get Storage Container Details",
+    Description = """
         Show/list containers in a storage account. Use this tool to list all blob containers in the storage account or
         show details for a specific Storage container. If no container specified, shows all containers in the storage
         account, optionally filtering on a prefix. The prefix is ignored if a container is specified.
-        
+
         Required: --account, --subscription
         Optional: --container, --tenant, --prefix
 
         Returns: container name, lastModified, leaseStatus, publicAccess, metadata, and container properties.
         Do not use this tool to list blobs in a container.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ContainerGetCommand(ILogger<ContainerGetCommand> logger, IStorageService storageService) : BaseStorageCommand<ContainerGetOptions>()
+{
+    private readonly ILogger<ContainerGetCommand> _logger = logger;
+    private readonly IStorageService _storageService = storageService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Table/TableListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Table/TableListCommand.cs
@@ -10,29 +10,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Storage.Table.Commands;
 
+[CommandMetadata(
+    Id = "1236ad1d-baf1-4b95-8c1d-420637ce08da",
+    Name = "list",
+    Title = "List Tables in Azure Storage",
+    Description = "List all tables in an Azure Storage account. Shows table names for the specified storage account. Required: account, subscription. Optional: tenant. Returns: table names. Do not use this tool for Cosmos DB tables or Kusto/Data Explorer tables.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class TableListCommand(ILogger<TableListCommand> logger, IStorageService storageService) : BaseStorageCommand<BaseStorageOptions>()
 {
-    private const string CommandTitle = "List Tables in Azure Storage";
     private readonly ILogger<TableListCommand> _logger = logger;
     private readonly IStorageService _storageService = storageService;
-
-    public override string Id => "1236ad1d-baf1-4b95-8c1d-420637ce08da";
-
-    public override string Name => "list";
-
-    public override string Description => "List all tables in an Azure Storage account. Shows table names for the specified storage account. Required: account, subscription. Optional: tenant. Returns: table names. Do not use this tool for Cosmos DB tables or Kusto/Data Explorer tables.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointCreateCommand.cs
@@ -13,29 +13,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.CloudEndpoint;
 
+[CommandMetadata(
+    Id = "df0d4ae3-519a-44f1-ad30-d25a0985e9c2",
+    Name = "create",
+    Title = "Create Cloud Endpoint",
+    Description = "Add a cloud endpoint to a sync group by connecting an Azure File Share. Cloud endpoints represent the Azure storage side of the sync relationship.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class CloudEndpointCreateCommand(ILogger<CloudEndpointCreateCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<CloudEndpointCreateOptions>
 {
-    private const string CommandTitle = "Create Cloud Endpoint";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<CloudEndpointCreateCommand> _logger = logger;
-
-    public override string Id => "df0d4ae3-519a-44f1-ad30-d25a0985e9c2";
-
-    public override string Name => "create";
-
-    public override string Description => "Add a cloud endpoint to a sync group by connecting an Azure File Share. Cloud endpoints represent the Azure storage side of the sync relationship.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointDeleteCommand.cs
@@ -12,29 +12,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.CloudEndpoint;
 
+[CommandMetadata(
+    Id = "f5e76906-cc2a-41a4-b4f9-498221aaaf2e",
+    Name = "delete",
+    Title = "Delete Cloud Endpoint",
+    Description = "Delete a cloud endpoint from a sync group.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class CloudEndpointDeleteCommand(ILogger<CloudEndpointDeleteCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<CloudEndpointDeleteOptions>
 {
-    private const string CommandTitle = "Delete Cloud Endpoint";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<CloudEndpointDeleteCommand> _logger = logger;
-
-    public override string Id => "f5e76906-cc2a-41a4-b4f9-498221aaaf2e";
-
-    public override string Name => "delete";
-
-    public override string Description => "Delete a cloud endpoint from a sync group.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointGetCommand.cs
@@ -14,29 +14,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.CloudEndpoint;
 
+[CommandMetadata(
+    Id = "25dd8bb3-5ba3-4c0d-993d-54917f63d52e",
+    Name = "get",
+    Title = "Get Cloud Endpoint",
+    Description = "List all cloud endpoints in a sync group or retrieve details about a specific cloud endpoint. Returns cloud endpoint properties including Azure File Share configuration, storage account details, and provisioning state. Use --cloud-endpoint-name for a specific endpoint.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class CloudEndpointGetCommand(ILogger<CloudEndpointGetCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<CloudEndpointGetOptions>
 {
-    private const string CommandTitle = "Get Cloud Endpoint";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<CloudEndpointGetCommand> _logger = logger;
-
-    public override string Id => "25dd8bb3-5ba3-4c0d-993d-54917f63d52e";
-
-    public override string Name => "get";
-
-    public override string Description => "List all cloud endpoints in a sync group or retrieve details about a specific cloud endpoint. Returns cloud endpoint properties including Azure File Share configuration, storage account details, and provisioning state. Use --cloud-endpoint-name for a specific endpoint.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointTriggerChangeDetectionCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointTriggerChangeDetectionCommand.cs
@@ -12,29 +12,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.CloudEndpoint;
 
+[CommandMetadata(
+    Id = "96f096a2-d36f-4361-aa74-4e393e7f48a5",
+    Name = "changedetection",
+    Title = "Trigger Change Detection",
+    Description = "Trigger change detection on a cloud endpoint to sync file changes.",
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class CloudEndpointTriggerChangeDetectionCommand(ILogger<CloudEndpointTriggerChangeDetectionCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<CloudEndpointTriggerChangeDetectionOptions>
 {
-    private const string CommandTitle = "Trigger Change Detection";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<CloudEndpointTriggerChangeDetectionCommand> _logger = logger;
-
-    public override string Id => "96f096a2-d36f-4361-aa74-4e393e7f48a5";
-
-    public override string Name => "changedetection";
-
-    public override string Description => "Trigger change detection on a cloud endpoint to sync file changes.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/RegisteredServer/RegisteredServerGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/RegisteredServer/RegisteredServerGetCommand.cs
@@ -14,29 +14,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.RegisteredServer;
 
+[CommandMetadata(
+    Id = "fe3b07c3-9a11-465e-bfb6-6461b85b2e52",
+    Name = "get",
+    Title = "Get Registered Server",
+    Description = "List all registered servers in a Storage Sync service or retrieve details about a specific registered server. Returns server properties including server ID, registration status, agent version, OS version, and last heartbeat. Use --server-id for a specific server.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class RegisteredServerGetCommand(ILogger<RegisteredServerGetCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<RegisteredServerGetOptions>
 {
-    private const string CommandTitle = "Get Registered Server";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<RegisteredServerGetCommand> _logger = logger;
-
-    public override string Id => "fe3b07c3-9a11-465e-bfb6-6461b85b2e52";
-
-    public override string Name => "get";
-
-    public override string Description => "List all registered servers in a Storage Sync service or retrieve details about a specific registered server. Returns server properties including server ID, registration status, agent version, OS version, and last heartbeat. Use --server-id for a specific server.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/RegisteredServer/RegisteredServerUnregisterCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/RegisteredServer/RegisteredServerUnregisterCommand.cs
@@ -12,29 +12,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.RegisteredServer;
 
+[CommandMetadata(
+    Id = "346661e1-64be-463a-96c6-3626966f55fa",
+    Name = "unregister",
+    Title = "Unregister Server",
+    Description = "Unregister a server from a Storage Sync service.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class RegisteredServerUnregisterCommand(ILogger<RegisteredServerUnregisterCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<RegisteredServerUnregisterOptions>
 {
-    private const string CommandTitle = "Unregister Server";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<RegisteredServerUnregisterCommand> _logger = logger;
-
-    public override string Id => "346661e1-64be-463a-96c6-3626966f55fa";
-
-    public override string Name => "unregister";
-
-    public override string Description => "Unregister a server from a Storage Sync service.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/RegisteredServer/RegisteredServerUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/RegisteredServer/RegisteredServerUpdateCommand.cs
@@ -13,29 +13,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.RegisteredServer;
 
+[CommandMetadata(
+    Id = "c443ed00-f17f-46a8-a5d3-df128aa1606b",
+    Name = "update",
+    Title = "Update Registered Server",
+    Description = "Update properties of a registered server.",
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class RegisteredServerUpdateCommand(ILogger<RegisteredServerUpdateCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<RegisteredServerUpdateOptions>
 {
-    private const string CommandTitle = "Update Registered Server";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<RegisteredServerUpdateCommand> _logger = logger;
-
-    public override string Id => "c443ed00-f17f-46a8-a5d3-df128aa1606b";
-
-    public override string Name => "update";
-
-    public override string Description => "Update properties of a registered server.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointCreateCommand.cs
@@ -13,29 +13,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.ServerEndpoint;
 
+[CommandMetadata(
+    Id = "fcbdf461-6fde-4cfb-a944-4a56a2be90e4",
+    Name = "create",
+    Title = "Create Server Endpoint",
+    Description = "Add a server endpoint to a sync group by specifying a local server path to sync. Server endpoints represent the on-premises side of the sync relationship and include cloud tiering configuration.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServerEndpointCreateCommand(ILogger<ServerEndpointCreateCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<ServerEndpointCreateOptions>
 {
-    private const string CommandTitle = "Create Server Endpoint";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<ServerEndpointCreateCommand> _logger = logger;
-
-    public override string Id => "fcbdf461-6fde-4cfb-a944-4a56a2be90e4";
-
-    public override string Name => "create";
-
-    public override string Description => "Add a server endpoint to a sync group by specifying a local server path to sync. Server endpoints represent the on-premises side of the sync relationship and include cloud tiering configuration.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointDeleteCommand.cs
@@ -12,29 +12,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.ServerEndpoint;
 
+[CommandMetadata(
+    Id = "ef6c2aa9-bb64-4f94-b18b-018e04b504c9",
+    Name = "delete",
+    Title = "Delete Server Endpoint",
+    Description = "Delete a server endpoint from a sync group.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServerEndpointDeleteCommand(ILogger<ServerEndpointDeleteCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<ServerEndpointDeleteOptions>
 {
-    private const string CommandTitle = "Delete Server Endpoint";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<ServerEndpointDeleteCommand> _logger = logger;
-
-    public override string Id => "ef6c2aa9-bb64-4f94-b18b-018e04b504c9";
-
-    public override string Name => "delete";
-
-    public override string Description => "Delete a server endpoint from a sync group.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointGetCommand.cs
@@ -14,29 +14,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.ServerEndpoint;
 
+[CommandMetadata(
+    Id = "cf197b94-6aa6-403b-8679-3a1ce5440ca3",
+    Name = "get",
+    Title = "Get Server Endpoint",
+    Description = "List all server endpoints in a sync group or retrieve details about a specific server endpoint. Returns server endpoint properties including local path, cloud tiering status, sync health, and provisioning state. Use --name for a specific endpoint.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServerEndpointGetCommand(ILogger<ServerEndpointGetCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<ServerEndpointGetOptions>
 {
-    private const string CommandTitle = "Get Server Endpoint";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<ServerEndpointGetCommand> _logger = logger;
-
-    public override string Id => "cf197b94-6aa6-403b-8679-3a1ce5440ca3";
-
-    public override string Name => "get";
-
-    public override string Description => "List all server endpoints in a sync group or retrieve details about a specific server endpoint. Returns server endpoint properties including local path, cloud tiering status, sync health, and provisioning state. Use --name for a specific endpoint.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointUpdateCommand.cs
@@ -13,29 +13,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.ServerEndpoint;
 
+[CommandMetadata(
+    Id = "7b35bb46-0a34-4e44-9d7c-148e9992b445",
+    Name = "update",
+    Title = "Update Server Endpoint",
+    Description = "Update properties of a server endpoint.",
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServerEndpointUpdateCommand(ILogger<ServerEndpointUpdateCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<ServerEndpointUpdateOptions>
 {
-    private const string CommandTitle = "Update Server Endpoint";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<ServerEndpointUpdateCommand> _logger = logger;
-
-    public override string Id => "7b35bb46-0a34-4e44-9d7c-148e9992b445";
-
-    public override string Name => "update";
-
-    public override string Description => "Update properties of a server endpoint.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceCreateCommand.cs
@@ -13,29 +13,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.StorageSyncService;
 
+[CommandMetadata(
+    Id = "7c76387f-c62e-48d1-af3b-d444d6b3b79c",
+    Name = "create",
+    Title = "Create Storage Sync Service",
+    Description = "Create a new Azure Storage Sync service resource in a resource group. This is the top-level service container that manages sync groups, registered servers, and synchronization workflows.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class StorageSyncServiceCreateCommand(ILogger<StorageSyncServiceCreateCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<StorageSyncServiceCreateOptions>
 {
-    private const string CommandTitle = "Create Storage Sync Service";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<StorageSyncServiceCreateCommand> _logger = logger;
-
-    public override string Id => "7c76387f-c62e-48d1-af3b-d444d6b3b79c";
-
-    public override string Name => "create";
-
-    public override string Description => "Create a new Azure Storage Sync service resource in a resource group. This is the top-level service container that manages sync groups, registered servers, and synchronization workflows.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceDeleteCommand.cs
@@ -12,29 +12,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.StorageSyncService;
 
+[CommandMetadata(
+    Id = "a7dcf4e2-fd1d-4d0a-acd3-f56ea5eceef6",
+    Name = "delete",
+    Title = "Delete Storage Sync Service",
+    Description = "Delete an Azure Storage Sync service and all its associated resources.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class StorageSyncServiceDeleteCommand(ILogger<StorageSyncServiceDeleteCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<StorageSyncServiceDeleteOptions>
 {
-    private const string CommandTitle = "Delete Storage Sync Service";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<StorageSyncServiceDeleteCommand> _logger = logger;
-
-    public override string Id => "a7dcf4e2-fd1d-4d0a-acd3-f56ea5eceef6";
-
-    public override string Name => "delete";
-
-    public override string Description => "Delete an Azure Storage Sync service and all its associated resources.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceGetCommand.cs
@@ -14,29 +14,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.StorageSyncService;
 
+[CommandMetadata(
+    Id = "77734a55-8290-4c16-8b37-cf37277f018f",
+    Name = "get",
+    Title = "Get Storage Sync Service",
+    Description = "Retrieve Azure Storage Sync service details or list all Storage Sync services. Use --name to get a specific service, or omit it to list all services in the subscription or resource group. Shows service properties, location, provisioning state, and configuration.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class StorageSyncServiceGetCommand(ILogger<StorageSyncServiceGetCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<StorageSyncServiceGetOptions>
 {
-    private const string CommandTitle = "Get Storage Sync Service";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<StorageSyncServiceGetCommand> _logger = logger;
-
-    public override string Id => "77734a55-8290-4c16-8b37-cf37277f018f";
-
-    public override string Name => "get";
-
-    public override string Description => "Retrieve Azure Storage Sync service details or list all Storage Sync services. Use --name to get a specific service, or omit it to list all services in the subscription or resource group. Shows service properties, location, provisioning state, and configuration.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceUpdateCommand.cs
@@ -13,29 +13,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.StorageSyncService;
 
+[CommandMetadata(
+    Id = "15db4769-1941-4b1e-9514-867b0f68eb2c",
+    Name = "update",
+    Title = "Update Storage Sync Service",
+    Description = "Update properties of an existing Azure Storage Sync service.",
+    Destructive = false,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class StorageSyncServiceUpdateCommand(ILogger<StorageSyncServiceUpdateCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<StorageSyncServiceUpdateOptions>
 {
-    private const string CommandTitle = "Update Storage Sync Service";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<StorageSyncServiceUpdateCommand> _logger = logger;
-
-    public override string Id => "15db4769-1941-4b1e-9514-867b0f68eb2c";
-
-    public override string Name => "update";
-
-    public override string Description => "Update properties of an existing Azure Storage Sync service.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/SyncGroup/SyncGroupCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/SyncGroup/SyncGroupCreateCommand.cs
@@ -13,29 +13,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.SyncGroup;
 
+[CommandMetadata(
+    Id = "3572833c-4fc2-4bb9-9eed-52ae8b8899b8",
+    Name = "create",
+    Title = "Create Sync Group",
+    Description = "Create a sync group within an existing Storage Sync service. Sync groups define a sync topology and contain cloud endpoints (Azure File Shares) and server endpoints (local server paths) that sync together.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SyncGroupCreateCommand(ILogger<SyncGroupCreateCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<SyncGroupCreateOptions>
 {
-    private const string CommandTitle = "Create Sync Group";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<SyncGroupCreateCommand> _logger = logger;
-
-    public override string Id => "3572833c-4fc2-4bb9-9eed-52ae8b8899b8";
-
-    public override string Name => "create";
-
-    public override string Description => "Create a sync group within an existing Storage Sync service. Sync groups define a sync topology and contain cloud endpoints (Azure File Shares) and server endpoints (local server paths) that sync together.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/SyncGroup/SyncGroupDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/SyncGroup/SyncGroupDeleteCommand.cs
@@ -12,29 +12,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.SyncGroup;
 
+[CommandMetadata(
+    Id = "c8f91bd7-ea1d-4af4-9703-fe83c43b34b5",
+    Name = "delete",
+    Title = "Delete Sync Group",
+    Description = "Remove a sync group from a Storage Sync service. Deleting a sync group also removes all associated cloud endpoints and server endpoints within that group.",
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SyncGroupDeleteCommand(ILogger<SyncGroupDeleteCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<SyncGroupDeleteOptions>
 {
-    private const string CommandTitle = "Delete Sync Group";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<SyncGroupDeleteCommand> _logger = logger;
-
-    public override string Id => "c8f91bd7-ea1d-4af4-9703-fe83c43b34b5";
-
-    public override string Name => "delete";
-
-    public override string Description => "Remove a sync group from a Storage Sync service. Deleting a sync group also removes all associated cloud endpoints and server endpoints within that group.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/SyncGroup/SyncGroupGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/SyncGroup/SyncGroupGetCommand.cs
@@ -14,29 +14,21 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.StorageSync.Commands.SyncGroup;
 
+[CommandMetadata(
+    Id = "95ce2336-19e6-40fb-a3ea-e2a76772036b",
+    Name = "get",
+    Title = "Get Sync Group",
+    Description = "Get details about a specific sync group or list all sync groups. If --sync-group-name is provided, returns a specific sync group; otherwise, lists all sync groups in the Storage Sync service.",
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SyncGroupGetCommand(ILogger<SyncGroupGetCommand> logger, IStorageSyncService service) : BaseStorageSyncCommand<SyncGroupGetOptions>
 {
-    private const string CommandTitle = "Get Sync Group";
     private readonly IStorageSyncService _service = service;
     private readonly ILogger<SyncGroupGetCommand> _logger = logger;
-
-    public override string Id => "95ce2336-19e6-40fb-a3ea-e2a76772036b";
-
-    public override string Name => "get";
-
-    public override string Description => "Get details about a specific sync group or list all sync groups. If --sync-group-name is provided, returns a specific sync group; otherwise, lists all sync groups in the Storage Sync service.";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/Hostpool/HostpoolListCommand.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/Hostpool/HostpoolListCommand.cs
@@ -10,34 +10,25 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.VirtualDesktop.Commands.Hostpool;
 
+[CommandMetadata(
+    Id = "bf0ae005-7dfd-4f96-8f45-3d0ba07f81ed",
+    Name = "list",
+    Title = "List hostpools",
+    Description = """
+        List all hostpools in a subscription or resource group. This command retrieves all Azure Virtual Desktop hostpool objects available
+        in the specified --subscription. If a resource group is specified, only hostpools in that resource group are returned.
+        Results include hostpool names and are returned as a JSON array.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class HostpoolListCommand(ILogger<HostpoolListCommand> logger, IVirtualDesktopService virtualDesktopService) : BaseVirtualDesktopCommand<HostpoolListOptions>
 {
-    private const string CommandTitle = "List hostpools";
     private readonly ILogger<HostpoolListCommand> _logger = logger;
     private readonly IVirtualDesktopService _virtualDesktopService = virtualDesktopService;
-
-    public override string Id => "bf0ae005-7dfd-4f96-8f45-3d0ba07f81ed";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        $"""
-		List all hostpools in a subscription or resource group. This command retrieves all Azure Virtual Desktop hostpool objects available
-		in the specified {OptionDefinitions.Common.Subscription.Name}. If a resource group is specified, only hostpools in that resource group are returned.
-		Results include hostpool names and are returned as a JSON array.
-		""";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/SessionHost/SessionHostListCommand.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/SessionHost/SessionHostListCommand.cs
@@ -12,34 +12,25 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.VirtualDesktop.Commands.SessionHost;
 
+[CommandMetadata(
+    Id = "6f543101-3c70-41bd-a6ed-5cc4af716081",
+    Name = "list",
+    Title = "List SessionHosts",
+    Description = """
+        List all SessionHosts in a hostpool. This command retrieves all Azure Virtual Desktop SessionHost objects available
+        in the specified --subscription and hostpool. Results include SessionHost details and are
+        returned as a JSON array.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SessionHostListCommand(ILogger<SessionHostListCommand> logger, IVirtualDesktopService virtualDesktopService) : BaseHostPoolCommand<SessionHostListOptions>
 {
-    private const string CommandTitle = "List SessionHosts";
     private readonly ILogger<SessionHostListCommand> _logger = logger;
     private readonly IVirtualDesktopService _virtualDesktopService = virtualDesktopService;
-
-    public override string Name => "list";
-
-    public override string Description =>
-        $"""
-		List all SessionHosts in a hostpool. This command retrieves all Azure Virtual Desktop SessionHost objects available
-		in the specified {OptionDefinitions.Common.Subscription.Name} and hostpool. Results include SessionHost details and are
-		returned as a JSON array.
-		""";
-
-    public override string Id => "6f543101-3c70-41bd-a6ed-5cc4af716081";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/SessionHost/SessionHostUserSessionListCommand.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/SessionHost/SessionHostUserSessionListCommand.cs
@@ -10,34 +10,26 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.VirtualDesktop.Commands.SessionHost;
 
+[CommandMetadata(
+    Id = "1653a208-ac9f-4e51-996f-fe2d29a79b2b",
+    Name = "user-list",
+    Title = "List User Sessions on Session Host",
+    Description = """
+        List all user sessions on a specific session host in a host pool. This command retrieves all Azure Virtual Desktop
+        user session objects available on the specified session host. Results include user session details such as
+        user principal name, session state, application type, and creation time.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class SessionHostUserSessionListCommand(ILogger<SessionHostUserSessionListCommand> logger, IVirtualDesktopService virtualDesktopService)
     : BaseSessionHostCommand
 {
-    private const string CommandTitle = "List User Sessions on Session Host";
     private readonly ILogger<SessionHostUserSessionListCommand> _logger = logger;
     private readonly IVirtualDesktopService _virtualDesktopService = virtualDesktopService;
-    public override string Id => "1653a208-ac9f-4e51-996f-fe2d29a79b2b";
-
-    public override string Name => "user-list";
-
-    public override string Description =>
-        """
-		List all user sessions on a specific session host in a host pool. This command retrieves all Azure Virtual Desktop
-		user session objects available on the specified session host. Results include user session details such as
-		user principal name, session state, application type, and creation time.
-		""";
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.WellArchitectedFramework/src/Commands/ServiceGuide/ServiceGuideGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.WellArchitectedFramework/src/Commands/ServiceGuide/ServiceGuideGetCommand.cs
@@ -11,35 +11,25 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.WellArchitectedFramework.Commands.ServiceGuide;
 
+[CommandMetadata(
+    Id = "a7d4e9f2-8c3b-4a1e-9f5d-6b2c8e4a7d3f",
+    Name = "get",
+    Title = "Get Well-Architected Framework Service Guide",
+    Description = """
+        Get Azure Well-Architected Framework guidance for a specific Azure service, or list all supported services when no service is specified. When a service is provided, returns architectural best practices, design patterns, and recommendations based on the five pillars: reliability, security, cost optimization, operational excellence, and performance efficiency.
+        Optional: --service: A single Azure service name. Service name format: case-insensitive; hyphens, underscores, spaces, and name variations allowed; use double quotes (not single quotes) for names with spaces. e.g., cosmos-db, Cosmos_DB, "Cosmos DB", cosmosdb, cosmos-database, cosmosdatabase
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class ServiceGuideGetCommand(ILogger<ServiceGuideGetCommand> logger, IServiceGuideService serviceGuideService)
     : BaseCommand<ServiceGuideGetOptions>
 {
-    private const string CommandTitle = "Get Well-Architected Framework Service Guide";
     private readonly ILogger<ServiceGuideGetCommand> _logger = logger;
     private readonly IServiceGuideService _serviceGuideService = serviceGuideService;
-
-    public override string Id => "a7d4e9f2-8c3b-4a1e-9f5d-6b2c8e4a7d3f";
-
-    public override string Name => "get";
-
-    public override string Description =>
-        "Get Azure Well-Architected Framework guidance for a specific Azure service, " +
-        "or list all supported services when no service is specified. " +
-        "When a service is provided, returns architectural best practices, design patterns, and recommendations based on the five pillars: " +
-        "reliability, security, cost optimization, operational excellence, and performance efficiency. " +
-        "Optional: --service: " + WellArchitectedFrameworkOptionDefinitions.ServiceNameDescription;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/CreateWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/CreateWorkbooksCommand.cs
@@ -14,33 +14,25 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Workbooks.Commands.Workbooks;
 
-public sealed class CreateWorkbooksCommand(ILogger<CreateWorkbooksCommand> logger, IWorkbooksService workbooksService) : SubscriptionCommand<CreateWorkbookOptions>
-{
-    private const string CommandTitle = "Create Workbook";
-    private readonly ILogger<CreateWorkbooksCommand> _logger = logger;
-    private readonly IWorkbooksService _workbooksService = workbooksService;
-    public override string Id => "a49c650d-8568-4b63-8bad-35eb6d9ab0a7";
-
-    public override string Name => "create";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "a49c650d-8568-4b63-8bad-35eb6d9ab0a7",
+    Name = "create",
+    Title = "Create Workbook",
+    Description = """
         Create a new workbook in the specified resource group and subscription.
         You can set the display name and serialized data JSON content for the workbook.
         Returns the created workbook information upon successful completion.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = false,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class CreateWorkbooksCommand(ILogger<CreateWorkbooksCommand> logger, IWorkbooksService workbooksService) : SubscriptionCommand<CreateWorkbookOptions>
+{
+    private readonly ILogger<CreateWorkbooksCommand> _logger = logger;
+    private readonly IWorkbooksService _workbooksService = workbooksService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/DeleteWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/DeleteWorkbooksCommand.cs
@@ -12,17 +12,11 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Workbooks.Commands.Workbooks;
 
-public sealed class DeleteWorkbooksCommand(ILogger<DeleteWorkbooksCommand> logger, IWorkbooksService workbooksService) : GlobalCommand<DeleteWorkbookOptions>
-{
-    private const string CommandTitle = "Delete Workbook";
-    private readonly ILogger<DeleteWorkbooksCommand> _logger = logger;
-    private readonly IWorkbooksService _workbooksService = workbooksService;
-    public override string Id => "17bb94ef-9df1-45d2-a1a0-ed57656ca067";
-
-    public override string Name => "delete";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "17bb94ef-9df1-45d2-a1a0-ed57656ca067",
+    Name = "delete",
+    Title = "Delete Workbook",
+    Description = """
         Delete one or more workbooks by their Azure resource IDs.
         This command soft deletes workbooks: they will be retained for 90 days.
         If needed, you can restore them from the Recycle Bin through the Azure Portal.
@@ -31,19 +25,17 @@ public sealed class DeleteWorkbooksCommand(ILogger<DeleteWorkbooksCommand> logge
         Individual failures do not fail the entire batch operation.
 
         To learn more, visit: https://learn.microsoft.com/azure/azure-monitor/visualize/workbooks-manage
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class DeleteWorkbooksCommand(ILogger<DeleteWorkbooksCommand> logger, IWorkbooksService workbooksService) : GlobalCommand<DeleteWorkbookOptions>
+{
+    private readonly ILogger<DeleteWorkbooksCommand> _logger = logger;
+    private readonly IWorkbooksService _workbooksService = workbooksService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ListWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ListWorkbooksCommand.cs
@@ -14,17 +14,11 @@ using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Workbooks.Commands.Workbooks;
 
-public sealed class ListWorkbooksCommand(ILogger<ListWorkbooksCommand> logger, IWorkbooksService workbooksService) : SubscriptionCommand<ListWorkbooksOptions>
-{
-    private const string CommandTitle = "List Workbooks";
-    private readonly ILogger<ListWorkbooksCommand> _logger = logger;
-    private readonly IWorkbooksService _workbooksService = workbooksService;
-    public override string Id => "c4c90435-fbc0-4598-ba82-3b9213d58b26";
-
-    public override string Name => "list";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "c4c90435-fbc0-4598-ba82-3b9213d58b26",
+    Name = "list",
+    Title = "List Workbooks",
+    Description = """
         Search Azure Workbooks using Resource Graph (fast metadata query).
 
         USE FOR: Discovery, filtering, counting workbooks across scopes.
@@ -37,19 +31,17 @@ public sealed class ListWorkbooksCommand(ILogger<ListWorkbooksCommand> logger, I
         OUTPUT FORMAT: Use --output-format=summary for minimal tokens, --output-format=full for serializedData.
 
         FILTERS: --name-contains, --category, --kind, --source-id, --modified-after for semantic filtering.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ListWorkbooksCommand(ILogger<ListWorkbooksCommand> logger, IWorkbooksService workbooksService) : SubscriptionCommand<ListWorkbooksOptions>
+{
+    private readonly ILogger<ListWorkbooksCommand> _logger = logger;
+    private readonly IWorkbooksService _workbooksService = workbooksService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ShowWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ShowWorkbooksCommand.cs
@@ -12,17 +12,11 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Workbooks.Commands.Workbooks;
 
-public sealed class ShowWorkbooksCommand(ILogger<ShowWorkbooksCommand> logger, IWorkbooksService workbooksService) : BaseWorkbooksCommand<ShowWorkbooksOptions>
-{
-    private const string CommandTitle = "Get Workbook";
-    private readonly ILogger<ShowWorkbooksCommand> _logger = logger;
-    private readonly IWorkbooksService _workbooksService = workbooksService;
-    public override string Id => "a7a882cd-1729-49ed-b349-2a79f8c7de56";
-
-    public override string Name => "show";
-
-    public override string Description =>
-        """
+[CommandMetadata(
+    Id = "a7a882cd-1729-49ed-b349-2a79f8c7de56",
+    Name = "show",
+    Title = "Get Workbook",
+    Description = """
         Retrieve full workbook details via ARM API (includes serializedData content).
 
         USE FOR: Getting complete workbook definition including visualization JSON.
@@ -30,19 +24,17 @@ public sealed class ShowWorkbooksCommand(ILogger<ShowWorkbooksCommand> logger, I
 
         BATCH: Accepts multiple --workbook-ids values. Partial failures reported per-workbook.
         PERFORMANCE: Use 'list' first for discovery, then 'show' for specific workbooks.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = false,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = true,
-        LocalRequired = false,
-        Secret = false
-    };
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ShowWorkbooksCommand(ILogger<ShowWorkbooksCommand> logger, IWorkbooksService workbooksService) : BaseWorkbooksCommand<ShowWorkbooksOptions>
+{
+    private readonly ILogger<ShowWorkbooksCommand> _logger = logger;
+    private readonly IWorkbooksService _workbooksService = workbooksService;
 
     protected override void RegisterOptions(Command command)
     {

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/UpdateWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/UpdateWorkbooksCommand.cs
@@ -12,31 +12,21 @@ using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.Workbooks.Commands.Workbooks;
 
+[CommandMetadata(
+    Id = "9efdc32c-22bc-4b85-8b5c-2fbefc0e927e",
+    Name = "update",
+    Title = "Update Workbook",
+    Description = "Updates properties of an existing Azure Workbook by adding new steps, modifying content, or changing the display name. Returns the updated workbook details.  Requires the workbook resource ID and either new serialized content or a new display name.",
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
 public sealed class UpdateWorkbooksCommand(ILogger<UpdateWorkbooksCommand> logger, IWorkbooksService workbooksService) : BaseWorkbooksCommand<UpdateWorkbooksOptions>
 {
-    private const string CommandTitle = "Update Workbook";
     private readonly ILogger<UpdateWorkbooksCommand> _logger = logger;
     private readonly IWorkbooksService _workbooksService = workbooksService;
-    public override string Id => "9efdc32c-22bc-4b85-8b5c-2fbefc0e927e";
-
-    public override string Name => "update";
-
-    public override string Description =>
-        """
-        Updates properties of an existing Azure Workbook by adding new steps, modifying content, or changing the display name. Returns the updated workbook details.  Requires the workbook resource ID and either new serialized content or a new display name.
-        """;
-
-    public override string Title => CommandTitle;
-
-    public override ToolMetadata Metadata => new()
-    {
-        Destructive = true,
-        Idempotent = true,
-        OpenWorld = false,
-        ReadOnly = false,
-        LocalRequired = false,
-        Secret = false
-    };
 
     protected override void RegisterOptions(Command command)
     {


### PR DESCRIPTION
## What does this PR do?

This pull request refactors the way command metadata is defined throughout the codebase by introducing and consistently applying the `[CommandMetadata]` attribute to all command classes. This change eliminates redundant property overrides and centralizes metadata definition, resulting in cleaner, more maintainable, and less error-prone command implementations. The update also aligns the command documentation template with this new pattern.

Key changes include:

**Refactoring Command Metadata Definition:**

* Replaced explicit property overrides (`Id`, `Name`, `Title`, `Description`, and `Metadata`) in command classes with the `[CommandMetadata]` attribute, streamlining metadata declaration and reducing boilerplate across all major command files, including `GroupListCommand`, `ResourceListCommand`, `SubscriptionListCommand`, `PluginTelemetryCommand`, `ServiceInfoCommand`, `ServiceStartCommand`, `ToolsListCommand`, `RegistryListCommand`, `RegistryRepositoryListCommand`, and `RecommendationListCommand`. [[1]](diffhunk://#diff-f247db43af0436a7d92d9827a3c907c91b9745ec02cbc7bec5038609d3fef1e4L10-R31) [[2]](diffhunk://#diff-f0ec7ef6de18c1733a2d5cbdc2381d615b461d407caf3ed2a6ef8b8e1ef26458L16-R35) [[3]](diffhunk://#diff-b9382c6389bb7e640b960e15ff6d7c82d7e8ebe75067a7d3c81e43f9c9974bffL14-R27) [[4]](diffhunk://#diff-70d80ff6f36e21de03bb29f4d90c41f568214a969866a652d41eeed4fb746b99L27-R50) [[5]](diffhunk://#diff-df3d011e4d184bbf84e127852ee3976576403d9657c7ed211a1841c5e9be9c62R17-L41) [[6]](diffhunk://#diff-fb227812e181824eda546090e1b2f4f17da608dfcb8a31401531472ba50c0cb0R44-L46) [[7]](diffhunk://#diff-fb227812e181824eda546090e1b2f4f17da608dfcb8a31401531472ba50c0cb0L58-L83) [[8]](diffhunk://#diff-d3693ae0a5c7bc091fb0467ba6ba62c070c803a98b8f919de5fa6c51b9c4256aL15-R31) [[9]](diffhunk://#diff-f1fe682720f3ed5775f144747cf65c7c3a94eae14892e23cc311317ab10eba36L12-R30) [[10]](diffhunk://#diff-07004b3617c7da9eaf470dd62efcbdc87e5c0a96e79299f0af68b486996d303dL14-R32) [[11]](diffhunk://#diff-f42d8b54ab6916471cada890988da17e52040f6a96b46f6f6e9326834991e31fL13-R27)

**Documentation and Template Updates:**

* Updated the new command documentation template (`new-command.md`) to demonstrate the use of `[CommandMetadata]`, ensuring that future commands follow the new, standardized pattern.

**Minor Cleanups:**

* Fixed a minor copyright header formatting issue.

These changes collectively improve consistency, readability, and maintainability of command definitions across the codebase.

## GitHub issue number?
Partially implements #2524

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
