### PR TITLE
feat(datafactory): bridge host auth to DataFactory.MCP.Core via TokenCredential

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -84,7 +84,7 @@
     <PackageVersion Include="Microsoft.HybridRow" Version="1.1.0-preview4" />
     <PackageVersion Include="Microsoft.Azure.Cosmos.Aot" Version="0.1.4-preview.2" />
     <PackageVersion Include="Microsoft.Azure.Mcp.AzTypes.Internal.Compact" Version="0.2.804" />
-    <PackageVersion Include="Microsoft.DataFactory.MCP.Core" Version="0.20.0-beta" />
+    <PackageVersion Include="Microsoft.DataFactory.MCP.Core" Version="0.21.0-preview" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -84,7 +84,7 @@
     <PackageVersion Include="Microsoft.HybridRow" Version="1.1.0-preview4" />
     <PackageVersion Include="Microsoft.Azure.Cosmos.Aot" Version="0.1.4-preview.2" />
     <PackageVersion Include="Microsoft.Azure.Mcp.AzTypes.Internal.Compact" Version="0.2.804" />
-    <PackageVersion Include="Microsoft.DataFactory.MCP.Core" Version="0.21.0-preview" />
+    <PackageVersion Include="Microsoft.DataFactory.MCP.Core" Version="0.21.0-beta" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />

--- a/tools/Fabric.Mcp.Tools.DataFactory/src/DataFactoryAreaSetup.cs
+++ b/tools/Fabric.Mcp.Tools.DataFactory/src/DataFactoryAreaSetup.cs
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Core;
 using Fabric.Mcp.Tools.DataFactory.Commands.Dataflow;
 using Fabric.Mcp.Tools.DataFactory.Commands.Pipeline;
 using global::DataFactory.MCP.Extensions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Mcp.Core.Areas;
 using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Services.Azure.Authentication;
 
 namespace Fabric.Mcp.Tools.DataFactory;
 
@@ -17,7 +20,16 @@ public class DataFactoryAreaSetup : IAreaSetup
 
     public void ConfigureServices(IServiceCollection services)
     {
-        // Register global::DataFactory.MCP.Core services (auth, HttpClients, all service implementations)
+        // Bridge host auth to DataFactory.MCP.Core: resolve TokenCredential from the host's
+        // IAzureTokenCredentialProvider so DataFactory services auto-use host authentication
+        services.TryAddSingleton<TokenCredential>(sp =>
+        {
+            var provider = sp.GetRequiredService<IAzureTokenCredentialProvider>();
+            return provider.GetTokenCredentialAsync(tenantId: null, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        });
+
+        // Register DataFactory.MCP.Core services (auth, HttpClients, all service implementations)
         services.AddDataFactoryMcpServices();
 
         // Register command instances

--- a/tools/Fabric.Mcp.Tools.DataFactory/src/DataFactoryAreaSetup.cs
+++ b/tools/Fabric.Mcp.Tools.DataFactory/src/DataFactoryAreaSetup.cs
@@ -20,10 +20,15 @@ public class DataFactoryAreaSetup : IAreaSetup
 
     public void ConfigureServices(IServiceCollection services)
     {
-        // Bridge host auth to DataFactory.MCP.Core via a delegating TokenCredential that
-        // calls through to IAzureTokenCredentialProvider on each token request. This avoids
-        // caching a single credential (which breaks OBO/multi-user) and sync-over-async.
-        services.TryAddSingleton<TokenCredential, ProviderDelegatingCredential>();
+        // Bridge host auth to DataFactory.MCP.Core: only register TokenCredential if the host
+        // provides IAzureTokenCredentialProvider. DataFactory.MCP.Core auto-detects TokenCredential
+        // in DI — if present, uses it; otherwise falls back to standalone auth.
+        // The delegating credential calls through to the provider on each token request,
+        // avoiding credential caching (which breaks OBO/multi-user).
+        if (services.Any(d => d.ServiceType == typeof(IAzureTokenCredentialProvider)))
+        {
+            services.TryAddSingleton<TokenCredential, ProviderDelegatingCredential>();
+        }
 
         // Register DataFactory.MCP.Core services (auth, HttpClients, all service implementations)
         services.AddDataFactoryMcpServices();

--- a/tools/Fabric.Mcp.Tools.DataFactory/src/DataFactoryAreaSetup.cs
+++ b/tools/Fabric.Mcp.Tools.DataFactory/src/DataFactoryAreaSetup.cs
@@ -20,14 +20,10 @@ public class DataFactoryAreaSetup : IAreaSetup
 
     public void ConfigureServices(IServiceCollection services)
     {
-        // Bridge host auth to DataFactory.MCP.Core: resolve TokenCredential from the host's
-        // IAzureTokenCredentialProvider so DataFactory services auto-use host authentication
-        services.TryAddSingleton<TokenCredential>(sp =>
-        {
-            var provider = sp.GetRequiredService<IAzureTokenCredentialProvider>();
-            return provider.GetTokenCredentialAsync(tenantId: null, CancellationToken.None)
-                .GetAwaiter().GetResult();
-        });
+        // Bridge host auth to DataFactory.MCP.Core via a delegating TokenCredential that
+        // calls through to IAzureTokenCredentialProvider on each token request. This avoids
+        // caching a single credential (which breaks OBO/multi-user) and sync-over-async.
+        services.TryAddSingleton<TokenCredential, ProviderDelegatingCredential>();
 
         // Register DataFactory.MCP.Core services (auth, HttpClients, all service implementations)
         services.AddDataFactoryMcpServices();

--- a/tools/Fabric.Mcp.Tools.DataFactory/src/Fabric.Mcp.Tools.DataFactory.csproj
+++ b/tools/Fabric.Mcp.Tools.DataFactory/src/Fabric.Mcp.Tools.DataFactory.csproj
@@ -3,6 +3,9 @@
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Fabric.Mcp.Tools.DataFactory.UnitTests" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\..\core\Fabric.Mcp.Core\src\Fabric.Mcp.Core.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/tools/Fabric.Mcp.Tools.DataFactory/src/ProviderDelegatingCredential.cs
+++ b/tools/Fabric.Mcp.Tools.DataFactory/src/ProviderDelegatingCredential.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Microsoft.Mcp.Core.Services.Azure.Authentication;
+
+namespace Fabric.Mcp.Tools.DataFactory;
+
+/// <summary>
+/// A <see cref="TokenCredential"/> that delegates to <see cref="IAzureTokenCredentialProvider"/>
+/// on each token request, preserving per-execution-context credential resolution (e.g. OBO)
+/// and avoiding sync-over-async in DI registration.
+/// </summary>
+internal sealed class ProviderDelegatingCredential(IAzureTokenCredentialProvider provider) : TokenCredential
+{
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        => GetTokenAsync(requestContext, cancellationToken).GetAwaiter().GetResult();
+
+    public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        var credential = await provider.GetTokenCredentialAsync(tenantId: null, cancellationToken).ConfigureAwait(false);
+        return await credential.GetTokenAsync(requestContext, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/tools/Fabric.Mcp.Tools.DataFactory/tests/Fabric.Mcp.Tools.DataFactory.UnitTests/ProviderDelegatingCredentialTests.cs
+++ b/tools/Fabric.Mcp.Tools.DataFactory/tests/Fabric.Mcp.Tools.DataFactory.UnitTests/ProviderDelegatingCredentialTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Mcp.Core.Services.Azure.Authentication;
+using NSubstitute;
+
+namespace Fabric.Mcp.Tools.DataFactory.UnitTests;
+
+public class ProviderDelegatingCredentialTests
+{
+    [Fact]
+    public async Task GetTokenAsync_DelegatesToProviderOnEachCall()
+    {
+        // Arrange — two distinct credentials to prove no caching
+        var credential1 = Substitute.For<TokenCredential>();
+        credential1.GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(new AccessToken("token1", DateTimeOffset.UtcNow.AddHours(1)));
+
+        var credential2 = Substitute.For<TokenCredential>();
+        credential2.GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(new AccessToken("token2", DateTimeOffset.UtcNow.AddHours(1)));
+
+        var provider = Substitute.For<IAzureTokenCredentialProvider>();
+        provider.GetTokenCredentialAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(credential1, credential2);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(provider);
+        services.AddSingleton<TokenCredential, ProviderDelegatingCredential>();
+
+        await using var sp = services.BuildServiceProvider();
+        var resolved = sp.GetRequiredService<TokenCredential>();
+
+        var context = new TokenRequestContext(["https://api.fabric.microsoft.com/.default"]);
+
+        // Act
+        var token1 = await resolved.GetTokenAsync(context, CancellationToken.None);
+        var token2 = await resolved.GetTokenAsync(context, CancellationToken.None);
+
+        // Assert — each call got a fresh credential from the provider (not cached)
+        Assert.Equal("token1", token1.Token);
+        Assert.Equal("token2", token2.Token);
+        await provider.Received(2).GetTokenCredentialAsync(null, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_PassesRequestContextToCredential()
+    {
+        // Arrange
+        var credential = Substitute.For<TokenCredential>();
+        credential.GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(new AccessToken("test-token", DateTimeOffset.UtcNow.AddHours(1)));
+
+        var provider = Substitute.For<IAzureTokenCredentialProvider>();
+        provider.GetTokenCredentialAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(credential);
+
+        var delegating = new ProviderDelegatingCredential(provider);
+        var scopes = new[] { "https://analysis.windows.net/powerbi/api/.default" };
+        var context = new TokenRequestContext(scopes);
+
+        // Act
+        var result = await delegating.GetTokenAsync(context, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("test-token", result.Token);
+        await credential.Received(1).GetTokenAsync(
+            Arg.Is<TokenRequestContext>(ctx => ctx.Scopes[0] == scopes[0]),
+            Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary

Bridges the Fabric MCP Server's authentication to DataFactory.MCP.Core so that Data Factory commands automatically use the host's IAzureTokenCredentialProvider instead of requiring a separate login flow.

## Changes

- **DataFactoryAreaSetup.cs** — Register TokenCredential from IAzureTokenCredentialProvider before calling AddDataFactoryMcpServices(). DataFactory.MCP.Core v0.21.0 auto-detects a TokenCredential in DI and uses it via TokenCredentialAuthenticationService.
- **Directory.Packages.props** — Bump Microsoft.DataFactory.MCP.Core from 0.20.0-beta to 0.21.0-preview (includes the TokenCredentialAuthenticationService adapter).

## Auth Flow

Fabric MCP Server (DefaultAzureCredential)
-> IAzureTokenCredentialProvider
-> TokenCredential (registered by DataFactoryAreaSetup)
-> TokenCredentialAuthenticationService (auto-detected)
-> FabricAuthenticationHandler -> Bearer token on API calls

## Why

Without this bridge, Data Factory commands fail at auth time because FabricAuthenticationHandler calls IAuthenticationService.GetAccessTokenAsync() which requires an explicit login that never happens in the Fabric MCP Server context. Other Fabric tools (OneLake, Core) accept TokenCredential via constructor — this aligns DataFactory with that pattern.

## Related

- DataFactory.MCP.Core PR: https://github.com/microsoft/DataFactory.MCP/pull/102 (adds TokenCredentialAuthenticationService + version 0.21.0)