### PR TITLE
Address status-code 500 in ResourceHealth

### DIFF
--- a/core/Azure.Mcp.Core/src/Services/Azure/Subscription/SubscriptionService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Subscription/SubscriptionService.cs
@@ -95,7 +95,7 @@ public class SubscriptionService(
     {
         var subscriptions = await GetSubscriptions(tenant, retryPolicy, cancellationToken);
         var subscription = subscriptions.FirstOrDefault(s => s.DisplayName.Equals(subscriptionName, StringComparison.OrdinalIgnoreCase)) ??
-            throw new Exception($"Could not find subscription with name {subscriptionName}");
+            throw new ArgumentException($"Could not find subscription with name {subscriptionName}", nameof(subscriptionName));
 
         return subscription.SubscriptionId;
     }
@@ -104,7 +104,7 @@ public class SubscriptionService(
     {
         var subscriptions = await GetSubscriptions(tenant, retryPolicy, cancellationToken);
         var subscription = subscriptions.FirstOrDefault(s => s.SubscriptionId.Equals(subscriptionId, StringComparison.OrdinalIgnoreCase)) ??
-            throw new Exception($"Could not find subscription with ID {subscriptionId}");
+            throw new ArgumentException($"Could not find subscription with ID {subscriptionId}", nameof(subscriptionId));
 
         return subscription.DisplayName;
     }

--- a/core/Microsoft.Mcp.Core/src/Commands/GlobalCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/GlobalCommand.cs
@@ -129,6 +129,7 @@ public abstract class GlobalCommand<
         AuthenticationFailedException => HttpStatusCode.Unauthorized,
         RequestFailedException rfEx => (HttpStatusCode)rfEx.Status,
         HttpRequestException httpEx => httpEx.StatusCode ?? HttpStatusCode.ServiceUnavailable,
+        InvalidOperationException => HttpStatusCode.UnprocessableEntity,
         TimeoutException => HttpStatusCode.GatewayTimeout,
         TaskCanceledException => HttpStatusCode.GatewayTimeout,
         _ => HttpStatusCode.InternalServerError

--- a/core/Microsoft.Mcp.Core/src/Commands/GlobalCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/GlobalCommand.cs
@@ -120,6 +120,7 @@ public abstract class GlobalCommand<
 
     protected override HttpStatusCode GetStatusCode(Exception ex) => ex switch
     {
+        ArgumentException => HttpStatusCode.BadRequest,
         KeyNotFoundException => HttpStatusCode.NotFound,
         AuthenticationFailedException => HttpStatusCode.Unauthorized,
         RequestFailedException rfEx => (HttpStatusCode)rfEx.Status,

--- a/core/Microsoft.Mcp.Core/src/Commands/GlobalCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/GlobalCommand.cs
@@ -115,6 +115,10 @@ public abstract class GlobalCommand<
         RequestFailedException rfEx => HandleRequestFailedException(rfEx),
         HttpRequestException httpEx =>
             $"Service unavailable or network connectivity issues. Details: {httpEx.Message}",
+        TimeoutException timeoutEx =>
+            $"The operation timed out. Details: {timeoutEx.Message.TrimEnd('.')}",
+        TaskCanceledException canceledEx =>
+            $"The operation timed out or was canceled. Details: {canceledEx.Message.TrimEnd('.')}",
         _ => ex.Message  // Just return the actual exception message
     };
 
@@ -125,6 +129,8 @@ public abstract class GlobalCommand<
         AuthenticationFailedException => HttpStatusCode.Unauthorized,
         RequestFailedException rfEx => (HttpStatusCode)rfEx.Status,
         HttpRequestException httpEx => httpEx.StatusCode ?? HttpStatusCode.ServiceUnavailable,
+        TimeoutException => HttpStatusCode.GatewayTimeout,
+        TaskCanceledException => HttpStatusCode.GatewayTimeout,
         _ => HttpStatusCode.InternalServerError
     };
 

--- a/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.UnitTests/Resource/ResourceDiagnoseCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.UnitTests/Resource/ResourceDiagnoseCommandTests.cs
@@ -258,7 +258,7 @@ public class ResourceDiagnoseCommandTests : CommandUnitTestsBase<ResourceDiagnos
             "--resource-type", "Microsoft.Web/sites");
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
         Assert.Contains("Resource not found", response.Message);
     }
 

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Database/DatabaseAddCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Database/DatabaseAddCommandTests.cs
@@ -226,6 +226,6 @@ public class DatabaseAddCommandTests : CommandUnitTestsBase<DatabaseAddCommand, 
 
         // Assert
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
     }
 }

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Deployment/DeploymentGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Deployment/DeploymentGetCommandTests.cs
@@ -100,7 +100,7 @@ public class DeploymentGetCommandTests : CommandUnitTestsBase<DeploymentGetComma
 
         // Assert
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
 
         await Service.Received(1).GetDeploymentsAsync("sub123", "rg1", "test-app", deploymentId,
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Diagnostic/DetectorDiagnoseCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Diagnostic/DetectorDiagnoseCommandTests.cs
@@ -167,7 +167,7 @@ public class DetectorDiagnoseCommandTests : CommandUnitTestsBase<DetectorDiagnos
 
         // Assert
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
 
         await Service.Received(1).DiagnoseDetectorAsync("sub123", "rg1", "test-app", "LinuxMemoryDrillDown",
             startTime, endTime, interval, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(),

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Diagnostic/DetectorListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Diagnostic/DetectorListCommandTests.cs
@@ -87,7 +87,7 @@ public class DetectorListCommandTests : CommandUnitTestsBase<DetectorListCommand
 
         // Assert
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
 
         await Service.Received(1).ListDetectorsAsync("sub123", "rg1", "test-app",
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Settings/AppSettingsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Settings/AppSettingsGetCommandTests.cs
@@ -84,7 +84,7 @@ public class AppSettingsGetCommandTests : CommandUnitTestsBase<AppSettingsGetCom
 
         // Assert
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
 
         await Service.Received(1).GetAppSettingsAsync("sub123", "rg1", "test-app", Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Settings/AppSettingsUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/Settings/AppSettingsUpdateCommandTests.cs
@@ -150,7 +150,7 @@ public class AppSettingsUpdateCommandTests : CommandUnitTestsBase<AppSettingsUpd
 
         // Assert
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
 
         await Service.Received(1).UpdateAppSettingsAsync("sub123", "rg1", "test-app", settingName,
             settingUpdateType, settingValue, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(),

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/WebappChangeStateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/WebappChangeStateCommandTests.cs
@@ -148,7 +148,7 @@ public class WebappChangeStateCommandTests : CommandUnitTestsBase<WebappChangeSt
 
         // Assert
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
 
         await Service.Received(1).ChangeWebAppStateAsync("sub123", "rg1", "test-app", stateChange,
             softRestart, waitForCompletion, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(),

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/WebappGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.UnitTests/Commands/Webapp/WebappGetCommandTests.cs
@@ -91,7 +91,7 @@ public class WebappGetCommandTests : CommandUnitTestsBase<WebappGetCommand, IApp
 
         // Assert
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
 
         await Service.Received(1).GetWebAppsAsync("sub123", "rg1", "test-app",
             Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());

--- a/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.UnitTests/PlatformLandingZone/RequestCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.UnitTests/PlatformLandingZone/RequestCommandTests.cs
@@ -442,7 +442,7 @@ public class RequestCommandTests : CommandUnitTestsBase<RequestCommand, IPlatfor
             "--migrate-project-name", projectName);
 
         // Assert
-        Assert.True(response.Status == HttpStatusCode.BadRequest || response.Status == HttpStatusCode.InternalServerError);
+        Assert.True(response.Status == HttpStatusCode.UnprocessableEntity || response.Status == HttpStatusCode.InternalServerError);
         Assert.Contains("Missing required parameters", response.Message);
     }
 

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskCreateCommandTests.cs
@@ -391,7 +391,7 @@ public class DiskCreateCommandTests : CommandUnitTestsBase<DiskCreateCommand, IC
 
         // Assert
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/Disk/DiskUpdateCommandTests.cs
@@ -400,7 +400,7 @@ public class DiskUpdateCommandTests : CommandUnitTestsBase<DiskUpdateCommand, IC
 
         // Assert
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Events/EventsPublishCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.UnitTests/Events/EventsPublishCommandTests.cs
@@ -207,7 +207,7 @@ public class EventsPublishCommandTests : CommandUnitTestsBase<EventGridPublishCo
             "--data", eventData);
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status); // The base command returns InternalServerError for general exceptions by default
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
         Assert.Contains("not found", response.Message);
     }
 

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsCreateOrUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.UnitTests/WebTests/WebTestsCreateOrUpdateCommandTests.cs
@@ -180,7 +180,7 @@ public class WebTestsCreateOrUpdateCommandTests : CommandUnitTestsBase<WebTestsC
         var response = await ExecuteCommandAsync(args);
 
         // Assert - Command catches validation errors and returns InternalServerError
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("required", response.Message.ToLower());
     }
 

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Database/DatabaseQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Database/DatabaseQueryCommandTests.cs
@@ -46,7 +46,7 @@ public class DatabaseQueryCommandTests : CommandUnitTestsBase<DatabaseQueryComma
             "--query", "INVALID SQL");
 
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
         Assert.Contains("Syntax error", response.Message);
     }
 

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Table/TableSchemaGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.UnitTests/Table/TableSchemaGetCommandTests.cs
@@ -46,7 +46,7 @@ public class TableSchemaGetCommandTests : CommandUnitTestsBase<TableSchemaGetCom
             "--table", "nonexistent");
 
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("Table not found", response.Message);
     }
 

--- a/tools/Azure.Mcp.Tools.ResourceHealth/src/Commands/AvailabilityStatus/AvailabilityStatusGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/src/Commands/AvailabilityStatus/AvailabilityStatusGetCommand.cs
@@ -107,12 +107,15 @@ public sealed class AvailabilityStatusGetCommand(ILogger<AvailabilityStatusGetCo
     {
         ResourceHealthUnprocessableEntityException unprocessableEx =>
             $"Azure Resource Health could not process availability status for resource type '{unprocessableEx.ResourceType}'. Error code: {unprocessableEx.ErrorCode ?? "UnprocessableEntity"}. Details: {unprocessableEx.ErrorDetails ?? unprocessableEx.Message}",
+        FormatException =>
+            "Invalid Azure resource ID. Provide a resource ID in the format /subscriptions/<subscription>/resourceGroups/<resource-group>/providers/<provider>/<type>/<name>",
         _ => base.GetErrorMessage(ex)
     };
 
     protected override HttpStatusCode GetStatusCode(Exception ex) => ex switch
     {
         ResourceHealthUnprocessableEntityException unprocessableEx => unprocessableEx.StatusCode,
+        FormatException => HttpStatusCode.BadRequest,
         _ => base.GetStatusCode(ex)
     };
 

--- a/tools/Azure.Mcp.Tools.ResourceHealth/src/Services/ResourceHealthService.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/src/Services/ResourceHealthService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Net;
+using System.Net.Http.Json;
 using System.Text.Json;
 using Azure.Core;
 using Azure.Mcp.Core.Services.Azure;
@@ -49,7 +50,7 @@ public class ResourceHealthService(
         var relativePath = $"{parsedResourceId}/providers/Microsoft.ResourceHealth/availabilityStatuses/current?api-version={ResourceHealthApiVersion}";
         var requestUri = new Uri(managementEndpoint, relativePath);
 
-        using var response = await client.GetAsync(requestUri, cancellationToken);
+        using var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         if (response.StatusCode == HttpStatusCode.UnprocessableEntity)
         {
             var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
@@ -64,8 +65,7 @@ public class ResourceHealthService(
 
         response.EnsureSuccessStatusCode();
 
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        var apiResponse = JsonSerializer.Deserialize(content, ResourceHealthJsonContext.Default.AvailabilityStatusResponse)
+        var apiResponse = await response.Content.ReadFromJsonAsync(ResourceHealthJsonContext.Default.AvailabilityStatusResponse, cancellationToken)
             ?? throw new InvalidOperationException($"Failed to deserialize availability status response for resource '{resourceId}'");
 
         return apiResponse.ToAvailabilityStatus();
@@ -95,11 +95,10 @@ public class ResourceHealthService(
             : $"/subscriptions/{subscriptionId}/providers/Microsoft.ResourceHealth/availabilityStatuses?api-version={ResourceHealthApiVersion}";
         var requestUri = new Uri(managementEndpoint, relativePath);
 
-        using var response = await client.GetAsync(requestUri, cancellationToken);
+        using var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         response.EnsureSuccessStatusCode();
 
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        var apiResponse = JsonSerializer.Deserialize(content, ResourceHealthJsonContext.Default.AvailabilityStatusListResponse);
+        var apiResponse = await response.Content.ReadFromJsonAsync(ResourceHealthJsonContext.Default.AvailabilityStatusListResponse, cancellationToken);
 
         if (apiResponse?.Value == null)
         {
@@ -183,11 +182,10 @@ public class ResourceHealthService(
         // Construct URL safely using Uri to ensure path is relative to base
         var requestUri = new Uri(managementEndpoint, relativePath);
 
-        using var response = await client.GetAsync(requestUri, cancellationToken);
+        using var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         response.EnsureSuccessStatusCode();
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
 
-        var apiResponse = JsonSerializer.Deserialize(content, ResourceHealthJsonContext.Default.ServiceHealthEventListResponse);
+        var apiResponse = await response.Content.ReadFromJsonAsync(ResourceHealthJsonContext.Default.ServiceHealthEventListResponse, cancellationToken);
 
         if (apiResponse?.Value == null)
         {

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/AvailabilityStatus/AvailabilityStatusGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/AvailabilityStatus/AvailabilityStatusGetCommandTests.cs
@@ -62,6 +62,23 @@ public class AvailabilityStatusGetCommandTests : CommandUnitTestsBase<Availabili
     }
 
     [Fact]
+    public async Task ExecuteAsync_ReturnsBadRequest_WhenResourceIdIsInvalid()
+    {
+        var resourceId = "not-a-resource-id";
+        var subscriptionId = "12345678-1234-1234-1234-123456789012";
+        var expectedError = "Invalid Azure resource ID. Provide a resource ID in the format /subscriptions/<subscription>/resourceGroups/<resource-group>/providers/<provider>/<type>/<name>. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
+
+        Service.GetAvailabilityStatusAsync(resourceId, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new FormatException("Invalid resource ID format."));
+
+        var response = await ExecuteCommandAsync("--resourceId", resourceId, "--subscription", subscriptionId);
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Equal(expectedError, response.Message);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ReturnsHelpfulError_WhenResourceHealthReturnsUnprocessableEntity()
     {
         var resourceId = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet";

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/AvailabilityStatus/AvailabilityStatusGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/AvailabilityStatus/AvailabilityStatusGetCommandTests.cs
@@ -181,6 +181,22 @@ public class AvailabilityStatusGetCommandTests : CommandUnitTestsBase<Availabili
         Assert.Equal(expectedError, response.Message);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_ReturnsBadRequest_WhenSubscriptionLookupFails()
+    {
+        var subscription = "missing-subscription";
+        var expectedError = $"Could not find subscription with name {subscription} (Parameter 'subscriptionName'). To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
+
+        Service.ListAvailabilityStatusesAsync(subscription, null, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ArgumentException($"Could not find subscription with name {subscription}", "subscriptionName"));
+
+        var response = await ExecuteCommandAsync("--subscription", subscription);
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Equal(expectedError, response.Message);
+    }
+
     #endregion
 
     #region Validation Tests

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/ServiceHealthEvents/ServiceHealthEventsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/ServiceHealthEvents/ServiceHealthEventsListCommandTests.cs
@@ -118,7 +118,7 @@ public class ServiceHealthEventsListCommandTests : CommandUnitTestsBase<ServiceH
 
         // Assert
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
         Assert.Contains(expectedError, response.Message ?? "");
     }
 

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/ServiceHealthEvents/ServiceHealthEventsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/ServiceHealthEvents/ServiceHealthEventsListCommandTests.cs
@@ -122,6 +122,32 @@ public class ServiceHealthEventsListCommandTests : CommandUnitTestsBase<ServiceH
         Assert.Contains(expectedError, response.Message ?? "");
     }
 
+    [Fact]
+    public async Task ExecuteAsync_ReturnsBadRequest_WhenSubscriptionLookupFails()
+    {
+        var subscription = "missing-subscription";
+        var expectedError = $"Could not find subscription with name {subscription} (Parameter 'subscriptionName'). To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
+
+        Service.ListServiceHealthEventsAsync(
+            subscription,
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ArgumentException($"Could not find subscription with name {subscription}", "subscriptionName"));
+
+        var response = await ExecuteCommandAsync("--subscription", subscription);
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Equal(expectedError, response.Message);
+    }
+
     [Theory]
     [InlineData("--subscription", "sub123")]
     [InlineData("--subscription", "sub123", "--event-type", "ServiceIssue", "--status", "Active")]

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/Services/ResourceHealthServiceSsrfValidationTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/Services/ResourceHealthServiceSsrfValidationTests.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT License.
 
 using System.Net;
+using System.Text;
 using Azure.Core;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.Mcp.Tools.ResourceHealth.Services;
 using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Services.Azure.Authentication;
 using NSubstitute;
@@ -35,7 +37,7 @@ public class ResourceHealthServiceSsrfValidationTests
         _service = new ResourceHealthService(_subscriptionService, _tenantService, _httpClientFactory, _logger);
     }
 
-    private void SetupMocksForValidRequest(HttpResponseMessage response)
+    private void SetupMocksForValidRequest(HttpResponseMessage response, string subscriptionId = "12345678-1234-1234-1234-123456789012")
     {
         // Mock CloudConfiguration to return a valid ArmEnvironment
         var cloudConfig = Substitute.For<IAzureCloudConfiguration>();
@@ -51,6 +53,11 @@ public class ResourceHealthServiceSsrfValidationTests
         // Mock TenantService to return the credential
         _tenantService.GetTokenCredentialAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(mockCredential));
+
+        var subscriptionResource = Substitute.For<SubscriptionResource>();
+        subscriptionResource.Id.Returns(SubscriptionResource.CreateResourceIdentifier(subscriptionId));
+        _subscriptionService.GetSubscription(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(subscriptionResource);
 
         // Mock HttpClientFactory
         var mockHttpMessageHandler = new MockHttpMessageHandler(response);
@@ -203,6 +210,39 @@ public class ResourceHealthServiceSsrfValidationTests
         Assert.Equal(HttpStatusCode.UnprocessableEntity, exception.StatusCode);
     }
 
+    [Fact]
+    public async Task ListServiceHealthEventsAsync_DeserializesSuccessResponseFromStream()
+    {
+        const string subscriptionId = "12345678-1234-1234-1234-123456789012";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamOnlyJsonContent("""
+                {
+                    "value": [
+                        {
+                            "id": "/subscriptions/12345678-1234-1234-1234-123456789012/providers/Microsoft.ResourceHealth/events/TRACK123",
+                            "name": "TRACK123",
+                            "type": "Microsoft.ResourceHealth/events",
+                            "properties": {
+                                "title": "Test event",
+                                "summary": "Test summary",
+                                "eventType": "ServiceIssue",
+                                "status": "Active",
+                                "trackingId": "TRACK123"
+                            }
+                        }
+                    ]
+                }
+                """)
+        };
+        SetupMocksForValidRequest(response, subscriptionId);
+
+        var result = await _service.ListServiceHealthEventsAsync(subscriptionId, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Single(result);
+        Assert.Equal("TRACK123", result[0].TrackingId);
+    }
+
     private sealed class MockHttpMessageHandler(HttpResponseMessage response) : HttpMessageHandler
     {
         private readonly HttpResponseMessage _response = response;
@@ -210,6 +250,23 @@ public class ResourceHealthServiceSsrfValidationTests
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return Task.FromResult(_response);
+        }
+    }
+
+    private sealed class StreamOnlyJsonContent(string json) : HttpContent
+    {
+        private readonly byte[] _content = Encoding.UTF8.GetBytes(json);
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            throw new InvalidOperationException("The response content should be read as a stream without buffering to a string.");
+
+        protected override Task<Stream> CreateContentReadStreamAsync() =>
+            Task.FromResult<Stream>(new MemoryStream(_content, writable: false));
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _content.Length;
+            return true;
         }
     }
 }

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Database/DatabaseDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Database/DatabaseDeleteCommandTests.cs
@@ -295,7 +295,7 @@ public class DatabaseDeleteCommandTests : CommandUnitTestsBase<DatabaseDeleteCom
             "--server", "server1",
             "--database", "invalidDb");
 
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("Invalid database name", response.Message);
     }
 

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Database/DatabaseUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.UnitTests/Database/DatabaseUpdateCommandTests.cs
@@ -460,7 +460,7 @@ public class DatabaseUpdateCommandTests : CommandUnitTestsBase<DatabaseUpdateCom
             "--database", "testdb");
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("Invalid server name", response.Message);
     }
 

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/CreateWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/CreateWorkbooksCommandTests.cs
@@ -174,7 +174,7 @@ public class CreateWorkbooksCommandTests : CommandUnitTestsBase<CreateWorkbooksC
             "--serialized-content", """{"items":[{"type":"text","content":"Test content"}]}""");
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, result.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, result.Status);
     }
 
     [Fact]
@@ -200,7 +200,7 @@ public class CreateWorkbooksCommandTests : CommandUnitTestsBase<CreateWorkbooksC
             "--serialized-content", """{"items":[{"type":"text","content":"Test content"}]}""");
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, result.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, result.Status);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/CreateWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/CreateWorkbooksCommandTests.cs
@@ -496,6 +496,6 @@ public class CreateWorkbooksCommandTests : CommandUnitTestsBase<CreateWorkbooksC
             "--serialized-content", """{"items":[]}""");
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, result.Status);
+        Assert.Equal(HttpStatusCode.BadRequest, result.Status);
     }
 }

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/UpdateWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/UpdateWorkbooksCommandTests.cs
@@ -241,7 +241,7 @@ public class UpdateWorkbooksCommandTests : CommandUnitTestsBase<UpdateWorkbooksC
         var response = await ExecuteCommandAsync("--workbook-id", workbookId, "--display-name", "Test Name");
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
         Assert.Contains("Failed to update workbook", response.Message);
     }
 

--- a/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.UnitTests/Commands/GetBestPracticesCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.UnitTests/Commands/GetBestPracticesCommandTests.cs
@@ -81,7 +81,7 @@ public class GetBestPracticesCommandTests : CommandUnitTestsBase<GetBestPractice
         var result = await ExecuteCommandAsync("--topic", "pagination");
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, result.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, result.Status);
         Assert.NotEmpty(result.Message);
     }
 }

--- a/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.UnitTests/Commands/GetExamplesCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.UnitTests/Commands/GetExamplesCommandTests.cs
@@ -72,7 +72,7 @@ public class GetExamplesCommandTests : CommandUnitTestsBase<GetExamplesCommand, 
         var result = await ExecuteCommandAsync("--workload-type", "notebook");
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, result.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, result.Status);
         Assert.NotEmpty(result.Message);
     }
 }

--- a/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.UnitTests/Commands/GetPlatformApisCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.UnitTests/Commands/GetPlatformApisCommandTests.cs
@@ -56,7 +56,7 @@ public class GetPlatformApisCommandTests : CommandUnitTestsBase<GetPlatformApisC
         var result = await ExecuteCommandAsync([]);
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, result.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, result.Status);
         Assert.NotEmpty(result.Message);
     }
 }

--- a/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.UnitTests/Commands/GetWorkloadApisCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.UnitTests/Commands/GetWorkloadApisCommandTests.cs
@@ -112,7 +112,7 @@ public class GetWorkloadApisCommandTests : CommandUnitTestsBase<GetWorkloadApisC
         var result = await ExecuteCommandAsync("--workload-type", "notebook");
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, result.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, result.Status);
         Assert.NotEmpty(result.Message);
     }
 }

--- a/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.UnitTests/Commands/GetWorkloadDefinitionCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.UnitTests/Commands/GetWorkloadDefinitionCommandTests.cs
@@ -81,7 +81,7 @@ public class GetWorkloadDefinitionCommandTests : CommandUnitTestsBase<GetWorkloa
         var result = await ExecuteCommandAsync("--workload-type", "notebook");
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, result.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, result.Status);
         Assert.NotEmpty(result.Message);
     }
 }

--- a/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.UnitTests/Commands/ListWorkloadCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.UnitTests/Commands/ListWorkloadCommandTests.cs
@@ -55,7 +55,7 @@ public class ListWorkloadCommandTests : CommandUnitTestsBase<ListWorkloadsComman
         var result = await ExecuteCommandAsync([]);
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, result.Status);
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, result.Status);
         Assert.NotEmpty(result.Message);
     }
 }


### PR DESCRIPTION
## What does this PR do?
Reduce Resource Health memory usage for large responses

Use ResponseHeadersRead and stream-based JSON deserialization for Resource
Health responses so large Service Health Events payloads are not buffered
multiple times before parsing. This avoids OutOfMemoryException failures in
resource-constrained environments where HttpClient.GetAsync previously tried
to load the entire response body before returning.

Also map missing subscription lookup failures to BadRequest and add regression
coverage for Resource Health availability/status and service health events
error handling.

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
