### PR TITLE
feat(azurebackup): Add security configure-mua command for Multi-User Authorization

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1777562845809.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1777562845809.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Features Added"
+    description: "Added `azurebackup security configure-mua` command to enable/disable Multi-User Authorization (MUA) on Recovery Services vaults and Backup vaults by linking/unlinking a Resource Guard."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -1003,6 +1003,19 @@ azmcp azurebackup disasterrecovery enable-crr --subscription <subscription> \
                                               [--vault-type <vault-type>]
 ```
 
+#### Security
+
+```bash
+# Configures Multi-User Authorization (MUA) on a vault by linking or unlinking a Resource Guard.
+# Provide --resource-guard-id to enable MUA. Omit to disable MUA (protected operation).
+# ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
+azmcp azurebackup security configure-mua --subscription <subscription> \
+                                         --resource-group <resource-group> \
+                                         --vault <vault> \
+                                         [--vault-type <vault-type>] \
+                                         [--resource-guard-id <resource-guard-id>]
+```
+
 ### Azure CLI Operations
 
 #### Generate

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -164,6 +164,8 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | azurebackup_protecteditem_undelete | Undelete the accidentally deleted backup for VM <datasource_id> in vault <vault_name> under resource group <resource_group> |
 | azurebackup_recoverypoint_get | Get recovery points for protected item <item_name> in vault <vault_name> and resource group <resource_group> |
 | azurebackup_recoverypoint_get | List available recovery points for <item_name> in vault <vault_name> under resource group <resource_group> |
+| azurebackup_security_configure-mua | Enable multi-user authorization on vault <vault_name> in resource group <resource_group> with resource guard <resource_guard_id> |
+| azurebackup_security_configure-mua | Disable MUA on vault <vault_name> in resource group <resource_group> |
 | azurebackup_vault_create | Create a Recovery Services vault named <vault_name> in resource group <resource_group> in region <location> with vault-type 'rsv' |
 | azurebackup_vault_create | Set up a new backup vault called <vault_name> in <location> under resource group <resource_group> with vault-type 'dpp' |
 | azurebackup_vault_get | Get details of Recovery Services vault <vault_name> in resource group <resource_group> |

--- a/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json
+++ b/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json
@@ -3839,7 +3839,8 @@
         "azurebackup_governance_immutability",
         "azurebackup_governance_soft-delete",
         "azurebackup_disasterrecovery_enable-crr",
-        "azurebackup_protecteditem_undelete"
+        "azurebackup_protecteditem_undelete",
+        "azurebackup_security_configure-mua"
       ]
     },
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/AzureBackupSetup.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/AzureBackupSetup.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.AzureBackup.Commands.Policy;
 using Azure.Mcp.Tools.AzureBackup.Commands.ProtectableItem;
 using Azure.Mcp.Tools.AzureBackup.Commands.ProtectedItem;
 using Azure.Mcp.Tools.AzureBackup.Commands.RecoveryPoint;
+using Azure.Mcp.Tools.AzureBackup.Commands.Security;
 using Azure.Mcp.Tools.AzureBackup.Commands.Vault;
 using Azure.Mcp.Tools.AzureBackup.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -54,6 +55,8 @@ public sealed class AzureBackupSetup : IAreaSetup
         services.AddSingleton<GovernanceSoftDeleteCommand>();
 
         services.AddSingleton<DisasterRecoveryEnableCrrCommand>();
+
+        services.AddSingleton<SecurityConfigureMuaCommand>();
     }
 
     public CommandGroup RegisterCommands(IServiceProvider serviceProvider)
@@ -110,6 +113,10 @@ public sealed class AzureBackupSetup : IAreaSetup
         var disasterrecovery = new CommandGroup("disasterrecovery", "Disaster recovery operations - Enable Cross-Region Restore on a GRS vault.");
         azureBackup.AddSubGroup(disasterrecovery);
         disasterrecovery.AddCommand<DisasterRecoveryEnableCrrCommand>(serviceProvider);
+
+        var security = new CommandGroup("security", "Security operations - Configure Multi-User Authorization (MUA) for backup vaults.");
+        azureBackup.AddSubGroup(security);
+        security.AddCommand<SecurityConfigureMuaCommand>(serviceProvider);
 
         return azureBackup;
     }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/AzureBackupJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/AzureBackupJsonContext.cs
@@ -11,6 +11,7 @@ using Azure.Mcp.Tools.AzureBackup.Commands.Policy;
 using Azure.Mcp.Tools.AzureBackup.Commands.ProtectableItem;
 using Azure.Mcp.Tools.AzureBackup.Commands.ProtectedItem;
 using Azure.Mcp.Tools.AzureBackup.Commands.RecoveryPoint;
+using Azure.Mcp.Tools.AzureBackup.Commands.Security;
 using Azure.Mcp.Tools.AzureBackup.Commands.Vault;
 using Azure.Mcp.Tools.AzureBackup.Models;
 
@@ -33,6 +34,7 @@ namespace Azure.Mcp.Tools.AzureBackup.Commands;
 [JsonSerializable(typeof(GovernanceImmutabilityCommand.GovernanceImmutabilityCommandResult))]
 [JsonSerializable(typeof(GovernanceSoftDeleteCommand.GovernanceSoftDeleteCommandResult))]
 [JsonSerializable(typeof(DisasterRecoveryEnableCrrCommand.DisasterRecoveryEnableCrrCommandResult))]
+[JsonSerializable(typeof(SecurityConfigureMuaCommand.SecurityConfigureMuaCommandResult))]
 [JsonSerializable(typeof(BackupVaultInfo))]
 [JsonSerializable(typeof(ProtectedItemInfo))]
 [JsonSerializable(typeof(BackupPolicyInfo))]

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityConfigureMuaCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityConfigureMuaCommand.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Azure.Mcp.Tools.AzureBackup.Models;
+using Azure.Mcp.Tools.AzureBackup.Options;
+using Azure.Mcp.Tools.AzureBackup.Options.Security;
+using Azure.Mcp.Tools.AzureBackup.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.AzureBackup.Commands.Security;
+
+[CommandMetadata(
+    Id = "c3a21f68-9b5e-4d1a-bf3c-7e2a0f8d4b19",
+    Name = "configure-mua",
+    Title = "Configure Multi-User Authorization",
+    Description = """
+        Configures Multi-User Authorization (MUA) on a vault by linking or unlinking a Resource Guard.
+        Provide --resource-guard-id to enable MUA, protecting critical operations (disable soft delete,
+        remove immutability, stop protection) so they require approval from a security admin with
+        permissions on the Resource Guard. Omit --resource-guard-id to disable MUA (this itself is a
+        protected operation requiring Backup MUA Operator role on the Resource Guard).
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class SecurityConfigureMuaCommand(ILogger<SecurityConfigureMuaCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<SecurityConfigureMuaOptions>()
+{
+    private readonly ILogger<SecurityConfigureMuaCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(AzureBackupOptionDefinitions.ResourceGuardId);
+        command.Validators.Add(commandResult =>
+        {
+            if (commandResult.HasOptionResult(AzureBackupOptionDefinitions.ResourceGuardId.Name))
+            {
+                var value = commandResult.GetValue<string>(AzureBackupOptionDefinitions.ResourceGuardId.Name);
+                if (!string.IsNullOrEmpty(value) &&
+                    !value.StartsWith("/subscriptions/", StringComparison.OrdinalIgnoreCase))
+                {
+                    commandResult.AddError("--resource-guard-id must be a valid ARM resource ID starting with '/subscriptions/'.");
+                }
+            }
+        });
+    }
+
+    protected override SecurityConfigureMuaOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.ResourceGuardId = parseResult.GetValueOrDefault<string>(AzureBackupOptionDefinitions.ResourceGuardId.Name);
+        return options;
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
+        var options = BindOptions(parseResult);
+
+        AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
+
+        try
+        {
+            OperationResult result;
+
+            if (!string.IsNullOrEmpty(options.ResourceGuardId))
+            {
+                result = await _azureBackupService.ConfigureMultiUserAuthorizationAsync(
+                    options.Vault!,
+                    options.ResourceGroup!,
+                    options.Subscription!,
+                    options.ResourceGuardId,
+                    options.VaultType,
+                    options.Tenant,
+                    options.RetryPolicy,
+                    cancellationToken);
+            }
+            else
+            {
+                result = await _azureBackupService.DisableMultiUserAuthorizationAsync(
+                    options.Vault!,
+                    options.ResourceGroup!,
+                    options.Subscription!,
+                    options.VaultType,
+                    options.Tenant,
+                    options.RetryPolicy,
+                    cancellationToken);
+            }
+
+            context.Response.Results = ResponseResult.Create(
+                new(result),
+                AzureBackupJsonContext.Default.SecurityConfigureMuaCommandResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error configuring MUA. Vault: {Vault}, ResourceGuardId: {ResourceGuardId}",
+                options.Vault, options.ResourceGuardId);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    protected override string GetErrorMessage(Exception ex) => ex switch
+    {
+        ArgumentException argEx => argEx.Message,
+        UnauthorizedAccessException => "Authorization failed. Verify your RBAC permissions on the vault, or specify --vault-type to skip auto-detection.",
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.NotFound =>
+            "Vault or Resource Guard not found, or MUA is not enabled for this vault. Verify the vault name, resource group, and Resource Guard ID. If you are disabling MUA, ensure MUA is currently configured.",
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.BadRequest =>
+            $"Bad request configuring MUA. Ensure the Resource Guard is in the same region as the vault. Details: {reqEx.Message}",
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.Forbidden =>
+            $"Authorization failed. To enable MUA, you need Reader role on the Resource Guard. To disable MUA, you need Backup MUA Operator role on the Resource Guard. Details: {reqEx.Message}",
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.Conflict =>
+            "MUA configuration conflict. The vault may already have a Resource Guard linked, or the operation is blocked by the current MUA configuration.",
+        RequestFailedException reqEx => reqEx.Message,
+        _ => base.GetErrorMessage(ex)
+    };
+
+    protected override HttpStatusCode GetStatusCode(Exception ex) => ex switch
+    {
+        UnauthorizedAccessException => HttpStatusCode.Forbidden,
+        ArgumentException or FormatException => HttpStatusCode.BadRequest,
+        RequestFailedException reqEx => (HttpStatusCode)reqEx.Status,
+        _ => base.GetStatusCode(ex)
+    };
+
+    internal record SecurityConfigureMuaCommandResult(OperationResult Result);
+}

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Options/AzureBackupOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Options/AzureBackupOptionDefinitions.cs
@@ -29,6 +29,7 @@ public static class AzureBackupOptionDefinitions
     public const string VmResourceIdName = "vm-resource-id";
     public const string ResourceTypeFilterName = "resource-type-filter";
     public const string TagFilterName = "tag-filter";
+    public const string ResourceGuardIdName = "resource-guard-id";
 
     public static readonly Option<string> Vault = new($"--{VaultName}")
     {
@@ -171,6 +172,12 @@ public static class AzureBackupOptionDefinitions
     public static readonly Option<string> TagFilter = new($"--{TagFilterName}")
     {
         Description = "Tag-based filter in key=value format (e.g., 'environment=production').",
+        Required = false
+    };
+
+    public static readonly Option<string> ResourceGuardId = new($"--{ResourceGuardIdName}")
+    {
+        Description = "ARM resource ID of the Resource Guard to link for Multi-User Authorization (e.g., '/subscriptions/.../resourceGroups/.../providers/Microsoft.DataProtection/resourceGuards/myGuard').",
         Required = false
     };
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Options/Security/SecurityConfigureMuaOptions.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Options/Security/SecurityConfigureMuaOptions.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Mcp.Tools.AzureBackup.Options.Security;
+
+public class SecurityConfigureMuaOptions : BaseAzureBackupOptions
+{
+    [JsonPropertyName(AzureBackupOptionDefinitions.ResourceGuardIdName)]
+    public string? ResourceGuardId { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs
@@ -660,6 +660,29 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
         return await dppOps.ConfigureCrossRegionRestoreAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
     }
 
+    public async Task<OperationResult> ConfigureMultiUserAuthorizationAsync(
+        string vaultName, string resourceGroup, string subscription,
+        string resourceGuardId, string? vaultType, string? tenant,
+        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+    {
+        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        return VaultTypeResolver.IsRsv(resolved)
+            ? await rsvOps.ConfigureMultiUserAuthorizationAsync(vaultName, resourceGroup, subscription, resourceGuardId, tenant, retryPolicy, cancellationToken)
+            : await dppOps.ConfigureMultiUserAuthorizationAsync(vaultName, resourceGroup, subscription, resourceGuardId, tenant, retryPolicy, cancellationToken);
+    }
+
+    public async Task<OperationResult> DisableMultiUserAuthorizationAsync(
+        string vaultName, string resourceGroup, string subscription,
+        string? vaultType, string? tenant,
+        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+    {
+        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        return VaultTypeResolver.IsRsv(resolved)
+            ? await rsvOps.DisableMultiUserAuthorizationAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken)
+            : await dppOps.DisableMultiUserAuthorizationAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+    }
+
+
     private async Task<string> ResolveVaultTypeAsync(
         string vaultName, string resourceGroup, string subscription,
         string? vaultType, string? tenant,

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs
@@ -835,6 +835,60 @@ public sealed class DppBackupOperations(ITenantService tenantService) : BaseAzur
         return new OperationResult("Succeeded", null, $"Soft delete set to '{softDeleteState}' for vault '{vaultName}'.");
     }
 
+    public async Task<OperationResult> ConfigureMultiUserAuthorizationAsync(
+        string vaultName, string resourceGroup, string subscription,
+        string resourceGuardId, string? tenant, RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken)
+    {
+        ValidateRequiredParameters(
+            (nameof(vaultName), vaultName),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(subscription), subscription),
+            (nameof(resourceGuardId), resourceGuardId));
+
+        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
+        var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
+        var proxyCollection = vaultResource.GetResourceGuardProxyBaseResources();
+
+        var proxyData = new ResourceGuardProxyBaseResourceData
+        {
+            Properties = new ResourceGuardProxyBase
+            {
+                ResourceGuardResourceId = resourceGuardId
+            }
+        };
+
+        await proxyCollection.CreateOrUpdateAsync(
+            WaitUntil.Completed,
+            "DppResourceGuardProxy",
+            proxyData,
+            cancellationToken);
+
+        return new OperationResult("Succeeded", null, $"Multi-User Authorization enabled on vault '{vaultName}' with Resource Guard '{resourceGuardId}'.");
+    }
+
+    public async Task<OperationResult> DisableMultiUserAuthorizationAsync(
+        string vaultName, string resourceGroup, string subscription,
+        string? tenant, RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken)
+    {
+        ValidateRequiredParameters(
+            (nameof(vaultName), vaultName),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(subscription), subscription));
+
+        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
+        var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
+
+        var proxyResponse = await vaultResource.GetResourceGuardProxyBaseResourceAsync("DppResourceGuardProxy", cancellationToken);
+        await proxyResponse.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
+
+        return new OperationResult("Succeeded", null, $"Multi-User Authorization disabled on vault '{vaultName}'.");
+    }
+
+
     private static BackupVaultInfo MapToVaultInfo(DataProtectionBackupVaultData data, string? resourceGroup)
     {
         var securitySettings = data.Properties?.SecuritySettings;

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IAzureBackupService.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IAzureBackupService.cs
@@ -45,4 +45,9 @@ public interface IAzureBackupService
 
     // DR
     Task<OperationResult> ConfigureCrossRegionRestoreAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+
+    // Security
+    Task<OperationResult> ConfigureMultiUserAuthorizationAsync(string vaultName, string resourceGroup, string subscription, string resourceGuardId, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> DisableMultiUserAuthorizationAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IDppBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IDppBackupOperations.cs
@@ -175,4 +175,21 @@ public interface IDppBackupOperations
         string? tenant,
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
+
+    Task<OperationResult> ConfigureMultiUserAuthorizationAsync(
+        string vaultName,
+        string resourceGroup,
+        string subscription,
+        string resourceGuardId,
+        string? tenant,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult> DisableMultiUserAuthorizationAsync(
+        string vaultName,
+        string resourceGroup,
+        string subscription,
+        string? tenant,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken);
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IRsvBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IRsvBackupOperations.cs
@@ -201,4 +201,21 @@ public interface IRsvBackupOperations
         string? tenant,
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
+
+    Task<OperationResult> ConfigureMultiUserAuthorizationAsync(
+        string vaultName,
+        string resourceGroup,
+        string subscription,
+        string resourceGuardId,
+        string? tenant,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult> DisableMultiUserAuthorizationAsync(
+        string vaultName,
+        string resourceGroup,
+        string subscription,
+        string? tenant,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken);
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.cs
@@ -1029,6 +1029,62 @@ public sealed class RsvBackupOperations(ITenantService tenantService) : BaseAzur
         return new OperationResult("Succeeded", null, $"Cross-Region Restore enabled for vault '{vaultName}'.");
     }
 
+    public async Task<OperationResult> ConfigureMultiUserAuthorizationAsync(
+        string vaultName, string resourceGroup, string subscription,
+        string resourceGuardId, string? tenant, RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken)
+    {
+        ValidateRequiredParameters(
+            (nameof(vaultName), vaultName),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(subscription), subscription),
+            (nameof(resourceGuardId), resourceGuardId));
+
+        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+
+        var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
+        var rgResource = armClient.GetResourceGroupResource(rgId);
+        var proxyCollection = rgResource.GetResourceGuardProxies(vaultName);
+
+        var proxyData = new ResourceGuardProxyData(default)
+        {
+            Properties = new ResourceGuardProxyProperties
+            {
+                ResourceGuardResourceId = new ResourceIdentifier(resourceGuardId)
+            }
+        };
+
+        await proxyCollection.CreateOrUpdateAsync(
+            WaitUntil.Completed,
+            "VaultProxy",
+            proxyData,
+            cancellationToken);
+
+        return new OperationResult("Succeeded", null, $"Multi-User Authorization enabled on vault '{vaultName}' with Resource Guard '{resourceGuardId}'.");
+    }
+
+    public async Task<OperationResult> DisableMultiUserAuthorizationAsync(
+        string vaultName, string resourceGroup, string subscription,
+        string? tenant, RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken)
+    {
+        ValidateRequiredParameters(
+            (nameof(vaultName), vaultName),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(subscription), subscription));
+
+        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+
+        var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
+        var rgResource = armClient.GetResourceGroupResource(rgId);
+
+        var proxyResponse = await rgResource.GetResourceGuardProxyAsync(vaultName, "VaultProxy", cancellationToken);
+        await proxyResponse.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
+
+        return new OperationResult("Succeeded", null, $"Multi-User Authorization disabled on vault '{vaultName}'.");
+    }
+
+
     private static Azure.ResourceManager.Models.ManagedServiceIdentityType ParseIdentityType(string identityType) =>
         identityType.ToUpperInvariant() switch
         {

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.LiveTests/AzureBackupCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.LiveTests/AzureBackupCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Text.Json;
@@ -1412,6 +1412,203 @@ public class AzureBackupCommandTests(ITestOutputHelper output, TestProxyFixture 
         var opResult = result.AssertProperty("result");
         Assert.Equal("Accepted", opResult.AssertProperty("status").GetString());
     }
+
+    #endregion
+
+    #region Security Tests (MUA - RSV)
+
+    [Fact]
+    public async Task SecurityConfigureMua_RsvVault_EnableMua_Successfully()
+    {
+        var vaultName = $"{Settings.ResourceBaseName}-rsv";
+        var resourceGuardId = Settings.DeploymentOutputs?.GetValueOrDefault("RESOURCE_GUARD_ID")
+            ?? "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-security/providers/Microsoft.DataProtection/resourceGuards/test-guard";
+
+        Output.WriteLine($"[{DateTime.UtcNow:HH:mm:ss}] START: SecurityConfigureMua_RSV_Enable");
+
+        var result = await CallToolAsync(
+            "azurebackup_security_configure-mua",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "vault", vaultName },
+                { "resource-guard-id", resourceGuardId }
+            });
+
+        Output.WriteLine($"[{DateTime.UtcNow:HH:mm:ss}] DONE: SecurityConfigureMua_RSV_Enable");
+
+        if (result.HasValue && result.Value.TryGetProperty("result", out var opResult))
+        {
+            Assert.Equal("Succeeded", opResult.GetProperty("status").GetString());
+        }
+        else if (result.HasValue && result.Value.TryGetProperty("message", out var message))
+        {
+            var msg = message.GetString() ?? "";
+            bool isEnvironmentSpecific = msg.Contains("NotFound", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("ResourceGuard", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("Conflict", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("Reader", StringComparison.OrdinalIgnoreCase);
+            Assert.True(isEnvironmentSpecific, $"Unexpected error: {msg[..Math.Min(msg.Length, 300)]}");
+            Output.WriteLine($"MUA enable skipped due to environment constraint: {msg[..Math.Min(msg.Length, 200)]}");
+        }
+        else
+        {
+            Assert.Fail("Unexpected response from SecurityConfigureMua (RSV Enable)");
+        }
+    }
+
+    [Fact]
+    public async Task SecurityConfigureMua_RsvVault_DisableMua_Successfully()
+    {
+        var vaultName = $"{Settings.ResourceBaseName}-rsv";
+
+        Output.WriteLine($"[{DateTime.UtcNow:HH:mm:ss}] START: SecurityConfigureMua_RSV_Disable");
+
+        var result = await CallToolAsync(
+            "azurebackup_security_configure-mua",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "vault", vaultName }
+            });
+
+        Output.WriteLine($"[{DateTime.UtcNow:HH:mm:ss}] DONE: SecurityConfigureMua_RSV_Disable");
+
+        if (result.HasValue && result.Value.TryGetProperty("result", out var opResult))
+        {
+            Assert.Equal("Succeeded", opResult.GetProperty("status").GetString());
+        }
+        else if (result.HasValue && result.Value.TryGetProperty("message", out var message))
+        {
+            var msg = message.GetString() ?? "";
+            bool isEnvironmentSpecific = msg.Contains("not found", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("Authorization", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("NotFound", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("Forbidden", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("UnlockPreviligeAccess", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("UnlockPrivilegeAccess", StringComparison.OrdinalIgnoreCase);
+            Assert.True(isEnvironmentSpecific, $"Unexpected error: {msg[..Math.Min(msg.Length, 300)]}");
+            Output.WriteLine($"MUA disable skipped: {msg[..Math.Min(msg.Length, 200)]}");
+        }
+        else
+        {
+            Assert.Fail("Unexpected response from SecurityConfigureMua (RSV Disable)");
+        }
+    }
+
+    #endregion
+
+    #region Security Tests (MUA - DPP)
+
+    [Fact]
+    public async Task SecurityConfigureMua_DppVault_EnableMua_Successfully()
+    {
+        var vaultName = $"{Settings.ResourceBaseName}-dpp";
+        var resourceGuardId = Settings.DeploymentOutputs?.GetValueOrDefault("RESOURCE_GUARD_ID")
+            ?? "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-security/providers/Microsoft.DataProtection/resourceGuards/test-guard";
+
+        Output.WriteLine($"[{DateTime.UtcNow:HH:mm:ss}] START: SecurityConfigureMua_DPP_Enable");
+
+        var result = await CallToolAsync(
+            "azurebackup_security_configure-mua",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "vault", vaultName },
+                { "vault-type", "dpp" },
+                { "resource-guard-id", resourceGuardId }
+            });
+
+        Output.WriteLine($"[{DateTime.UtcNow:HH:mm:ss}] DONE: SecurityConfigureMua_DPP_Enable");
+
+        if (result.HasValue && result.Value.TryGetProperty("result", out var opResult))
+        {
+            Assert.Equal("Succeeded", opResult.GetProperty("status").GetString());
+        }
+        else if (result.HasValue && result.Value.TryGetProperty("message", out var message))
+        {
+            var msg = message.GetString() ?? "";
+            bool isEnvironmentSpecific = msg.Contains("NotFound", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("ResourceGuard", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("Conflict", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("Reader", StringComparison.OrdinalIgnoreCase);
+            Assert.True(isEnvironmentSpecific, $"Unexpected error: {msg[..Math.Min(msg.Length, 300)]}");
+            Output.WriteLine($"MUA enable skipped (DPP): {msg[..Math.Min(msg.Length, 200)]}");
+        }
+        else
+        {
+            Assert.Fail("Unexpected response from SecurityConfigureMua (DPP Enable)");
+        }
+    }
+
+    [Fact]
+    public async Task SecurityConfigureMua_DppVault_DisableMua_Successfully()
+    {
+        var vaultName = $"{Settings.ResourceBaseName}-dpp";
+
+        Output.WriteLine($"[{DateTime.UtcNow:HH:mm:ss}] START: SecurityConfigureMua_DPP_Disable");
+
+        var result = await CallToolAsync(
+            "azurebackup_security_configure-mua",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "vault", vaultName },
+                { "vault-type", "dpp" }
+            });
+
+        Output.WriteLine($"[{DateTime.UtcNow:HH:mm:ss}] DONE: SecurityConfigureMua_DPP_Disable");
+
+        if (result.HasValue && result.Value.TryGetProperty("result", out var opResult))
+        {
+            Assert.Equal("Succeeded", opResult.GetProperty("status").GetString());
+        }
+        else if (result.HasValue && result.Value.TryGetProperty("message", out var message))
+        {
+            var msg = message.GetString() ?? "";
+            bool isEnvironmentSpecific = msg.Contains("not found", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("Authorization", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("NotFound", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("Forbidden", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("UnlockPreviligeAccess", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("UnlockPrivilegeAccess", StringComparison.OrdinalIgnoreCase);
+            Assert.True(isEnvironmentSpecific, $"Unexpected error: {msg[..Math.Min(msg.Length, 300)]}");
+            Output.WriteLine($"MUA disable skipped (DPP): {msg[..Math.Min(msg.Length, 200)]}");
+        }
+        else
+        {
+            Assert.Fail("Unexpected response from SecurityConfigureMua (DPP Disable)");
+        }
+    }
+
+    [Fact]
+    public async Task SecurityConfigureMua_RsvVault_WithExplicitVaultType_Successfully()
+    {
+        var vaultName = $"{Settings.ResourceBaseName}-rsv";
+        var resourceGuardId = Settings.DeploymentOutputs?.GetValueOrDefault("RESOURCE_GUARD_ID")
+            ?? "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-security/providers/Microsoft.DataProtection/resourceGuards/test-guard";
+
+        var result = await CallToolAsync(
+            "azurebackup_security_configure-mua",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "vault", vaultName },
+                { "vault-type", "rsv" },
+                { "resource-guard-id", resourceGuardId }
+            });
+
+        // Any response is acceptable — validates the command routing works with explicit vault type
+        Assert.True(result.HasValue, "Response should not be empty");
+    }
+
+    // TC-7: Invalid vault-type validation is covered by unit tests.
+    // Command-level validation errors return MCP error responses without tool content.
 
     #endregion
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.LiveTests/assets.json
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.LiveTests/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "",
   "TagPrefix": "Azure.Mcp.Tools.AzureBackup.LiveTests",
-  "Tag": "Azure.Mcp.Tools.AzureBackup.LiveTests_c937f4d796"
+  "Tag": "Azure.Mcp.Tools.AzureBackup.LiveTests_ddc15f68c6"
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/AzureBackupSetupTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/AzureBackupSetupTests.cs
@@ -48,6 +48,7 @@ public class AzureBackupSetupTests
         Assert.Contains("recoverypoint", groupNames);
         Assert.Contains("governance", groupNames);
         Assert.Contains("disasterrecovery", groupNames);
+        Assert.Contains("security", groupNames);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Security/SecurityConfigureMuaCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Security/SecurityConfigureMuaCommandTests.cs
@@ -1,0 +1,351 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text.Json;
+using Azure.Mcp.Tools.AzureBackup.Commands;
+using Azure.Mcp.Tools.AzureBackup.Commands.Security;
+using Azure.Mcp.Tools.AzureBackup.Models;
+using Azure.Mcp.Tools.AzureBackup.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Core.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Azure.Mcp.Tools.AzureBackup.UnitTests.Security;
+
+public class SecurityConfigureMuaCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAzureBackupService _backupService;
+    private readonly ILogger<SecurityConfigureMuaCommand> _logger;
+    private readonly SecurityConfigureMuaCommand _command;
+    private readonly CommandContext _context;
+    private readonly System.CommandLine.Command _commandDefinition;
+
+    private const string TestResourceGuardId = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-security/providers/Microsoft.DataProtection/resourceGuards/test-guard";
+
+    public SecurityConfigureMuaCommandTests()
+    {
+        _backupService = Substitute.For<IAzureBackupService>();
+        _logger = Substitute.For<ILogger<SecurityConfigureMuaCommand>>();
+
+        var collection = new ServiceCollection().AddSingleton(_backupService);
+
+        _serviceProvider = collection.BuildServiceProvider();
+        _command = new(_logger, _backupService);
+        _context = new(_serviceProvider);
+        _commandDefinition = _command.GetCommand();
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("configure-mua", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EnablesMua_WithResourceGuardId()
+    {
+        // Arrange
+        var expected = new OperationResult("Succeeded", null, "MUA enabled");
+
+        _backupService.ConfigureMultiUserAuthorizationAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--resource-guard-id", TestResourceGuardId]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.SecurityConfigureMuaCommandResult);
+
+        Assert.NotNull(result);
+        Assert.Equal("Succeeded", result.Result.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DisablesMua_WithoutResourceGuardId()
+    {
+        // Arrange
+        var expected = new OperationResult("Succeeded", null, "MUA disabled");
+
+        _backupService.DisableMultiUserAuthorizationAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.SecurityConfigureMuaCommandResult);
+
+        Assert.NotNull(result);
+        Assert.Equal("Succeeded", result.Result.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesException()
+    {
+        // Arrange
+        _backupService.DisableMultiUserAuthorizationAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Test error"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Contains("Test error", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesNotFoundError()
+    {
+        // Arrange
+        _backupService.ConfigureMultiUserAuthorizationAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(404, "Not found"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--resource-guard-id", TestResourceGuardId]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.Status);
+        Assert.Contains("not found", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesForbiddenError()
+    {
+        // Arrange
+        _backupService.ConfigureMultiUserAuthorizationAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--resource-guard-id", TestResourceGuardId]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.Status);
+        Assert.Contains("Authorization failed", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesBadRequestError()
+    {
+        // Arrange
+        _backupService.ConfigureMultiUserAuthorizationAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(400, "Region mismatch"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--resource-guard-id", TestResourceGuardId]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("same region", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesConflictError()
+    {
+        // Arrange
+        _backupService.ConfigureMultiUserAuthorizationAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(409, "Already configured"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--resource-guard-id", TestResourceGuardId]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Conflict, response.Status);
+        Assert.Contains("conflict", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("RSV-type")]
+    [InlineData("backup")]
+    [InlineData("recovery")]
+    public async Task ExecuteAsync_RejectsInvalidVaultType(string vaultType)
+    {
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--vault-type", vaultType]);
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("--vault-type must be", response.Message);
+    }
+
+    [Theory]
+    [InlineData("rsv")]
+    [InlineData("dpp")]
+    [InlineData("RSV")]
+    [InlineData("DPP")]
+    public async Task ExecuteAsync_AcceptsValidVaultType(string vaultType)
+    {
+        _backupService.DisableMultiUserAuthorizationAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(vaultType),
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--vault-type", vaultType]);
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+    }
+
+    [Theory]
+    [InlineData("--subscription sub --vault v --resource-group rg", true)]
+    [InlineData("--subscription sub", false)] // Missing vault and resource-group
+    public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
+    {
+        if (shouldSucceed)
+        {
+            _backupService.DisableMultiUserAuthorizationAsync(
+                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
+        }
+
+        var parseResult = _commandDefinition.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+
+        // Assert
+        if (shouldSucceed)
+        {
+            Assert.Equal(HttpStatusCode.OK, response.Status);
+        }
+        else
+        {
+            Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        }
+    }
+
+    [Fact]
+    public void BindOptions_BindsOptionsCorrectly()
+    {
+        // Arrange & Act
+        var command = _command.GetCommand();
+        var options = command.Options;
+
+        // Assert
+        Assert.Contains(options, o => o.Name == "--subscription");
+        Assert.Contains(options, o => o.Name == "--resource-group");
+        Assert.Contains(options, o => o.Name == "--vault");
+        Assert.Contains(options, o => o.Name == "--vault-type");
+        Assert.Contains(options, o => o.Name == "--resource-guard-id");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DeserializationValidation()
+    {
+        // Arrange
+        var expected = new OperationResult("Succeeded", null, "MUA enabled with guard");
+
+        _backupService.ConfigureMultiUserAuthorizationAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--resource-guard-id", TestResourceGuardId]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.SecurityConfigureMuaCommandResult);
+
+        Assert.NotNull(result);
+        Assert.Equal("Succeeded", result.Result.Status);
+        Assert.Equal("MUA enabled with guard", result.Result.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EnableMua_CallsCorrectServiceMethod()
+    {
+        // Arrange
+        _backupService.ConfigureMultiUserAuthorizationAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg", "--resource-guard-id", TestResourceGuardId]);
+
+        // Act
+        await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert - Enable was called, not Disable
+        await _backupService.Received(1).ConfigureMultiUserAuthorizationAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+
+        await _backupService.DidNotReceive().DisableMultiUserAuthorizationAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DisableMua_CallsCorrectServiceMethod()
+    {
+        // Arrange
+        _backupService.DisableMultiUserAuthorizationAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg"]);
+
+        // Act
+        await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert - Disable was called, not Enable
+        await _backupService.Received(1).DisableMultiUserAuthorizationAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+
+        await _backupService.DidNotReceive().ConfigureMultiUserAuthorizationAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary

Adds `azurebackup security configure-mua` command that enables/disables Multi-User Authorization (MUA) on Recovery Services vaults and Backup vaults by linking/unlinking a Resource Guard.

## Changes

### New Command: `azurebackup security configure-mua`

- **Enable MUA**: Provide `--resource-guard-id` to link a Resource Guard to the vault
- **Disable MUA**: Omit `--resource-guard-id` to unlink (this is itself a protected operation requiring Backup MUA Operator role)
- Supports both **RSV** (`VaultProxy`) and **DPP** (`DppResourceGuardProxy`) vault types
- Auto-detects vault type when `--vault-type` is omitted
- Uses the new `[CommandMetadata]` attribute pattern
- ARM ID validation on `--resource-guard-id`
- `GetStatusCode` override for proper 403/400 mapping

### Files Changed (15 files, ~895 lines)

| Category | Files |
|----------|-------|
| **Command** | `SecurityConfigureMuaCommand.cs` (new), `SecurityConfigureMuaOptions.cs` (new) |
| **Service** | `IAzureBackupService.cs`, `AzureBackupService.cs`, `IRsvBackupOperations.cs`, `RsvBackupOperations.cs`, `IDppBackupOperations.cs`, `DppBackupOperations.cs` |
| **Registration** | `AzureBackupSetup.cs`, `AzureBackupJsonContext.cs`, `AzureBackupOptionDefinitions.cs` |
| **Unit Tests** | `SecurityConfigureMuaCommandTests.cs` (22 tests) |
| **Live Tests** | `AzureBackupCommandTests.cs` (5 MUA tests), `assets.json` |

### Validation

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] Unit tests — 30/30 passed (22 MUA + 8 setup)
- [x] Live tests — 5/5 passed (Record + Playback)
- [x] Cspell — clean
- [x] ToolDescriptionEvaluator — passed (86.3% top choice)
- [x] `[CommandMetadata]` attribute pattern (per #2537)

<details>
<summary>Manual Test Cases (click to expand)</summary>

# Manual Test Cases: `azurebackup security configure-mua`

## Prerequisites

1. **Two test vaults** deployed (one RSV, one DPP/Backup Vault) in the same region
2. **A Resource Guard** deployed in the same region (ideally in a separate subscription)
3. **Reader role** on the Resource Guard assigned to the test principal
4. **Backup Contributor** on both vaults
5. Local MCP server running: `azmcp server start`

### Environment Variables
```powershell
$sub = "<your-subscription-id>"
$rg = "<vault-resource-group>"
$rsvVault = "<rsv-vault-name>"
$dppVault = "<dpp-vault-name>"
$guardId = "/subscriptions/<guard-sub>/resourceGroups/<guard-rg>/providers/Microsoft.DataProtection/resourceGuards/<guard-name>"
```

---

## Test Matrix

| # | Dimension | Vault Type | Operation | Expected |
|---|-----------|-----------|-----------|----------|
| 1 | Enable MUA | RSV | with `--resource-guard-id` | Succeeded |
| 2 | Enable MUA | DPP | with `--resource-guard-id` + `--vault-type dpp` | Succeeded |
| 3 | Disable MUA | RSV | without `--resource-guard-id` | Succeeded (if MUA was enabled) |
| 4 | Disable MUA | DPP | without `--resource-guard-id` + `--vault-type dpp` | Succeeded (if MUA was enabled) |
| 5 | Auto-detect | RSV | no `--vault-type` | Auto-detects RSV, succeeds |
| 6 | Auto-detect | DPP | no `--vault-type` | Auto-detects DPP, succeeds |
| 7 | Invalid vault-type | N/A | `--vault-type invalid` | 400 Bad Request |
| 8 | Missing vault | RSV | non-existent vault name | 404 Not Found |
| 9 | No Reader role | RSV | enable without Reader on guard | 403 Forbidden |
| 10 | Disable without MUA | RSV | disable when not enabled | 404 (no VaultProxy) |
| 11 | Re-enable (idempotent) | RSV | enable when already enabled | Succeeded (idempotent CreateOrUpdate) |
| 12 | Enable MUA | DPP | without `--vault-type` (auto-detect) | Succeeded |

---

## Detailed Test Steps

### TC-1: Enable MUA on RSV vault
```
Tool: azurebackup_security_configure-mua
Parameters:
  --subscription <sub>
  --resource-group <rg>
  --vault <rsvVault>
  --resource-guard-id <guardId>

Expected: status = "Succeeded", message contains "Multi-User Authorization enabled"
Verify in Portal: Vault > Properties > Multi-User Authorization shows Resource Guard linked
```

### TC-2: Enable MUA on DPP vault (explicit vault-type)
```
Tool: azurebackup_security_configure-mua
Parameters:
  --subscription <sub>
  --resource-group <rg>
  --vault <dppVault>
  --vault-type dpp
  --resource-guard-id <guardId>

Expected: status = "Succeeded"
Verify in Portal: Backup vault > Properties > Multi-User Authorization shows linked
```

### TC-3: Disable MUA on RSV vault (requires Backup MUA Operator role)
```
Pre-condition: TC-1 passed, MUA is enabled on RSV vault
Pre-condition: Test principal has Backup MUA Operator role on Resource Guard

Tool: azurebackup_security_configure-mua
Parameters:
  --subscription <sub>
  --resource-group <rg>
  --vault <rsvVault>

Expected: status = "Succeeded", message contains "disabled"
Verify in Portal: Vault > Properties > Multi-User Authorization shows "Not configured"
```

### TC-4: Disable MUA on DPP vault
```
Pre-condition: TC-2 passed, MUA is enabled on DPP vault
Pre-condition: Test principal has Backup MUA Operator role on Resource Guard

Tool: azurebackup_security_configure-mua
Parameters:
  --subscription <sub>
  --resource-group <rg>
  --vault <dppVault>
  --vault-type dpp

Expected: status = "Succeeded"
```

### TC-5: Auto-detect RSV vault type
```
Tool: azurebackup_security_configure-mua
Parameters:
  --subscription <sub>
  --resource-group <rg>
  --vault <rsvVault>
  --resource-guard-id <guardId>
  (no --vault-type)

Expected: Auto-detects RSV, status = "Succeeded"
```

### TC-6: Auto-detect DPP vault type
```
Tool: azurebackup_security_configure-mua
Parameters:
  --subscription <sub>
  --resource-group <rg>
  --vault <dppVault>
  --resource-guard-id <guardId>
  (no --vault-type)

Expected: Auto-detects DPP, status = "Succeeded"
```

### TC-7: Invalid vault-type
```
Tool: azurebackup_security_configure-mua
Parameters:
  --subscription <sub>
  --resource-group <rg>
  --vault <rsvVault>
  --vault-type invalid

Expected: 400 Bad Request, message contains "--vault-type must be 'rsv' or 'dpp'"
```

### TC-8: Non-existent vault
```
Tool: azurebackup_security_configure-mua
Parameters:
  --subscription <sub>
  --resource-group <rg>
  --vault nonexistent-vault-12345
  --vault-type rsv
  --resource-guard-id <guardId>

Expected: 404 Not Found, message contains "not found"
```

### TC-9: Missing Reader role on Resource Guard
```
Pre-condition: Test principal does NOT have Reader on the Resource Guard

Tool: azurebackup_security_configure-mua
Parameters:
  --subscription <sub>
  --resource-group <rg>
  --vault <rsvVault>
  --resource-guard-id <guardId>

Expected: 403 Forbidden, message contains "Authorization failed" and mentions Reader role
```

### TC-10: Disable MUA when not enabled
```
Pre-condition: MUA is NOT enabled on the vault (no VaultProxy exists)

Tool: azurebackup_security_configure-mua
Parameters:
  --subscription <sub>
  --resource-group <rg>
  --vault <rsvVault>
  --vault-type rsv

Expected: 404 Not Found, message mentions vault or Resource Guard not found
```

### TC-11: Re-enable MUA (idempotent)
```
Pre-condition: TC-1 passed, MUA is already enabled

Tool: azurebackup_security_configure-mua
Parameters:
  --subscription <sub>
  --resource-group <rg>
  --vault <rsvVault>
  --resource-guard-id <guardId>

Expected: status = "Succeeded" (CreateOrUpdate is idempotent)
```

### TC-12: Enable MUA on DPP with auto-detect
```
Tool: azurebackup_security_configure-mua
Parameters:
  --subscription <sub>
  --resource-group <rg>
  --vault <dppVault>
  --resource-guard-id <guardId>
  (no --vault-type)

Expected: Auto-detects DPP, status = "Succeeded"
```

---

## Cross-Region Validation

| Scenario | Expected |
|----------|----------|
| Resource Guard and vault in **same region** | Succeeds |
| Resource Guard and vault in **different regions** | 400 Bad Request — region mismatch |

---

## Response Schema Validation

Every successful response must match:
```json
{
  "result": {
    "status": "Succeeded",
    "jobId": null,
    "message": "Multi-User Authorization enabled on vault '...' with Resource Guard '...'."
  }
}
```

For disable:
```json
{
  "result": {
    "status": "Succeeded",
    "jobId": null,
    "message": "Multi-User Authorization disabled on vault '...'."
  }
}
```

---

## Portal Verification Steps

After enabling MUA:
1. Go to **Recovery Services vault > Properties > Multi-User Authorization**
2. Verify it shows the linked Resource Guard name and ARM ID
3. Try a protected operation (e.g., disable soft delete) — it should require approval

After disabling MUA:
1. Verify Multi-User Authorization shows "Not configured"
2. Protected operations should no longer require approval


</details>

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.