### PR TITLE
feat(azurebackup): Add security configure-encryption command for CMK

### DIFF
--- a/tools/Azure.Mcp.Tools.AzureBackup/src/AzureBackupSetup.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/AzureBackupSetup.cs
@@ -57,6 +57,7 @@ public sealed class AzureBackupSetup : IAreaSetup
         services.AddSingleton<DisasterRecoveryEnableCrrCommand>();
 
         services.AddSingleton<SecurityConfigureMuaCommand>();
+        services.AddSingleton<SecurityConfigureEncryptionCommand>();
     }
 
     public CommandGroup RegisterCommands(IServiceProvider serviceProvider)
@@ -114,9 +115,10 @@ public sealed class AzureBackupSetup : IAreaSetup
         azureBackup.AddSubGroup(disasterrecovery);
         disasterrecovery.AddCommand<DisasterRecoveryEnableCrrCommand>(serviceProvider);
 
-        var security = new CommandGroup("security", "Security operations - Configure Multi-User Authorization (MUA) for backup vaults.");
+        var security = new CommandGroup("security", "Security operations - Configure Multi-User Authorization (MUA) and Customer-Managed Key (CMK) encryption for backup vaults.");
         azureBackup.AddSubGroup(security);
         security.AddCommand<SecurityConfigureMuaCommand>(serviceProvider);
+        security.AddCommand<SecurityConfigureEncryptionCommand>(serviceProvider);
 
         return azureBackup;
     }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/AzureBackupJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/AzureBackupJsonContext.cs
@@ -35,6 +35,7 @@ namespace Azure.Mcp.Tools.AzureBackup.Commands;
 [JsonSerializable(typeof(GovernanceSoftDeleteCommand.GovernanceSoftDeleteCommandResult))]
 [JsonSerializable(typeof(DisasterRecoveryEnableCrrCommand.DisasterRecoveryEnableCrrCommandResult))]
 [JsonSerializable(typeof(SecurityConfigureMuaCommand.SecurityConfigureMuaCommandResult))]
+[JsonSerializable(typeof(SecurityConfigureEncryptionCommand.SecurityConfigureEncryptionCommandResult))]
 [JsonSerializable(typeof(BackupVaultInfo))]
 [JsonSerializable(typeof(ProtectedItemInfo))]
 [JsonSerializable(typeof(BackupPolicyInfo))]

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityConfigureEncryptionCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityConfigureEncryptionCommand.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Azure.Mcp.Tools.AzureBackup.Models;
+using Azure.Mcp.Tools.AzureBackup.Options;
+using Azure.Mcp.Tools.AzureBackup.Options.Security;
+using Azure.Mcp.Tools.AzureBackup.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
+using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Core.Models.Option;
+
+namespace Azure.Mcp.Tools.AzureBackup.Commands.Security;
+
+[CommandMetadata(
+    Id = "d4b32g79-ac6f-5e2b-cg4d-8f3b1g9e5c30",
+    Name = "configure-encryption",
+    Title = "Configure Customer-Managed Key Encryption",
+    Description = """
+        Configures Customer-Managed Key (CMK) encryption on a Recovery Services vault using a key
+        from Azure Key Vault. The vault's managed identity must be pre-configured with the
+        Key Vault Crypto Service Encryption User role on the Key Vault. Use --identity-type to
+        specify SystemAssigned or UserAssigned identity, and --user-assigned-identity-id when using
+        a user-assigned identity. Only supported for RSV vaults.
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class SecurityConfigureEncryptionCommand(ILogger<SecurityConfigureEncryptionCommand> logger, IAzureBackupService azureBackupService) : BaseAzureBackupCommand<SecurityConfigureEncryptionOptions>()
+{
+    private readonly ILogger<SecurityConfigureEncryptionCommand> _logger = logger;
+    private readonly IAzureBackupService _azureBackupService = azureBackupService;
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(AzureBackupOptionDefinitions.KeyVaultUri);
+        command.Options.Add(AzureBackupOptionDefinitions.KeyNameOption);
+        command.Options.Add(AzureBackupOptionDefinitions.KeyVersion);
+        command.Options.Add(AzureBackupOptionDefinitions.IdentityType.AsRequired());
+        command.Options.Add(AzureBackupOptionDefinitions.UserAssignedIdentityId);
+
+        command.Validators.Add(commandResult =>
+        {
+            var identityType = commandResult.GetValue<string>(AzureBackupOptionDefinitions.IdentityType.Name);
+            if (!string.IsNullOrEmpty(identityType) &&
+                !identityType.Equals("SystemAssigned", StringComparison.OrdinalIgnoreCase) &&
+                !identityType.Equals("UserAssigned", StringComparison.OrdinalIgnoreCase))
+            {
+                commandResult.AddError("--identity-type must be 'SystemAssigned' or 'UserAssigned' for CMK encryption.");
+            }
+
+            if (string.Equals(identityType, "UserAssigned", StringComparison.OrdinalIgnoreCase))
+            {
+                var uaId = commandResult.GetValue<string>(AzureBackupOptionDefinitions.UserAssignedIdentityId.Name);
+                if (string.IsNullOrEmpty(uaId))
+                {
+                    commandResult.AddError("--user-assigned-identity-id is required when --identity-type is 'UserAssigned'.");
+                }
+                else if (!uaId.StartsWith("/subscriptions/", StringComparison.OrdinalIgnoreCase))
+                {
+                    commandResult.AddError("--user-assigned-identity-id must be a valid ARM resource ID starting with '/subscriptions/'.");
+                }
+            }
+
+            var keyVaultUri = commandResult.GetValue<string>(AzureBackupOptionDefinitions.KeyVaultUri.Name);
+            if (!string.IsNullOrEmpty(keyVaultUri) &&
+                !Uri.TryCreate(keyVaultUri, UriKind.Absolute, out var uri))
+            {
+                commandResult.AddError("--key-vault-uri must be a valid URI (e.g., 'https://kv-name.vault.azure.net/').");
+            }
+        });
+    }
+
+    protected override SecurityConfigureEncryptionOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.KeyVaultUri = parseResult.GetValueOrDefault<string>(AzureBackupOptionDefinitions.KeyVaultUri.Name);
+        options.KeyName = parseResult.GetValueOrDefault<string>(AzureBackupOptionDefinitions.KeyNameOption.Name);
+        options.KeyVersion = parseResult.GetValueOrDefault<string>(AzureBackupOptionDefinitions.KeyVersion.Name);
+        options.IdentityType = parseResult.GetValueOrDefault<string>(AzureBackupOptionDefinitions.IdentityType.Name);
+        options.UserAssignedIdentityId = parseResult.GetValueOrDefault<string>(AzureBackupOptionDefinitions.UserAssignedIdentityId.Name);
+        return options;
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+        {
+            return context.Response;
+        }
+
+        var options = BindOptions(parseResult);
+
+        AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
+
+        try
+        {
+            var result = await _azureBackupService.ConfigureEncryptionAsync(
+                options.Vault!,
+                options.ResourceGroup!,
+                options.Subscription!,
+                options.KeyVaultUri!,
+                options.KeyName!,
+                options.IdentityType!,
+                options.KeyVersion,
+                options.UserAssignedIdentityId,
+                options.VaultType,
+                options.Tenant,
+                options.RetryPolicy,
+                cancellationToken);
+
+            context.Response.Results = ResponseResult.Create(
+                new(result),
+                AzureBackupJsonContext.Default.SecurityConfigureEncryptionCommandResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error configuring CMK encryption. Vault: {Vault}", options.Vault);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    protected override string GetErrorMessage(Exception ex) => ex switch
+    {
+        ArgumentException argEx => argEx.Message,
+        NotSupportedException nsEx => nsEx.Message,
+        UnauthorizedAccessException => "Authorization failed. Verify your RBAC permissions on the vault and Key Vault, or specify --vault-type to skip auto-detection.",
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.NotFound =>
+            "Vault or Key Vault key not found. Verify the vault name, resource group, Key Vault URI, and key name.",
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.BadRequest =>
+            $"Bad request configuring CMK encryption. Ensure the vault has a managed identity enabled, the Key Vault Crypto Service Encryption User role is assigned, and the Key Vault is not network-restricted when the vault has private endpoints. Details: {reqEx.Message}",
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.Forbidden =>
+            $"Authorization failed. The vault's managed identity needs Key Vault Crypto Service Encryption User role on the Key Vault. Details: {reqEx.Message}",
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.Conflict =>
+            "Encryption configuration conflict. The vault may already have CMK configured or an operation is in progress.",
+        RequestFailedException reqEx => reqEx.Message,
+        _ => base.GetErrorMessage(ex)
+    };
+
+    protected override HttpStatusCode GetStatusCode(Exception ex) => ex switch
+    {
+        UnauthorizedAccessException => HttpStatusCode.Forbidden,
+        NotSupportedException => HttpStatusCode.BadRequest,
+        ArgumentException or FormatException => HttpStatusCode.BadRequest,
+        RequestFailedException reqEx => (HttpStatusCode)reqEx.Status,
+        _ => base.GetStatusCode(ex)
+    };
+
+    internal record SecurityConfigureEncryptionCommandResult(OperationResult Result);
+}

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Options/AzureBackupOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Options/AzureBackupOptionDefinitions.cs
@@ -31,6 +31,12 @@ public static class AzureBackupOptionDefinitions
     public const string TagFilterName = "tag-filter";
     public const string ResourceGuardIdName = "resource-guard-id";
 
+    // Security - CMK encryption
+    public const string KeyVaultUriName = "key-vault-uri";
+    public const string KeyNameOptionName = "key-name";
+    public const string KeyVersionName = "key-version";
+    public const string UserAssignedIdentityIdName = "user-assigned-identity-id";
+
     public static readonly Option<string> Vault = new($"--{VaultName}")
     {
         Description = "The name of the backup vault (Recovery Services vault or Backup vault).",
@@ -178,6 +184,30 @@ public static class AzureBackupOptionDefinitions
     public static readonly Option<string> ResourceGuardId = new($"--{ResourceGuardIdName}")
     {
         Description = "ARM resource ID of the Resource Guard to link for Multi-User Authorization (e.g., '/subscriptions/.../resourceGroups/.../providers/Microsoft.DataProtection/resourceGuards/myGuard').",
+        Required = false
+    };
+
+    public static readonly Option<string> KeyVaultUri = new($"--{KeyVaultUriName}")
+    {
+        Description = "Key Vault URI (e.g., 'https://kv-security-prod.vault.azure.net/').",
+        Required = true
+    };
+
+    public static readonly Option<string> KeyNameOption = new($"--{KeyNameOptionName}")
+    {
+        Description = "Name of the encryption key in the Key Vault.",
+        Required = true
+    };
+
+    public static readonly Option<string> KeyVersion = new($"--{KeyVersionName}")
+    {
+        Description = "Specific key version. Omit to always use the latest version.",
+        Required = false
+    };
+
+    public static readonly Option<string> UserAssignedIdentityId = new($"--{UserAssignedIdentityIdName}")
+    {
+        Description = "ARM resource ID of the user-assigned managed identity for Key Vault access. Required when --identity-type is 'UserAssigned'.",
         Required = false
     };
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Options/Security/SecurityConfigureEncryptionOptions.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Options/Security/SecurityConfigureEncryptionOptions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Azure.Mcp.Tools.AzureBackup.Options.Security;
+
+public class SecurityConfigureEncryptionOptions : BaseAzureBackupOptions
+{
+    [JsonPropertyName(AzureBackupOptionDefinitions.KeyVaultUriName)]
+    public string? KeyVaultUri { get; set; }
+
+    [JsonPropertyName(AzureBackupOptionDefinitions.KeyNameOptionName)]
+    public string? KeyName { get; set; }
+
+    [JsonPropertyName(AzureBackupOptionDefinitions.KeyVersionName)]
+    public string? KeyVersion { get; set; }
+
+    [JsonPropertyName(AzureBackupOptionDefinitions.IdentityTypeName)]
+    public string? IdentityType { get; set; }
+
+    [JsonPropertyName(AzureBackupOptionDefinitions.UserAssignedIdentityIdName)]
+    public string? UserAssignedIdentityId { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs
@@ -683,6 +683,20 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
     }
 
 
+
+    public async Task<OperationResult> ConfigureEncryptionAsync(
+        string vaultName, string resourceGroup, string subscription,
+        string keyVaultUri, string keyName, string identityType,
+        string? keyVersion, string? userAssignedIdentityId,
+        string? vaultType, string? tenant,
+        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+    {
+        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        return VaultTypeResolver.IsRsv(resolved)
+            ? await rsvOps.ConfigureEncryptionAsync(vaultName, resourceGroup, subscription, keyVaultUri, keyName, identityType, keyVersion, userAssignedIdentityId, tenant, retryPolicy, cancellationToken)
+            : await dppOps.ConfigureEncryptionAsync(vaultName, resourceGroup, subscription, keyVaultUri, keyName, identityType, keyVersion, userAssignedIdentityId, tenant, retryPolicy, cancellationToken);
+    }
+
     private async Task<string> ResolveVaultTypeAsync(
         string vaultName, string resourceGroup, string subscription,
         string? vaultType, string? tenant,

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs
@@ -888,6 +888,19 @@ public sealed class DppBackupOperations(ITenantService tenantService) : BaseAzur
         return new OperationResult("Succeeded", null, $"Multi-User Authorization disabled on vault '{vaultName}'.");
     }
 
+    public Task<OperationResult> ConfigureEncryptionAsync(
+        string vaultName, string resourceGroup, string subscription,
+        string keyVaultUri, string keyName, string identityType,
+        string? keyVersion, string? userAssignedIdentityId,
+        string? tenant, RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken)
+    {
+        throw new NotSupportedException(
+            "Customer-Managed Key (CMK) encryption configuration is only supported for Recovery Services vaults (RSV). " +
+            "For Backup vaults (DPP), CMK encryption must be configured at vault creation time. " +
+            "Use --vault-type rsv or create a new Backup vault with encryption settings.");
+    }
+
 
     private static BackupVaultInfo MapToVaultInfo(DataProtectionBackupVaultData data, string? resourceGroup)
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IAzureBackupService.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IAzureBackupService.cs
@@ -49,5 +49,6 @@ public interface IAzureBackupService
     // Security
     Task<OperationResult> ConfigureMultiUserAuthorizationAsync(string vaultName, string resourceGroup, string subscription, string resourceGuardId, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
     Task<OperationResult> DisableMultiUserAuthorizationAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> ConfigureEncryptionAsync(string vaultName, string resourceGroup, string subscription, string keyVaultUri, string keyName, string identityType, string? keyVersion = null, string? userAssignedIdentityId = null, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
 
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IDppBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IDppBackupOperations.cs
@@ -192,4 +192,17 @@ public interface IDppBackupOperations
         string? tenant,
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
+
+    Task<OperationResult> ConfigureEncryptionAsync(
+        string vaultName,
+        string resourceGroup,
+        string subscription,
+        string keyVaultUri,
+        string keyName,
+        string identityType,
+        string? keyVersion,
+        string? userAssignedIdentityId,
+        string? tenant,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken);
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IRsvBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IRsvBackupOperations.cs
@@ -218,4 +218,17 @@ public interface IRsvBackupOperations
         string? tenant,
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
+
+    Task<OperationResult> ConfigureEncryptionAsync(
+        string vaultName,
+        string resourceGroup,
+        string subscription,
+        string keyVaultUri,
+        string keyName,
+        string identityType,
+        string? keyVersion,
+        string? userAssignedIdentityId,
+        string? tenant,
+        RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken);
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.cs
@@ -1085,6 +1085,77 @@ public sealed class RsvBackupOperations(ITenantService tenantService) : BaseAzur
     }
 
 
+    public async Task<OperationResult> ConfigureEncryptionAsync(
+        string vaultName, string resourceGroup, string subscription,
+        string keyVaultUri, string keyName, string identityType,
+        string? keyVersion, string? userAssignedIdentityId,
+        string? tenant, RetryPolicyOptions? retryPolicy,
+        CancellationToken cancellationToken)
+    {
+        ValidateRequiredParameters(
+            (nameof(vaultName), vaultName),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(subscription), subscription),
+            (nameof(keyVaultUri), keyVaultUri),
+            (nameof(keyName), keyName),
+            (nameof(identityType), identityType));
+
+        var normalizedIdentity = identityType.ToUpperInvariant();
+        if (normalizedIdentity != "SYSTEMASSIGNED" && normalizedIdentity != "USERASSIGNED")
+        {
+            throw new ArgumentException(
+                $"Invalid identity type '{identityType}' for CMK encryption. Supported values: 'SystemAssigned', 'UserAssigned'.");
+        }
+
+        if (normalizedIdentity == "USERASSIGNED" && string.IsNullOrWhiteSpace(userAssignedIdentityId))
+        {
+            throw new ArgumentException(
+                "The --user-assigned-identity-id parameter is required when --identity-type is 'UserAssigned'.");
+        }
+
+        // Build the full key URI: {keyVaultUri}/keys/{keyName}[/{keyVersion}]
+        var kvUri = keyVaultUri.TrimEnd('/');
+        var keyUriString = string.IsNullOrEmpty(keyVersion)
+            ? $"{kvUri}/keys/{keyName}"
+            : $"{kvUri}/keys/{keyName}/{keyVersion}";
+
+        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var vaultId = RecoveryServicesVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
+        var vaultResource = armClient.GetRecoveryServicesVaultResource(vaultId);
+        var vault = await vaultResource.GetAsync(cancellationToken);
+
+        var kekIdentity = new CmkKekIdentity();
+        if (normalizedIdentity == "SYSTEMASSIGNED")
+        {
+            kekIdentity.UseSystemAssignedIdentity = true;
+        }
+        else
+        {
+            kekIdentity.UseSystemAssignedIdentity = false;
+            kekIdentity.UserAssignedIdentity = new ResourceIdentifier(userAssignedIdentityId!);
+        }
+
+        var encryption = new VaultPropertiesEncryption
+        {
+            KeyUri = new Uri(keyUriString),
+            KekIdentity = kekIdentity,
+            InfrastructureEncryption = Azure.ResourceManager.RecoveryServices.Models.InfrastructureEncryptionState.Enabled
+        };
+
+        var patchData = new RecoveryServicesVaultPatch(vault.Value.Data.Location)
+        {
+            Properties = new RecoveryServicesVaultProperties
+            {
+                Encryption = encryption
+            }
+        };
+
+        await vaultResource.UpdateAsync(WaitUntil.Completed, patchData, cancellationToken);
+
+        return new OperationResult("Succeeded", null,
+            $"Customer-Managed Key encryption configured on vault '{vaultName}' using key '{keyName}' from '{kvUri}'.");
+    }
+
     private static Azure.ResourceManager.Models.ManagedServiceIdentityType ParseIdentityType(string identityType) =>
         identityType.ToUpperInvariant() switch
         {

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.LiveTests/AzureBackupCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.LiveTests/AzureBackupCommandTests.cs
@@ -1611,4 +1611,44 @@ public class AzureBackupCommandTests(ITestOutputHelper output, TestProxyFixture 
     // Command-level validation errors return MCP error responses without tool content.
 
     #endregion
+
+    #region Security - Configure Encryption (CMK)
+
+    [Fact]
+    [LiveTestOnly]
+    public async Task SecurityConfigureEncryption_RsvVault_SystemAssigned()
+    {
+        var vaultName = $"{Settings.ResourceBaseName}-rsv";
+
+        Output.WriteLine($"[{DateTime.UtcNow:HH:mm:ss}] START: SecurityConfigureEncryption_RSV_SystemAssigned");
+
+        var result = await CallToolAsync(
+            "azurebackup_security_configure-encryption",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "vault", vaultName },
+                { "vault-type", "rsv" },
+                { "key-vault-uri", Settings.DeploymentOutputs?.GetValueOrDefault("KEY_VAULT_URI") ?? "https://kv-backup-test.vault.azure.net/" },
+                { "key-name", Settings.DeploymentOutputs?.GetValueOrDefault("KEY_NAME") ?? "backup-cmk" },
+                { "identity-type", "SystemAssigned" }
+            });
+
+        Output.WriteLine($"[{DateTime.UtcNow:HH:mm:ss}] DONE: SecurityConfigureEncryption_RSV_SystemAssigned");
+
+        if (result.HasValue)
+        {
+            var text = result.Value.GetProperty("text").GetString() ?? "";
+            Output.WriteLine($"Result: {text}");
+            Assert.Contains("Succeeded", text);
+        }
+        else
+        {
+            Assert.Fail("Unexpected response from SecurityConfigureEncryption (RSV SystemAssigned)");
+        }
+    }
+
+    #endregion
+
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Security/SecurityConfigureEncryptionCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Security/SecurityConfigureEncryptionCommandTests.cs
@@ -1,0 +1,405 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text.Json;
+using Azure.Mcp.Tools.AzureBackup.Commands;
+using Azure.Mcp.Tools.AzureBackup.Commands.Security;
+using Azure.Mcp.Tools.AzureBackup.Models;
+using Azure.Mcp.Tools.AzureBackup.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Core.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Azure.Mcp.Tools.AzureBackup.UnitTests.Security;
+
+public class SecurityConfigureEncryptionCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAzureBackupService _backupService;
+    private readonly ILogger<SecurityConfigureEncryptionCommand> _logger;
+    private readonly SecurityConfigureEncryptionCommand _command;
+    private readonly CommandContext _context;
+    private readonly System.CommandLine.Command _commandDefinition;
+
+    private const string TestKeyVaultUri = "https://kv-security-prod.vault.azure.net/";
+    private const string TestKeyName = "backup-cmk";
+    private const string TestKeyVersion = "abc123";
+    private const string TestUserAssignedIdentityId = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-identity/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity";
+
+    public SecurityConfigureEncryptionCommandTests()
+    {
+        _backupService = Substitute.For<IAzureBackupService>();
+        _logger = Substitute.For<ILogger<SecurityConfigureEncryptionCommand>>();
+
+        var collection = new ServiceCollection().AddSingleton(_backupService);
+
+        _serviceProvider = collection.BuildServiceProvider();
+        _command = new(_logger, _backupService);
+        _context = new(_serviceProvider);
+        _commandDefinition = _command.GetCommand();
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("configure-encryption", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SystemAssigned_ConfiguresEncryption()
+    {
+        // Arrange
+        var expected = new OperationResult("Succeeded", null, "CMK configured");
+
+        _backupService.ConfigureEncryptionAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
+            Arg.Is(TestKeyVaultUri), Arg.Is(TestKeyName), Arg.Is("SystemAssigned"),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", "SystemAssigned"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.SecurityConfigureEncryptionCommandResult);
+
+        Assert.NotNull(result);
+        Assert.Equal("Succeeded", result.Result.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UserAssigned_ConfiguresEncryption()
+    {
+        // Arrange
+        var expected = new OperationResult("Succeeded", null, "CMK configured with UA identity");
+
+        _backupService.ConfigureEncryptionAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
+            Arg.Is(TestKeyVaultUri), Arg.Is(TestKeyName), Arg.Is("UserAssigned"),
+            Arg.Any<string?>(), Arg.Is(TestUserAssignedIdentityId), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", "UserAssigned",
+            "--user-assigned-identity-id", TestUserAssignedIdentityId]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithKeyVersion_ConfiguresEncryption()
+    {
+        // Arrange
+        var expected = new OperationResult("Succeeded", null, "CMK configured with version");
+
+        _backupService.ConfigureEncryptionAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
+            Arg.Is(TestKeyVaultUri), Arg.Is(TestKeyName), Arg.Is("SystemAssigned"),
+            Arg.Is(TestKeyVersion), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", "SystemAssigned",
+            "--key-version", TestKeyVersion]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesException()
+    {
+        // Arrange
+        _backupService.ConfigureEncryptionAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Test error"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", "SystemAssigned"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Contains("Test error", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesNotFoundError()
+    {
+        // Arrange
+        _backupService.ConfigureEncryptionAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(404, "Not found"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", "SystemAssigned"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.Status);
+        Assert.Contains("not found", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesForbiddenError()
+    {
+        // Arrange
+        _backupService.ConfigureEncryptionAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", "SystemAssigned"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.Status);
+        Assert.Contains("Authorization failed", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesBadRequestError()
+    {
+        // Arrange
+        _backupService.ConfigureEncryptionAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(400, "Bad request"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", "SystemAssigned"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("managed identity", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesNotSupportedError()
+    {
+        // Arrange
+        _backupService.ConfigureEncryptionAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new NotSupportedException("CMK not supported for DPP"));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", "SystemAssigned"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("CMK not supported for DPP", response.Message);
+    }
+
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("None")]
+    [InlineData("SystemAssigned,UserAssigned")]
+    public async Task ExecuteAsync_RejectsInvalidIdentityType(string identityType)
+    {
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", identityType]);
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RejectsUserAssigned_WithoutIdentityId()
+    {
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", "UserAssigned"]);
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+    }
+
+    [Theory]
+    [InlineData("rsv")]
+    [InlineData("dpp")]
+    [InlineData("RSV")]
+    [InlineData("DPP")]
+    public async Task ExecuteAsync_AcceptsValidVaultType(string vaultType)
+    {
+        _backupService.ConfigureEncryptionAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Is(vaultType),
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", "SystemAssigned",
+            "--vault-type", vaultType]);
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+    }
+
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("RSV-type")]
+    public async Task ExecuteAsync_RejectsInvalidVaultType(string vaultType)
+    {
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", "SystemAssigned",
+            "--vault-type", vaultType]);
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("--vault-type must be", response.Message);
+    }
+
+    [Fact]
+    public void BindOptions_BindsOptionsCorrectly()
+    {
+        // Arrange & Act
+        var command = _command.GetCommand();
+        var options = command.Options;
+
+        // Assert
+        Assert.Contains(options, o => o.Name == "--subscription");
+        Assert.Contains(options, o => o.Name == "--resource-group");
+        Assert.Contains(options, o => o.Name == "--vault");
+        Assert.Contains(options, o => o.Name == "--vault-type");
+        Assert.Contains(options, o => o.Name == "--key-vault-uri");
+        Assert.Contains(options, o => o.Name == "--key-name");
+        Assert.Contains(options, o => o.Name == "--key-version");
+        Assert.Contains(options, o => o.Name == "--identity-type");
+        Assert.Contains(options, o => o.Name == "--user-assigned-identity-id");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DeserializationValidation()
+    {
+        // Arrange
+        var expected = new OperationResult("Succeeded", null, "CMK configured successfully");
+
+        _backupService.ConfigureEncryptionAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", "SystemAssigned"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize(json, AzureBackupJsonContext.Default.SecurityConfigureEncryptionCommandResult);
+
+        Assert.NotNull(result);
+        Assert.Equal("Succeeded", result.Result.Status);
+        Assert.Equal("CMK configured successfully", result.Result.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CallsCorrectServiceMethod()
+    {
+        // Arrange
+        _backupService.ConfigureEncryptionAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
+
+        var args = _commandDefinition.Parse(["--subscription", "sub", "--vault", "v", "--resource-group", "rg",
+            "--key-vault-uri", TestKeyVaultUri, "--key-name", TestKeyName, "--identity-type", "SystemAssigned"]);
+
+        // Act
+        await _command.ExecuteAsync(_context, args, TestContext.Current.CancellationToken);
+
+        // Assert
+        await _backupService.Received(1).ConfigureEncryptionAsync(
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
+            Arg.Is(TestKeyVaultUri), Arg.Is(TestKeyName), Arg.Is("SystemAssigned"),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("--subscription sub --vault v --resource-group rg --key-vault-uri https://kv.vault.azure.net/ --key-name mykey --identity-type SystemAssigned", true)]
+    [InlineData("--subscription sub --vault v --resource-group rg", false)] // Missing required options
+    public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
+    {
+        if (shouldSucceed)
+        {
+            _backupService.ConfigureEncryptionAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+                Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
+        }
+
+        var parseResult = _commandDefinition.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult, TestContext.Current.CancellationToken);
+
+        // Assert
+        if (shouldSucceed)
+        {
+            Assert.Equal(HttpStatusCode.OK, response.Status);
+        }
+        else
+        {
+            Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds \zurebackup security configure-encryption\ command that enables Customer-Managed Key (CMK) encryption on Recovery Services vaults using a key from Azure Key Vault.

## Changes

### New Command: \zurebackup security configure-encryption\

- Configure CMK encryption by providing \--key-vault-uri\, \--key-name\, and \--identity-type\
- Supports \SystemAssigned\ and \UserAssigned\ managed identity types
- Optional \--key-version\ to pin a specific key version (omit for latest)
- Optional \--user-assigned-identity-id\ (required when \--identity-type\ is \UserAssigned\)
- RSV-only: DPP vaults return \NotSupportedException\ with guidance to configure CMK at vault creation
- Auto-detects vault type when \--vault-type\ is omitted
- Uses \[CommandMetadata]\ attribute pattern
- ARM ID validation on \--user-assigned-identity-id\
- URI validation on \--key-vault-uri\
- Telemetry tags via \AzureBackupTelemetryTags.AddVaultTags\
- Comprehensive error handling for 400/403/404/409 status codes

### Files Changed (13 files, ~787 lines)

| Category | Files |
|----------|-------|
| Command | \SecurityConfigureEncryptionCommand.cs\ (new), \SecurityConfigureEncryptionOptions.cs\ (new) |
| Options | \AzureBackupOptionDefinitions.cs\ (4 new option constants + 4 Option fields) |
| Service | \IAzureBackupService.cs\, \AzureBackupService.cs\, \IRsvBackupOperations.cs\, \RsvBackupOperations.cs\, \IDppBackupOperations.cs\, \DppBackupOperations.cs\ |
| Registration | \AzureBackupSetup.cs\, \AzureBackupJsonContext.cs\ |
| Unit Tests | \SecurityConfigureEncryptionCommandTests.cs\ (24 tests) |
| Live Tests | \AzureBackupCommandTests.cs\ (1 CMK test) |

### Validation

- \dotnet build\ - 0 errors, 0 warnings
- Unit tests - 413/413 passed (24 new CMK + 389 existing)
- Live test build succeeds

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with \write\ access to the repo need to validate the contents of this PR before leaving a comment with the text \/azp run mcp - pullrequest - live\. This will trigger the necessary livetest workflows to complete required validation.