### PR TITLE
Verify npm links against Azure DevOps Artifacts

### DIFF
--- a/eng/common/pipelines/templates/steps/check-spelling.yml
+++ b/eng/common/pipelines/templates/steps/check-spelling.yml
@@ -24,6 +24,9 @@ parameters:
   - name: ScriptToValidateUpgrade
     type: string
     default: ''
+  - name: NpmConfigUserConfig
+    type: string
+    default: ''
 
 steps:
   - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
@@ -38,6 +41,9 @@ steps:
           -CspellConfigPath ${{ parameters.CspellConfigPath }}
           -ExitWithError:(!$${{ parameters.ContinueOnError }})
         pwsh: true
+      env:
+        ${{ if ne(parameters.NpmConfigUserConfig, '') }}:
+          npm_config_userconfig: ${{ parameters.NpmConfigUserConfig }}
     - ${{ if ne('', parameters.ScriptToValidateUpgrade) }}:
       - pwsh: |
           $changedFiles = ./eng/common/scripts/get-changedfiles.ps1

--- a/eng/common/pipelines/templates/steps/verify-links.yml
+++ b/eng/common/pipelines/templates/steps/verify-links.yml
@@ -10,6 +10,7 @@ parameters:
   BranchReplacementName: "${env:SYSTEM_PULLREQUEST_SOURCECOMMITID}"
   Condition: succeeded() # If you want to run on failure for the link checker, set it to `Condition: succeededOrFailed()`.
   AllowRelativeLinksFile: '$(Build.SourcesDirectory)/eng/common/scripts/allow-relative-links.txt'
+  NpmRegistryUrl: 'https://registry.npmjs.org/'
 
 steps:
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
@@ -34,3 +35,6 @@ steps:
         -localBuildRepoPath $(Build.SourcesDirectory)
         -inputCacheFile "https://azuresdkartifacts.blob.core.windows.net/verify-links-cache/verify-links-cache.txt"
         -allowRelativeLinksFile "${{ parameters.AllowRelativeLinksFile }}"
+        -npmRegistryUrl "${{ parameters.NpmRegistryUrl }}"
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/common/scripts/Verify-Links.ps1
+++ b/eng/common/scripts/Verify-Links.ps1
@@ -59,6 +59,9 @@
   checkLinkGuidance is true. Relative links in matching files are still verified for correctness. One pattern per line;
   lines beginning with '#' are treated as comments.
 
+  .PARAMETER npmRegistryUrl
+  Registry URL to use when validating npmjs.com package links. Defaults to the public npm registry.
+
   .EXAMPLE
   PS> .\Verify-Links.ps1 C:\README.md
 
@@ -86,7 +89,8 @@ param (
   [string] $localBuildRepoName = "",
   [string] $localBuildRepoPath = "",
   [string] $requestTimeoutSec = 15,
-  [string] $allowRelativeLinksFile = (Join-Path $PSScriptRoot "allow-relative-links.txt")
+  [string] $allowRelativeLinksFile = (Join-Path $PSScriptRoot "allow-relative-links.txt"),
+  [string] $npmRegistryUrl = "https://registry.npmjs.org/"
 )
 
 Set-StrictMode -Version 3.0
@@ -94,6 +98,19 @@ Set-StrictMode -Version 3.0
 . "$PSScriptRoot/logging.ps1"
 
 $ProgressPreference = "SilentlyContinue"; # Disable invoke-webrequest progress dialog
+
+function GetAzureArtifactsHeaders([System.Uri]$linkUri) {
+  if ($linkUri.Host -ne "pkgs.dev.azure.com" -or !$env:SYSTEM_ACCESSTOKEN) {
+    return @{}
+  }
+
+  $tokenBytes = [System.Text.Encoding]::ASCII.GetBytes(":$env:SYSTEM_ACCESSTOKEN")
+  $basicToken = [Convert]::ToBase64String($tokenBytes)
+
+  return @{
+    Authorization = "Basic $basicToken"
+  }
+}
 
 function ProcessLink([System.Uri]$linkUri) {
   # To help improve performance and rate limiting issues with github links we try to resolve them based on a local clone if one exists.
@@ -175,13 +192,14 @@ function ProcessNpmLink([System.Uri]$linkUri) {
   # The regex captures the package name (which may contain a slash for scoped packages) and optionally the version.
   # Query parameters and URL fragments are excluded from the transformation.
   $urlString = $linkUri.ToString()
+  $registryUrl = $npmRegistryUrl.TrimEnd('/')
   if ($urlString -match '^https?://(?:www\.)?npmjs\.com/package/([^?#]+)/v/([^?#]+)') {
     # Versioned URL: remove the /v/ segment but keep the version
-    $apiUrl = "https://registry.npmjs.org/$($matches[1])/$($matches[2])"
+    $apiUrl = "$registryUrl/$($matches[1])/$($matches[2])"
   }
   elseif ($urlString -match '^https?://(?:www\.)?npmjs\.com/package/([^?#]+)') {
     # Non-versioned URL: just replace the domain
-    $apiUrl = "https://registry.npmjs.org/$($matches[1])"
+    $apiUrl = "$registryUrl/$($matches[1])"
   }
   else {
     # Fallback: use the original URL if it doesn't match expected patterns
@@ -193,16 +211,17 @@ function ProcessNpmLink([System.Uri]$linkUri) {
 
 function ProcessStandardLink([System.Uri]$linkUri) {
   $headRequestSucceeded = $true
+  $headers = GetAzureArtifactsHeaders $linkUri
   try {
     # Attempt HEAD request first
-    $response = Invoke-WebRequest -Uri $linkUri -Method HEAD -UserAgent $userAgent -TimeoutSec $requestTimeoutSec
+    $response = Invoke-WebRequest -Uri $linkUri -Method HEAD -Headers $headers -UserAgent $userAgent -TimeoutSec $requestTimeoutSec
   }
   catch {
     $headRequestSucceeded = $false
   }
   if (!$headRequestSucceeded) {
     # Attempt a GET request if the HEAD request failed.
-    $response = Invoke-WebRequest -Uri $linkUri -Method GET -UserAgent $userAgent -TimeoutSec $requestTimeoutSec
+    $response = Invoke-WebRequest -Uri $linkUri -Method GET -Headers $headers -UserAgent $userAgent -TimeoutSec $requestTimeoutSec
   }
   $statusCode = $response.StatusCode
   if ($statusCode -ne 200) {

--- a/eng/pipelines/templates/jobs/analyze.yml
+++ b/eng/pipelines/templates/jobs/analyze.yml
@@ -3,11 +3,17 @@ jobs:
   condition: and(succeededOrFailed(), ne(variables['Skip.Analyze'], 'true'))
   timeoutInMinutes: 120
   dependsOn: []
+  variables:
+    npm_config_userconfig: $(Agent.TempDirectory)/.npmrc
   steps:
   - checkout: self
     fetchDepth: 0
 
   - template: /eng/pipelines/templates/steps/install-dotnet.yml
+
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: $(npm_config_userconfig)
   
   - task: Powershell@2
     displayName: "Run source analysis"
@@ -22,12 +28,15 @@ jobs:
       sourceDirectory: $(Build.SourcesDirectory)
 
   - template: /eng/common/pipelines/templates/steps/check-spelling.yml
+    parameters:
+      NpmConfigUserConfig: $(npm_config_userconfig)
 
   - template: /eng/common/pipelines/templates/steps/verify-links.yml
     parameters:
       Condition: succeededOrFailed()
       Directory: ""
       CheckLinkGuidance: $true
+      NpmRegistryUrl: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/
       ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
 


### PR DESCRIPTION
This PR adds pipeline support for CFSClean network isolation scenarios by ensuring validation steps can resolve packages and links through authenticated/internal npm configuration. It updates spelling and link verification jobs to use injected npm config, internal registry URLs, and authenticated requests so analysis can run correctly in isolated environments.