### PR TITLE
Improve Resource Health error handling

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/chidozieononiwu-resourcehealth-request-failed.yml
+++ b/servers/Azure.Mcp.Server/changelog-entries/chidozieononiwu-resourcehealth-request-failed.yml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Improved Azure Resource Health error handling to preserve non-success ARM response details and return clearer guidance for conflict responses such as missing or in-progress Microsoft.ResourceHealth provider registration."

--- a/tools/Azure.Mcp.Tools.ResourceHealth/src/Commands/BaseResourceHealthCommand.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/src/Commands/BaseResourceHealthCommand.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Tools.ResourceHealth.Options;
+using Azure.Mcp.Tools.ResourceHealth.Services;
 using Microsoft.Mcp.Core.Commands;
 
 namespace Azure.Mcp.Tools.ResourceHealth.Commands;
@@ -13,4 +15,18 @@ public abstract class BaseResourceHealthCommand<
     : SubscriptionCommand<T>
     where T : BaseResourceHealthOptions, new()
 {
+    protected override string GetErrorMessage(Exception ex) => ex switch
+    {
+        ResourceHealthRequestFailedException { StatusCode: HttpStatusCode.Conflict } requestFailedEx =>
+            $"Azure Resource Health returned Conflict. The subscription may need the Microsoft.ResourceHealth provider registered, or the provider may still be registering. Details: {requestFailedEx.ErrorDetails ?? requestFailedEx.Message}",
+        ResourceHealthRequestFailedException requestFailedEx =>
+            $"Azure Resource Health request failed with status {(int)requestFailedEx.StatusCode} ({requestFailedEx.StatusCode}). Error code: {requestFailedEx.ErrorCode ?? requestFailedEx.StatusCode.ToString()}. Details: {requestFailedEx.ErrorDetails ?? requestFailedEx.Message}",
+        _ => base.GetErrorMessage(ex)
+    };
+
+    protected override HttpStatusCode GetStatusCode(Exception ex) => ex switch
+    {
+        ResourceHealthRequestFailedException requestFailedEx => requestFailedEx.StatusCode,
+        _ => base.GetStatusCode(ex)
+    };
 }

--- a/tools/Azure.Mcp.Tools.ResourceHealth/src/Commands/BaseResourceHealthCommand.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/src/Commands/BaseResourceHealthCommand.cs
@@ -18,9 +18,9 @@ public abstract class BaseResourceHealthCommand<
     protected override string GetErrorMessage(Exception ex) => ex switch
     {
         ResourceHealthRequestFailedException { StatusCode: HttpStatusCode.Conflict } requestFailedEx =>
-            $"Azure Resource Health returned Conflict. The subscription may need the Microsoft.ResourceHealth provider registered, or the provider may still be registering. Details: {requestFailedEx.ErrorDetails ?? requestFailedEx.Message}",
+            $"Azure Resource Health returned Conflict. The subscription may need the Microsoft.ResourceHealth provider registered, or the provider may still be registering. Details: {requestFailedEx.ErrorMessage ?? requestFailedEx.Message}",
         ResourceHealthRequestFailedException requestFailedEx =>
-            $"Azure Resource Health request failed with status {(int)requestFailedEx.StatusCode} ({requestFailedEx.StatusCode}). Error code: {requestFailedEx.ErrorCode ?? requestFailedEx.StatusCode.ToString()}. Details: {requestFailedEx.ErrorDetails ?? requestFailedEx.Message}",
+            $"Azure Resource Health request failed with status {(int)requestFailedEx.StatusCode} ({requestFailedEx.StatusCode}). Error code: {requestFailedEx.ErrorCode ?? requestFailedEx.StatusCode.ToString()}. Details: {requestFailedEx.ErrorMessage ?? requestFailedEx.Message}",
         _ => base.GetErrorMessage(ex)
     };
 

--- a/tools/Azure.Mcp.Tools.ResourceHealth/src/Services/ResourceHealthRequestFailedException.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/src/Services/ResourceHealthRequestFailedException.cs
@@ -16,17 +16,23 @@ public sealed class ResourceHealthRequestFailedException(
 
     public string? ErrorCode { get; } = errorCode;
 
-    public string? ErrorDetails { get; } = errorMessage;
+    public string? ErrorMessage { get; } = errorMessage;
 
     public string? ResponseContent { get; } = responseContent;
 
     private static string CreateMessage(HttpStatusCode statusCode, string? errorCode, string? errorMessage)
     {
-        var code = string.IsNullOrWhiteSpace(errorCode) ? statusCode.ToString() : errorCode;
-        var details = string.IsNullOrWhiteSpace(errorMessage)
-            ? $"Azure Resource Health returned status {(int)statusCode} ({statusCode})"
-            : errorMessage;
+        var message = $"Azure Resource Health request failed with status {(int)statusCode} ({statusCode})";
+        if (!string.IsNullOrWhiteSpace(errorCode))
+        {
+            message += $". Error code: {errorCode.Trim()}";
+        }
 
-        return $"Azure Resource Health returned {code}: {details}";
+        if (!string.IsNullOrWhiteSpace(errorMessage))
+        {
+            message += $". Details: {errorMessage.Trim()}";
+        }
+
+        return message;
     }
 }

--- a/tools/Azure.Mcp.Tools.ResourceHealth/src/Services/ResourceHealthRequestFailedException.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/src/Services/ResourceHealthRequestFailedException.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+
+namespace Azure.Mcp.Tools.ResourceHealth.Services;
+
+public sealed class ResourceHealthRequestFailedException(
+    HttpStatusCode statusCode,
+    string? errorCode,
+    string? errorMessage,
+    string? responseContent = null)
+    : Exception(CreateMessage(statusCode, errorCode, errorMessage))
+{
+    public HttpStatusCode StatusCode { get; } = statusCode;
+
+    public string? ErrorCode { get; } = errorCode;
+
+    public string? ErrorDetails { get; } = errorMessage;
+
+    public string? ResponseContent { get; } = responseContent;
+
+    private static string CreateMessage(HttpStatusCode statusCode, string? errorCode, string? errorMessage)
+    {
+        var code = string.IsNullOrWhiteSpace(errorCode) ? statusCode.ToString() : errorCode;
+        var details = string.IsNullOrWhiteSpace(errorMessage)
+            ? $"Azure Resource Health returned status {(int)statusCode} ({statusCode})"
+            : errorMessage;
+
+        return $"Azure Resource Health returned {code}: {details}";
+    }
+}

--- a/tools/Azure.Mcp.Tools.ResourceHealth/src/Services/ResourceHealthService.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/src/Services/ResourceHealthService.cs
@@ -51,19 +51,7 @@ public class ResourceHealthService(
         var requestUri = new Uri(managementEndpoint, relativePath);
 
         using var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-        if (response.StatusCode == HttpStatusCode.UnprocessableEntity)
-        {
-            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-            var (errorCode, errorMessage) = ParseErrorResponse(responseContent);
-            throw new ResourceHealthUnprocessableEntityException(
-                resourceId,
-                parsedResourceId.ResourceType.ToString(),
-                errorCode,
-                errorMessage,
-                responseContent);
-        }
-
-        response.EnsureSuccessStatusCode();
+        await EnsureResourceHealthSuccessAsync(response, cancellationToken, resourceId, parsedResourceId.ResourceType.ToString());
 
         var apiResponse = await response.Content.ReadFromJsonAsync(ResourceHealthJsonContext.Default.AvailabilityStatusResponse, cancellationToken)
             ?? throw new InvalidOperationException($"Failed to deserialize availability status response for resource '{resourceId}'");
@@ -96,7 +84,7 @@ public class ResourceHealthService(
         var requestUri = new Uri(managementEndpoint, relativePath);
 
         using var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await EnsureResourceHealthSuccessAsync(response, cancellationToken);
 
         var apiResponse = await response.Content.ReadFromJsonAsync(ResourceHealthJsonContext.Default.AvailabilityStatusListResponse, cancellationToken);
 
@@ -183,7 +171,7 @@ public class ResourceHealthService(
         var requestUri = new Uri(managementEndpoint, relativePath);
 
         using var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        await EnsureResourceHealthSuccessAsync(response, cancellationToken);
 
         var apiResponse = await response.Content.ReadFromJsonAsync(ResourceHealthJsonContext.Default.ServiceHealthEventListResponse, cancellationToken);
 
@@ -196,6 +184,37 @@ public class ResourceHealthService(
             .Select(item => item.ToServiceHealthEvent(subscriptionId))
             .Where(evt => !string.IsNullOrEmpty(evt.Id)) // Filter out any invalid entries
             .ToList();
+    }
+
+    private static async Task EnsureResourceHealthSuccessAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken,
+        string? resourceId = null,
+        string? resourceType = null)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+        var (errorCode, errorMessage) = ParseErrorResponse(responseContent);
+
+        if (response.StatusCode == HttpStatusCode.UnprocessableEntity && resourceId is not null && resourceType is not null)
+        {
+            throw new ResourceHealthUnprocessableEntityException(
+                resourceId,
+                resourceType,
+                errorCode,
+                errorMessage,
+                responseContent);
+        }
+
+        throw new ResourceHealthRequestFailedException(
+            response.StatusCode,
+            errorCode,
+            errorMessage,
+            responseContent);
     }
 
     private static (string? Code, string? Message) ParseErrorResponse(string responseContent)

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/AvailabilityStatus/AvailabilityStatusGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/AvailabilityStatus/AvailabilityStatusGetCommandTests.cs
@@ -182,6 +182,24 @@ public class AvailabilityStatusGetCommandTests : CommandUnitTestsBase<Availabili
     }
 
     [Fact]
+    public async Task ExecuteAsync_ReturnsConflict_WhenResourceHealthListRequestConflicts()
+    {
+        var subscriptionId = "12345678-1234-1234-1234-123456789012";
+        var errorCode = "MissingSubscriptionRegistration";
+        var errorMessage = "The subscription is not registered to use namespace 'Microsoft.ResourceHealth'.";
+        var expectedError = $"Azure Resource Health returned Conflict. The subscription may need the Microsoft.ResourceHealth provider registered, or the provider may still be registering. Details: {errorMessage}. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
+
+        Service.ListAvailabilityStatusesAsync(subscriptionId, null, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ResourceHealthRequestFailedException(HttpStatusCode.Conflict, errorCode, errorMessage));
+
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId);
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.Conflict, response.Status);
+        Assert.Equal(expectedError, response.Message);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ReturnsBadRequest_WhenSubscriptionLookupFails()
     {
         var subscription = "missing-subscription";

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/ServiceHealthEvents/ServiceHealthEventsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/ServiceHealthEvents/ServiceHealthEventsListCommandTests.cs
@@ -123,6 +123,34 @@ public class ServiceHealthEventsListCommandTests : CommandUnitTestsBase<ServiceH
     }
 
     [Fact]
+    public async Task ExecuteAsync_ReturnsConflict_WhenResourceHealthRequestConflicts()
+    {
+        var subscription = "sub123";
+        var errorCode = "MissingSubscriptionRegistration";
+        var errorMessage = "The subscription is not registered to use namespace 'Microsoft.ResourceHealth'.";
+        var expectedError = $"Azure Resource Health returned Conflict. The subscription may need the Microsoft.ResourceHealth provider registered, or the provider may still be registering. Details: {errorMessage}. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
+
+        Service.ListServiceHealthEventsAsync(
+            subscription,
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ResourceHealthRequestFailedException(HttpStatusCode.Conflict, errorCode, errorMessage));
+
+        var response = await ExecuteCommandAsync("--subscription", subscription);
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.Conflict, response.Status);
+        Assert.Equal(expectedError, response.Message);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ReturnsBadRequest_WhenSubscriptionLookupFails()
     {
         var subscription = "missing-subscription";

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/Services/ResourceHealthServiceSsrfValidationTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/Services/ResourceHealthServiceSsrfValidationTests.cs
@@ -211,6 +211,26 @@ public class ResourceHealthServiceSsrfValidationTests
     }
 
     [Fact]
+    public async Task ListAvailabilityStatusesAsync_ThrowsRequestFailedException_WhenRequestConflicts()
+    {
+        const string subscriptionId = "12345678-1234-1234-1234-123456789012";
+        var responseContent = "{\"error\":{\"code\":\"MissingSubscriptionRegistration\",\"message\":\"The subscription is not registered to use namespace 'Microsoft.ResourceHealth'.\"}}";
+        var response = new HttpResponseMessage(HttpStatusCode.Conflict)
+        {
+            Content = new StringContent(responseContent)
+        };
+        SetupMocksForValidRequest(response, subscriptionId);
+
+        var exception = await Assert.ThrowsAsync<ResourceHealthRequestFailedException>(
+            () => _service.ListAvailabilityStatusesAsync(subscriptionId, cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
+        Assert.Equal("MissingSubscriptionRegistration", exception.ErrorCode);
+        Assert.Equal("The subscription is not registered to use namespace 'Microsoft.ResourceHealth'.", exception.ErrorDetails);
+        Assert.Equal(responseContent, exception.ResponseContent);
+    }
+
+    [Fact]
     public async Task ListServiceHealthEventsAsync_DeserializesSuccessResponseFromStream()
     {
         const string subscriptionId = "12345678-1234-1234-1234-123456789012";

--- a/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/Services/ResourceHealthServiceSsrfValidationTests.cs
+++ b/tools/Azure.Mcp.Tools.ResourceHealth/tests/Azure.Mcp.Tools.ResourceHealth.UnitTests/Services/ResourceHealthServiceSsrfValidationTests.cs
@@ -226,7 +226,7 @@ public class ResourceHealthServiceSsrfValidationTests
 
         Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
         Assert.Equal("MissingSubscriptionRegistration", exception.ErrorCode);
-        Assert.Equal("The subscription is not registered to use namespace 'Microsoft.ResourceHealth'.", exception.ErrorDetails);
+        Assert.Equal("The subscription is not registered to use namespace 'Microsoft.ResourceHealth'.", exception.ErrorMessage);
         Assert.Equal(responseContent, exception.ResponseContent);
     }
 


### PR DESCRIPTION
## What does this PR do?
Add ResourceHealthRequestFailedException to preserve non-success ARM response details from Resource Health calls.

Replace raw EnsureSuccessStatusCode handling with parsed Resource Health failures, including clearer 409 Conflict guidance for provider registration or registration-in-progress cases.

Add unit coverage for availability status and service health event conflict responses.

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
