### PR TITLE
Document central nuget feed in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,9 +74,6 @@ If you are contributing significant changes, or if the issue is already assigned
 
 This repository uses a single Azure DevOps package feed for all NuGet packages instead of nuget.org directly. The feed is configured in `nuget.config`.
 
-> [!IMPORTANT]
-> Do **not** add additional feeds to `nuget.config` or bypass the feed with `--source "https://api.nuget.org/v3/index.json"`. All CI builds pull packages exclusively from the DevOps feed, so local development should match this behavior.
-
 The feed has an **upstream** configured to nuget.org. When an authenticated user restores a package that is not yet cached in the feed, it is automatically ingested from nuget.org.  Unauthenticated users can only consume package versions that have already been ingested into the feed.
 
 You can browse the feed directly at: <https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-net>
@@ -95,7 +92,11 @@ The feed is **public**, so anyone can read packages that are already cached. The
 
 #### External Contributors
 
-External contributors will not be able to authenticate to the feed as **Collaborator**, but our Pull Request pipeline can.  External contributors should temporarily add nuget.org as an additional source in `nuget.config` to build locally with new packages, then revert that `nuget.config` change before submitting their pull request.  Our pipeline will authenticate to the feed, ingest the new package, and build normally.
+External contributors will not be able to authenticate to the feed as **Collaborator**, but our Pull Request pipeline can. External contributors should temporarily add nuget.org as an additional source in `nuget.config` to build locally with new packages, then revert that `nuget.config` change before submitting their pull request. Our pipeline will authenticate to the feed, ingest the new package, and build normally.
+
+If you need local-only NuGet configuration for development, use a user-level `NuGet.Config` and a temporary `--configfile` rather than editing this repository's tracked `nuget.config`. Do not commit local feed changes to the repo.
+
+Do not assume the Pull Request pipeline will always ingest a missing package automatically. Upstream ingestion can fail or be delayed. If your PR depends on a package/version that is not yet visible in the feed, ask a maintainer or Microsoft contributor to pre-ingest it by restoring against the feed first, then retry once the package appears in <https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-net>.
 
 ### Project Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ If you are contributing significant changes, or if the issue is already assigned
 
 This repository uses a single Azure DevOps package feed for all NuGet packages instead of nuget.org directly. The feed is configured in `nuget.config`.
 
-The feed has an **upstream** configured to nuget.org. When an authenticated user restores a package that is not yet cached in the feed, it is automatically ingested from nuget.org.  Unauthenticated users can only consume package versions that have already been ingested into the feed.
+The feed has an **upstream** configured to nuget.org. When an authenticated user restores a package that is not yet cached in the feed, it is automatically ingested from nuget.org. Unauthenticated users can only consume package versions that have already been ingested into the feed.
 
 You can browse the feed directly at: <https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-net>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ If you are contributing significant changes, or if the issue is already assigned
   - [Table of Contents](#table-of-contents)
   - [Getting Started](#getting-started)
     - [Prerequisites](#prerequisites)
+    - [Central NuGet Feed](#central-nuget-feed)
     - [Project Structure](#project-structure)
   - [Development Workflow](#development-workflow)
     - [Development Process](#development-process)
@@ -68,6 +69,33 @@ If you are contributing significant changes, or if the issue is already assigned
 2. **GitHub Copilot**: Install [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) and [GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) extensions
 3. **Node.js**: Install [Node.js](https://nodejs.org/en/download) 20 or later (ensure `node` and `npm` are in your PATH)
 4. **PowerShell**: Install [PowerShell](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) 7.0 or later (required for build and test scripts)
+
+### Central NuGet Feed
+
+This repository uses a single Azure DevOps package feed for all NuGet packages instead of nuget.org directly. The feed is configured in [`nuget.config`](nuget.config).
+
+> [!IMPORTANT]
+> Do **not** add additional feeds to `nuget.config` or bypass the feed with `--source "https://api.nuget.org/v3/index.json"`. All CI builds pull packages exclusively from the DevOps feed, so local development should match this behavior.
+
+The feed has an **upstream** configured to nuget.org. When an authenticated user restores a package that is not yet cached in the feed, it is automatically ingested from nuget.org.  Unauthenticated users can only consume package versions that have already been ingested into the feed.
+
+You can browse the feed directly at: <https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-net>
+
+#### Installing the Azure Artifacts Credential Provider
+
+To authenticate with the feed you need the **Azure Artifacts Credential Provider**:
+
+1. Install it from <https://go.microsoft.com/fwlink/?linkid=2099625> (you can also find this link by clicking **Connect to Feed** from the feed page above).
+2. Once installed, the first `dotnet restore` (or any command with an implicit restore) will trigger an authentication prompt.
+3. Valid Users of the Azure DevOps project will be authenticated as a **Collaborator** on the feed, which allows you to:
+   - Pull any package already in the feed.
+   - Trigger the feed to query nuget.org and ingest new packages or versions that are not yet present.
+
+The feed is **public**, so anyone can read packages that are already cached. The credential provider is only needed to cause new packages to be ingested from the upstream.
+
+#### External Contributors
+
+External contributors will not be able to authenticate to the feed as **Collaborator**, but our Pull Request pipeline can.  External contributors should temporarily add nuget.org as an additional source in `nuget.config` to build locally with new packages, then revert that `nuget.config` change before submitting their pull request.  Our pipeline will authenticate to the feed, ingest the new package, and build normally.
 
 ### Project Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ If you are contributing significant changes, or if the issue is already assigned
 
 ### Central NuGet Feed
 
-This repository uses a single Azure DevOps package feed for all NuGet packages instead of nuget.org directly. The feed is configured in [`nuget.config`](nuget.config).
+This repository uses a single Azure DevOps package feed for all NuGet packages instead of nuget.org directly. The feed is configured in `nuget.config`.
 
 > [!IMPORTANT]
 > Do **not** add additional feeds to `nuget.config` or bypass the feed with `--source "https://api.nuget.org/v3/index.json"`. All CI builds pull packages exclusively from the DevOps feed, so local development should match this behavior.

--- a/nuget.config
+++ b/nuget.config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear />
     <!-- Do not add any additional feeds. If new packages are needed, they need to come from our azure-sdk-for-net DevOps feed which has an upstream set to nuget.org -->
+    <!-- See the Central NuGet Feed documentation in CONTRIBUTING.md for more details -->
     <add key="azure-sdk-for-net" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>


### PR DESCRIPTION
## What does this PR do?
This pull request updates the documentation and configuration to clarify and reinforce the use of a central Azure DevOps NuGet feed for package management. The main changes include expanded instructions in `CONTRIBUTING.md` about the central NuGet feed and a reference comment in `nuget.config`.

**Documentation updates:**

* Added a new "Central NuGet Feed" section to `CONTRIBUTING.md`, providing detailed instructions on using the Azure DevOps package feed, including authentication steps and guidance for external contributors.
* Updated the Table of Contents in `CONTRIBUTING.md` to include the new "Central NuGet Feed" section.

**Configuration updates:**

* Added a reference comment in `nuget.config` pointing to the central feed documentation in `CONTRIBUTING.md`.

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
