### PR TITLE
Update Copilot SDK version and fix API usage in CopilotCliTester

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -115,6 +115,6 @@
     <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="GitHub.Copilot.SDK" Version="0.1.26" />
+    <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.0-beta.3" />
   </ItemGroup>
 </Project>

--- a/eng/tools/CopilotCliTester/src/AgentRunner.cs
+++ b/eng/tools/CopilotCliTester/src/AgentRunner.cs
@@ -352,13 +352,12 @@ internal sealed partial class AgentRunner(CopilotClient client, string serverExe
     /// <summary>
     /// Builds the MCP servers configuration for stdio transport using a pre-resolved server executable path.
     /// </summary>
-    private static Dictionary<string, object> BuildMcpServersConfig(string serverPath)
+    private static Dictionary<string, McpServerConfig> BuildMcpServersConfig(string serverPath)
     {
-        return new Dictionary<string, object>
+        return new Dictionary<string, McpServerConfig>
         {
-            ["azure"] = new McpLocalServerConfig
+            ["azure"] = new McpStdioServerConfig
             {
-                Type = "stdio",
                 Command = serverPath,
                 Args = ["server", "start", "--mode", "namespace", "--dangerously-disable-elicitation"],
                 Env = new Dictionary<string, string>


### PR DESCRIPTION
## What does this PR do?

Updates the GitHub Copilot SDK package version in `Directory.Packages.props` and fixes a resulting build error in `CopilotCliTester` by migrating from the removed `McpLocalServerConfig` to `McpStdioServerConfig` to match the current Copilot SDK API.

### Changes
- **Directory.Packages.props**: Updated GitHub Copilot SDK package version
- **CopilotCliTester/AgentRunner.cs**: Replaced `McpLocalServerConfig` with `McpStdioServerConfig` and corrected the return type to `Dictionary<string, McpServerConfig>`

### Verification: `Type = "stdio"` omission is safe

`McpStdioServerConfig.Type` is a **read-only** property that defaults to `"stdio"` — confirmed programmatically:
```csharp
var config = new McpStdioServerConfig { Command = "test" };
Console.WriteLine(config.Type); // Output: "stdio"
```

### E2E Test Results (CopilotCliTester)

Ran Copilot SDK E2E tests across 5 namespaces to verify stdio transport works correctly with the new API.

**How the tests were run:**
```bash
cd eng/tools/CopilotCliTester/src
dotnet build

# Ran each namespace individually:
dotnet run -- run --namespace storage --max 2 --parallel 1
dotnet run -- run --namespace keyvault --max 2 --parallel 1
dotnet run -- run --namespace cosmos --max 2 --parallel 1
dotnet run -- run --namespace sql --max 2 --parallel 1
dotnet run -- run --namespace appservice --max 2 --parallel 1
```

Each run creates a Copilot SDK agent session with the local `azmcp.exe` server configured over stdio (using the updated `McpStdioServerConfig`), sends prompts from `e2eTestPrompts.md`, and validates the expected MCP tools are invoked.

**Results:**

| Namespace | Prompts | Passed | Failed | Pass Rate |
|-----------|---------|--------|--------|-----------|
| storage | 2 | 2 | 0 | 100% |
| keyvault | 2 | 2 | 0 | 100% |
| cosmos | 2 | 2 | 0 | 100% |
| sql | 2 | 2 | 0 | 100% |
| appservice | 2 | 2 | 0 | 100% |
| **Total** | **10** | **10** | **0** | **100%** |

All tests confirm the MCP server correctly runs in stdio mode with `McpStdioServerConfig` and no explicit `Type` assignment.

## GitHub issue number

N/A — Dependency version update and build fix.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.