### PR TITLE
Prepare MCP release 3.0.0-beta.8

### DIFF
--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -12,12 +12,12 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 - Improved Resource Health availability status errors for unsupported resource types. [[#2554](https://github.com/microsoft/mcp/pull/2554)]
 - Fixed parameter handling to honor the optional `--resource-group` parameter, which was previously not passed through to the service layer, causing subscription-wide results to always be returned regardless of the specified resource group for the following tools: [[#2552](https://github.com/microsoft/mcp/pull/2552)]
-  - `azmcp grafana list`
-  - `azmcp kusto cluster list`
-  - `azmcp appconfig account list`
-  - `azmcp storage account get`
-  - `azmcp monitor workspace list`
-  - `azmcp search service list`
+  - `appconfig_account_list`
+  - `grafana_list`
+  - `kusto_cluster_list`
+  - `monitor_workspace_list`
+  - `search_service_list`
+  - `storage_account_get`
 - Fixed issue where exceptions written to stdout were incorrectly interpreted as JSON RPC response. [[#2559](https://github.com/microsoft/mcp/pull/2559)]
 
 ### Other Changes

--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -2,15 +2,27 @@
 
 The Azure MCP Server updates automatically by default whenever a new release comes out 🚀. We ship updates twice a week on Tuesdays and Thursdays 😊
 
-## 3.0.0-beta.8 (Unreleased)
+## 3.0.0-beta.8 (2026-05-01)
 
 ### Features Added
 
-### Breaking Changes
+- Added `appservice_webapp_change-state` tool to change the running state of an App Service web app. [[#1934](https://github.com/microsoft/mcp/pull/1934)]
 
 ### Bugs Fixed
 
+- Improved Resource Health availability status errors for unsupported resource types. [[#2554](https://github.com/microsoft/mcp/pull/2554)]
+- Fixed parameter handling to honor the optional `--resource-group` parameter, which was previously not passed through to the service layer, causing subscription-wide results to always be returned regardless of the specified resource group for the following tools: [[#2552](https://github.com/microsoft/mcp/pull/2552)]
+  - `azmcp grafana list`
+  - `azmcp kusto cluster list`
+  - `azmcp appconfig account list`
+  - `azmcp storage account get`
+  - `azmcp monitor workspace list`
+  - `azmcp search service list`
+- Fixed issue where exceptions written to stdout were incorrectly interpreted as JSON RPC response. [[#2559](https://github.com/microsoft/mcp/pull/2559)]
+
 ### Other Changes
+
+- Improved Azure Functions tool descriptions and prompts for better AI agent tool selection and invocation. [[#2517](https://github.com/microsoft/mcp/pull/2517)]
 
 ## 3.0.0-beta.7 (2026-04-30)
 

--- a/servers/Azure.Mcp.Server/changelog-entries/1772648289840.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1772648289840.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Features Added"
-    description: "Added tool to change the running state of an App Service web app"

--- a/servers/Azure.Mcp.Server/changelog-entries/1777429555278.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1777429555278.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Other Changes"
-    description: "Improved Azure Functions tool descriptions and prompts for better AI agent tool selection and invocation."

--- a/servers/Azure.Mcp.Server/changelog-entries/1777586912472.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1777586912472.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Bugs Fixed"
-    description: "Improved Resource Health availability status errors for unsupported resource types."

--- a/servers/Azure.Mcp.Server/changelog-entries/1777656937957.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1777656937957.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Bugs Fixed"
-    description: "Fixed `azmcp grafana list`, `azmcp kusto cluster list`, `azmcp appconfig account list`, `azmcp storage account get`, `azmcp monitor workspace list`, and `azmcp search service list` to honor the optional `--resource-group` parameter, which was previously registered but not passed through to the service layer, causing subscription-wide results to always be returned regardless of the specified resource group."

--- a/servers/Azure.Mcp.Server/changelog-entries/1777662676190.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1777662676190.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Bugs Fixed"
-    description: "Fix issue where writing exception to stdout is interpreted as JSON RPC response."

--- a/servers/Azure.Mcp.Server/vscode/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/vscode/CHANGELOG.md
@@ -10,12 +10,12 @@
 
 - Improved Resource Health availability status errors for unsupported resource types. [[#2554](https://github.com/microsoft/mcp/pull/2554)]
 - Fixed parameter handling to honor the optional `--resource-group` parameter, which was previously not passed through to the service layer, causing subscription-wide results to always be returned regardless of the specified resource group for the following tools: [[#2552](https://github.com/microsoft/mcp/pull/2552)]
-  - `azmcp grafana list`
-  - `azmcp kusto cluster list`
-  - `azmcp appconfig account list`
-  - `azmcp storage account get`
-  - `azmcp monitor workspace list`
-  - `azmcp search service list`
+  - `appconfig_account_list`
+  - `grafana_list`
+  - `kusto_cluster_list`
+  - `monitor_workspace_list`
+  - `search_service_list`
+  - `storage_account_get`
 - Fixed issue where exceptions written to stdout were incorrectly interpreted as JSON RPC response. [[#2559](https://github.com/microsoft/mcp/pull/2559)]
 
 ### Changesd

--- a/servers/Azure.Mcp.Server/vscode/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/vscode/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Release History
 
+## 3.0.8 (2026-05-01) (pre-release)
+
+### Added
+
+- Added `appservice_webapp_change-state` tool to change the running state of an App Service web app. [[#1934](https://github.com/microsoft/mcp/pull/1934)]
+
+### Fixed
+
+- Improved Resource Health availability status errors for unsupported resource types. [[#2554](https://github.com/microsoft/mcp/pull/2554)]
+- Fixed parameter handling to honor the optional `--resource-group` parameter, which was previously not passed through to the service layer, causing subscription-wide results to always be returned regardless of the specified resource group for the following tools: [[#2552](https://github.com/microsoft/mcp/pull/2552)]
+  - `azmcp grafana list`
+  - `azmcp kusto cluster list`
+  - `azmcp appconfig account list`
+  - `azmcp storage account get`
+  - `azmcp monitor workspace list`
+  - `azmcp search service list`
+- Fixed issue where exceptions written to stdout were incorrectly interpreted as JSON RPC response. [[#2559](https://github.com/microsoft/mcp/pull/2559)]
+
+### Changesd
+
+- Improved Azure Functions tool descriptions and prompts for better AI agent tool selection and invocation. [[#2517](https://github.com/microsoft/mcp/pull/2517)]
+
 ## 3.0.7 (2026-04-30) (pre-release)
 
 ### Added

--- a/servers/Azure.Mcp.Server/vscode/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/vscode/CHANGELOG.md
@@ -18,7 +18,7 @@
   - `azmcp search service list`
 - Fixed issue where exceptions written to stdout were incorrectly interpreted as JSON RPC response. [[#2559](https://github.com/microsoft/mcp/pull/2559)]
 
-### Changesd
+### Changed
 
 - Improved Azure Functions tool descriptions and prompts for better AI agent tool selection and invocation. [[#2517](https://github.com/microsoft/mcp/pull/2517)]
 


### PR DESCRIPTION
## What does this PR do?

Prepare MCP release 3.0.0-beta.8

This release is primarily being done to ensure that npmjs has the latest mcp version available, as 3.0.0-beta.7 failed to successfully publish in npm.

