### PR TITLE
Remove usage of CommandContext.GetService in AppService, Function, Compute

### DIFF
--- a/core/Azure.Mcp.Core/src/Areas/Group/Commands/GroupListCommand.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Group/Commands/GroupListCommand.cs
@@ -26,9 +26,10 @@ namespace Azure.Mcp.Core.Areas.Group.Commands;
     ReadOnly = true,
     LocalRequired = false,
     Secret = false)]
-public sealed class GroupListCommand(ILogger<GroupListCommand> logger) : SubscriptionCommand<BaseGroupOptions>()
+public sealed class GroupListCommand(ILogger<GroupListCommand> logger, IResourceGroupService resourceGroupService) : SubscriptionCommand<BaseGroupOptions>()
 {
     private readonly ILogger<GroupListCommand> _logger = logger;
+    private readonly IResourceGroupService _resourceGroupService = resourceGroupService;
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {
@@ -41,8 +42,7 @@ public sealed class GroupListCommand(ILogger<GroupListCommand> logger) : Subscri
 
         try
         {
-            var resourceGroupService = context.GetService<IResourceGroupService>();
-            var groups = await resourceGroupService.GetResourceGroups(
+            var groups = await _resourceGroupService.GetResourceGroups(
                 options.Subscription!,
                 options.Tenant,
                 options.RetryPolicy,

--- a/core/Azure.Mcp.Core/src/Areas/Subscription/Commands/SubscriptionListCommand.cs
+++ b/core/Azure.Mcp.Core/src/Areas/Subscription/Commands/SubscriptionListCommand.cs
@@ -22,9 +22,10 @@ namespace Azure.Mcp.Core.Areas.Subscription.Commands;
     ReadOnly = true,
     LocalRequired = false,
     Secret = false)]
-public sealed class SubscriptionListCommand(ILogger<SubscriptionListCommand> logger) : GlobalCommand<SubscriptionListOptions>()
+public sealed class SubscriptionListCommand(ILogger<SubscriptionListCommand> logger, ISubscriptionService subscriptionService) : GlobalCommand<SubscriptionListOptions>()
 {
     private readonly ILogger<SubscriptionListCommand> _logger = logger;
+    private readonly ISubscriptionService _subscriptionService = subscriptionService;
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {
@@ -37,10 +38,9 @@ public sealed class SubscriptionListCommand(ILogger<SubscriptionListCommand> log
 
         try
         {
-            var subscriptionService = context.GetService<ISubscriptionService>();
-            var subscriptions = await subscriptionService.GetSubscriptions(options.Tenant, options.RetryPolicy, cancellationToken);
+            var subscriptions = await _subscriptionService.GetSubscriptions(options.Tenant, options.RetryPolicy, cancellationToken);
 
-            var defaultSubscriptionId = subscriptionService.GetDefaultSubscriptionId();
+            var defaultSubscriptionId = _subscriptionService.GetDefaultSubscriptionId();
             var subscriptionInfos = MapToSubscriptionInfos(subscriptions, defaultSubscriptionId);
 
             context.Response.Results = ResponseResult.Create(

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Helpers/CommandHelperTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Helpers/CommandHelperTests.cs
@@ -1,6 +1,9 @@
 using System.CommandLine;
 using Azure.Mcp.Core.Areas.Group.Commands;
+using Azure.Mcp.Core.Services.Azure.ResourceGroup;
+using Azure.Mcp.Tools.AppService.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Tests.Helpers;
 using NSubstitute;
@@ -134,7 +137,7 @@ public class CommandHelperTests
 
     private static ParseResult GetParseResult(params string[] args)
     {
-        var command = new GroupListCommand(Substitute.For<ILogger<GroupListCommand>>());
+        var command = new GroupListCommand(NullLogger<GroupListCommand>.Instance, Substitute.For<IResourceGroupService>());
         var commandDefinition = command.GetCommand();
         return commandDefinition.Parse(args);
     }

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Deployment/DeploymentGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Deployment/DeploymentGetCommand.cs
@@ -29,10 +29,11 @@ namespace Azure.Mcp.Tools.AppService.Commands.Webapp.Deployment;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class DeploymentGetCommand(ILogger<DeploymentGetCommand> logger)
+public sealed class DeploymentGetCommand(ILogger<DeploymentGetCommand> logger, IAppServiceService appServiceService)
     : BaseAppServiceCommand<DeploymentGetOptions>(resourceGroupRequired: true, appRequired: true)
 {
     private readonly ILogger<DeploymentGetCommand> _logger = logger;
+    private readonly IAppServiceService _appServiceService = appServiceService;
 
     protected override void RegisterOptions(Command command)
     {
@@ -61,8 +62,7 @@ public sealed class DeploymentGetCommand(ILogger<DeploymentGetCommand> logger)
         {
             context.Activity?.AddTag("subscription", options.Subscription);
 
-            var appServiceService = context.GetService<IAppServiceService>();
-            var deployments = await appServiceService.GetDeploymentsAsync(
+            var deployments = await _appServiceService.GetDeploymentsAsync(
                 options.Subscription!,
                 options.ResourceGroup!,
                 options.AppName!,

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Diagnostic/DetectorDiagnoseCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Diagnostic/DetectorDiagnoseCommand.cs
@@ -29,10 +29,11 @@ namespace Azure.Mcp.Tools.AppService.Commands.Webapp.Diagnostic;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class DetectorDiagnoseCommand(ILogger<DetectorDiagnoseCommand> logger)
+public sealed class DetectorDiagnoseCommand(ILogger<DetectorDiagnoseCommand> logger, IAppServiceService appServiceService)
     : BaseAppServiceCommand<DetectorDiagnoseOptions>(resourceGroupRequired: true, appRequired: true)
 {
     private readonly ILogger<DetectorDiagnoseCommand> _logger = logger;
+    private readonly IAppServiceService _appServiceService = appServiceService;
 
     protected override void RegisterOptions(Command command)
     {
@@ -99,8 +100,7 @@ public sealed class DetectorDiagnoseCommand(ILogger<DetectorDiagnoseCommand> log
         {
             context.Activity?.AddTag("subscription", options.Subscription);
 
-            var appServiceService = context.GetService<IAppServiceService>();
-            var diagnoses = await appServiceService.DiagnoseDetectorAsync(
+            var diagnoses = await _appServiceService.DiagnoseDetectorAsync(
                 options.Subscription!,
                 options.ResourceGroup!,
                 options.AppName!,

--- a/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Diagnostic/DetectorListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Commands/Webapp/Diagnostic/DetectorListCommand.cs
@@ -26,10 +26,11 @@ namespace Azure.Mcp.Tools.AppService.Commands.Webapp.Diagnostic;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class DetectorListCommand(ILogger<DetectorListCommand> logger)
+public sealed class DetectorListCommand(ILogger<DetectorListCommand> logger, IAppServiceService appServiceService)
     : BaseAppServiceCommand<BaseAppServiceOptions>(resourceGroupRequired: true, appRequired: true)
 {
     private readonly ILogger<DetectorListCommand> _logger = logger;
+    private readonly IAppServiceService _appServiceService = appServiceService;
 
     protected override void RegisterOptions(Command command) => base.RegisterOptions(command);
 
@@ -49,8 +50,7 @@ public sealed class DetectorListCommand(ILogger<DetectorListCommand> logger)
         {
             context.Activity?.AddTag("subscription", options.Subscription);
 
-            var appServiceService = context.GetService<IAppServiceService>();
-            var detectors = await appServiceService.ListDetectorsAsync(
+            var detectors = await _appServiceService.ListDetectorsAsync(
                 options.Subscription!,
                 options.ResourceGroup!,
                 options.AppName!,

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmCreateCommand.cs
@@ -35,10 +35,11 @@ namespace Azure.Mcp.Tools.Compute.Commands.Vm;
     ReadOnly = false,
     Secret = true,
     LocalRequired = false)]
-public sealed class VmCreateCommand(ILogger<VmCreateCommand> logger)
+public sealed class VmCreateCommand(ILogger<VmCreateCommand> logger, IComputeService computeService)
     : BaseComputeCommand<VmCreateOptions>(true)
 {
     private readonly ILogger<VmCreateCommand> _logger = logger;
+    private readonly IComputeService _computeService = computeService;
 
     protected override void RegisterOptions(Command command)
     {
@@ -140,13 +141,11 @@ public sealed class VmCreateCommand(ILogger<VmCreateCommand> logger)
 
         var options = BindOptions(parseResult);
 
-        var computeService = context.GetService<IComputeService>();
-
         try
         {
             context.Activity?.AddTag("subscription", options.Subscription);
 
-            var result = await computeService.CreateVmAsync(
+            var result = await _computeService.CreateVmAsync(
                 options.VmName!,
                 options.ResourceGroup!,
                 options.Subscription!,

--- a/tools/Azure.Mcp.Tools.Functions/src/Commands/Language/LanguageListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Functions/src/Commands/Language/LanguageListCommand.cs
@@ -21,9 +21,10 @@ namespace Azure.Mcp.Tools.Functions.Commands.Language;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class LanguageListCommand(ILogger<LanguageListCommand> logger) : BaseCommand<EmptyOptions>
+public sealed class LanguageListCommand(ILogger<LanguageListCommand> logger, IFunctionsService functionsService) : BaseCommand<EmptyOptions>
 {
     private readonly ILogger<LanguageListCommand> _logger = logger;
+    private readonly IFunctionsService _functionsService = functionsService;
 
     protected override void RegisterOptions(Command command)
     {
@@ -39,8 +40,7 @@ public sealed class LanguageListCommand(ILogger<LanguageListCommand> logger) : B
     {
         try
         {
-            var service = context.GetService<IFunctionsService>();
-            var result = await service.GetLanguageListAsync(cancellationToken);
+            var result = await _functionsService.GetLanguageListAsync(cancellationToken);
 
             context.Response.Status = HttpStatusCode.OK;
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.Functions/src/Commands/Project/ProjectGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Functions/src/Commands/Project/ProjectGetCommand.cs
@@ -22,9 +22,10 @@ namespace Azure.Mcp.Tools.Functions.Commands.Project;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class ProjectGetCommand(ILogger<ProjectGetCommand> logger) : BaseCommand<ProjectGetOptions>
+public sealed class ProjectGetCommand(ILogger<ProjectGetCommand> logger, IFunctionsService functionsService) : BaseCommand<ProjectGetOptions>
 {
     private readonly ILogger<ProjectGetCommand> _logger = logger;
+    private readonly IFunctionsService _functionsService = functionsService;
 
     protected override void RegisterOptions(Command command)
     {
@@ -67,8 +68,7 @@ public sealed class ProjectGetCommand(ILogger<ProjectGetCommand> logger) : BaseC
 
         try
         {
-            var service = context.GetService<IFunctionsService>();
-            var result = await service.GetProjectTemplateAsync(options.Language!, cancellationToken);
+            var result = await _functionsService.GetProjectTemplateAsync(options.Language!, cancellationToken);
 
             context.Response.Status = HttpStatusCode.OK;
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.Functions/src/Commands/Template/TemplateGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Functions/src/Commands/Template/TemplateGetCommand.cs
@@ -29,9 +29,10 @@ internal record TemplateGetCommandResult(TemplateListResult? TemplateList, Funct
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class TemplateGetCommand(ILogger<TemplateGetCommand> logger) : BaseCommand<TemplateGetOptions>
+public sealed class TemplateGetCommand(ILogger<TemplateGetCommand> logger, IFunctionsService functionsService) : BaseCommand<TemplateGetOptions>
 {
     private readonly ILogger<TemplateGetCommand> _logger = logger;
+    private readonly IFunctionsService _functionsService = functionsService;
 
     protected override void RegisterOptions(Command command)
     {
@@ -80,12 +81,10 @@ public sealed class TemplateGetCommand(ILogger<TemplateGetCommand> logger) : Bas
 
         try
         {
-            var service = context.GetService<IFunctionsService>();
-
             if (string.IsNullOrEmpty(options.Template))
             {
                 // List mode: return all templates grouped by binding type
-                var templateList = await service.GetTemplateListAsync(options.Language!, cancellationToken);
+                var templateList = await _functionsService.GetTemplateListAsync(options.Language!, cancellationToken);
 
                 context.Response.Status = HttpStatusCode.OK;
                 context.Response.Results = ResponseResult.Create(
@@ -96,7 +95,7 @@ public sealed class TemplateGetCommand(ILogger<TemplateGetCommand> logger) : Bas
             else
             {
                 // Get mode: fetch specific template files
-                var functionTemplate = await service.GetFunctionTemplateAsync(
+                var functionTemplate = await _functionsService.GetFunctionTemplateAsync(
                     options.Language!, options.Template, options.RuntimeVersion, options.Output, cancellationToken);
 
                 context.Response.Status = HttpStatusCode.OK;

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/OrchestratorNextCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/OrchestratorNextCommand.cs
@@ -33,10 +33,11 @@ namespace Azure.Mcp.Tools.Monitor.Commands;
     ReadOnly = false,
     Secret = false,
     LocalRequired = true)]
-public sealed class OrchestratorNextCommand(ILogger<OrchestratorNextCommand> logger)
+public sealed class OrchestratorNextCommand(ILogger<OrchestratorNextCommand> logger, OrchestratorTool orchestratorTool)
     : BaseCommand<OrchestratorNextOptions>
 {
     private readonly ILogger<OrchestratorNextCommand> _logger = logger;
+    private readonly OrchestratorTool _orchestratorTool = orchestratorTool;
 
     protected override void RegisterOptions(Command command)
     {
@@ -64,8 +65,7 @@ public sealed class OrchestratorNextCommand(ILogger<OrchestratorNextCommand> log
 
         try
         {
-            var tool = context.GetService<OrchestratorTool>();
-            var result = tool.Next(options.SessionId!, options.CompletionNote!);
+            var result = _orchestratorTool.Next(options.SessionId!, options.CompletionNote!);
 
             context.Response.Status = HttpStatusCode.OK;
             context.Response.Results = ResponseResult.Create(result, MonitorInstrumentationJsonContext.Default.String);

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/OrchestratorStartCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/OrchestratorStartCommand.cs
@@ -22,10 +22,11 @@ namespace Azure.Mcp.Tools.Monitor.Commands;
     ReadOnly = false,
     Secret = false,
     LocalRequired = true)]
-public sealed class OrchestratorStartCommand(ILogger<OrchestratorStartCommand> logger)
+public sealed class OrchestratorStartCommand(ILogger<OrchestratorStartCommand> logger, OrchestratorTool orchestratorTool)
     : BaseCommand<OrchestratorStartOptions>
 {
     private readonly ILogger<OrchestratorStartCommand> _logger = logger;
+    private readonly OrchestratorTool _orchestratorTool = orchestratorTool;
 
     protected override void RegisterOptions(Command command)
     {
@@ -51,8 +52,7 @@ public sealed class OrchestratorStartCommand(ILogger<OrchestratorStartCommand> l
 
         try
         {
-            var tool = context.GetService<OrchestratorTool>();
-            var result = tool.Start(options.WorkspacePath!);
+            var result = _orchestratorTool.Start(options.WorkspacePath!);
 
             context.Response.Status = HttpStatusCode.OK;
             context.Response.Results = ResponseResult.Create(result, MonitorInstrumentationJsonContext.Default.String);

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/SendBrownfieldAnalysisCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/SendBrownfieldAnalysisCommand.cs
@@ -29,10 +29,11 @@ namespace Azure.Mcp.Tools.Monitor.Commands;
     ReadOnly = false,
     Secret = false,
     LocalRequired = true)]
-public sealed class SendBrownfieldAnalysisCommand(ILogger<SendBrownfieldAnalysisCommand> logger)
+public sealed class SendBrownfieldAnalysisCommand(ILogger<SendBrownfieldAnalysisCommand> logger, SendBrownfieldAnalysisTool sendBrownfieldAnalysisTool)
     : BaseCommand<SendBrownfieldAnalysisOptions>
 {
     private readonly ILogger<SendBrownfieldAnalysisCommand> _logger = logger;
+    private readonly SendBrownfieldAnalysisTool _sendBrownfieldAnalysisTool = sendBrownfieldAnalysisTool;
 
     protected override void RegisterOptions(Command command)
     {
@@ -68,8 +69,7 @@ public sealed class SendBrownfieldAnalysisCommand(ILogger<SendBrownfieldAnalysis
                 return Task.FromResult(context.Response);
             }
 
-            var tool = context.GetService<SendBrownfieldAnalysisTool>();
-            var result = tool.Submit(
+            var result = _sendBrownfieldAnalysisTool.Submit(
                 options.SessionId!,
                 findings.ServiceOptions,
                 findings.Initializers,

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/SendEnhancementSelectCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/SendEnhancementSelectCommand.cs
@@ -27,10 +27,11 @@ namespace Azure.Mcp.Tools.Monitor.Commands;
     ReadOnly = false,
     Secret = false,
     LocalRequired = true)]
-public sealed class SendEnhancementSelectCommand(ILogger<SendEnhancementSelectCommand> logger)
+public sealed class SendEnhancementSelectCommand(ILogger<SendEnhancementSelectCommand> logger, SendEnhancementSelectTool sendEnhancementSelectTool)
     : BaseCommand<SendEnhancementSelectOptions>
 {
     private readonly ILogger<SendEnhancementSelectCommand> _logger = logger;
+    private readonly SendEnhancementSelectTool _sendEnhancementSelectTool = sendEnhancementSelectTool;
 
     protected override void RegisterOptions(Command command)
     {
@@ -58,8 +59,7 @@ public sealed class SendEnhancementSelectCommand(ILogger<SendEnhancementSelectCo
 
         try
         {
-            var tool = context.GetService<SendEnhancementSelectTool>();
-            var result = tool.Send(options.SessionId!, options.EnhancementKeys!);
+            var result = _sendEnhancementSelectTool.Send(options.SessionId!, options.EnhancementKeys!);
 
             context.Response.Status = HttpStatusCode.OK;
             context.Response.Results = ResponseResult.Create(result, MonitorInstrumentationJsonContext.Default.String);


### PR DESCRIPTION
## What does this PR do?

- Remove additional usages of `CommandContext.GetService<T>`.
- Services: AppService, Compute, Functions, Monitor, and Subscription and Group Commands.

## GitHub issue number?

Related #158 

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
