### PR TITLE
Fix/Add  Resource Group Scoping

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Subscription/SubscriptionCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Subscription/SubscriptionCommandTests.cs
@@ -45,6 +45,7 @@ public class SubscriptionCommandTests : CommandUnitTestsBase<AccountGetCommand, 
         Service.GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is(subscription),
+            Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
@@ -60,6 +61,7 @@ public class SubscriptionCommandTests : CommandUnitTestsBase<AccountGetCommand, 
         await Service.Received(1).GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             subscription,
+            Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
@@ -82,6 +84,7 @@ public class SubscriptionCommandTests : CommandUnitTestsBase<AccountGetCommand, 
         Service.GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is(expectedSubscription),
+            Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
@@ -97,12 +100,14 @@ public class SubscriptionCommandTests : CommandUnitTestsBase<AccountGetCommand, 
         await Service.Received(1).GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             expectedSubscription,
+            Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
         await Service.DidNotReceive().GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             ignoredSubscription,
+            Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());

--- a/servers/Azure.Mcp.Server/changelog-entries/1777656937957.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1777656937957.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed `azmcp grafana list`, `azmcp kusto cluster list`, `azmcp appconfig account list`, `azmcp storage account get`, `azmcp monitor workspace list`, and `azmcp search service list` to honor the optional `--resource-group` parameter, which was previously registered but not passed through to the service layer, causing subscription-wide results to always be returned regardless of the specified resource group."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -366,7 +366,8 @@ azmcp search knowledge source get --service <service>
 
 # List AI Search accounts in a subscription
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp search service list --subscription <subscription>
+azmcp search service list --subscription <subscription> \
+                         [--resource-group <resource-group>]
 ```
 
 ### Azure AI Services Speech Operations
@@ -479,7 +480,8 @@ azmcp speech tts synthesize --endpoint https://myservice.cognitiveservices.azure
 ```bash
 # List App Configuration stores in a subscription
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp appconfig account list --subscription <subscription>
+azmcp appconfig account list --subscription <subscription> \
+                            [--resource-group <resource-group>]
 
 # Delete a key-value setting
 # ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
@@ -1826,7 +1828,8 @@ azmcp kusto cluster get --subscription <subscription> \
 
 # List Azure Data Explorer clusters in a subscription
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp kusto cluster list --subscription <subscription>
+azmcp kusto cluster list --subscription <subscription> \
+                        [--resource-group <resource-group>]
 
 # List databases in a Azure Data Explorer cluster
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
@@ -2513,7 +2516,8 @@ azmcp loadtesting testrun createorupdate --subscription <subscription> \
 ```bash
 # List Azure Managed Grafana
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp grafana list --subscription <subscription>
+azmcp grafana list --subscription <subscription> \
+                  [--resource-group <resource-group>]
 ```
 
 ### Azure Marketplace Operations
@@ -2636,7 +2640,8 @@ azmcp monitor table list --subscription <subscription> \
 
 # List Log Analytics workspaces in a subscription
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp monitor workspace list --subscription <subscription>
+azmcp monitor workspace list --subscription <subscription> \
+                            [--resource-group <resource-group>]
 
 # Query logs from Azure Monitor using KQL
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
@@ -3455,6 +3460,7 @@ azmcp storage account create --subscription <subscription> \
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp storage account get --subscription <subscription> \
                           [--account <account>] \
+                          [--resource-group <resource-group>] \
                           [--tenant <tenant>]
 ```
 

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/Account/AccountListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/Account/AccountListCommand.cs
@@ -7,7 +7,9 @@ using Azure.Mcp.Tools.AppConfig.Options.Account;
 using Azure.Mcp.Tools.AppConfig.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
 using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.AppConfig.Commands.Account;
 
@@ -30,6 +32,19 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger, IAppC
     private readonly ILogger<AccountListCommand> _logger = logger;
     private readonly IAppConfigService _appConfigService = appConfigService;
 
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsOptional());
+    }
+
+    protected override AccountListOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.ResourceGroup = parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
+        return options;
+    }
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {
         if (!Validate(parseResult.CommandResult, context.Response).IsValid)
@@ -43,6 +58,7 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger, IAppC
         {
             var accounts = await _appConfigService.GetAppConfigAccounts(
                 options.Subscription!,
+                options.ResourceGroup,
                 options.Tenant,
                 options.RetryPolicy,
                 cancellationToken);

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
@@ -26,6 +26,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
 
     public async Task<ResourceQueryResults<AppConfigurationAccount>> GetAppConfigAccounts(
         string subscription,
+        string? resourceGroup = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
@@ -34,7 +35,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
 
         return await ExecuteResourceQueryAsync(
             "Microsoft.AppConfiguration/configurationStores",
-            resourceGroup: null, // all resource groups
+            resourceGroup: resourceGroup,
             subscription,
             retryPolicy,
             ConvertToAppConfigurationAccountModel,

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/IAppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/IAppConfigService.cs
@@ -11,6 +11,7 @@ public interface IAppConfigService
 {
     Task<ResourceQueryResults<AppConfigurationAccount>> GetAppConfigAccounts(
         string subscription,
+        string? resourceGroup = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/Account/AccountListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/Account/AccountListCommandTests.cs
@@ -29,6 +29,7 @@ public class AccountListCommandTests : CommandUnitTestsBase<AccountListCommand, 
         Service.GetAppConfigAccounts(
             "sub123",
             Arg.Any<string?>(),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedAccounts);
@@ -50,6 +51,7 @@ public class AccountListCommandTests : CommandUnitTestsBase<AccountListCommand, 
         // Arrange
         Service.GetAppConfigAccounts(
             Arg.Any<string>(),
+            Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
@@ -68,11 +70,7 @@ public class AccountListCommandTests : CommandUnitTestsBase<AccountListCommand, 
     public async Task ExecuteAsync_Returns500_WhenServiceThrowsException()
     {
         // Arrange
-        Service.GetAppConfigAccounts(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<CancellationToken>())
+        Service.GetAppConfigAccounts(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Service error"));
 
         // Act
@@ -98,7 +96,7 @@ public class AccountListCommandTests : CommandUnitTestsBase<AccountListCommand, 
     public async Task ExecuteAsync_Returns503_WhenServiceIsUnavailable()
     {
         // Arrange
-        Service.GetAppConfigAccounts(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.GetAppConfigAccounts(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("Service Unavailable", null, HttpStatusCode.ServiceUnavailable));
 
         // Act

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/Account/AccountListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/Account/AccountListCommandTests.cs
@@ -106,4 +106,20 @@ public class AccountListCommandTests : CommandUnitTestsBase<AccountListCommand, 
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.Status);
         Assert.Contains("Service Unavailable", response.Message);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_WithResourceGroup_ForwardsResourceGroupToService()
+    {
+        // Arrange
+        const string resourceGroup = "test-rg";
+        Service.GetAppConfigAccounts(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(new ResourceQueryResults<AppConfigurationAccount>([], false));
+
+        // Act
+        var response = await ExecuteCommandAsync("--subscription", "sub123", "--resource-group", resourceGroup);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).GetAppConfigAccounts(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tools/Azure.Mcp.Tools.Grafana/src/Commands/Workspace/WorkspaceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/src/Commands/Workspace/WorkspaceListCommand.cs
@@ -7,7 +7,9 @@ using Azure.Mcp.Tools.Grafana.Options.Workspace;
 using Azure.Mcp.Tools.Grafana.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
 using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Grafana.Commands.Workspace;
 
@@ -33,6 +35,19 @@ public sealed class WorkspaceListCommand(IGrafanaService grafanaService, ILogger
     private readonly IGrafanaService _grafanaService = grafanaService;
     private readonly ILogger<WorkspaceListCommand> _logger = logger;
 
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsOptional());
+    }
+
+    protected override WorkspaceListOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.ResourceGroup = parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
+        return options;
+    }
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {
         if (!Validate(parseResult.CommandResult, context.Response).IsValid)
@@ -46,6 +61,7 @@ public sealed class WorkspaceListCommand(IGrafanaService grafanaService, ILogger
         {
             var workspaces = await _grafanaService.ListWorkspacesAsync(
                 options.Subscription!,
+                options.ResourceGroup,
                 options.Tenant,
                 options.RetryPolicy,
                 cancellationToken);

--- a/tools/Azure.Mcp.Tools.Grafana/src/Services/GrafanaService.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/src/Services/GrafanaService.cs
@@ -25,6 +25,7 @@ public class GrafanaService(
 
     public async Task<ResourceQueryResults<GrafanaWorkspace>> ListWorkspacesAsync(
         string subscription,
+        string? resourceGroup = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
@@ -33,7 +34,7 @@ public class GrafanaService(
 
         var workspaces = await ExecuteResourceQueryAsync(
             "Microsoft.Dashboard/grafana",
-            resourceGroup: null, // all resource groups
+            resourceGroup: resourceGroup,
             subscription,
             retryPolicy,
             ConvertToWorkspaceModel,

--- a/tools/Azure.Mcp.Tools.Grafana/src/Services/IGrafanaService.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/src/Services/IGrafanaService.cs
@@ -19,6 +19,7 @@ public interface IGrafanaService
     /// <exception cref="Exception">When the service request fails</exception>
     Task<ResourceQueryResults<GrafanaWorkspace>> ListWorkspacesAsync(
         string subscription,
+        string? resourceGroup = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);

--- a/tools/Azure.Mcp.Tools.Grafana/tests/Azure.Mcp.Tools.Grafana.UnitTests/WorkspaceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/tests/Azure.Mcp.Tools.Grafana.UnitTests/WorkspaceListCommandTests.cs
@@ -61,7 +61,7 @@ public sealed class WorkspaceListCommandTests : CommandUnitTestsBase<WorkspaceLi
             )
         ], false);
 
-        Service.ListWorkspacesAsync("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspacesAsync("sub123", Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedWorkspaces);
 
         // Act
@@ -79,7 +79,7 @@ public sealed class WorkspaceListCommandTests : CommandUnitTestsBase<WorkspaceLi
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoWorkspacesExist()
     {
         // Arrange
-        Service.ListWorkspacesAsync("sub123", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspacesAsync("sub123", Arg.Any<string?>(), null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(new ResourceQueryResults<GrafanaWorkspace>([], false));
 
         // Act
@@ -112,7 +112,7 @@ public sealed class WorkspaceListCommandTests : CommandUnitTestsBase<WorkspaceLi
             )
         ], false);
 
-        Service.ListWorkspacesAsync("sub123", "tenant456", Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspacesAsync("sub123", Arg.Any<string?>(), "tenant456", Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedWorkspaces);
 
         // Act
@@ -130,7 +130,7 @@ public sealed class WorkspaceListCommandTests : CommandUnitTestsBase<WorkspaceLi
         var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
         var subscriptionId = "sub123";
 
-        Service.ListWorkspacesAsync(subscriptionId, null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspacesAsync(subscriptionId, Arg.Any<string?>(), null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act

--- a/tools/Azure.Mcp.Tools.Grafana/tests/Azure.Mcp.Tools.Grafana.UnitTests/WorkspaceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/tests/Azure.Mcp.Tools.Grafana.UnitTests/WorkspaceListCommandTests.cs
@@ -141,4 +141,20 @@ public sealed class WorkspaceListCommandTests : CommandUnitTestsBase<WorkspaceLi
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.Equal(expectedError, response.Message);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_WithResourceGroup_ForwardsResourceGroupToService()
+    {
+        // Arrange
+        const string resourceGroup = "test-rg";
+        Service.ListWorkspacesAsync(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(new ResourceQueryResults<GrafanaWorkspace>([], false));
+
+        // Act
+        var response = await ExecuteCommandAsync("--subscription", "sub123", "--resource-group", resourceGroup);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).ListWorkspacesAsync(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterListCommand.cs
@@ -6,7 +6,9 @@ using Azure.Mcp.Tools.Kusto.Options;
 using Azure.Mcp.Tools.Kusto.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
 using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Kusto.Commands;
 
@@ -26,6 +28,19 @@ public sealed class ClusterListCommand(ILogger<ClusterListCommand> logger, IKust
     private readonly ILogger<ClusterListCommand> _logger = logger;
     private readonly IKustoService _kustoService = kustoService;
 
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsOptional());
+    }
+
+    protected override ClusterListOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.ResourceGroup = parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
+        return options;
+    }
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {
         if (!Validate(parseResult.CommandResult, context.Response).IsValid)
@@ -39,6 +54,7 @@ public sealed class ClusterListCommand(ILogger<ClusterListCommand> logger, IKust
         {
             var clusterNames = await _kustoService.ListClustersAsync(
                 options.Subscription!,
+                options.ResourceGroup,
                 options.Tenant,
                 options.RetryPolicy,
                 cancellationToken);

--- a/tools/Azure.Mcp.Tools.Kusto/src/Services/IKustoService.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Services/IKustoService.cs
@@ -12,6 +12,7 @@ public interface IKustoService
 {
     Task<ResourceQueryResults<string>> ListClustersAsync(
         string subscription,
+        string? resourceGroup = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);

--- a/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoService.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoService.cs
@@ -66,6 +66,7 @@ public sealed class KustoService(
 
     public async Task<ResourceQueryResults<string>> ListClustersAsync(
         string subscriptionId,
+        string? resourceGroup = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
@@ -74,7 +75,7 @@ public sealed class KustoService(
 
         var clusters = await ExecuteResourceQueryAsync(
             "Microsoft.Kusto/clusters",
-            resourceGroup: null, // all resource groups
+            resourceGroup: resourceGroup,
             subscriptionId,
             retryPolicy,
             item => ConvertToClusterModel(item).ClusterName,

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/ClusterListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/ClusterListCommandTests.cs
@@ -21,7 +21,7 @@ public sealed class ClusterListCommandTests : CommandUnitTestsBase<ClusterListCo
         // Arrange
         var expectedClusters = new ResourceQueryResults<string>(["clusterA", "clusterB"], false);
         Service.ListClustersAsync(
-            "sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            "sub123", Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedClusters);
 
         // Act
@@ -37,7 +37,7 @@ public sealed class ClusterListCommandTests : CommandUnitTestsBase<ClusterListCo
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoClustersExist()
     {
         // Arrange
-        Service.ListClustersAsync("sub123", null, null, Arg.Any<CancellationToken>())
+        Service.ListClustersAsync("sub123", Arg.Any<string?>(), null, null, Arg.Any<CancellationToken>())
             .Returns(new ResourceQueryResults<string>([], false));
 
         // Act
@@ -57,7 +57,7 @@ public sealed class ClusterListCommandTests : CommandUnitTestsBase<ClusterListCo
         var subscriptionId = "sub123";
 
         // Arrange
-        Service.ListClustersAsync(subscriptionId, null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListClustersAsync(subscriptionId, Arg.Any<string?>(), null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/ClusterListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.UnitTests/ClusterListCommandTests.cs
@@ -68,4 +68,20 @@ public sealed class ClusterListCommandTests : CommandUnitTestsBase<ClusterListCo
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.Equal(expectedError, response.Message);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_WithResourceGroup_ForwardsResourceGroupToService()
+    {
+        // Arrange
+        const string resourceGroup = "test-rg";
+        Service.ListClustersAsync(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(new ResourceQueryResults<string>([], false));
+
+        // Act
+        var response = await ExecuteCommandAsync("--subscription", "sub123", "--resource-group", resourceGroup);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).ListClustersAsync(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Workspace/WorkspaceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Workspace/WorkspaceListCommand.cs
@@ -7,7 +7,9 @@ using Azure.Mcp.Tools.Monitor.Options;
 using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
 using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.Workspace;
 
@@ -31,6 +33,19 @@ public sealed class WorkspaceListCommand(ILogger<WorkspaceListCommand> logger, I
     private readonly ILogger<WorkspaceListCommand> _logger = logger;
     private readonly IMonitorService _monitorService = monitorService;
 
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsOptional());
+    }
+
+    protected override WorkspaceListOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.ResourceGroup = parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
+        return options;
+    }
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {
         if (!Validate(parseResult.CommandResult, context.Response).IsValid)
@@ -44,6 +59,7 @@ public sealed class WorkspaceListCommand(ILogger<WorkspaceListCommand> logger, I
         {
             var workspaces = await _monitorService.ListWorkspaces(
                 options.Subscription!,
+                options.ResourceGroup,
                 options.Tenant,
                 options.RetryPolicy,
                 cancellationToken);

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/IMonitorService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/IMonitorService.cs
@@ -40,6 +40,7 @@ public interface IMonitorService
 
     Task<List<WorkspaceInfo>> ListWorkspaces(
         string subscription,
+        string? resourceGroup = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorService.cs
@@ -198,11 +198,29 @@ public class MonitorService(
 
     public async Task<List<WorkspaceInfo>> ListWorkspaces(
         string subscription,
-        string? tenant,
-        RetryPolicyOptions? retryPolicy,
-        CancellationToken cancellationToken)
+        string? resourceGroup = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
+
+        if (!string.IsNullOrEmpty(resourceGroup))
+        {
+            var rgResource = await resourceGroupService.GetResourceGroupResource(subscription, resourceGroup, tenant, retryPolicy, cancellationToken)
+                ?? throw new Exception($"Resource group '{resourceGroup}' not found in subscription '{subscription}'.");
+
+            return await rgResource
+                .GetOperationalInsightsWorkspaces()
+                .GetAllAsync(cancellationToken)
+                .Select(workspace => new WorkspaceInfo
+                {
+                    Name = workspace.Data.Name,
+                    CustomerId = workspace.Data.CustomerId?.ToString() ?? string.Empty,
+                })
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
 
         var subscriptionResource = await subscriptionService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
 
@@ -484,7 +502,7 @@ public class MonitorService(
     {
         // If we're given an ID and need an ID, or given a name and need a name, return as is
         bool isId = IsWorkspaceId(workspace);
-        var workspaces = await ListWorkspaces(subscription, tenant, retryPolicy, cancellationToken);
+        var workspaces = await ListWorkspaces(subscription, resourceGroup: null, tenant, retryPolicy, cancellationToken);
 
         // Find the workspace
         var matchingWorkspace = workspaces.FirstOrDefault(w =>

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.LiveTests/LogAnalyticsHelper.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.LiveTests/LogAnalyticsHelper.cs
@@ -51,7 +51,7 @@ public class LogAnalyticsHelper(
         }
 
         // Get workspace info using the monitor service
-        var workspaces = await _monitorService.ListWorkspaces(_subscription, _tenantId, retryPolicy: null).ConfigureAwait(false);
+        var workspaces = await _monitorService.ListWorkspaces(_subscription, tenant: _tenantId, retryPolicy: null).ConfigureAwait(false);
         var workspace = workspaces.FirstOrDefault(w => w.Name.Equals(_workspaceName, StringComparison.OrdinalIgnoreCase))
             ?? throw new InvalidOperationException($"Could not find workspace {_workspaceName}");
 

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Workspace/WorkspaceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Workspace/WorkspaceListCommandTests.cs
@@ -32,7 +32,7 @@ public sealed class WorkspaceListCommandTests : CommandUnitTestsBase<WorkspaceLi
                 new() { Name = "workspace1", CustomerId = "guid1" },
                 new() { Name = "workspace2", CustomerId = "guid2" }
             };
-            Service.ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Service.ListWorkspaces(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
                 .Returns(testWorkspaces);
         }
 
@@ -62,7 +62,7 @@ public sealed class WorkspaceListCommandTests : CommandUnitTestsBase<WorkspaceLi
             new() { Name = "workspace2", CustomerId = "guid2" },
             new() { Name = "workspace3", CustomerId = "guid3" }
         };
-        Service.ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspaces(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns(expectedWorkspaces);
 
         // Act
@@ -70,7 +70,7 @@ public sealed class WorkspaceListCommandTests : CommandUnitTestsBase<WorkspaceLi
 
         // Assert
         // Verify the mock was called
-        await Service.Received(1).ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListWorkspaces(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
 
         var result = ValidateAndDeserializeResponse(response, MonitorJsonContext.Default.WorkspaceListCommandResult);
 
@@ -85,7 +85,7 @@ public sealed class WorkspaceListCommandTests : CommandUnitTestsBase<WorkspaceLi
     public async Task ExecuteAsync_ReturnsEmptyWhenNoWorkspaces()
     {
         // Arrange
-        Service.ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspaces(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act
@@ -101,7 +101,7 @@ public sealed class WorkspaceListCommandTests : CommandUnitTestsBase<WorkspaceLi
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        Service.ListWorkspaces(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspaces(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Workspace/WorkspaceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/Workspace/WorkspaceListCommandTests.cs
@@ -112,4 +112,20 @@ public sealed class WorkspaceListCommandTests : CommandUnitTestsBase<WorkspaceLi
         Assert.Contains("Test error", response.Message);
         Assert.Contains("troubleshooting", response.Message);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_WithResourceGroup_ForwardsResourceGroupToService()
+    {
+        // Arrange
+        const string resourceGroup = "test-rg";
+        Service.ListWorkspaces(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        // Act
+        var response = await ExecuteCommandAsync($"--subscription {_knownSubscription} --resource-group {resourceGroup}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).ListWorkspaces(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Service/ServiceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Service/ServiceListCommand.cs
@@ -6,7 +6,9 @@ using Azure.Mcp.Tools.Search.Options.Service;
 using Azure.Mcp.Tools.Search.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
 using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Search.Commands.Service;
 
@@ -26,6 +28,19 @@ public sealed class ServiceListCommand(ILogger<ServiceListCommand> logger, ISear
     private readonly ILogger<ServiceListCommand> _logger = logger;
     private readonly ISearchService _searchService = searchService;
 
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsOptional());
+    }
+
+    protected override ServiceListOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.ResourceGroup = parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
+        return options;
+    }
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {
         if (!Validate(parseResult.CommandResult, context.Response).IsValid)
@@ -39,6 +54,7 @@ public sealed class ServiceListCommand(ILogger<ServiceListCommand> logger, ISear
         {
             var services = await _searchService.ListServices(
                 options.Subscription!,
+                options.ResourceGroup,
                 options.Tenant,
                 options.RetryPolicy,
                 cancellationToken);

--- a/tools/Azure.Mcp.Tools.Search/src/Services/ISearchService.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Services/ISearchService.cs
@@ -10,6 +10,7 @@ public interface ISearchService
 {
     Task<List<string>> ListServices(
         string subscription,
+        string? resourceGroup = null,
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);

--- a/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
@@ -41,11 +41,27 @@ public sealed partial class SearchService(
 
     public async Task<List<string>> ListServices(
         string subscription,
+        string? resourceGroup = null,
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
+
+        if (!string.IsNullOrEmpty(resourceGroup))
+        {
+            var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenantId, retryPolicy, cancellationToken);
+            var rgResource = (await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken)).Value;
+            var rgServices = new List<string>();
+            await foreach (var service in rgResource.GetSearchServices().GetAllAsync(cancellationToken: cancellationToken))
+            {
+                if (service?.Data?.Name != null)
+                {
+                    rgServices.Add(service.Data.Name);
+                }
+            }
+            return rgServices;
+        }
 
         var cacheKey = string.IsNullOrEmpty(tenantId)
             ? CacheKeyBuilder.Build(SearchServicesCacheKey, subscription, _tenantService.CloudConfiguration.CloudType.ToString())
@@ -57,9 +73,9 @@ public sealed partial class SearchService(
             return cachedServices;
         }
 
-        var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenantId, retryPolicy, cancellationToken);
+        var subscriptionResourceSub = await _subscriptionService.GetSubscription(subscription, tenantId, retryPolicy, cancellationToken);
         var services = new List<string>();
-        await foreach (var service in subscriptionResource.GetSearchServicesAsync(cancellationToken: cancellationToken))
+        await foreach (var service in subscriptionResourceSub.GetSearchServicesAsync(cancellationToken: cancellationToken))
         {
             if (service?.Data?.Name != null)
             {

--- a/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
@@ -50,8 +50,8 @@ public sealed partial class SearchService(
 
         if (!string.IsNullOrEmpty(resourceGroup))
         {
-            var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenantId, retryPolicy, cancellationToken);
-            var rgResource = (await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken)).Value;
+            var subForRg = await _subscriptionService.GetSubscription(subscription, tenantId, retryPolicy, cancellationToken);
+            var rgResource = (await subForRg.GetResourceGroupAsync(resourceGroup, cancellationToken)).Value;
             var rgServices = new List<string>();
             await foreach (var service in rgResource.GetSearchServices().GetAllAsync(cancellationToken: cancellationToken))
             {
@@ -73,9 +73,9 @@ public sealed partial class SearchService(
             return cachedServices;
         }
 
-        var subscriptionResourceSub = await _subscriptionService.GetSubscription(subscription, tenantId, retryPolicy, cancellationToken);
+        var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenantId, retryPolicy, cancellationToken);
         var services = new List<string>();
-        await foreach (var service in subscriptionResourceSub.GetSearchServicesAsync(cancellationToken: cancellationToken))
+        await foreach (var service in subscriptionResource.GetSearchServicesAsync(cancellationToken: cancellationToken))
         {
             if (service?.Data?.Name != null)
             {

--- a/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
@@ -50,6 +50,16 @@ public sealed partial class SearchService(
 
         if (!string.IsNullOrEmpty(resourceGroup))
         {
+            var rgCacheKey = string.IsNullOrEmpty(tenantId)
+                ? CacheKeyBuilder.Build(SearchServicesCacheKey, subscription, resourceGroup, _tenantService.CloudConfiguration.CloudType.ToString())
+                : CacheKeyBuilder.Build(SearchServicesCacheKey, subscription, resourceGroup, tenantId, _tenantService.CloudConfiguration.CloudType.ToString());
+
+            var cachedRgServices = await _cacheService.GetAsync<List<string>>(CacheGroup, rgCacheKey, s_cacheDurationServices, cancellationToken);
+            if (cachedRgServices != null)
+            {
+                return cachedRgServices;
+            }
+
             var subForRg = await _subscriptionService.GetSubscription(subscription, tenantId, retryPolicy, cancellationToken);
             var rgResource = (await subForRg.GetResourceGroupAsync(resourceGroup, cancellationToken)).Value;
             var rgServices = new List<string>();
@@ -60,6 +70,8 @@ public sealed partial class SearchService(
                     rgServices.Add(service.Data.Name);
                 }
             }
+
+            await _cacheService.SetAsync(CacheGroup, rgCacheKey, rgServices, s_cacheDurationServices, cancellationToken);
             return rgServices;
         }
 

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Service/SearchServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Service/SearchServiceTests.cs
@@ -2,11 +2,97 @@
 // Licensed under the MIT License.
 
 using System.Text;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.Search.Services;
+using Azure.ResourceManager;
 using Azure.Search.Documents.KnowledgeBases.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Options;
+using Microsoft.Mcp.Core.Services.Azure.Authentication;
+using Microsoft.Mcp.Core.Services.Caching;
+using NSubstitute;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Search.UnitTests.Service;
+
+public class SearchServiceCacheTests
+{
+    private readonly ISubscriptionService _subscriptionService;
+    private readonly ICacheService _cacheService;
+    private readonly ITenantService _tenantService;
+    private readonly SearchService _service;
+
+    public SearchServiceCacheTests()
+    {
+        _subscriptionService = Substitute.For<ISubscriptionService>();
+        _cacheService = Substitute.For<ICacheService>();
+        _tenantService = Substitute.For<ITenantService>();
+
+        var cloudConfig = Substitute.For<IAzureCloudConfiguration>();
+        cloudConfig.CloudType.Returns(AzureCloudConfiguration.AzureCloud.AzurePublicCloud);
+        cloudConfig.AuthorityHost.Returns(new Uri("https://login.microsoftonline.com"));
+        cloudConfig.ArmEnvironment.Returns(ArmEnvironment.AzurePublicCloud);
+        _tenantService.CloudConfiguration.Returns(cloudConfig);
+
+        _service = new SearchService(
+            _subscriptionService,
+            _cacheService,
+            _tenantService,
+            Substitute.For<ILogger<SearchService>>());
+    }
+
+    [Fact]
+    public async Task ListServices_ReturnsCachedResult_WhenSubscriptionWideCacheHit()
+    {
+        // Arrange: cache already has data for this subscription
+        var cached = new List<string> { "cached-svc" };
+        _cacheService
+            .GetAsync<List<string>>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(cached);
+
+        // Act
+        var result = await _service.ListServices("sub123", cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert: result comes from cache and no ARM call is made
+        Assert.Equal(cached, result);
+        await _subscriptionService.DidNotReceive().GetSubscription(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListServices_RgCacheKey_IsDistinctFromSubscriptionWideKey()
+    {
+        // Arrange: both paths hit the cache so no ARM call is needed
+        _cacheService
+            .GetAsync<List<string>>("search", Arg.Is<string>(k => k.Contains("my-rg")), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(["rg-svc"]);
+        _cacheService
+            .GetAsync<List<string>>("search", Arg.Is<string>(k => !k.Contains("my-rg")), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(["sub-svc"]);
+
+        // Act
+        var subResult = await _service.ListServices("sub123", cancellationToken: TestContext.Current.CancellationToken);
+        var rgResult = await _service.ListServices("sub123", resourceGroup: "my-rg", cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert: results are distinct — the RG key and sub-wide key are different
+        Assert.Equal(["sub-svc"], subResult);
+        Assert.Equal(["rg-svc"], rgResult);
+
+        // Verify the cache was queried with a key that includes "my-rg" for the RG call
+        await _cacheService.Received(1).GetAsync<List<string>>(
+            "search",
+            Arg.Is<string>(k => k.Contains("my-rg")),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        // Verify the cache was queried with a key that excludes "my-rg" for the sub-wide call
+        await _cacheService.Received(1).GetAsync<List<string>>(
+            "search",
+            Arg.Is<string>(k => !k.Contains("my-rg")),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+}
 
 public class SearchServiceTests
 {

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Service/ServiceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Service/ServiceListCommandTests.cs
@@ -22,6 +22,7 @@ public class ServiceListCommandTests : CommandUnitTestsBase<ServiceListCommand, 
         var expectedServices = new List<string> { "service1", "service2" };
         Service.ListServices(
             Arg.Any<string>(),
+            Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
@@ -42,6 +43,7 @@ public class ServiceListCommandTests : CommandUnitTestsBase<ServiceListCommand, 
         // Arrange
         Service.ListServices(
             Arg.Any<string>(),
+            Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
@@ -65,6 +67,7 @@ public class ServiceListCommandTests : CommandUnitTestsBase<ServiceListCommand, 
 
         Service.ListServices(
             Arg.Any<string>(),
+            Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Service/ServiceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.UnitTests/Service/ServiceListCommandTests.cs
@@ -81,4 +81,20 @@ public class ServiceListCommandTests : CommandUnitTestsBase<ServiceListCommand, 
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.StartsWith(expectedError, response.Message);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_WithResourceGroup_ForwardsResourceGroupToService()
+    {
+        // Arrange
+        const string resourceGroup = "test-rg";
+        Service.ListServices(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        // Act
+        var response = await ExecuteCommandAsync("--subscription", "sub123", "--resource-group", resourceGroup);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).ListServices(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountGetCommand.cs
@@ -34,12 +34,14 @@ public sealed class AccountGetCommand(ILogger<AccountGetCommand> logger, IStorag
     {
         base.RegisterOptions(command);
         command.Options.Add(StorageOptionDefinitions.Account.AsOptional());
+        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsOptional());
     }
 
     protected override AccountGetOptions BindOptions(ParseResult parseResult)
     {
         var options = base.BindOptions(parseResult);
         options.Account = parseResult.GetValueOrDefault<string>(StorageOptionDefinitions.Account.Name);
+        options.ResourceGroup = parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
         return options;
     }
 
@@ -58,6 +60,7 @@ public sealed class AccountGetCommand(ILogger<AccountGetCommand> logger, IStorag
             var accounts = await _storageService.GetAccountDetails(
                 options.Account,
                 options.Subscription!,
+                options.ResourceGroup,
                 options.Tenant,
                 options.RetryPolicy,
                 cancellationToken);

--- a/tools/Azure.Mcp.Tools.Storage/src/Services/IStorageService.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Services/IStorageService.cs
@@ -12,6 +12,7 @@ public interface IStorageService
     Task<ResourceQueryResults<StorageAccountInfo>> GetAccountDetails(
         string? account,
         string subscription,
+        string? resourceGroup = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);

--- a/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
@@ -41,6 +41,7 @@ public class StorageService(
     public async Task<ResourceQueryResults<StorageAccountInfo>> GetAccountDetails(
         string? account,
         string subscription,
+        string? resourceGroup = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
@@ -54,7 +55,7 @@ public class StorageService(
             // List all accounts
             return await ExecuteResourceQueryAsync(
                 "Microsoft.Storage/storageAccounts",
-                null,
+                resourceGroup,
                 subscription,
                 retryPolicy,
                 ConvertToAccountInfoModel,
@@ -65,7 +66,7 @@ public class StorageService(
         {
             var storageAccount = await ExecuteSingleResourceQueryAsync(
                 "Microsoft.Storage/storageAccounts",
-                resourceGroup: null,
+                resourceGroup: resourceGroup,
                 subscription: subscription,
                 retryPolicy: retryPolicy,
                 converter: ConvertToAccountInfoModel,

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.UnitTests/Account/AccountGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.UnitTests/Account/AccountGetCommandTests.cs
@@ -233,4 +233,21 @@ public class AccountGetCommandTests : CommandUnitTestsBase<AccountGetCommand, IS
         Assert.Equal(HttpStatusCode.Forbidden, response.Status);
         Assert.Contains("Authorization failed", response.Message);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_WithResourceGroup_ForwardsResourceGroupToService()
+    {
+        // Arrange
+        const string resourceGroup = "test-rg";
+        const string subscription = "sub123";
+        Service.GetAccountDetails(Arg.Any<string?>(), Arg.Is(subscription), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(new ResourceQueryResults<StorageAccountInfo>([], false));
+
+        // Act
+        var response = await ExecuteCommandAsync("--subscription", subscription, "--resource-group", resourceGroup);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).GetAccountDetails(Arg.Any<string?>(), Arg.Is(subscription), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.UnitTests/Account/AccountGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.UnitTests/Account/AccountGetCommandTests.cs
@@ -31,6 +31,7 @@ public class AccountGetCommandTests : CommandUnitTestsBase<AccountGetCommand, IS
         Service.GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is(subscription),
+            Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
@@ -56,6 +57,7 @@ public class AccountGetCommandTests : CommandUnitTestsBase<AccountGetCommand, IS
         Service.GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is(subscription),
+            Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
@@ -80,6 +82,7 @@ public class AccountGetCommandTests : CommandUnitTestsBase<AccountGetCommand, IS
         Service.GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is(subscription),
+            Arg.Any<string?>(),
             null,
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
@@ -119,6 +122,7 @@ public class AccountGetCommandTests : CommandUnitTestsBase<AccountGetCommand, IS
             Service.GetAccountDetails(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
+                Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
@@ -154,6 +158,7 @@ public class AccountGetCommandTests : CommandUnitTestsBase<AccountGetCommand, IS
         Service.GetAccountDetails(
             Arg.Is(account),
             Arg.Is(subscription),
+            Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
@@ -179,7 +184,7 @@ public class AccountGetCommandTests : CommandUnitTestsBase<AccountGetCommand, IS
         var subscription = "sub123";
 
         Service.GetAccountDetails(
-            Arg.Is(account), Arg.Is(subscription), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Arg.Is(account), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -199,7 +204,7 @@ public class AccountGetCommandTests : CommandUnitTestsBase<AccountGetCommand, IS
         var subscription = "sub123";
 
         Service.GetAccountDetails(
-            Arg.Is(account), Arg.Is(subscription), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Arg.Is(account), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Storage account not found"));
 
         // Act
@@ -218,7 +223,7 @@ public class AccountGetCommandTests : CommandUnitTestsBase<AccountGetCommand, IS
         var subscription = "sub123";
 
         Service.GetAccountDetails(
-            Arg.Is(account), Arg.Is(subscription), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Arg.Is(account), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.Forbidden, "Authorization failed"));
 
         // Act


### PR DESCRIPTION
# Fix/Add: `--resource-group` parameter ignored in 6 list/get commands

Six commands were not supporting a `--resource-group`  parameter.  As a result, passing `--resource-group my-rg` had no effect and always returned subscription-wide results.

**Affected commands:**
- `azmcp grafana list`
- `azmcp kusto cluster list`
- `azmcp appconfig account list`
- `azmcp storage account get`
- `azmcp monitor workspace list`
- `azmcp search service list`

## What was fixed

The `resourceGroup` value is now correctly passed from each command's `BindOptions` through to the service layer, so results are filtered to the specified resource group when provided.

## Changes

- **Bug fix** — 6 commands now forward `--resource-group` to their service methods
- **Tests** — added `ExecuteAsync_WithResourceGroup_ForwardsResourceGroupToService` unit test to each affected command's test file
- **Docs** — updated `azmcp-commands.md` to show `--resource-group` as an optional parameter for all 6 commands
- **Changelog** — added entry under "Bugs Fixed"
- **Code quality** — cleaned up an awkward variable name in `SearchService.cs` (`subscriptionResourceSub` → `subscriptionResource`, inner scope renamed to `subForRg`)