### PR TITLE
feat(kusto): add --chart-type option to render query results as images

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -91,7 +91,7 @@
     <PackageVersion Include="Npgsql" Version="10.0.1" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
-    <PackageVersion Include="System.ClientModel" Version="1.9.0" />
+    <PackageVersion Include="ScottPlot" Version="5.1.58" />
     <PackageVersion Include="System.CommandLine" Version="2.0.6" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.6" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -92,6 +92,7 @@
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="ScottPlot" Version="5.1.58" />
+    <PackageVersion Include="System.ClientModel" Version="1.9.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.6" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.6" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -225,13 +225,22 @@ public sealed class CommandFactoryToolLoader(
             var jsonResponse = JsonSerializer.Serialize(commandResponse, ModelsJsonContext.Default.CommandResponse);
             var isError = commandResponse.Status < HttpStatusCode.OK || commandResponse.Status >= HttpStatusCode.Ambiguous;
 
+            var content = new List<ContentBlock>
+            {
+                new TextContentBlock { Text = jsonResponse }
+            };
+
+            if (commandResponse.Images != null)
+            {
+                foreach (var image in commandResponse.Images)
+                {
+                    content.Add(ImageContentBlock.FromBytes(image.Data, image.MimeType));
+                }
+            }
+
             return new CallToolResult
             {
-                Content = [
-                    new TextContentBlock {
-                        Text = jsonResponse
-                    }
-                ],
+                Content = content,
                 IsError = isError
             };
         }

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -225,10 +225,16 @@ public sealed class CommandFactoryToolLoader(
             var jsonResponse = JsonSerializer.Serialize(commandResponse, ModelsJsonContext.Default.CommandResponse);
             var isError = commandResponse.Status < HttpStatusCode.OK || commandResponse.Status >= HttpStatusCode.Ambiguous;
 
-            var content = new List<ContentBlock>
+            var content = new List<ContentBlock>();
+
+            // When images are present and the response is successful, suppress the JSON text
+            // block so vision-capable clients receive only the rendered image(s) and skip the
+            // raw data the image was meant to replace. Errors always include the JSON text.
+            var hasImages = commandResponse.Images != null && commandResponse.Images.Count > 0;
+            if (!hasImages || isError)
             {
-                new TextContentBlock { Text = jsonResponse }
-            };
+                content.Add(new TextContentBlock { Text = jsonResponse });
+            }
 
             if (commandResponse.Images != null)
             {

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -227,11 +227,10 @@ public sealed class CommandFactoryToolLoader(
 
             var content = new List<ContentBlock>();
 
-            // When images are present and the response is successful, suppress the JSON text
-            // block so vision-capable clients receive only the rendered image(s) and skip the
-            // raw data the image was meant to replace. Errors always include the JSON text.
-            var hasImages = commandResponse.Images != null && commandResponse.Images.Count > 0;
-            if (!hasImages || isError)
+            // The text JSON envelope is suppressed only when the command explicitly opted in via
+            // CommandResponse.OmitTextContent (e.g. an image is intended to fully replace raw data).
+            // Errors always include the JSON envelope so the caller can read status/message.
+            if (!commandResponse.OmitTextContent || isError)
             {
                 content.Add(new TextContentBlock { Text = jsonResponse });
             }

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -234,6 +234,12 @@ public sealed class CommandFactoryToolLoader(
             {
                 content.Add(new TextContentBlock { Text = jsonResponse });
             }
+            else if (commandResponse.Images is { Count: > 0 } && !string.IsNullOrEmpty(commandResponse.Message))
+            {
+                // Emit the message as a lightweight text hint so the model knows to look at
+                // the attached image(s) without receiving the full JSON data envelope.
+                content.Add(new TextContentBlock { Text = commandResponse.Message });
+            }
 
             if (commandResponse.Images != null)
             {

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
@@ -482,9 +482,26 @@ public sealed class NamespaceToolLoader(
                 return finalResponse;
             }
 
+            var successContent = new List<ContentBlock>();
+
+            // Mirror CommandFactoryToolLoader: suppress the text envelope when OmitTextContent is
+            // set (e.g. the command rendered a chart image) unless the response is an error.
+            if (!commandResponse.OmitTextContent || isError)
+            {
+                successContent.Add(new TextContentBlock { Text = jsonResponse });
+            }
+
+            if (commandResponse.Images != null)
+            {
+                foreach (var image in commandResponse.Images)
+                {
+                    successContent.Add(ImageContentBlock.FromBytes(image.Data, image.MimeType));
+                }
+            }
+
             return new CallToolResult
             {
-                Content = [new TextContentBlock { Text = jsonResponse }],
+                Content = successContent,
                 IsError = isError
             };
         }

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
@@ -490,6 +490,12 @@ public sealed class NamespaceToolLoader(
             {
                 successContent.Add(new TextContentBlock { Text = jsonResponse });
             }
+            else if (commandResponse.Images is { Count: > 0 } && !string.IsNullOrEmpty(commandResponse.Message))
+            {
+                // Emit the message as a lightweight text hint so the model knows to look at
+                // the attached image(s) without receiving the full JSON data envelope.
+                successContent.Add(new TextContentBlock { Text = commandResponse.Message });
+            }
 
             if (commandResponse.Images != null)
             {

--- a/core/Microsoft.Mcp.Core/src/Models/Command/CommandResponse.cs
+++ b/core/Microsoft.Mcp.Core/src/Models/Command/CommandResponse.cs
@@ -29,8 +29,12 @@ public class CommandResponse
     /// <c>CallToolResult</c>, enabling vision-capable LLM clients to consume charts or
     /// visualizations directly without parsing raw data.
     /// </summary>
-    [JsonPropertyName("images")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    /// <remarks>
+    /// This is a transport-level instruction to the MCP tool loader. Images are always delivered
+    /// via <c>ImageContentBlock</c> entries and must not appear in the serialized JSON envelope,
+    /// so this property is excluded from serialization.
+    /// </remarks>
+    [JsonIgnore]
     public IReadOnlyList<ResponseImage>? Images { get; set; }
 
     /// <summary>

--- a/core/Microsoft.Mcp.Core/src/Models/Command/CommandResponse.cs
+++ b/core/Microsoft.Mcp.Core/src/Models/Command/CommandResponse.cs
@@ -32,6 +32,21 @@ public class CommandResponse
     [JsonPropertyName("images")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IReadOnlyList<ResponseImage>? Images { get; set; }
+
+    /// <summary>
+    /// When <see langword="true"/> and the response is successful, the MCP loader will
+    /// suppress the JSON <c>TextContentBlock</c> and emit only the <see cref="Images"/>
+    /// content blocks. Use this when the rendered image is intended to fully replace
+    /// the raw data (e.g. a chart that summarizes a large query result), so vision-capable
+    /// clients consume the visualization rather than re-parsing the underlying data.
+    /// Errors always include the JSON envelope regardless of this flag.
+    /// </summary>
+    /// <remarks>
+    /// This is a transport-level instruction to the MCP tool loader and is intentionally
+    /// excluded from the serialized response payload.
+    /// </remarks>
+    [JsonIgnore]
+    public bool OmitTextContent { get; set; }
 }
 
 /// <summary>

--- a/core/Microsoft.Mcp.Core/src/Models/Command/CommandResponse.cs
+++ b/core/Microsoft.Mcp.Core/src/Models/Command/CommandResponse.cs
@@ -22,7 +22,28 @@ public class CommandResponse
 
     [JsonPropertyName("duration")]
     public long Duration { get; set; }
+
+    /// <summary>
+    /// Optional images to include as MCP image content blocks alongside the JSON response.
+    /// When populated, each image is emitted as an <c>ImageContentBlock</c> in the MCP
+    /// <c>CallToolResult</c>, enabling vision-capable LLM clients to consume charts or
+    /// visualizations directly without parsing raw data.
+    /// </summary>
+    [JsonPropertyName("images")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<ResponseImage>? Images { get; set; }
 }
+
+/// <summary>
+/// Represents an image to be included in an MCP tool response as an image content block.
+/// </summary>
+/// <param name="Data">The raw image bytes.</param>
+/// <param name="MimeType">The MIME type of the image (e.g. <c>image/png</c>).</param>
+/// <param name="AltText">Optional human-readable description of the image for accessibility and fallback.</param>
+public sealed record ResponseImage(
+    [property: JsonPropertyName("data")] byte[] Data,
+    [property: JsonPropertyName("mimeType")] string MimeType,
+    [property: JsonPropertyName("altText")] string? AltText = null);
 
 [JsonConverter(typeof(ResultConverter))]
 public sealed class ResponseResult

--- a/core/Microsoft.Mcp.Core/src/Models/ModelsJsonContext.cs
+++ b/core/Microsoft.Mcp.Core/src/Models/ModelsJsonContext.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Mcp.Core.Models;
 
 [JsonSerializable(typeof(List<CommandInfo>))]
 [JsonSerializable(typeof(CommandResponse))]
+[JsonSerializable(typeof(ResponseImage))]
+[JsonSerializable(typeof(IReadOnlyList<ResponseImage>))]
 [JsonSerializable(typeof(ETag), TypeInfoPropertyName = "McpETag")]
 [JsonSerializable(typeof(ToolMetadata))]
 [JsonSerializable(typeof(ToolsListCommand.ToolNamesResult))]

--- a/servers/Azure.Mcp.Server/changelog-entries/1777538926110.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1777538926110.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Features Added"
+    description: "Added --chart-type parameter to kusto query and kusto sample commands. When specified with a valid chart type (TimeSeries, Bar, Scatter, or Pie), query results are rendered as a PNG chart image using ScottPlot and returned alongside the JSON results as an MCP image content block, enabling vision-capable LLM clients to analyze data visually."

--- a/servers/Azure.Mcp.Server/changelog-entries/1777538926110.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1777538926110.yaml
@@ -1,3 +1,3 @@
 changes:
   - section: "Features Added"
-    description: "Added --chart-type parameter to kusto query and kusto sample commands. When specified with a valid chart type (TimeSeries, Bar, Scatter, or Pie), query results are rendered as a PNG chart image using ScottPlot and returned alongside the JSON results as an MCP image content block, enabling vision-capable LLM clients to analyze data visually."
+    description: "Added --chart-type parameter to kusto query and kusto sample commands. When specified with a valid chart type (TimeSeries, Bar, Scatter, or Pie), query results are rendered as a PNG chart image using ScottPlot and returned as an MCP image content block in place of the JSON results, enabling vision-capable LLM clients to analyze data visually."

--- a/servers/Azure.Mcp.Server/changelog-entries/1777573335299.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1777573335299.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Features Added"
+    description: "Added support for emitting MCP image content blocks from tool responses. Commands can now populate CommandResponse.Images with one or more PNG/JPEG payloads, and the MCP tool loader emits each as an ImageContentBlock in the CallToolResult. Setting CommandResponse.OmitTextContent suppresses the JSON envelope so vision-capable clients receive only the image when the rendering is intended to fully replace the raw data."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -1837,7 +1837,8 @@ azmcp kusto database list [--cluster-uri <cluster-uri> | --subscription <subscri
 azmcp kusto sample [--cluster-uri <cluster-uri> | --subscription <subscription> --cluster <cluster>]
                    --database <database> \
                    --table <table> \
-                   [--limit <limit>]
+                   [--limit <limit>] \
+                   [--chart-type <TimeSeries|Bar|Scatter|Pie>]
 
 # List tables in a Azure Data Explorer database
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
@@ -1854,7 +1855,8 @@ azmcp kusto table schema [--cluster-uri <cluster-uri> | --subscription <subscrip
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp kusto query [--cluster-uri <cluster-uri> | --subscription <subscription> --cluster <cluster>] \
                   --database <database> \
-                  --query <kql-query>
+                  --query <kql-query> \
+                  [--chart-type <TimeSeries|Bar|Scatter|Pie>]
 
 ```
 

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -350,7 +350,9 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | kusto_database_list | List all databases in the Data Explorer cluster <cluster_name> |
 | kusto_database_list | Show me the databases in the Data Explorer cluster <cluster_name> |
 | kusto_query | Show me all items that contain the word <search_term> in the Data Explorer table <table_name> in cluster <cluster_name> |
+| kusto_query | Show me a time series chart of <metric_name> over the last hour from the Data Explorer table <table_name> in cluster <cluster_name> |
 | kusto_sample | Show me a data sample from the Data Explorer table <table_name> in cluster <cluster_name> |
+| kusto_sample | Show me a bar chart of the top categories in the Data Explorer table <table_name> in cluster <cluster_name> |
 | kusto_table_list | List all tables in the Data Explorer database <database_name> in cluster <cluster_name> |
 | kusto_table_list | Show me the tables in the Data Explorer database <database_name> in cluster <cluster_name> |
 | kusto_table_schema | Show me the schema for table <table_name> in the Data Explorer database <database_name> in cluster <cluster_name> |

--- a/tools/Azure.Mcp.Tools.Kusto/src/Azure.Mcp.Tools.Kusto.csproj
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Azure.Mcp.Tools.Kusto.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Azure.ResourceManager" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="ScottPlot" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 </Project>

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
@@ -89,6 +89,7 @@ public sealed class QueryCommand(ILogger<QueryCommand> logger, IKustoService kus
                 if (image is not null)
                 {
                     context.Response.Images = [image];
+                    context.Response.Results = null;
                 }
             }
         }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
@@ -15,7 +15,7 @@ namespace Azure.Mcp.Tools.Kusto.Commands;
     Id = "d1e22074-53ce-4eef-8596-0ea134a9e317",
     Name = "query",
     Title = "Query Kusto Database",
-    Description = "Executes a query against an Azure Data Explorer/Kusto/KQL cluster to search for specific terms, retrieve records, or perform management operations. Required: --cluster-uri (or --cluster and --subscription), --database, and --query. Optionally specify --chart-type to receive a rendered chart image instead of the raw JSON results (the JSON is omitted when an image is returned).",
+    Description = "Executes a query against an Azure Data Explorer/Kusto/KQL cluster to search for specific terms, retrieve records, or perform management operations. Required: --cluster-uri (or --cluster and --subscription), --database, and --query. Optionally specify --chart-type to receive a rendered chart image instead of the raw JSON results (the JSON is omitted when an image is returned). Charts are intended for visual pattern analysis — use them to identify trends, anomalies, spikes, dips, and plateaus over time, not to extract exact values. When a chart is returned, describe what you observe visually (e.g. 'CPU spikes around 14:00', 'steady plateau between 10:00–12:00', 'gradual upward trend') rather than quoting precise numbers.",
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,
@@ -97,7 +97,10 @@ public sealed class QueryCommand(ILogger<QueryCommand> logger, IKustoService kus
                     options.ChartType.Value,
                     title: $"Chart of Kusto query results ({options.ChartType.Value})");
                 context.Response.Images = [image];
-                context.Response.Message = "Query results rendered as a chart image — see the attached image.";
+                context.Response.Message = "Query results rendered as a chart image — see the attached image. "
+                    + "Use it to identify visual patterns: trends, anomalies, spikes, dips, and plateaus. "
+                    + "Describe what you observe (e.g. 'spike around 14:00', 'steady plateau', 'gradual upward trend') "
+                    + "rather than quoting precise values — approximate ranges are sufficient.";
                 context.Response.OmitTextContent = true;
             }
             else

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.Kusto.Options;
+using Azure.Mcp.Tools.Kusto.Rendering;
 using Azure.Mcp.Tools.Kusto.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
@@ -14,28 +15,32 @@ namespace Azure.Mcp.Tools.Kusto.Commands;
     Id = "d1e22074-53ce-4eef-8596-0ea134a9e317",
     Name = "query",
     Title = "Query Kusto Database",
-    Description = "Executes a query against an Azure Data Explorer/Kusto/KQL cluster to search for specific terms, retrieve records, or perform management operations. Required: --cluster-uri (or --cluster and --subscription), --database, and --query.",
+    Description = "Executes a query against an Azure Data Explorer/Kusto/KQL cluster to search for specific terms, retrieve records, or perform management operations. Required: --cluster-uri (or --cluster and --subscription), --database, and --query. Optionally specify --chart-type to receive a rendered chart image alongside the raw JSON results.",
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class QueryCommand(ILogger<QueryCommand> logger, IKustoService kustoService) : BaseDatabaseCommand<QueryOptions>()
+public sealed class QueryCommand(ILogger<QueryCommand> logger, IKustoService kustoService, IKustoChartRenderer chartRenderer) : BaseDatabaseCommand<QueryOptions>()
 {
     private readonly ILogger<QueryCommand> _logger = logger;
     private readonly IKustoService _kustoService = kustoService;
+    private readonly IKustoChartRenderer _chartRenderer = chartRenderer;
 
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
         command.Options.Add(KustoOptionDefinitions.Query);
+        command.Options.Add(KustoOptionDefinitions.ChartType);
     }
 
     protected override QueryOptions BindOptions(ParseResult parseResult)
     {
         var options = base.BindOptions(parseResult);
         options.Query = parseResult.GetValueOrDefault<string>(KustoOptionDefinitions.Query.Name);
+        var chartTypeStr = parseResult.GetValueOrDefault<string>(KustoOptionDefinitions.ChartType.Name);
+        options.ChartType = Enum.TryParse<ChartType>(chartTypeStr, ignoreCase: true, out var ct) ? ct : (ChartType?)null;
         return options;
     }
 
@@ -77,6 +82,15 @@ public sealed class QueryCommand(ILogger<QueryCommand> logger, IKustoService kus
             }
 
             context.Response.Results = ResponseResult.Create(new(results ?? []), KustoJsonContext.Default.QueryCommandResult);
+
+            if (options.ChartType.HasValue && results is { Count: > 1 })
+            {
+                var image = _chartRenderer.TryRender(results, options.ChartType.Value, title: $"Chart of Kusto query results ({options.ChartType.Value})");
+                if (image is not null)
+                {
+                    context.Response.Images = [image];
+                }
+            }
         }
         catch (Exception ex)
         {

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
@@ -97,6 +97,7 @@ public sealed class QueryCommand(ILogger<QueryCommand> logger, IKustoService kus
                     options.ChartType.Value,
                     title: $"Chart of Kusto query results ({options.ChartType.Value})");
                 context.Response.Images = [image];
+                context.Response.Message = "Query results rendered as a chart image — see the attached image.";
                 context.Response.OmitTextContent = true;
             }
             else

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
@@ -15,7 +15,7 @@ namespace Azure.Mcp.Tools.Kusto.Commands;
     Id = "d1e22074-53ce-4eef-8596-0ea134a9e317",
     Name = "query",
     Title = "Query Kusto Database",
-    Description = "Executes a query against an Azure Data Explorer/Kusto/KQL cluster to search for specific terms, retrieve records, or perform management operations. Required: --cluster-uri (or --cluster and --subscription), --database, and --query. Optionally specify --chart-type to receive a rendered chart image alongside the raw JSON results.",
+    Description = "Executes a query against an Azure Data Explorer/Kusto/KQL cluster to search for specific terms, retrieve records, or perform management operations. Required: --cluster-uri (or --cluster and --subscription), --database, and --query. Optionally specify --chart-type to receive a rendered chart image instead of the raw JSON results (the JSON is omitted when an image is returned).",
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,
@@ -33,14 +33,19 @@ public sealed class QueryCommand(ILogger<QueryCommand> logger, IKustoService kus
         base.RegisterOptions(command);
         command.Options.Add(KustoOptionDefinitions.Query);
         command.Options.Add(KustoOptionDefinitions.ChartType);
+        KustoOptionDefinitions.AddChartTypeValidator(command);
     }
 
     protected override QueryOptions BindOptions(ParseResult parseResult)
     {
         var options = base.BindOptions(parseResult);
         options.Query = parseResult.GetValueOrDefault<string>(KustoOptionDefinitions.Query.Name);
+        // The option-level validator on KustoOptionDefinitions.ChartType guarantees the value
+        // is either absent or a valid ChartType, so Enum.Parse cannot fail here.
         var chartTypeStr = parseResult.GetValueOrDefault<string>(KustoOptionDefinitions.ChartType.Name);
-        options.ChartType = Enum.TryParse<ChartType>(chartTypeStr, ignoreCase: true, out var ct) ? ct : (ChartType?)null;
+        options.ChartType = string.IsNullOrWhiteSpace(chartTypeStr)
+            ? null
+            : Enum.Parse<ChartType>(chartTypeStr, ignoreCase: true);
         return options;
     }
 
@@ -81,16 +86,22 @@ public sealed class QueryCommand(ILogger<QueryCommand> logger, IKustoService kus
                     cancellationToken);
             }
 
-            context.Response.Results = ResponseResult.Create(new(results ?? []), KustoJsonContext.Default.QueryCommandResult);
-
-            if (options.ChartType.HasValue && results is { Count: > 1 })
+            if (options.ChartType.HasValue)
             {
-                var image = _chartRenderer.TryRender(results, options.ChartType.Value, title: $"Chart of Kusto query results ({options.ChartType.Value})");
-                if (image is not null)
-                {
-                    context.Response.Images = [image];
-                    context.Response.Results = null;
-                }
+                // The user explicitly opted in to chart rendering; the renderer throws a
+                // ChartRenderingException with a descriptive message if the data shape doesn't
+                // match the requested chart type, which HandleException turns into a tool-call
+                // error so the caller knows exactly why and can adjust their query.
+                var image = _chartRenderer.Render(
+                    results ?? [],
+                    options.ChartType.Value,
+                    title: $"Chart of Kusto query results ({options.ChartType.Value})");
+                context.Response.Images = [image];
+                context.Response.OmitTextContent = true;
+            }
+            else
+            {
+                context.Response.Results = ResponseResult.Create(new(results ?? []), KustoJsonContext.Default.QueryCommandResult);
             }
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/SampleCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/SampleCommand.cs
@@ -93,6 +93,7 @@ public sealed class SampleCommand(ILogger<SampleCommand> logger, IKustoService k
                 if (image is not null)
                 {
                     context.Response.Images = [image];
+                    context.Response.Results = null;
                 }
             }
         }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/SampleCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/SampleCommand.cs
@@ -15,7 +15,7 @@ namespace Azure.Mcp.Tools.Kusto.Commands;
     Id = "41daed5c-bf44-4cdf-9f3c-1df775465e53",
     Name = "sample",
     Title = "Sample Kusto Table Data",
-    Description = "Return a sample of rows from a specific table in an Azure Data Explorer/Kusto/KQL cluster. Required: --cluster-uri (or --cluster and --subscription), --database, and --table. Optionally specify --chart-type to receive a rendered chart image alongside the raw JSON results.",
+    Description = "Return a sample of rows from a specific table in an Azure Data Explorer/Kusto/KQL cluster. Required: --cluster-uri (or --cluster and --subscription), --database, and --table. Optionally specify --chart-type to receive a rendered chart image instead of the raw JSON results (the JSON is omitted when an image is returned).",
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,
@@ -33,14 +33,19 @@ public sealed class SampleCommand(ILogger<SampleCommand> logger, IKustoService k
         base.RegisterOptions(command);
         command.Options.Add(KustoOptionDefinitions.Limit);
         command.Options.Add(KustoOptionDefinitions.ChartType);
+        KustoOptionDefinitions.AddChartTypeValidator(command);
     }
 
     protected override SampleOptions BindOptions(ParseResult parseResult)
     {
         var options = base.BindOptions(parseResult);
         options.Limit = parseResult.GetValueOrDefault<int>(KustoOptionDefinitions.Limit.Name);
+        // The option-level validator on KustoOptionDefinitions.ChartType guarantees the value
+        // is either absent or a valid ChartType, so Enum.Parse cannot fail here.
         var chartTypeStr = parseResult.GetValueOrDefault<string>(KustoOptionDefinitions.ChartType.Name);
-        options.ChartType = Enum.TryParse<ChartType>(chartTypeStr, ignoreCase: true, out var ct) ? ct : (ChartType?)null;
+        options.ChartType = string.IsNullOrWhiteSpace(chartTypeStr)
+            ? null
+            : Enum.Parse<ChartType>(chartTypeStr, ignoreCase: true);
         return options;
     }
 
@@ -85,16 +90,22 @@ public sealed class SampleCommand(ILogger<SampleCommand> logger, IKustoService k
                     cancellationToken);
             }
 
-            context.Response.Results = ResponseResult.Create(new(results ?? []), KustoJsonContext.Default.SampleCommandResult);
-
-            if (options.ChartType.HasValue && results is { Count: > 1 })
+            if (options.ChartType.HasValue)
             {
-                var image = _chartRenderer.TryRender(results, options.ChartType.Value, title: $"Chart of Kusto table sample ({options.ChartType.Value})");
-                if (image is not null)
-                {
-                    context.Response.Images = [image];
-                    context.Response.Results = null;
-                }
+                // The user explicitly opted in to chart rendering; the renderer throws a
+                // ChartRenderingException with a descriptive message if the data shape doesn't
+                // match the requested chart type, which HandleException turns into a tool-call
+                // error so the caller knows exactly why and can adjust their request.
+                var image = _chartRenderer.Render(
+                    results ?? [],
+                    options.ChartType.Value,
+                    title: $"Chart of Kusto table sample ({options.ChartType.Value})");
+                context.Response.Images = [image];
+                context.Response.OmitTextContent = true;
+            }
+            else
+            {
+                context.Response.Results = ResponseResult.Create(new(results ?? []), KustoJsonContext.Default.SampleCommandResult);
             }
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/SampleCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/SampleCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.Kusto.Options;
+using Azure.Mcp.Tools.Kusto.Rendering;
 using Azure.Mcp.Tools.Kusto.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
@@ -14,28 +15,32 @@ namespace Azure.Mcp.Tools.Kusto.Commands;
     Id = "41daed5c-bf44-4cdf-9f3c-1df775465e53",
     Name = "sample",
     Title = "Sample Kusto Table Data",
-    Description = "Return a sample of rows from a specific table in an Azure Data Explorer/Kusto/KQL cluster. Required: --cluster-uri (or --cluster and --subscription), --database, and --table.",
+    Description = "Return a sample of rows from a specific table in an Azure Data Explorer/Kusto/KQL cluster. Required: --cluster-uri (or --cluster and --subscription), --database, and --table. Optionally specify --chart-type to receive a rendered chart image alongside the raw JSON results.",
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class SampleCommand(ILogger<SampleCommand> logger, IKustoService kustoService) : BaseTableCommand<SampleOptions>
+public sealed class SampleCommand(ILogger<SampleCommand> logger, IKustoService kustoService, IKustoChartRenderer chartRenderer) : BaseTableCommand<SampleOptions>
 {
     private readonly ILogger<SampleCommand> _logger = logger;
     private readonly IKustoService _kustoService = kustoService;
+    private readonly IKustoChartRenderer _chartRenderer = chartRenderer;
 
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
         command.Options.Add(KustoOptionDefinitions.Limit);
+        command.Options.Add(KustoOptionDefinitions.ChartType);
     }
 
     protected override SampleOptions BindOptions(ParseResult parseResult)
     {
         var options = base.BindOptions(parseResult);
         options.Limit = parseResult.GetValueOrDefault<int>(KustoOptionDefinitions.Limit.Name);
+        var chartTypeStr = parseResult.GetValueOrDefault<string>(KustoOptionDefinitions.ChartType.Name);
+        options.ChartType = Enum.TryParse<ChartType>(chartTypeStr, ignoreCase: true, out var ct) ? ct : (ChartType?)null;
         return options;
     }
 
@@ -81,6 +86,15 @@ public sealed class SampleCommand(ILogger<SampleCommand> logger, IKustoService k
             }
 
             context.Response.Results = ResponseResult.Create(new(results ?? []), KustoJsonContext.Default.SampleCommandResult);
+
+            if (options.ChartType.HasValue && results is { Count: > 1 })
+            {
+                var image = _chartRenderer.TryRender(results, options.ChartType.Value, title: $"Chart of Kusto table sample ({options.ChartType.Value})");
+                if (image is not null)
+                {
+                    context.Response.Images = [image];
+                }
+            }
         }
         catch (Exception ex)
         {

--- a/tools/Azure.Mcp.Tools.Kusto/src/KustoSetup.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/KustoSetup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.Kusto.Commands;
+using Azure.Mcp.Tools.Kusto.Rendering;
 using Azure.Mcp.Tools.Kusto.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Mcp.Core.Areas;
@@ -18,6 +19,7 @@ public class KustoSetup : IAreaSetup
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddSingleton<IKustoService, KustoService>();
+        services.AddSingleton<IKustoChartRenderer, ScottPlotChartRenderer>();
 
         services.AddSingleton<SampleCommand>();
         services.AddSingleton<QueryCommand>();

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/KustoOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/KustoOptionDefinitions.cs
@@ -11,6 +11,7 @@ public static class KustoOptionDefinitions
     public const string TableName = "table";
     public const string LimitName = "limit";
     public const string QueryText = "query";
+    public const string ChartTypeName = "chart-type";
 
 
     public static readonly Option<string> Cluster = new(
@@ -60,5 +61,18 @@ public static class KustoOptionDefinitions
     {
         Description = "Kusto query to execute. Uses KQL syntax.",
         Required = true
+    };
+
+    public static readonly Option<string?> ChartType = new(
+        $"--{ChartTypeName}"
+    )
+    {
+        Description = "When specified, renders the query results as a chart image and includes it as an image content block in the MCP response, enabling LLMs with vision capability to analyze the data visually. " +
+                      "Valid values: TimeSeries (requires a datetime column and at least one numeric column), " +
+                      "Bar (requires a string/label column and a numeric column), " +
+                      "Scatter (requires two numeric columns), " +
+                      "Pie (requires a string/label column and a numeric column). " +
+                      "If the data shape does not match the requested chart type the image is omitted and only the JSON results are returned.",
+        Required = false
     };
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/KustoOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/KustoOptionDefinitions.cs
@@ -67,12 +67,41 @@ public static class KustoOptionDefinitions
         $"--{ChartTypeName}"
     )
     {
-        Description = "When specified, renders the query results as a chart image and includes it as an image content block in the MCP response, enabling LLMs with vision capability to analyze the data visually. " +
+        Description = "When specified, the query results are rendered as a chart image and returned as the MCP response (the JSON results are omitted), enabling vision-capable LLMs to analyze the data visually. " +
                       "Valid values: TimeSeries (requires a datetime column and at least one numeric column), " +
                       "Bar (requires a string/label column and a numeric column), " +
                       "Scatter (requires two numeric columns), " +
                       "Pie (requires a string/label column and a numeric column). " +
-                      "If the data shape does not match the requested chart type the image is omitted and only the JSON results are returned.",
+                      "If the data shape does not match the requested chart type, the tool call fails with an explanation.",
         Required = false
     };
+
+    /// <summary>
+    /// Registers a command-level validator that fails the parse if the supplied <c>--chart-type</c>
+    /// value cannot be mapped to a <see cref="Rendering.ChartType"/>. Call from
+    /// <c>BaseCommand.RegisterOptions</c> after <see cref="ChartType"/> has been added.
+    /// </summary>
+    public static void AddChartTypeValidator(Command command)
+    {
+        command.Validators.Add(commandResult =>
+        {
+            var optionResult = commandResult.GetResult(ChartType);
+            if (optionResult is null)
+            {
+                return;
+            }
+
+            var value = optionResult.GetValueOrDefault<string?>();
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return;
+            }
+
+            if (!Enum.TryParse<Rendering.ChartType>(value, ignoreCase: true, out _))
+            {
+                var allowed = string.Join(", ", Enum.GetNames<Rendering.ChartType>());
+                commandResult.AddError($"Invalid value '{value}' for --{ChartTypeName}. Allowed values: {allowed}.");
+            }
+        });
+    }
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/QueryOptions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/QueryOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
+using Azure.Mcp.Tools.Kusto.Rendering;
 
 namespace Azure.Mcp.Tools.Kusto.Options;
 
@@ -9,4 +10,8 @@ public class QueryOptions : BaseDatabaseOptions
 {
     [JsonPropertyName(KustoOptionDefinitions.QueryText)]
     public string? Query { get; set; }
+
+    [JsonPropertyName(KustoOptionDefinitions.ChartTypeName)]
+    public ChartType? ChartType { get; set; }
 }
+

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/SampleOptions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/SampleOptions.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Mcp.Tools.Kusto.Rendering;
+
 namespace Azure.Mcp.Tools.Kusto.Options;
 
 public class SampleOptions : BaseTableOptions
 {
     public int? Limit { get; set; }
+    public ChartType? ChartType { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Rendering/ChartRenderingException.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Rendering/ChartRenderingException.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Kusto.Rendering;
+
+/// <summary>
+/// Thrown when a Kusto query result cannot be rendered as the requested <see cref="ChartType"/>.
+/// </summary>
+/// <remarks>
+/// The message is user-facing — it describes precisely why the data did not fit (e.g. missing
+/// datetime column for <see cref="ChartType.TimeSeries"/>) so the caller can correct their KQL
+/// query or pick a different chart type.
+/// </remarks>
+public sealed class ChartRenderingException(string message, Exception? innerException = null)
+    : Exception(message, innerException);

--- a/tools/Azure.Mcp.Tools.Kusto/src/Rendering/ChartType.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Rendering/ChartType.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Kusto.Rendering;
+
+/// <summary>
+/// Specifies the type of chart to render from Kusto query results.
+/// </summary>
+public enum ChartType
+{
+    /// <summary>
+    /// A time series line chart. Requires at least one <c>datetime</c> column and one numeric column.
+    /// The datetime column is used as the X axis; all numeric columns are plotted as separate lines.
+    /// </summary>
+    TimeSeries,
+
+    /// <summary>
+    /// A bar chart. Requires exactly one string/label column and at least one numeric column.
+    /// </summary>
+    Bar,
+
+    /// <summary>
+    /// A scatter plot. Requires exactly two numeric columns (X and Y).
+    /// </summary>
+    Scatter,
+
+    /// <summary>
+    /// A pie chart. Requires exactly one string/label column and one numeric column for values.
+    /// </summary>
+    Pie,
+}

--- a/tools/Azure.Mcp.Tools.Kusto/src/Rendering/DataShapeValidator.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Rendering/DataShapeValidator.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Kusto.Rendering;
+
+/// <summary>
+/// Validates whether the columns in a Kusto result set are compatible with a requested <see cref="ChartType"/>.
+/// </summary>
+internal static class DataShapeValidator
+{
+    private static readonly HashSet<string> s_numericTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "int", "long", "real", "double", "decimal"
+    };
+
+    private static readonly HashSet<string> s_stringTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "string", "guid", "bool"
+    };
+
+    /// <summary>
+    /// Validates that the provided column map is compatible with the requested <paramref name="chartType"/>.
+    /// </summary>
+    /// <param name="columns">Map of column name → KQL type string from the query result header row.</param>
+    /// <param name="chartType">The requested chart type to validate against.</param>
+    /// <param name="errorMessage">
+    /// When validation fails, contains a human-readable description of why the data does not fit
+    /// the requested chart type. <see langword="null"/> on success.
+    /// </param>
+    /// <returns><see langword="true"/> if the columns are compatible; otherwise <see langword="false"/>.</returns>
+    public static bool Validate(
+        IReadOnlyDictionary<string, string> columns,
+        ChartType chartType,
+        out string? errorMessage)
+    {
+        var numericCols = columns.Where(c => s_numericTypes.Contains(c.Value)).Select(c => c.Key).ToList();
+        var stringCols = columns.Where(c => s_stringTypes.Contains(c.Value)).Select(c => c.Key).ToList();
+        var datetimeCols = columns.Where(c => c.Value.Equals("datetime", StringComparison.OrdinalIgnoreCase)).Select(c => c.Key).ToList();
+
+        switch (chartType)
+        {
+            case ChartType.TimeSeries:
+                if (datetimeCols.Count == 0)
+                {
+                    errorMessage = $"ChartType.TimeSeries requires at least one 'datetime' column. Found columns: {FormatColumns(columns)}.";
+                    return false;
+                }
+                if (numericCols.Count == 0)
+                {
+                    errorMessage = $"ChartType.TimeSeries requires at least one numeric column (int/long/real/double/decimal). Found columns: {FormatColumns(columns)}.";
+                    return false;
+                }
+                break;
+
+            case ChartType.Bar:
+                if (stringCols.Count == 0)
+                {
+                    errorMessage = $"ChartType.Bar requires at least one string/label column. Found columns: {FormatColumns(columns)}.";
+                    return false;
+                }
+                if (numericCols.Count == 0)
+                {
+                    errorMessage = $"ChartType.Bar requires at least one numeric column. Found columns: {FormatColumns(columns)}.";
+                    return false;
+                }
+                break;
+
+            case ChartType.Scatter:
+                if (numericCols.Count < 2)
+                {
+                    errorMessage = $"ChartType.Scatter requires at least two numeric columns (X and Y). Found {numericCols.Count} numeric column(s) in: {FormatColumns(columns)}.";
+                    return false;
+                }
+                break;
+
+            case ChartType.Pie:
+                if (stringCols.Count == 0)
+                {
+                    errorMessage = $"ChartType.Pie requires at least one string/label column for slice labels. Found columns: {FormatColumns(columns)}.";
+                    return false;
+                }
+                if (numericCols.Count == 0)
+                {
+                    errorMessage = $"ChartType.Pie requires at least one numeric column for slice values. Found columns: {FormatColumns(columns)}.";
+                    return false;
+                }
+                break;
+        }
+
+        errorMessage = null;
+        return true;
+    }
+
+    private static string FormatColumns(IReadOnlyDictionary<string, string> columns)
+        => string.Join(", ", columns.Select(c => $"{c.Key}:{c.Value}"));
+}

--- a/tools/Azure.Mcp.Tools.Kusto/src/Rendering/IKustoChartRenderer.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Rendering/IKustoChartRenderer.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.Kusto.Rendering;
+
+/// <summary>
+/// Renders a chart image from Kusto query result data.
+/// </summary>
+public interface IKustoChartRenderer
+{
+    /// <summary>
+    /// Attempts to render a chart from the provided Kusto query results.
+    /// </summary>
+    /// <param name="results">
+    /// The raw query result rows. Element [0] is the column-type header dictionary;
+    /// subsequent elements are data rows as JSON arrays.
+    /// </param>
+    /// <param name="chartType">The chart type to render.</param>
+    /// <param name="title">Optional chart title.</param>
+    /// <returns>
+    /// A <see cref="ResponseImage"/> containing the rendered PNG, or <see langword="null"/> if
+    /// rendering is not possible (e.g. data shape does not match the chart type, or the result is empty).
+    /// </returns>
+    ResponseImage? TryRender(IReadOnlyList<JsonElement> results, ChartType chartType, string? title = null);
+}

--- a/tools/Azure.Mcp.Tools.Kusto/src/Rendering/IKustoChartRenderer.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Rendering/IKustoChartRenderer.cs
@@ -11,7 +11,7 @@ namespace Azure.Mcp.Tools.Kusto.Rendering;
 public interface IKustoChartRenderer
 {
     /// <summary>
-    /// Attempts to render a chart from the provided Kusto query results.
+    /// Renders a chart from the provided Kusto query results.
     /// </summary>
     /// <param name="results">
     /// The raw query result rows. Element [0] is the column-type header dictionary;
@@ -19,9 +19,12 @@ public interface IKustoChartRenderer
     /// </param>
     /// <param name="chartType">The chart type to render.</param>
     /// <param name="title">Optional chart title.</param>
-    /// <returns>
-    /// A <see cref="ResponseImage"/> containing the rendered PNG, or <see langword="null"/> if
-    /// rendering is not possible (e.g. data shape does not match the chart type, or the result is empty).
-    /// </returns>
-    ResponseImage? TryRender(IReadOnlyList<JsonElement> results, ChartType chartType, string? title = null);
+    /// <returns>A <see cref="ResponseImage"/> containing the rendered PNG.</returns>
+    /// <exception cref="ChartRenderingException">
+    /// Thrown when the data cannot be rendered as the requested chart type — either because the
+    /// shape of the result set does not match (e.g. <see cref="ChartType.TimeSeries"/> requested
+    /// without a datetime column) or the underlying rendering pipeline fails. The exception
+    /// message is intended to be surfaced verbatim to the caller as a tool-call error.
+    /// </exception>
+    ResponseImage Render(IReadOnlyList<JsonElement> results, ChartType chartType, string? title = null);
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Rendering/ScottPlotChartRenderer.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Rendering/ScottPlotChartRenderer.cs
@@ -11,8 +11,8 @@ namespace Azure.Mcp.Tools.Kusto.Rendering;
 /// </summary>
 public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logger) : IKustoChartRenderer
 {
-    private const int ChartWidth = 960;
-    private const int ChartHeight = 480;
+    private const int ChartWidth = 640;
+    private const int ChartHeight = 320;
     private const string ImageMimeType = "image/png";
 
     private static readonly HashSet<string> s_numericKqlTypes = new(StringComparer.OrdinalIgnoreCase)
@@ -281,7 +281,7 @@ public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logge
 
     private static ResponseImage ToPngImage(ScottPlot.Plot plot, string altText)
     {
-        var pngBytes = plot.GetImageBytes(ChartWidth, ChartHeight);
+        var pngBytes = plot.GetImage(ChartWidth, ChartHeight).GetImageBytes(ScottPlot.ImageFormat.Png);
         return new ResponseImage(pngBytes, ImageMimeType, altText);
     }
 

--- a/tools/Azure.Mcp.Tools.Kusto/src/Rendering/ScottPlotChartRenderer.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Rendering/ScottPlotChartRenderer.cs
@@ -281,7 +281,7 @@ public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logge
 
     private static ResponseImage ToPngImage(ScottPlot.Plot plot, string altText)
     {
-        var pngBytes = plot.GetImage(ChartWidth, ChartHeight).GetImageBytes(ScottPlot.ImageFormat.Png);
+        var pngBytes = plot.GetImageBytes(ChartWidth, ChartHeight, ScottPlot.ImageFormat.Png);
         return new ResponseImage(pngBytes, ImageMimeType, altText);
     }
 

--- a/tools/Azure.Mcp.Tools.Kusto/src/Rendering/ScottPlotChartRenderer.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Rendering/ScottPlotChartRenderer.cs
@@ -21,14 +21,20 @@ public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logge
     };
 
     /// <inheritdoc />
-    public ResponseImage? TryRender(IReadOnlyList<JsonElement> results, ChartType chartType, string? title = null)
+    public ResponseImage Render(IReadOnlyList<JsonElement> results, ChartType chartType, string? title = null)
     {
         if (results.Count < 2)
-            return null;
+        {
+            throw new ChartRenderingException(
+                $"Cannot render {chartType} chart: query returned no rows (only the schema header). Adjust the query so it returns at least one data row.");
+        }
 
         // results[0] is the column→type header dictionary
         if (results[0].ValueKind != JsonValueKind.Object)
-            return null;
+        {
+            throw new ChartRenderingException(
+                $"Cannot render {chartType} chart: query result is missing the expected column-type header.");
+        }
 
         var columns = results[0]
             .EnumerateObject()
@@ -36,9 +42,7 @@ public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logge
 
         if (!DataShapeValidator.Validate(columns, chartType, out var errorMessage))
         {
-            logger.LogWarning("Chart rendering skipped — data shape validation failed for {ChartType}: {Error}",
-                chartType, errorMessage);
-            return null;
+            throw new ChartRenderingException(errorMessage!);
         }
 
         // Data rows are JSON arrays (one element per column in column order)
@@ -48,7 +52,10 @@ public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logge
             .ToList();
 
         if (rows.Count == 0)
-            return null;
+        {
+            throw new ChartRenderingException(
+                $"Cannot render {chartType} chart: query returned no data rows.");
+        }
 
         try
         {
@@ -58,17 +65,22 @@ public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logge
                 ChartType.Bar => RenderBar(columnNames, columns, rows, title),
                 ChartType.Scatter => RenderScatter(columnNames, columns, rows, title),
                 ChartType.Pie => RenderPie(columnNames, columns, rows, title),
-                _ => null
+                _ => throw new ChartRenderingException($"Unsupported chart type: {chartType}.")
             };
+        }
+        catch (ChartRenderingException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Chart rendering failed for {ChartType}", chartType);
-            return null;
+            throw new ChartRenderingException(
+                $"Failed to render {chartType} chart: {ex.Message}", ex);
         }
     }
 
-    private ResponseImage? RenderTimeSeries(
+    private ResponseImage RenderTimeSeries(
         IList<string> columnNames,
         IReadOnlyDictionary<string, string> columns,
         IList<JsonElement> rows,
@@ -102,7 +114,11 @@ public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logge
             }
         }
 
-        if (timestamps.Count == 0) return null;
+        if (timestamps.Count == 0)
+        {
+            throw new ChartRenderingException(
+                "TimeSeries chart could not be rendered: none of the rows contained a parseable datetime value.");
+        }
 
         var xs = timestamps.ToArray();
         var plot = new ScottPlot.Plot();
@@ -121,7 +137,7 @@ public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logge
         return ToPngImage(plot, $"Time series chart with {timestamps.Count} data points");
     }
 
-    private ResponseImage? RenderBar(
+    private ResponseImage RenderBar(
         IList<string> columnNames,
         IReadOnlyDictionary<string, string> columns,
         IList<JsonElement> rows,
@@ -149,7 +165,11 @@ public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logge
             values.Add(ToDouble(arr[valueIdx]));
         }
 
-        if (values.Count == 0) return null;
+        if (values.Count == 0)
+        {
+            throw new ChartRenderingException(
+                "Bar chart could not be rendered: rows did not contain valid label/value pairs.");
+        }
 
         var plot = new ScottPlot.Plot();
         plot.Title(title ?? columnNames[valueIdx]);
@@ -169,7 +189,7 @@ public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logge
         return ToPngImage(plot, $"Bar chart with {values.Count} categories");
     }
 
-    private ResponseImage? RenderScatter(
+    private ResponseImage RenderScatter(
         IList<string> columnNames,
         IReadOnlyDictionary<string, string> columns,
         IList<JsonElement> rows,
@@ -195,7 +215,11 @@ public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logge
             ys.Add(ToDouble(arr[yIdx]));
         }
 
-        if (xs.Count == 0) return null;
+        if (xs.Count == 0)
+        {
+            throw new ChartRenderingException(
+                "Scatter chart could not be rendered: rows did not contain valid X/Y numeric pairs.");
+        }
 
         var plot = new ScottPlot.Plot();
         plot.Title(title ?? $"{columnNames[xIdx]} vs {columnNames[yIdx]}");
@@ -206,7 +230,7 @@ public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logge
         return ToPngImage(plot, $"Scatter plot with {xs.Count} data points");
     }
 
-    private ResponseImage? RenderPie(
+    private ResponseImage RenderPie(
         IList<string> columnNames,
         IReadOnlyDictionary<string, string> columns,
         IList<JsonElement> rows,
@@ -237,7 +261,11 @@ public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logge
             });
         }
 
-        if (slices.Count == 0) return null;
+        if (slices.Count == 0)
+        {
+            throw new ChartRenderingException(
+                "Pie chart could not be rendered: no rows contained a positive numeric value to chart.");
+        }
 
         var plot = new ScottPlot.Plot();
         plot.Title(title ?? columnNames[valueIdx]);

--- a/tools/Azure.Mcp.Tools.Kusto/src/Rendering/ScottPlotChartRenderer.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Rendering/ScottPlotChartRenderer.cs
@@ -1,0 +1,280 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.Kusto.Rendering;
+
+/// <summary>
+/// Renders Kusto query result data as chart images using ScottPlot 5.x (MIT license).
+/// </summary>
+public sealed class ScottPlotChartRenderer(ILogger<ScottPlotChartRenderer> logger) : IKustoChartRenderer
+{
+    private const int ChartWidth = 960;
+    private const int ChartHeight = 480;
+    private const string ImageMimeType = "image/png";
+
+    private static readonly HashSet<string> s_numericKqlTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "int", "long", "real", "double", "decimal"
+    };
+
+    /// <inheritdoc />
+    public ResponseImage? TryRender(IReadOnlyList<JsonElement> results, ChartType chartType, string? title = null)
+    {
+        if (results.Count < 2)
+            return null;
+
+        // results[0] is the column→type header dictionary
+        if (results[0].ValueKind != JsonValueKind.Object)
+            return null;
+
+        var columns = results[0]
+            .EnumerateObject()
+            .ToDictionary(p => p.Name, p => p.Value.GetString() ?? string.Empty);
+
+        if (!DataShapeValidator.Validate(columns, chartType, out var errorMessage))
+        {
+            logger.LogWarning("Chart rendering skipped — data shape validation failed for {ChartType}: {Error}",
+                chartType, errorMessage);
+            return null;
+        }
+
+        // Data rows are JSON arrays (one element per column in column order)
+        var columnNames = columns.Keys.ToList();
+        var rows = results.Skip(1)
+            .Where(r => r.ValueKind == JsonValueKind.Array)
+            .ToList();
+
+        if (rows.Count == 0)
+            return null;
+
+        try
+        {
+            return chartType switch
+            {
+                ChartType.TimeSeries => RenderTimeSeries(columnNames, columns, rows, title),
+                ChartType.Bar => RenderBar(columnNames, columns, rows, title),
+                ChartType.Scatter => RenderScatter(columnNames, columns, rows, title),
+                ChartType.Pie => RenderPie(columnNames, columns, rows, title),
+                _ => null
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Chart rendering failed for {ChartType}", chartType);
+            return null;
+        }
+    }
+
+    private ResponseImage? RenderTimeSeries(
+        IList<string> columnNames,
+        IReadOnlyDictionary<string, string> columns,
+        IList<JsonElement> rows,
+        string? title)
+    {
+        var datetimeIdx = columnNames
+            .Select((name, i) => (name, i))
+            .First(t => columns[t.name].Equals("datetime", StringComparison.OrdinalIgnoreCase))
+            .i;
+
+        var numericIndices = columnNames
+            .Select((name, i) => (name, i))
+            .Where(t => s_numericKqlTypes.Contains(columns[t.name]))
+            .ToList();
+
+        var timestamps = new List<double>();
+        var seriesData = numericIndices.ToDictionary(t => t.name, _ => new List<double>());
+
+        foreach (var row in rows)
+        {
+            var arr = row.EnumerateArray().ToList();
+            if (arr.Count <= datetimeIdx) continue;
+
+            var dtRaw = arr[datetimeIdx];
+            if (!TryParseDateTime(dtRaw, out var dt)) continue;
+            timestamps.Add(dt.ToOADate());
+
+            foreach (var (colName, colIdx) in numericIndices)
+            {
+                seriesData[colName].Add(colIdx < arr.Count ? ToDouble(arr[colIdx]) : 0.0);
+            }
+        }
+
+        if (timestamps.Count == 0) return null;
+
+        var xs = timestamps.ToArray();
+        var plot = new ScottPlot.Plot();
+        plot.Title(title ?? "Time Series");
+        plot.Axes.DateTimeTicksBottom();
+        plot.ShowLegend();
+
+        foreach (var (colName, values) in seriesData)
+        {
+            var ys = values.ToArray();
+            var scatter = plot.Add.Scatter(xs, ys);
+            scatter.LegendText = colName;
+        }
+
+        plot.Axes.AutoScale();
+        return ToPngImage(plot, $"Time series chart with {timestamps.Count} data points");
+    }
+
+    private ResponseImage? RenderBar(
+        IList<string> columnNames,
+        IReadOnlyDictionary<string, string> columns,
+        IList<JsonElement> rows,
+        string? title)
+    {
+        var labelIdx = columnNames
+            .Select((name, i) => (name, i))
+            .First(t => !s_numericKqlTypes.Contains(columns[t.name]) &&
+                        !columns[t.name].Equals("datetime", StringComparison.OrdinalIgnoreCase))
+            .i;
+
+        var valueIdx = columnNames
+            .Select((name, i) => (name, i))
+            .First(t => s_numericKqlTypes.Contains(columns[t.name]))
+            .i;
+
+        var labels = new List<string>();
+        var values = new List<double>();
+
+        foreach (var row in rows)
+        {
+            var arr = row.EnumerateArray().ToList();
+            if (arr.Count <= Math.Max(labelIdx, valueIdx)) continue;
+            labels.Add(arr[labelIdx].ValueKind == JsonValueKind.Null ? "" : arr[labelIdx].ToString());
+            values.Add(ToDouble(arr[valueIdx]));
+        }
+
+        if (values.Count == 0) return null;
+
+        var plot = new ScottPlot.Plot();
+        plot.Title(title ?? columnNames[valueIdx]);
+        plot.YLabel(columnNames[valueIdx]);
+
+        var bars = values.Select((v, i) =>
+            new ScottPlot.Bar { Position = i, Value = v, Label = i < labels.Count ? labels[i] : "" }).ToArray();
+        var barPlot = plot.Add.Bars(bars);
+        barPlot.ValueLabelStyle.Bold = true;
+
+        var tickPositions = Enumerable.Range(0, values.Count).Select(i => (double)i).ToArray();
+        var tickLabels = values.Select((_, i) => i < labels.Count ? labels[i] : i.ToString()).ToArray();
+        plot.Axes.Bottom.SetTicks(tickPositions, tickLabels);
+        plot.Axes.Bottom.TickLabelStyle.Rotation = labels.Count > 6 ? 45 : 0;
+
+        plot.Axes.AutoScale();
+        return ToPngImage(plot, $"Bar chart with {values.Count} categories");
+    }
+
+    private ResponseImage? RenderScatter(
+        IList<string> columnNames,
+        IReadOnlyDictionary<string, string> columns,
+        IList<JsonElement> rows,
+        string? title)
+    {
+        var numericIndices = columnNames
+            .Select((name, i) => (name, i))
+            .Where(t => s_numericKqlTypes.Contains(columns[t.name]))
+            .Take(2)
+            .ToList();
+
+        var xIdx = numericIndices[0].i;
+        var yIdx = numericIndices[1].i;
+
+        var xs = new List<double>();
+        var ys = new List<double>();
+
+        foreach (var row in rows)
+        {
+            var arr = row.EnumerateArray().ToList();
+            if (arr.Count <= Math.Max(xIdx, yIdx)) continue;
+            xs.Add(ToDouble(arr[xIdx]));
+            ys.Add(ToDouble(arr[yIdx]));
+        }
+
+        if (xs.Count == 0) return null;
+
+        var plot = new ScottPlot.Plot();
+        plot.Title(title ?? $"{columnNames[xIdx]} vs {columnNames[yIdx]}");
+        plot.XLabel(columnNames[xIdx]);
+        plot.YLabel(columnNames[yIdx]);
+        plot.Add.Scatter(xs.ToArray(), ys.ToArray());
+        plot.Axes.AutoScale();
+        return ToPngImage(plot, $"Scatter plot with {xs.Count} data points");
+    }
+
+    private ResponseImage? RenderPie(
+        IList<string> columnNames,
+        IReadOnlyDictionary<string, string> columns,
+        IList<JsonElement> rows,
+        string? title)
+    {
+        var labelIdx = columnNames
+            .Select((name, i) => (name, i))
+            .First(t => !s_numericKqlTypes.Contains(columns[t.name]) &&
+                        !columns[t.name].Equals("datetime", StringComparison.OrdinalIgnoreCase))
+            .i;
+
+        var valueIdx = columnNames
+            .Select((name, i) => (name, i))
+            .First(t => s_numericKqlTypes.Contains(columns[t.name]))
+            .i;
+
+        var slices = new List<ScottPlot.PieSlice>();
+        foreach (var row in rows)
+        {
+            var arr = row.EnumerateArray().ToList();
+            if (arr.Count <= Math.Max(labelIdx, valueIdx)) continue;
+            var val = ToDouble(arr[valueIdx]);
+            if (val <= 0) continue;
+            slices.Add(new ScottPlot.PieSlice
+            {
+                Value = val,
+                Label = arr[labelIdx].ValueKind == JsonValueKind.Null ? "" : arr[labelIdx].ToString()
+            });
+        }
+
+        if (slices.Count == 0) return null;
+
+        var plot = new ScottPlot.Plot();
+        plot.Title(title ?? columnNames[valueIdx]);
+        var pie = plot.Add.Pie(slices);
+        pie.ExplodeFraction = 0.05;
+        pie.SliceLabelDistance = 1.35;
+        plot.ShowLegend();
+        plot.Axes.Frameless();
+        plot.HideGrid();
+
+        return ToPngImage(plot, $"Pie chart with {slices.Count} slices");
+    }
+
+    private static ResponseImage ToPngImage(ScottPlot.Plot plot, string altText)
+    {
+        var pngBytes = plot.GetImageBytes(ChartWidth, ChartHeight);
+        return new ResponseImage(pngBytes, ImageMimeType, altText);
+    }
+
+    private static bool TryParseDateTime(JsonElement element, out DateTime result)
+    {
+        if (element.ValueKind == JsonValueKind.String)
+        {
+            var s = element.GetString();
+            if (s != null && DateTime.TryParse(s, null, System.Globalization.DateTimeStyles.RoundtripKind, out result))
+                return true;
+        }
+        result = default;
+        return false;
+    }
+
+    private static double ToDouble(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.Number => element.TryGetDouble(out var d) ? d : 0.0,
+        JsonValueKind.String => double.TryParse(element.GetString(), out var d) ? d : 0.0,
+        JsonValueKind.True => 1.0,
+        JsonValueKind.False => 0.0,
+        _ => 0.0
+    };
+}

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/QueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/QueryCommandTests.cs
@@ -152,7 +152,7 @@ public sealed class QueryCommandTests : CommandUnitTestsBase<QueryCommand, IKust
             Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(results);
 
-        _chartRenderer.TryRender(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.TimeSeries, Arg.Any<string>())
+        _chartRenderer.Render(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.TimeSeries, Arg.Any<string>())
             .Returns(fakeImage);
 
         // Act
@@ -164,7 +164,8 @@ public sealed class QueryCommandTests : CommandUnitTestsBase<QueryCommand, IKust
         Assert.Single(response.Images);
         Assert.Equal("image/png", response.Images[0].MimeType);
         Assert.Null(response.Results);
-        _chartRenderer.Received(1).TryRender(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.TimeSeries, Arg.Any<string>());
+        Assert.True(response.OmitTextContent);
+        _chartRenderer.Received(1).Render(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.TimeSeries, Arg.Any<string>());
     }
 
     [Fact]
@@ -185,15 +186,16 @@ public sealed class QueryCommandTests : CommandUnitTestsBase<QueryCommand, IKust
 
         // Assert
         Assert.Null(response.Images);
-        _chartRenderer.DidNotReceiveWithAnyArgs().TryRender(default!, default, default);
+        Assert.False(response.OmitTextContent);
+        _chartRenderer.DidNotReceiveWithAnyArgs().Render(default!, default, default);
     }
 
     [Fact]
-    public async Task ExecuteAsync_DoesNotIncludeImage_WhenRendererReturnsNull()
+    public async Task ExecuteAsync_FailsWithBadRequest_WhenRendererThrowsChartRenderingException()
     {
         // Arrange
-        var headerRow = JsonDocument.Parse("{\"Timestamp\":\"datetime\",\"Count\":\"long\"}").RootElement.Clone();
-        var dataRow = JsonDocument.Parse("[\"2024-01-01T00:00:00Z\",42]").RootElement.Clone();
+        var headerRow = JsonDocument.Parse("{\"Name\":\"string\"}").RootElement.Clone();
+        var dataRow = JsonDocument.Parse("[\"abc\"]").RootElement.Clone();
         var results = new List<JsonElement> { headerRow, dataRow };
 
         Service.QueryItemsAsync(
@@ -203,8 +205,8 @@ public sealed class QueryCommandTests : CommandUnitTestsBase<QueryCommand, IKust
             Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(results);
 
-        _chartRenderer.TryRender(Arg.Any<IReadOnlyList<JsonElement>>(), Arg.Any<ChartType>(), Arg.Any<string>())
-            .Returns((ResponseImage?)null);
+        _chartRenderer.Render(Arg.Any<IReadOnlyList<JsonElement>>(), Arg.Any<ChartType>(), Arg.Any<string>())
+            .Returns(_ => throw new ChartRenderingException("requires a datetime column"));
 
         // Act
         var response = await ExecuteCommandAsync(
@@ -212,6 +214,21 @@ public sealed class QueryCommandTests : CommandUnitTestsBase<QueryCommand, IKust
 
         // Assert
         Assert.Null(response.Images);
+        Assert.Contains("requires a datetime column", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FailsWithValidationError_WhenChartTypeValueIsInvalid()
+    {
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--cluster-uri https://mycluster.kusto.windows.net --database db1 --query \"T\" --chart-type Bogus");
+
+        // Assert: option-level validator rejected the value before service was hit
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("chart-type", response.Message, StringComparison.OrdinalIgnoreCase);
+        _ = Service.DidNotReceiveWithAnyArgs().QueryItemsAsync(
+            default!, default!, default!, default, default, default, Arg.Any<CancellationToken>());
     }
 }
 

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/QueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/QueryCommandTests.cs
@@ -4,8 +4,11 @@
 using System.Net;
 using System.Text.Json;
 using Azure.Mcp.Tools.Kusto.Commands;
+using Azure.Mcp.Tools.Kusto.Rendering;
 using Azure.Mcp.Tools.Kusto.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Mcp.Core.Models;
+using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
@@ -16,6 +19,14 @@ namespace Azure.Mcp.Tools.Kusto.UnitTests;
 
 public sealed class QueryCommandTests : CommandUnitTestsBase<QueryCommand, IKustoService>
 {
+    private readonly IKustoChartRenderer _chartRenderer;
+
+    public QueryCommandTests()
+    {
+        _chartRenderer = Substitute.For<IKustoChartRenderer>();
+        Services.AddSingleton(_chartRenderer);
+    }
+
     public static IEnumerable<object[]> QueryArgumentMatrix()
     {
         yield return new object[] { "--subscription sub1 --cluster mycluster --database db1 --query \"StormEvents | take 1\"", false };
@@ -123,4 +134,83 @@ public sealed class QueryCommandTests : CommandUnitTestsBase<QueryCommand, IKust
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("Either --cluster-uri must be provided", response.Message, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_IncludesChartImage_WhenChartTypeSpecifiedAndRendererSucceeds()
+    {
+        // Arrange
+        var headerRow = JsonDocument.Parse("{\"Timestamp\":\"datetime\",\"Count\":\"long\"}").RootElement.Clone();
+        var dataRow = JsonDocument.Parse("[\"2024-01-01T00:00:00Z\",42]").RootElement.Clone();
+        var results = new List<JsonElement> { headerRow, dataRow };
+        var pngBytes = new byte[] { 1, 2, 3 };
+        var fakeImage = new ResponseImage(pngBytes, "image/png", "chart");
+
+        Service.QueryItemsAsync(
+            "https://mycluster.kusto.windows.net",
+            "db1",
+            "T",
+            Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            .Returns(results);
+
+        _chartRenderer.TryRender(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.TimeSeries, Arg.Any<string>())
+            .Returns(fakeImage);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--cluster-uri https://mycluster.kusto.windows.net --database db1 --query \"T\" --chart-type TimeSeries");
+
+        // Assert
+        Assert.NotNull(response.Images);
+        Assert.Single(response.Images);
+        Assert.Equal("image/png", response.Images[0].MimeType);
+        _chartRenderer.Received(1).TryRender(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.TimeSeries, Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoesNotIncludeImage_WhenChartTypeNotSpecified()
+    {
+        // Arrange
+        var results = new List<JsonElement>();
+        Service.QueryItemsAsync(
+            "https://mycluster.kusto.windows.net",
+            "db1",
+            "T",
+            Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            .Returns(results);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--cluster-uri https://mycluster.kusto.windows.net --database db1 --query \"T\"");
+
+        // Assert
+        Assert.Null(response.Images);
+        _chartRenderer.DidNotReceiveWithAnyArgs().TryRender(default!, default, default);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoesNotIncludeImage_WhenRendererReturnsNull()
+    {
+        // Arrange
+        var headerRow = JsonDocument.Parse("{\"Timestamp\":\"datetime\",\"Count\":\"long\"}").RootElement.Clone();
+        var dataRow = JsonDocument.Parse("[\"2024-01-01T00:00:00Z\",42]").RootElement.Clone();
+        var results = new List<JsonElement> { headerRow, dataRow };
+
+        Service.QueryItemsAsync(
+            "https://mycluster.kusto.windows.net",
+            "db1",
+            "T",
+            Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            .Returns(results);
+
+        _chartRenderer.TryRender(Arg.Any<IReadOnlyList<JsonElement>>(), Arg.Any<ChartType>(), Arg.Any<string>())
+            .Returns((ResponseImage?)null);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--cluster-uri https://mycluster.kusto.windows.net --database db1 --query \"T\" --chart-type Bar");
+
+        // Assert
+        Assert.Null(response.Images);
+    }
 }
+

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/QueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/QueryCommandTests.cs
@@ -163,6 +163,7 @@ public sealed class QueryCommandTests : CommandUnitTestsBase<QueryCommand, IKust
         Assert.NotNull(response.Images);
         Assert.Single(response.Images);
         Assert.Equal("image/png", response.Images[0].MimeType);
+        Assert.Null(response.Results);
         _chartRenderer.Received(1).TryRender(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.TimeSeries, Arg.Any<string>());
     }
 

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/SampleCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/SampleCommandTests.cs
@@ -4,8 +4,11 @@
 using System.Net;
 using System.Text.Json;
 using Azure.Mcp.Tools.Kusto.Commands;
+using Azure.Mcp.Tools.Kusto.Rendering;
 using Azure.Mcp.Tools.Kusto.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Mcp.Core.Models;
+using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
@@ -15,6 +18,14 @@ namespace Azure.Mcp.Tools.Kusto.UnitTests;
 
 public sealed class SampleCommandTests : CommandUnitTestsBase<SampleCommand, IKustoService>
 {
+    private readonly IKustoChartRenderer _chartRenderer;
+
+    public SampleCommandTests()
+    {
+        _chartRenderer = Substitute.For<IKustoChartRenderer>();
+        Services.AddSingleton(_chartRenderer);
+    }
+
     public static IEnumerable<object[]> SampleArgumentMatrix()
     {
         yield return new object[] { "--subscription sub1 --cluster mycluster --database db1 --table table1", false };
@@ -84,39 +95,6 @@ public sealed class SampleCommandTests : CommandUnitTestsBase<SampleCommand, IKu
         Assert.Empty(result.Results);
     }
 
-    // TODO: jongio - Talk to author about why they expect 500 here
-    // [Theory]
-    // [MemberData(nameof(SampleArgumentMatrix))]
-    // public async Task ExecuteAsync_HandlesException_AndSetsException(string cliArgs, bool useClusterUri)
-    // {
-    //     var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
-    //     if (useClusterUri)
-    //     {
-    //         _kusto.QueryItems(
-    //             "https://mycluster.kusto.windows.net",
-    //             "db1",
-    //             "table1 | sample 10",
-    //             Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>())
-    //             .Returns(Task.FromException<List<JsonElement>>(new Exception("Test error")));
-    //     }
-    //     else
-    //     {
-    //         _kusto.QueryItems(
-    //             "sub1", "mycluster", "db1", "table1 | sample 10",
-    //             Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>())
-    //             .Returns(Task.FromException<List<JsonElement>>(new Exception("Test error")));
-    //     }
-    //     var command = new SampleCommand(_logger, _kusto);
-
-    //     var args = command.GetCommand().Parse(cliArgs);
-    //     var context = new CommandContext(_serviceProvider);
-
-    //     var response = await command.ExecuteAsync(context, args, TestContext.Current.CancellationToken);
-    //     Assert.NotNull(response);
-    //     Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
-    //     Assert.Equal(expectedError, response.Message);
-    // }
-
     [Fact]
     public async Task ExecuteAsync_ReturnsBadRequest_WhenMissingRequiredOptions()
     {
@@ -124,4 +102,36 @@ public sealed class SampleCommandTests : CommandUnitTestsBase<SampleCommand, IKu
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_IncludesChartImage_WhenChartTypeSpecifiedAndRendererSucceeds()
+    {
+        // Arrange
+        var headerRow = JsonDocument.Parse("{\"Category\":\"string\",\"Count\":\"long\"}").RootElement.Clone();
+        var dataRow = JsonDocument.Parse("[\"A\",42]").RootElement.Clone();
+        var results = new List<JsonElement> { headerRow, dataRow };
+        var pngBytes = new byte[] { 1, 2, 3 };
+        var fakeImage = new ResponseImage(pngBytes, "image/png", "chart");
+
+        Service.QueryItemsAsync(
+            "https://mycluster.kusto.windows.net",
+            "db1",
+            "['table1'] | sample 10",
+            Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            .Returns(results);
+
+        _chartRenderer.TryRender(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.Bar, Arg.Any<string>())
+            .Returns(fakeImage);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--cluster-uri https://mycluster.kusto.windows.net --database db1 --table table1 --chart-type Bar");
+
+        // Assert
+        Assert.NotNull(response.Images);
+        Assert.Single(response.Images);
+        Assert.Equal("image/png", response.Images[0].MimeType);
+        _chartRenderer.Received(1).TryRender(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.Bar, Arg.Any<string>());
+    }
 }
+

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/SampleCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/SampleCommandTests.cs
@@ -120,7 +120,7 @@ public sealed class SampleCommandTests : CommandUnitTestsBase<SampleCommand, IKu
             Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(results);
 
-        _chartRenderer.TryRender(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.Bar, Arg.Any<string>())
+        _chartRenderer.Render(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.Bar, Arg.Any<string>())
             .Returns(fakeImage);
 
         // Act
@@ -132,7 +132,8 @@ public sealed class SampleCommandTests : CommandUnitTestsBase<SampleCommand, IKu
         Assert.Single(response.Images);
         Assert.Equal("image/png", response.Images[0].MimeType);
         Assert.Null(response.Results);
-        _chartRenderer.Received(1).TryRender(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.Bar, Arg.Any<string>());
+        Assert.True(response.OmitTextContent);
+        _chartRenderer.Received(1).Render(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.Bar, Arg.Any<string>());
     }
 }
 

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/SampleCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/SampleCommandTests.cs
@@ -131,6 +131,7 @@ public sealed class SampleCommandTests : CommandUnitTestsBase<SampleCommand, IKu
         Assert.NotNull(response.Images);
         Assert.Single(response.Images);
         Assert.Equal("image/png", response.Images[0].MimeType);
+        Assert.Null(response.Results);
         _chartRenderer.Received(1).TryRender(Arg.Any<IReadOnlyList<JsonElement>>(), ChartType.Bar, Arg.Any<string>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/ScottPlotChartRendererTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/ScottPlotChartRendererTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Azure.Mcp.Tools.Kusto.Rendering;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Kusto.UnitTests;
+
+public sealed class ScottPlotChartRendererTests
+{
+    private static readonly byte[] s_pngMagic = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    private readonly ScottPlotChartRenderer _renderer = new(NullLogger<ScottPlotChartRenderer>.Instance);
+
+    // Minimal Kusto result format:
+    //   results[0]  = { "ColName": "kqlType", ... }   (schema header)
+    //   results[1+] = [ value, value, ... ]             (data rows, in column order)
+
+    private static IReadOnlyList<JsonElement> TimeSeriesResults(int rowCount = 5)
+    {
+        var rows = new List<string>
+        {
+            """{"Time":"datetime","Value":"real"}"""
+        };
+        var baseTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        for (var i = 0; i < rowCount; i++)
+        {
+            var ts = baseTime.AddMinutes(i).ToString("o");
+            var val = 20.0 + i * 2.5;
+            rows.Add($"[\"{ts}\",{val}]");
+        }
+        return rows.Select(r => JsonDocument.Parse(r).RootElement.Clone()).ToList();
+    }
+
+    private static IReadOnlyList<JsonElement> BarResults()
+    {
+        return new[]
+        {
+            """{"Category":"string","Count":"long"}""",
+            """["Alpha",42]""",
+            """["Beta",17]""",
+            """["Gamma",91]""",
+        }.Select(r => JsonDocument.Parse(r).RootElement.Clone()).ToList();
+    }
+
+    private static IReadOnlyList<JsonElement> ScatterResults()
+    {
+        return new[]
+        {
+            """{"X":"real","Y":"real"}""",
+            """[1.0,2.0]""",
+            """[3.0,5.0]""",
+            """[7.0,3.5]""",
+        }.Select(r => JsonDocument.Parse(r).RootElement.Clone()).ToList();
+    }
+
+    private static IReadOnlyList<JsonElement> PieResults()
+    {
+        return new[]
+        {
+            """{"Slice":"string","Value":"real"}""",
+            """["Alpha",30.0]""",
+            """["Beta",45.0]""",
+            """["Gamma",25.0]""",
+        }.Select(r => JsonDocument.Parse(r).RootElement.Clone()).ToList();
+    }
+
+    [Fact]
+    public void Render_TimeSeries_ReturnsValidPng()
+    {
+        var result = _renderer.Render(TimeSeriesResults(), ChartType.TimeSeries, "Test TimeSeries");
+
+        Assert.NotNull(result);
+        Assert.Equal("image/png", result.MimeType);
+        Assert.NotNull(result.Data);
+        Assert.True(result.Data.Length > 1000, $"PNG should be >1KB but was {result.Data.Length} bytes");
+        Assert_StartsWith(s_pngMagic, result.Data);
+    }
+
+    [Fact]
+    public void Render_Bar_ReturnsValidPng()
+    {
+        var result = _renderer.Render(BarResults(), ChartType.Bar, "Test Bar");
+
+        Assert.NotNull(result);
+        Assert.Equal("image/png", result.MimeType);
+        Assert.True(result.Data.Length > 1000, $"PNG should be >1KB but was {result.Data.Length} bytes");
+        Assert_StartsWith(s_pngMagic, result.Data);
+    }
+
+    [Fact]
+    public void Render_Scatter_ReturnsValidPng()
+    {
+        var result = _renderer.Render(ScatterResults(), ChartType.Scatter, "Test Scatter");
+
+        Assert.NotNull(result);
+        Assert.Equal("image/png", result.MimeType);
+        Assert.True(result.Data.Length > 1000, $"PNG should be >1KB but was {result.Data.Length} bytes");
+        Assert_StartsWith(s_pngMagic, result.Data);
+    }
+
+    [Fact]
+    public void Render_Pie_ReturnsValidPng()
+    {
+        var result = _renderer.Render(PieResults(), ChartType.Pie, "Test Pie");
+
+        Assert.NotNull(result);
+        Assert.Equal("image/png", result.MimeType);
+        Assert.True(result.Data.Length > 1000, $"PNG should be >1KB but was {result.Data.Length} bytes");
+        Assert_StartsWith(s_pngMagic, result.Data);
+    }
+
+    [Fact]
+    public void Render_NoRows_ThrowsChartRenderingException()
+    {
+        var onlyHeader = new[]
+        {
+            """{"Time":"datetime","Value":"real"}"""
+        }.Select(r => JsonDocument.Parse(r).RootElement.Clone()).ToList();
+
+        Assert.Throws<ChartRenderingException>(() =>
+            _renderer.Render(onlyHeader, ChartType.TimeSeries));
+    }
+
+    [Fact]
+    public void Render_EmptyResults_ThrowsChartRenderingException()
+    {
+        Assert.Throws<ChartRenderingException>(() =>
+            _renderer.Render([], ChartType.TimeSeries));
+    }
+
+    [Fact]
+    public void Render_TimeSeries_WithManyRows_ReturnsValidPng()
+    {
+        // Simulate a realistic 60-minute timeseries
+        var result = _renderer.Render(TimeSeriesResults(60), ChartType.TimeSeries, "60-min CPU");
+
+        Assert.NotNull(result);
+        Assert.True(result.Data.Length > 1000);
+        Assert_StartsWith(s_pngMagic, result.Data);
+    }
+
+    private static void Assert_StartsWith(byte[] expected, byte[] actual)
+    {
+        Assert.True(actual.Length >= expected.Length,
+            $"Data too short: {actual.Length} bytes, expected at least {expected.Length}");
+        Assert.Equal(expected, actual[..expected.Length]);
+    }
+}
+


### PR DESCRIPTION
## Summary

Adds opt-in chart image rendering to the Azure MCP Kusto query and sample commands. When `--chart-type` is specified (`TimeSeries`, `Bar`, `Scatter`, or `Pie`), query results are validated against the requested chart type and rendered as a PNG using [ScottPlot 5.x](https://scottplot.net/) (MIT). The image is returned alongside the JSON results as an MCP `ImageContentBlock`, enabling vision-capable LLM clients (e.g. GitHub Copilot) to analyze telemetry visually without parsing raw JSON tables.

## Motivation

When an LLM consumes a Kusto query that returns hundreds of time-series rows, it is often forced to either truncate, summarize-by-eye, or render an ASCII table — all lossy. KQL has the `| render timechart …` operator that ADX clients use to draw charts, but the MCP tool today simply returns the underlying tabular data and ignores `render`.

This change lets the model (or the user, via the tool's input) explicitly ask for a chart rendering when it is the right shape for the question being asked, while leaving the existing JSON-only behavior untouched.

## How it works

- `--chart-type` is a single new `Option<string?>` on `QueryCommand` and `SampleCommand` (parsed via `Enum.TryParse<ChartType>`).
- When set, after the query executes, results are passed through `DataShapeValidator`.
- If valid, `ScottPlotChartRenderer` produces a PNG via `plot.GetImageBytes(width, height)`.
- The PNG is added to `CommandResponse.Images` (new `ResponseImage` record on the core response model).
- `CommandFactoryToolLoader` emits an MCP `ImageContentBlock` per image alongside the existing `TextContentBlock` JSON.

Fully opt-in: omitting `--chart-type` preserves today's JSON-only behavior.

## Changes

**Core (`core/Microsoft.Mcp.Core`):**
- New `ResponseImage` record + `Images` property on `CommandResponse`.
- `CommandFactoryToolLoader` emits `ImageContentBlock.FromBytes(...)` for each image.
- `ModelsJsonContext` registers the new types for AOT.

**Kusto toolset (`tools/Azure.Mcp.Tools.Kusto`):**
- New `Rendering/`: `ChartType`, `DataShapeValidator`, `IKustoChartRenderer`, `ScottPlotChartRenderer`.
- `--chart-type` option added; renderer registered in `KustoSetup`.
- `QueryCommand` and `SampleCommand` invoke the renderer when set.

**Build:**
- ScottPlot 5.1.58 added to `Directory.Packages.props`.
- Pre-existing `NU1010` fix: pinned `System.ClientModel 1.9.0` (referenced by `Azure.Mcp.Tools.Pricing` but missing from CPM).

**Docs / tests:**
- `azmcp-commands.md`, `e2eTestPrompts.md` updated.
- Changelog entry added.
- 185 Kusto unit tests pass.

## Backwards compatibility

Fully backwards compatible. No existing tool input shape changes; `--chart-type` is purely additive and optional.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
