### PR TITLE
Skip ResourceHealth tests that depend on Azure CLI profile absence

### DIFF
--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Helpers/TestEnvironment.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Helpers/TestEnvironment.cs
@@ -34,4 +34,19 @@ public static class TestEnvironment
     /// </summary>
     public static void ClearAzureSubscriptionId()
         => Environment.SetEnvironmentVariable(EnvironmentHelpers.AzureSubscriptionIdEnvironmentVariable, null);
+
+    /// <summary>
+    /// Skips the test if a default subscription is configured via Azure CLI profile or AZURE_SUBSCRIPTION_ID.
+    /// This is useful for tests that validate missing required --subscription parameters,
+    /// which have fallback to default subscription sources in SubscriptionCommand.
+    /// </summary>
+    public static void SkipIfDefaultSubscriptionConfigured()
+    {
+        if (!string.IsNullOrEmpty(CommandHelper.GetDefaultSubscription()))
+        {
+            Xunit.Assert.Skip(
+                "An Azure CLI default subscription is configured; cannot validate missing --subscription. " +
+                "Run 'az logout' or 'az account clear' to clear the profile, then restart the test runner.");
+        }
+    }
 }

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/AvailabilityStatus/AvailabilityStatusGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/AvailabilityStatus/AvailabilityStatusGetCommandTests.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using Azure.Mcp.Tools.ResourceHealth.Commands.AvailabilityStatus;
 using Azure.Mcp.Tools.ResourceHealth.Services;
+using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
@@ -172,6 +173,13 @@ public class AvailabilityStatusGetCommandTests : CommandUnitTestsBase<Availabili
     [InlineData("--subscription")]
     public async Task ExecuteAsync_ReturnsError_WhenRequiredParameterIsMissing(string missingParameter)
     {
+        // The subscription option falls back to the Azure CLI profile or AZURE_SUBSCRIPTION_ID env var.
+        // Skip if a CLI profile default is present so the test only runs when
+        // the missing-subscription path is actually exercised.
+        Assert.SkipWhen(
+            !string.IsNullOrEmpty(CommandHelper.GetDefaultSubscription()),
+            "An Azure CLI default subscription is configured; cannot validate missing --subscription.");
+
         var argsList = new List<string>();
         if (missingParameter != "--subscription")
         {

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/AvailabilityStatus/AvailabilityStatusGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/AvailabilityStatus/AvailabilityStatusGetCommandTests.cs
@@ -4,9 +4,9 @@
 using System.Net;
 using Azure.Mcp.Tools.ResourceHealth.Commands.AvailabilityStatus;
 using Azure.Mcp.Tools.ResourceHealth.Services;
-using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
+using Microsoft.Mcp.Tests.Helpers;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -176,9 +176,7 @@ public class AvailabilityStatusGetCommandTests : CommandUnitTestsBase<Availabili
         // The subscription option falls back to the Azure CLI profile or AZURE_SUBSCRIPTION_ID env var.
         // Skip if a CLI profile default is present so the test only runs when
         // the missing-subscription path is actually exercised.
-        Assert.SkipWhen(
-            !string.IsNullOrEmpty(CommandHelper.GetDefaultSubscription()),
-            "An Azure CLI default subscription is configured; cannot validate missing --subscription.");
+        TestEnvironment.SkipIfDefaultSubscriptionConfigured();
 
         var argsList = new List<string>();
         if (missingParameter != "--subscription")

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/ServiceHealthEvents/ServiceHealthEventsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/ServiceHealthEvents/ServiceHealthEventsListCommandTests.cs
@@ -4,9 +4,9 @@
 using System.Net;
 using Azure.Mcp.Tools.ResourceHealth.Commands.ServiceHealthEvents;
 using Azure.Mcp.Tools.ResourceHealth.Services;
-using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
+using Microsoft.Mcp.Tests.Helpers;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -31,9 +31,7 @@ public class ServiceHealthEventsListCommandTests : CommandUnitTestsBase<ServiceH
         // profile default is present so we only assert when validation actually fails.
         if (!shouldSucceed && string.IsNullOrWhiteSpace(args))
         {
-            Assert.SkipWhen(
-                !string.IsNullOrEmpty(CommandHelper.GetDefaultSubscription()),
-                "An Azure CLI default subscription is configured; cannot validate missing --subscription.");
+            TestEnvironment.SkipIfDefaultSubscriptionConfigured();
         }
 
         // Arrange

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/ServiceHealthEvents/ServiceHealthEventsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/ServiceHealthEvents/ServiceHealthEventsListCommandTests.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using Azure.Mcp.Tools.ResourceHealth.Commands.ServiceHealthEvents;
 using Azure.Mcp.Tools.ResourceHealth.Services;
+using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
@@ -25,6 +26,16 @@ public class ServiceHealthEventsListCommandTests : CommandUnitTestsBase<ServiceH
     [InlineData("--subscription sub123 --filter startTime ge 2023-01-01", true)]
     public async Task ExecuteAsync_ValidatesInput(string args, bool shouldSucceed)
     {
+        // The subscription option falls back to the Azure CLI profile or AZURE_SUBSCRIPTION_ID env var.
+        // For the empty-args (missing subscription) cases, skip when a CLI
+        // profile default is present so we only assert when validation actually fails.
+        if (!shouldSucceed && string.IsNullOrWhiteSpace(args))
+        {
+            Assert.SkipWhen(
+                !string.IsNullOrEmpty(CommandHelper.GetDefaultSubscription()),
+                "An Azure CLI default subscription is configured; cannot validate missing --subscription.");
+        }
+
         // Arrange
         if (shouldSucceed)
         {


### PR DESCRIPTION
## What does this PR do?
Skip ResourceHealth tests that depend on Azure CLI profile absence when the profile is present

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
