### PR TITLE
Redirect writing errors to stdio to stderr

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/WindowHandleProvider.cs
+++ b/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/WindowHandleProvider.cs
@@ -26,7 +26,10 @@ public static partial class WindowHandleProvider
             try
             {
                 IntPtr display = XOpenDisplay(":1");
-                Console.WriteLine(display == IntPtr.Zero
+
+                // Do not write to standard output because it is interpreted as a JSON RPC response
+                // from the MCP server. Instead, write to standard error for diagnostics.
+                Console.Error.WriteLine(display == IntPtr.Zero
                     ? "No X display available. Running in headless mode."
                     : "X display is available.");
                 return display;
@@ -35,9 +38,7 @@ public static partial class WindowHandleProvider
             {
                 // X11 display detection failed; running in headless mode.
                 // Avoid logging exception details to console to prevent information disclosure.
-                Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine($"Failed to detect X display. Running in headless mode. Exception type: {typeof(Exception).FullName}");
-                Console.ResetColor();
+                Console.Error.WriteLine($"Failed to detect X display. Running in headless mode. Exception type: {typeof(Exception).FullName}");
             }
         }
 

--- a/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/WindowHandleProvider.cs
+++ b/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/WindowHandleProvider.cs
@@ -34,11 +34,11 @@ public static partial class WindowHandleProvider
                     : "X display is available.");
                 return display;
             }
-            catch (Exception)
+            catch (Exception exception)
             {
                 // X11 display detection failed; running in headless mode.
                 // Avoid logging exception details to console to prevent information disclosure.
-                Console.Error.WriteLine($"Failed to detect X display. Running in headless mode. Exception type: {typeof(Exception).FullName}");
+                Console.Error.WriteLine($"Failed to detect X display. Running in headless mode. Exception type: {exception.GetType().FullName}");
             }
         }
 

--- a/servers/Azure.Mcp.Server/changelog-entries/1777662676190.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1777662676190.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fix issue where writing exception to stdio is interpreted as JSON RPC response."

--- a/servers/Azure.Mcp.Server/changelog-entries/1777662676190.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1777662676190.yaml
@@ -1,3 +1,3 @@
 changes:
   - section: "Bugs Fixed"
-    description: "Fix issue where writing exception to stdio is interpreted as JSON RPC response."
+    description: "Fix issue where writing exception to stdout is interpreted as JSON RPC response."


### PR DESCRIPTION
## What does this PR do?

This redirects writing exceptions to stdio and writes to err instead. Anything written to stdio is considered a response from the MCP server and is interpreted as JSON RPC.  Consequently, is failed to be interpreted by Docker gateway.

In Visual Studio Code, it outputs a warning but keeps reading from stdio which succeeds later on.
```
2026-05-01 12:09:18.285 [warning] Failed to parse message: "Failed to detect X display. Running in headless mode. Exception type: System.Exception\n"
2026-05-01 12:23:03.878 [debug] [server -> editor] {"result":{"content":[{"type":"text","text":"{\"status\":200,\"message\":\"Success\",\"results\":{\"subscriptions\":[{\"subscriptionId\" ...
```

In Docker Gateway, it stops reading input from stdio:
```
Error: MPC 0: calling "tools/call": invalid character 'F' looking for beginning of value
```

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
