### PR TITLE
docs: rename MCP server key to lowercase-hyphenated convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -588,7 +588,7 @@ mcp.json configuration for local development:
 # Use in mcp.json
 {
   "servers": {
-    "Azure MCP Server": {
+    "azure-mcp-server": {
       "command": "docker",
       "args": ["run", "-i", "--rm", "--env-file", "/path/to/.env", "azure-sdk/azure-mcp:<version-number-of-docker-image>"]
     }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -340,7 +340,7 @@ Update your mcp.json to point to the locally built azmcp executable.
 ```json
 {
   "servers": {
-    "Azure MCP Server": {
+    "azure-mcp-server": {
       "url": "https://localhost:1031/",
       "type": "http"
     }
@@ -481,7 +481,7 @@ To build a local image for testing purposes:
     ```json
     {
       "servers": {
-        "Azure MCP Server": {
+        "azure-mcp-server": {
           "command": "docker",
           "args": [
             "run",

--- a/llms-install.md
+++ b/llms-install.md
@@ -28,7 +28,7 @@ The Azure MCP Server requires configuration based on the client type. Below are 
 ```json
 {
   "servers": {
-    "Azure MCP Server": {
+    "azure-mcp-server": {
       "command": "npx",
       "args": [
         "-y",
@@ -50,7 +50,7 @@ The Azure MCP Server requires configuration based on the client type. Below are 
 ```json
 {
   "mcpServers": {
-    "Azure MCP Server": {
+    "azure-mcp-server": {
       "command": "npx",
       "args": [
         "-y",

--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -169,7 +169,7 @@ To verify the .NET version, run the following command in the terminal: `dotnet -
     ```json
     {
         "mcpServers": {
-            "Azure MCP Server": {
+            "azure-mcp-server": {
                 "command": "dnx",
                 "args": [
                     "Azure.Mcp",
@@ -196,7 +196,7 @@ To verify the .NET version, run the following command in the terminal: `dotnet -
     ```json
     {
         "mcpServers": {
-            "Azure MCP Server": {
+            "azure-mcp-server": {
             "command": "npx",
             "args": [
                 "-y",
@@ -218,7 +218,7 @@ To verify the .NET version, run the following command in the terminal: `dotnet -
     ```json
     {
         "mcpServers": {
-            "Azure MCP Server": {
+            "azure-mcp-server": {
                 "command": "uvx",
                 "args": [
                     "--from",
@@ -386,7 +386,7 @@ AZURE_CLIENT_SECRET={YOUR_AZURE_CLIENT_SECRET}
 ```json
    {
       "mcpServers": {
-         "Azure MCP Server": {
+         "azure-mcp-server": {
             "command": "docker",
             "args": [
                "run",

--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -197,12 +197,12 @@ To verify the .NET version, run the following command in the terminal: `dotnet -
     {
         "mcpServers": {
             "azure-mcp-server": {
-            "command": "npx",
-            "args": [
-                "-y",
-                "@azure/mcp@latest",
-                "server",
-                "start"
+                "command": "npx",
+                "args": [
+                    "-y",
+                    "@azure/mcp@latest",
+                    "server",
+                    "start"
                 ]
             }
         }

--- a/servers/Azure.Mcp.Server/TROUBLESHOOTING.md
+++ b/servers/Azure.Mcp.Server/TROUBLESHOOTING.md
@@ -968,7 +968,7 @@ To use Azure Entra ID with the Docker image update the MCP client configuration 
    ```json
       {
          "mcpServers": {
-            "Azure MCP Server": {
+            "azure-mcp-server": {
                "command": "docker",
                "args": [
                   "run",
@@ -997,7 +997,7 @@ On Windows, Azure CLI stores credentials in an encrypted format that cannot be a
    ```json
       {
          "mcpServers": {
-            "Azure MCP Server": {
+            "azure-mcp-server": {
                "command": "docker",
                "args": [
                   "run",
@@ -1349,7 +1349,7 @@ This starts the MCP server in **remote HTTP mode** with the following configurat
 ```json
 {
   "servers": {
-    "Azure MCP Server": {
+    "azure-mcp-server": {
       "url": "https://localhost:1031/",
       "type": "http"
     }


### PR DESCRIPTION
Rename JSON key from `"Azure MCP Server"` to `"azure-mcp-server"` in all config examples across `llms-install.md` and `servers/Azure.Mcp.Server/README.md`.

### Why

The previous name with spaces is rejected by GitHub Copilot CLI, which only allows alphanumeric characters, underscores, and hyphens in server names. Since `llms-install.md` is specifically designed for AI agents to follow when helping users install the MCP server, this results in broken configs being generated automatically.

The lowercase-hyphenated format also:
- Aligns with MCP ecosystem conventions (`github-mcp-server`, `kusto-mcp`, `adx-mcp-server`)
- Matches this project's own Copilot CLI E2E tester which uses `"azure"`
- Is the safest common denominator across MCP clients (some are case-sensitive)

Fixes #2589