### PR TITLE
Clean up examples of bad patterns in MD files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,10 +428,12 @@ try
 }
 catch (Exception ex)
 {
-    _logger.LogError(ex, "Error in {Operation}. Options: {@Options}", Name, options);
-    HandleException(context, ex);  // Always call base handler
+    _logger.LogError(ex, "Error in {Operation}. Resource: {Resource}", Name, resourceId, options);
+    HandleException(context, ex);
 }
 ```
+
+**DO NOT** log `{@Options}` as this may log sensitive information. Only log parameters that are known to be safe.
 
 ## Service Implementation Patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 - Run `dotnet build` after making changes
 - Follow the `{Resource}{Operation}Command` naming pattern
 - Use extension methods `.AsRequired()` and `.AsOptional()` for option handling
-- Use name-based binding with `parseResult.GetValueOrDefault<T>()`
+- Use Option-based binding with `parseResult.GetValueOrDefault(Option<T>)`
 - Always call `HandleException(context, ex)` in catch blocks
 - Include live tests for all commands that interact with Azure resources
 - Create Bicep templates for Azure service commands (`test-resources.bicep`)
@@ -140,7 +140,7 @@ Microsoft MCP (Model Context Protocol) servers provide AI agents with structured
 ### Prerequisites
 1. **Visual Studio Code**: [VS Code Stable](https://code.visualstudio.com/download) or [Insiders](https://code.visualstudio.com/insiders)
 2. **GitHub Copilot**: Install [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) and [GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) extensions
-3. **Node.js**: [Node.js 20+](https://nodejs.org/en/download) (ensure `node` and `npm` are in PATH)
+3. **Node.js**: [Latest Node.js LTS](https://nodejs.org/en/download) (ensure `node` and `npm` are in PATH)
 4. **PowerShell**: [PowerShell 7.0+](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) (required for build/test scripts)
 5. **.NET SDK**: .NET 10.0.201 (configured in `global.json`)
 6. **Azure PowerShell**: For live tests - [Install Azure PowerShell](https://learn.microsoft.com/powershell/azure/install-azure-powershell)
@@ -377,12 +377,12 @@ protected override void RegisterOptions(Command command)
     command.Options.Add(StorageOptionDefinitions.Account.AsOptional());
 }
 
-// Use name-based binding with type safety
+// Use Option-based binding with type safety
 protected override StorageAccountListOptions BindOptions(ParseResult parseResult)
 {
     var options = base.BindOptions(parseResult);
-    options.ResourceGroup ??= parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
-    options.Account = parseResult.GetValueOrDefault<string>(StorageOptionDefinitions.Account.Name);
+    options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
+    options.Account = parseResult.GetValueOrDefault(StorageOptionDefinitions.Account);
     return options;
 }
 ```
@@ -428,7 +428,7 @@ try
 }
 catch (Exception ex)
 {
-    _logger.LogError(ex, "Error in {Operation}. Resource: {Resource}", Name, resourceId, options);
+    _logger.LogError(ex, "Error in {Operation}. Subscription: {Subscription}", Name, options.Subscription);
     HandleException(context, ex);
 }
 ```

--- a/servers/Azure.Mcp.Server/docs/new-command.md
+++ b/servers/Azure.Mcp.Server/docs/new-command.md
@@ -472,14 +472,14 @@ public class MyService(
 ```csharp
 // ❌ Hardcoded public-cloud endpoint
 var client = new BlobServiceClient(
-    new Uri($"https://{account}.blob.core.windows.net"), credential, options);
+    new($"https://{account}.blob.core.windows.net"), credential, options);
 
 // ❌ Hardcoded connection string
 var connectionString = $"AccountEndpoint=https://{server}.documents.azure.com:443/;...";
 
 // ✅ Cloud-aware endpoint via switch expression
 var endpoint = GetBlobEndpoint(account);  // private helper using CloudType switch
-var client = new BlobServiceClient(new Uri(endpoint), credential, options);
+var client = new BlobServiceClient(new(endpoint), credential, options);
 ```
 
 ### 3. Options Class
@@ -746,10 +746,11 @@ using Microsoft.Mcp.Core.Models.Command;
     ReadOnly = true,        // Set to false for tools that modify resources
     Secret = false,         // Set to true for tools that may return sensitive information
     LocalRequired = false)] // Set to true for tools requiring local execution/resources
-public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Command> logger)
+public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Command> logger, I{Toolset}Service service)
     : Base{Toolset}Command<{Resource}{Operation}Options>
 {
     private readonly ILogger<{Resource}{Operation}Command> _logger = logger;
+    private readonly I{Toolset}Service _service = service;
 
     protected override void RegisterOptions(Command command)
     {
@@ -785,11 +786,8 @@ public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Co
         {
             context.Activity?.WithSubscriptionTag(options);
 
-            // Get the appropriate service from DI
-            var service = context.GetService<I{Toolset}Service>();
-
             // Call service operation(s) with required parameters
-            var results = await service.{Operation}(
+            var results = await _service.{Operation}(
                 options.RequiredParam!,  // Required parameters end with !
                 options.OptionalParam,   // Optional parameters are nullable
                 options.Subscription!,   // From SubscriptionCommand
@@ -803,9 +801,8 @@ public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Co
         catch (Exception ex)
         {
             // Log error with all relevant context
-            _logger.LogError(ex,
-                "Error in {Operation}. Required: {Required}, Optional: {Optional}, Options: {@Options}",
-                Name, options.RequiredParam, options.OptionalParam, options);
+            _logger.LogError(ex, "Error in {Operation}. Required: {Required}, Optional: {Optional}",
+                Name, options.RequiredParam, options.OptionalParam);
             HandleException(context, ex);
         }
 
@@ -1046,17 +1043,16 @@ await foreach (var resourceGroup in subscription.GetResourceGroups())
 Example:
 ```csharp
 // Mock setup in unit tests
-_mockervice
-    .GetResourceAsync(
-        Arg.Any<string>(),
-        Arg.Any<string>(),
-        Arg.Any<string>(),
-        Arg.Any<RetryPolicyOptions>(),
-        Arg.Any<CancellationToken>())
+Service.GetResourceAsync(
+    Arg.Any<string>(),
+    Arg.Any<string>(),
+    Arg.Any<string>(),
+    Arg.Any<RetryPolicyOptions>(),
+    Arg.Any<CancellationToken>())
     .Returns(mockResource);
 
 // Invoking product code in unit tests
-var result = await _service.GetResourceAsync(
+var result = await Service.GetResourceAsync(
     "test-resource",
     "test-subscription",
     "test-rg",
@@ -1159,31 +1155,12 @@ public class {Toolset}Service(ISubscriptionService subscriptionService, ITenantS
 Unit tests follow a standardized pattern that tests initialization, validation, and execution:
 
 ```csharp
-public class {Resource}{Operation}CommandTests
+public class {Resource}{Operation}CommandTests : CommandUnitTestsBase<{Resource}{Operation}Command, I{Toolset}Service>
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly I{Toolset}Service _service;
-    private readonly ILogger<{Resource}{Operation}Command> _logger;
-    private readonly {Resource}{Operation}Command _command;
-    private readonly CommandContext _context;
-    private readonly Command _commandDefinition;
-
-    public {Resource}{Operation}CommandTests()
-    {
-        _service = Substitute.For<I{Toolset}Service>();
-        _logger = Substitute.For<ILogger<{Resource}{Operation}Command>>();
-
-        var collection = new ServiceCollection().AddSingleton(_service);
-        _serviceProvider = collection.BuildServiceProvider();
-        _command = new(_logger);
-        _context = new(_serviceProvider);
-        _commandDefinition = _command.GetCommand();
-    }
-
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var command = _command.GetCommand();
+        var command = Command.GetCommand();
         Assert.Equal("operation", command.Name);
         Assert.NotNull(command.Description);
         Assert.NotEmpty(command.Description);
@@ -1198,20 +1175,16 @@ public class {Resource}{Operation}CommandTests
         // Arrange
         if (shouldSucceed)
         {
-            _service
-                .{Operation}(
-                    Arg.Any<string>(),
-                    Arg.Any<string>(),
-                    Arg.Any<RetryPolicyOptions>(),
-                    Arg.Any<CancellationToken>())
+            Service.{Operation}(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<RetryPolicyOptions>(),
+                Arg.Any<CancellationToken>())
                 .Returns([]);
         }
 
-        // Build args from a single string in tests using the test-only splitter
-        var parseResult = _commandDefinition.Parse(args);
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult);
+        var response = await ExecuteCommandAsync(args);
 
         // Assert
         Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
@@ -1230,27 +1203,22 @@ public class {Resource}{Operation}CommandTests
     public async Task ExecuteAsync_DeserializationValidation()
     {
         // Arrange
-        _service
-            .{Operation}(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
+        Service.{Operation}(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var parseResult = _commandDefinition.Parse({argsArray});
-
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult);
+        var response = await ExecuteCommandAsync({argsArray});
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(
+            response
+            {Toolset}JsonContext.Default.{Operation}CommandResult,
+            expectedStatus: HttpStatusCode.OK); // expectedStatus defaults to OK, omit if expecting OK.
 
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize(json, {Toolset}JsonContext.Default.{Operation}CommandResult);
-
-        Assert.NotNull(result);
         Assert.Empty(result.Items);
     }
 
@@ -1258,18 +1226,15 @@ public class {Resource}{Operation}CommandTests
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        _service
-            .{Operation}(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<ResultType>>(new Exception("Test error")));
-
-        var parseResult = _commandDefinition.Parse(["--required", "value"]);
+        Service.{Operation}(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Test error"));
 
         // Act
-        var response = await _command.ExecuteAsync(_context, parseResult);
+        var response = await ExecuteCommandAsync("--required", "value");
 
         // Assert
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -1281,10 +1246,10 @@ public class {Resource}{Operation}CommandTests
     public void BindOptions_BindsOptionsCorrectly()
     {
         // Arrange
-        var parseResult = _parser.Parse(["--subscription", "test-sub", "--required", "value"]);
+        var parseResult = CommandDefinition.Parse(["--subscription", "test-sub", "--required", "value"]);
 
         // Act
-        var options = _command.BindOptions(parseResult);
+        var options = Command.BindOptions(parseResult);
 
         // Assert
         Assert.Equal("test-sub", options.Subscription);
@@ -1523,12 +1488,13 @@ Always log errors with relevant context information:
 ```csharp
 catch (Exception ex)
 {
-    _logger.LogError(ex,
-        "Error in {Operation}. Resource: {Resource}, Options: {@Options}",
+    _logger.LogError(ex, "Error in {Operation}. Resource: {Resource}",
         Name, resourceId, options);
     HandleException(context, ex);
 }
 ```
+
+**DO NOT** log `{@Options}` as this may log sensitive information. Only log parameters that are known to be safe.
 
 ### 6. Common Error Scenarios to Handle
 
@@ -1569,7 +1535,7 @@ Core test cases for every command:
 public async Task ExecuteAsync_ValidatesInput(
     string args, bool shouldSucceed, string expectedError)
 {
-    var response = await ExecuteCommand(args);
+    var response = await ExecuteCommandAsync(args);
     Assert.Equal(shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest, response.Status);
     if (!shouldSucceed)
         Assert.Contains(expectedError, response.Message);
@@ -1579,11 +1545,10 @@ public async Task ExecuteAsync_ValidatesInput(
 public async Task ExecuteAsync_HandlesServiceError()
 {
     // Arrange
-    _service.Operation()
-        .Returns(Task.FromException(new ServiceException("Test error")));
+    Service.Operation().ThrowsAsync(new ServiceException("Test error"));
 
     // Act
-    var response = await ExecuteCommand("--param value");
+    var response = await ExecuteCommandAsync("--param value");
 
     // Assert
     Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -1748,7 +1713,7 @@ catch {
 Integration tests should use the deployed infrastructure:
 
 ```csharp
-public class {Toolset}CommandTests( ITestOutputHelper output)
+public class {Toolset}CommandTests(ITestOutputHelper output)
     : CommandTestsBase(output)
 {
     [Fact]

--- a/servers/Azure.Mcp.Server/docs/new-command.md
+++ b/servers/Azure.Mcp.Server/docs/new-command.md
@@ -66,7 +66,7 @@ If your command is a wrapper/utility (CLI tools, best practices, documentation):
      ```
 
    IMPORTANT:
-   - Commands use primary constructors with ILogger injection
+   - Commands use primary constructors with ILogger and service interface injection
    - Classes are always sealed unless explicitly intended for inheritance
    - Commands inheriting from `SubscriptionCommand` must handle subscription parameters
    - Service-specific base commands should add service-wide options
@@ -394,6 +394,7 @@ public class MyService(ISubscriptionService subscriptionService, ITenantService 
     public async Task<ResourceQueryResults<MyResource>> ListResourcesAsync(
         string resourceGroup,
         string subscription,
+        string? tenant = null,
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken)
     {
@@ -403,6 +404,7 @@ public class MyService(ISubscriptionService subscriptionService, ITenantService 
             subscription,
             retryPolicy,
             ConvertToModel,
+            tenant: tenant,
             cancellationToken: cancellationToken);
     }
 }
@@ -417,9 +419,7 @@ Some Azure services use data plane SDKs that require an explicit endpoint URL (e
 3. Add a private method that switches on `CloudType` and returns the cloud-correct URL.
 
 ```csharp
-public class MyService(
-    ISubscriptionService subscriptionService,
-    ITenantService tenantService)
+public class MyService(ISubscriptionService subscriptionService, ITenantService tenantService)
     : BaseAzureResourceService(subscriptionService, tenantService), IMyService
 {
     private readonly ITenantService _tenantService = tenantService
@@ -518,7 +518,7 @@ Commands explicitly register options as required or optional using extension met
 **Key principles:**
 - Commands explicitly register options when needed using extension methods
 - Each command controls whether each option is required or optional
-- Binding is explicit using `parseResult.GetValueOrDefault<T>()`
+- Binding is explicit using `parseResult.GetValueOrDefault(Option<T>)`
 - No shared state between commands - each gets its own option instance
 - Only use `.AsRequired()` and `.AsOptional()` if they will change the `Required` setting.
 - Use `Command.Validators.Add` to add unique option validation.
@@ -541,10 +541,10 @@ protected override MyCommandOptions BindOptions(ParseResult parseResult)
 {
     var options = base.BindOptions(parseResult);
     // Use ??= for options that might be set by base classes
-    options.ResourceGroup ??= parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
+    options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
     // Direct assignment for command-specific options
-    options.Account = parseResult.GetValueOrDefault<string>(ServiceOptionDefinitions.Account.Name);
-    options.Database = parseResult.GetValueOrDefault<string>(ServiceOptionDefinitions.Database.Name);
+    options.Account = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Account);
+    options.Database = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Database);
     return options;
 }
 ```
@@ -562,8 +562,8 @@ protected override void RegisterOptions(Command command)
 protected override MyCommandOptions BindOptions(ParseResult parseResult)
 {
     var options = base.BindOptions(parseResult);
-    options.Account = parseResult.GetValueOrDefault<string>(ServiceOptionDefinitions.Account.Name);
-    options.ResourceGroup ??= parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
+    options.Account = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Account);
+    options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
     return options;
 }
 ```
@@ -583,8 +583,8 @@ protected override void RegisterOptions(Command command)
     command.Validators.Add(commandResult =>
     {
         // Retrieve values once and infer presence from non-empty values
-        var eitherThis = commandResult.GetOrDefaultValue<string>(ServiceOptionDefinitions.EitherThis.Name);
-        var orThat = commandResult.GetOrDefaultValue<string>(ServiceOptionDefinitions.OrThat.Name);
+        var eitherThis = commandResult.GetOrDefaultValue(ServiceOptionDefinitions.EitherThis);
+        var orThat = commandResult.GetOrDefaultValue(ServiceOptionDefinitions.OrThat);
 
         var hasEitherThis = !string.IsNullOrWhiteSpace(eitherThis);
         var hasOrThat = !string.IsNullOrWhiteSpace(orThat);
@@ -605,10 +605,10 @@ protected override void RegisterOptions(Command command)
 protected override MyCommandOptions BindOptions(ParseResult parseResult)
 {
     var options = base.BindOptions(parseResult);
-    options.Account = parseResult.GetValueOrDefault<string>(ServiceOptionDefinitions.Account.Name);
-    options.ResourceGroup ??= parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
-    options.EitherThis = parseResult.GetValueOrDefault<string>(ServiceOptionDefinitions.EitherThis.Name);
-    options.OrThat = parseResult.GetValueOrDefault<string>(ServiceOptionDefinitions.OrThat.Name);
+    options.Account = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Account);
+    options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
+    options.EitherThis = parseResult.GetValueOrDefault(ServiceOptionDefinitions.EitherThis);
+    options.OrThat = parseResult.GetValueOrDefault(ServiceOptionDefinitions.OrThat);
     return options;
 }
 ```
@@ -616,7 +616,7 @@ protected override MyCommandOptions BindOptions(ParseResult parseResult)
 **Important binding patterns:**
 - Use `??=` assignment for options that might be set by base classes (like global options)
 - Use direct assignment for command-specific options
-- Use `parseResult.GetValueOrDefault<T>(optionName)` instead of holding Option<T> references
+- Use `parseResult.GetValueOrDefault(Option<T>)`
 - The extension methods handle the required/optional logic at the parser level
 
 **Benefits of the new pattern:**
@@ -686,9 +686,9 @@ protected override void RegisterOptions(Command command)
 }
 ```
 
-**Name-Based Binding Pattern:**
+**Option-Based Binding Pattern:**
 
-With the new pattern, option binding uses the name-based `GetValueOrDefault<T>()` method:
+With the new pattern, option binding uses the option-based `GetValueOrDefault(Option<T>)` method:
 
 ```csharp
 protected override MyCommandOptions BindOptions(ParseResult parseResult)
@@ -696,19 +696,19 @@ protected override MyCommandOptions BindOptions(ParseResult parseResult)
     var options = base.BindOptions(parseResult);
 
     // Use ??= for options that might be set by base classes
-    options.ResourceGroup ??= parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
+    options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
 
     // Use direct assignment for command-specific options
-    options.Account = parseResult.GetValueOrDefault<string>(ServiceOptionDefinitions.Account.Name);
-    options.Database = parseResult.GetValueOrDefault<string>(ServiceOptionDefinitions.Database.Name);
-    options.Filter = parseResult.GetValueOrDefault<string>(ServiceOptionDefinitions.Filter.Name);
+    options.Account = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Account);
+    options.Database = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Database);
+    options.Filter = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Filter);
 
     return options;
 }
 ```
 
 **Key Benefits:**
-- **Type Safety**: Generic `GetValueOrDefault<T>()` provides compile-time type checking
+- **Type Safety**: Generic `GetValueOrDefault(Option<T>)` provides compile-time type checking
 - **No Field References**: Eliminates need for readonly option fields in commands
 - **Flexible Requirements**: Each command controls which options are required/optional
 - **Clear Dependencies**: All option usage visible in `RegisterOptions` method
@@ -765,10 +765,10 @@ public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Co
     protected override {Resource}{Operation}Options BindOptions(ParseResult parseResult)
     {
         var options = base.BindOptions(parseResult);
-        // Bind options using GetValueOrDefault<T>(optionName)
-        options.RequiredOption = parseResult.GetValueOrDefault<string>({Toolset}OptionDefinitions.RequiredOption.Name);
-        options.OptionalOption = parseResult.GetValueOrDefault<string>({Toolset}OptionDefinitions.OptionalOption.Name);
-        options.StandardOption = parseResult.GetValueOrDefault<string>({Toolset}OptionDefinitions.StandardOption.Name);
+        // Bind options using GetValueOrDefault(Option<T>)
+        options.RequiredOption = parseResult.GetValueOrDefault({Toolset}OptionDefinitions.RequiredOption);
+        options.OptionalOption = parseResult.GetValueOrDefault({Toolset}OptionDefinitions.OptionalOption);
+        options.StandardOption = parseResult.GetValueOrDefault({Toolset}OptionDefinitions.StandardOption;
         return options;
     }
 
@@ -1097,8 +1097,8 @@ public abstract class Base{Toolset}Command<
     protected override TOptions BindOptions(ParseResult parseResult)
     {
         var options = base.BindOptions(parseResult);
-        // Bind common options using GetValueOrDefault<T>()
-        options.CommonOption = parseResult.GetValueOrDefault<string>({Toolset}OptionDefinitions.CommonOption.Name);
+        // Bind common options using GetValueOrDefault(Option<T>)
+        options.CommonOption = parseResult.GetValueOrDefault({Toolset}OptionDefinitions.CommonOption);
         return options;
     }
 }
@@ -1120,8 +1120,8 @@ public abstract class Base{Resource}Command<
     {
         var options = base.BindOptions(parseResult);
         // Bind resource-specific options
-        options.{Resource}Name = parseResult.GetValueOrDefault<string>({Toolset}OptionDefinitions.{Resource}Name.Name);
-        options.{Resource}Type = parseResult.GetValueOrDefault<string>({Toolset}OptionDefinitions.{Resource}Type.Name);
+        options.{Resource}Name = parseResult.GetValueOrDefault({Toolset}OptionDefinitions.{Resource}Name);
+        options.{Resource}Type = parseResult.GetValueOrDefault({Toolset}OptionDefinitions.{Resource}Type);
         return options;
     }
 }
@@ -1215,7 +1215,7 @@ public class {Resource}{Operation}CommandTests : CommandUnitTestsBase<{Resource}
 
         // Assert
         var result = ValidateAndDeserializeResponse(
-            response
+            response,
             {Toolset}JsonContext.Default.{Operation}CommandResult,
             expectedStatus: HttpStatusCode.OK); // expectedStatus defaults to OK, omit if expecting OK.
 
@@ -1389,7 +1389,10 @@ using Azure.Mcp.Tools.{Toolset}.Models;
 
 [JsonSerializable(typeof({Resource}{Operation}Command.{Resource}{Operation}CommandResult))]
 [JsonSerializable(typeof(YourModelType))]
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+)]
 internal partial class {Toolset}JsonContext : JsonSerializerContext;
 ```
 
@@ -1488,8 +1491,7 @@ Always log errors with relevant context information:
 ```csharp
 catch (Exception ex)
 {
-    _logger.LogError(ex, "Error in {Operation}. Resource: {Resource}",
-        Name, resourceId, options);
+    _logger.LogError(ex, "Error in {Operation}. Subscription: {Subscription}", Name, options.Subscription);
     HandleException(context, ex);
 }
 ```
@@ -2019,8 +2021,8 @@ protected override MyOptions BindOptions(ParseResult parseResult)
 {
     var options = base.BindOptions(parseResult);
     // Use name-based binding with generic type parameters
-    options.ResourceGroup ??= parseResult.GetValueOrDefault<string>(OptionDefinitions.Common.ResourceGroup.Name);
-    options.ServiceOption = parseResult.GetValueOrDefault<string>(ServiceOptionDefinitions.ServiceOption.Name);
+    options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
+    options.ServiceOption = parseResult.GetValueOrDefault(ServiceOptionDefinitions.ServiceOption);
     return options;
 }
 ```
@@ -2168,7 +2170,7 @@ catch (Exception ex)
    - **CRITICAL**: Define readonly option fields in commands - Use `OptionDefinitions` directly in `RegisterOptions` and `BindOptions`
    - **CRITICAL**: Use the old `UseResourceGroup()` or `RequireResourceGroup()` pattern - These methods no longer exist. Use extension methods like `.AsRequired()` or `.AsOptional()` instead
    - **CRITICAL**: Skip live test infrastructure for Azure service commands - Create `test-resources.bicep` template early in development
-   - **CRITICAL**: Use `parseResult.GetValue()` without the generic type parameter - Use `parseResult.GetValueOrDefault<T>(optionName)` instead
+   - **CRITICAL**: Use `parseResult.GetValue()` without the generic type parameter - Use `parseResult.GetValueOrDefault(Option<T>)` instead
    - Redefine base class properties in Options classes
    - Skip base.RegisterOptions() call
    - Skip base.Dispose() call
@@ -2185,7 +2187,7 @@ catch (Exception ex)
 2. Always:
    - Create a static `{Toolset}OptionDefinitions` class for the toolset
    - **For option handling**: Use extension methods like `.AsRequired()` or `.AsOptional()` to control option requirements per command. Register explicitly in `RegisterOptions` and bind explicitly in `BindOptions`
-   - **For option binding**: Use `parseResult.GetValueOrDefault<T>(optionDefinition.Name)` pattern for all options
+   - **For option binding**: Use `parseResult.GetValueOrDefault(Option<T>)` pattern for all options
    - **For Azure service commands**: Create test infrastructure (`test-resources.bicep`) before implementing live tests
    - Use OptionDefinitions for options
    - Follow exact file structure
@@ -2468,23 +2470,22 @@ Commands should be **transport-agnostic** - they work identically in stdio and H
 
 **Good:**
 ```csharp
-public sealed class StorageAccountGetCommand : SubscriptionCommand<StorageAccountGetOptions>
+public sealed class StorageAccountGetCommand(IStorageService storageService, ILogger<StorageAccountGetCommand> logger)
+    : SubscriptionCommand<StorageAccountGetOptions>
 {
-    private readonly IStorageService _storageService;
-
-    public StorageAccountGetCommand(
-        IStorageService storageService,
-        ILogger<StorageAccountGetCommand> logger)
-        : base(logger)
-    {
-        _storageService = storageService;
-    }
+    private readonly IStorageService _storageService = storageService;
+    private readonly ILogger<StorageAccountGetCommand> _logger = logger;
 
     public override async Task<CommandResponse> ExecuteAsync(
         CommandContext context,
         ParseResult parseResult,
         CancellationToken cancellationToken)
     {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
         var options = BindOptions(parseResult);
 
         // Authentication provider handles both stdio and HTTP scenarios
@@ -2529,14 +2530,12 @@ public override async Task<CommandResponse> ExecuteAsync(...)
 When implementing services that call Azure, use `IAzureTokenCredentialProvider`:
 
 ```csharp
-public class StorageService : BaseAzureService, IStorageService
+public class StorageService(
+    ITenantService tenantService,
+    ILogger<StorageService> logger)
+    : BaseAzureService(tenantService), IStorageService
 {
-    public StorageService(
-        ITenantService tenantService,
-        ILogger<StorageService> logger)
-        : base(tenantService, logger)
-    {
-    }
+    private readonly ILogger<StorageService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     public async Task<List<StorageAccount>> GetStorageAccountsAsync(
         string subscription,
@@ -2570,23 +2569,22 @@ Remote HTTP mode supports **multiple concurrent users**:
 
 **Good:**
 ```csharp
-public sealed class SqlDatabaseListCommand : SubscriptionCommand<SqlDatabaseListOptions>
+public sealed class SqlDatabaseListCommand(ISqlService sqlService, ILogger<SqlDatabaseListCommand> logger)
+    : SubscriptionCommand<SqlDatabaseListOptions>
 {
-    private readonly ISqlService _sqlService;  // ✅ Singleton service, thread-safe
-
-    public SqlDatabaseListCommand(
-        ISqlService sqlService,
-        ILogger<SqlDatabaseListCommand> logger)
-        : base(logger)
-    {
-        _sqlService = sqlService;
-    }
+    private readonly ISqlService _sqlService = sqlService;  // ✅ Singleton service, thread-safe
+    private readonly ILogger<SqlDatabaseListCommand> _logger = logger;
 
     public override async Task<CommandResponse> ExecuteAsync(
         CommandContext context,
         ParseResult parseResult,
         CancellationToken cancellationToken)
     {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
         // ✅ Options created per-request, no shared state
         var options = BindOptions(parseResult);
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/docs/new-tools.md
+++ b/tools/Azure.Mcp.Tools.AzureBackup/docs/new-tools.md
@@ -438,28 +438,21 @@ resource testVm 'Microsoft.Compute/virtualMachines@2024-03-01' = {
 Create a test class in `tests/Azure.Mcp.Tools.AzureBackup.UnitTests/{Group}/`:
 
 ```csharp
-public class VaultDeleteCommandTests
+public class VaultDeleteCommandTests : CommandUnitTestsBase<VaultDeleteCommand, IAzureBackupService>
 {
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        var logger = Substitute.For<ILogger<VaultDeleteCommand>>();
-        var service = Substitute.For<IAzureBackupService>();
-        var command = new VaultDeleteCommand(logger, service);
-
-        Assert.Equal("delete", command.Name);
-        Assert.True(command.Metadata.Destructive);
+        Assert.Equal("delete", Command.Name);
+        Assert.True(Command.Metadata.Destructive);
     }
 
     [Fact]
     public async Task ExecuteAsync_DeletesVault_Successfully()
     {
-        var logger = Substitute.For<ILogger<VaultDeleteCommand>>();
-        var service = Substitute.For<IAzureBackupService>();
-        service.DeleteVaultAsync(Arg.Any<string>(), /* ... */)
+        Service.DeleteVaultAsync(Arg.Any<string>(), /* ... */)
             .Returns(new OperationResult("Succeeded", null, "Deleted."));
 
-        var command = new VaultDeleteCommand(logger, service);
         // ... invoke and assert
     }
 


### PR DESCRIPTION
## What does this PR do?

Update MD files that commonly have agents pointed to them to perform code generation to stop reference bad patterns.

- Do not log `{@Options}` when a tool call fails.
- `IService` should be dependency injected in the constructor of the command.
- Command unit tests should extend from `CommandUnitTestsBase` as it provides common mocking and testing functionality.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
