### PR TITLE
Transition to GitHub App auth, remove azuresdk-github-pat usage

### DIFF
--- a/eng/pipelines/templates/jobs/mcpb/release-mcpb.yml
+++ b/eng/pipelines/templates/jobs/mcpb/release-mcpb.yml
@@ -40,6 +40,8 @@ jobs:
       deploy:
         steps:
         # Note: checkout is not allowed in release jobs, so we inline the script logic here
+        - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
         - pwsh: |
             $ErrorActionPreference = "Stop"
             $serverName = '${{ parameters.ServerName }}'
@@ -108,4 +110,4 @@ jobs:
             Write-Host "`n✓ All MCPB files uploaded successfully"
           displayName: "Upload MCPB to GitHub Release"
           env:
-            GH_TOKEN: $(azuresdk-github-pat)
+            GH_TOKEN: $(GH_TOKEN)

--- a/eng/pipelines/templates/jobs/release.yml
+++ b/eng/pipelines/templates/jobs/release.yml
@@ -31,6 +31,8 @@ jobs:
 
   - template: /eng/common/pipelines/templates/steps/retain-run.yml
 
+  - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
   - pwsh: |
       $buildInfoPath = "$(Pipeline.Workspace)/build_info/build_info.json"
       $buildInfo = Get-Content -Raw -Path $buildInfoPath | ConvertFrom-Json
@@ -49,7 +51,7 @@ jobs:
       gh release upload $tag $(Pipeline.Workspace)/binaries_signed_zipped/*.zip
     displayName: Create GitHub Release and upload artifacts
     env:
-      GH_TOKEN: $(azuresdk-github-pat)
+      GH_TOKEN: $(GH_TOKEN)
 
 - template: /eng/pipelines/templates/jobs/publish-symbols.yml
 
@@ -129,3 +131,4 @@ jobs:
       PRTitle: "Increment version after release"
       RepoOwner: microsoft
       CloseAfterOpenForTesting: ${{ parameters.IsTestPipeline }}
+      AuthToken: ''


### PR DESCRIPTION

This pull request updates the release pipeline templates to standardize GitHub authentication and improve security. The most important changes include switching the GitHub token environment variable to use `GH_TOKEN` and adding a step to log in to GitHub before release operations.

**Authentication and Security Improvements:**

* Changed the environment variable used for GitHub authentication from `azuresdk-github-pat` to `GH_TOKEN` in both `release.yml` and `release-mcpb.yml` to standardize and improve token management. [[1]](diffhunk://#diff-d9cb815966a57d5f892d6c63b81b63a61d4cc7ac25e3ec9540414778de77b18cL52-R54) [[2]](diffhunk://#diff-8fe374fde7326850473c26bd48ac7f3aca23be86d92f0b06fbb69d747930442aL111-R113)
* Added the `/eng/common/pipelines/templates/steps/login-to-github.yml` template step before release operations in both `release.yml` and `release-mcpb.yml` to ensure authentication with GitHub is performed securely. [[1]](diffhunk://#diff-d9cb815966a57d5f892d6c63b81b63a61d4cc7ac25e3ec9540414778de77b18cR34-R35) [[2]](diffhunk://#diff-8fe374fde7326850473c26bd48ac7f3aca23be86d92f0b06fbb69d747930442aR43-R44)

**Pipeline Parameter Updates:**

* Added an explicit `AuthToken` parameter (set to empty) to the PR creation step in `release.yml` for improved parameter clarity and possible future extensibility.

Related to Azure/azure-sdk-tools#9842

Test Pipeline [mcp - Template.Mcp.Server](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6369297&view=results)