### PR TITLE
Introduce the new options pattern

### DIFF
--- a/core/Azure.Mcp.Core/src/Commands/Subscription/SubscriptionCommand`2.cs
+++ b/core/Azure.Mcp.Core/src/Commands/Subscription/SubscriptionCommand`2.cs
@@ -33,7 +33,7 @@ public abstract class SubscriptionCommand<
     {
         var options = base.BindOptions(parseResult);
         // Always post-process subscription via resolver (env var / CLI profile fallback)
-        options.Subscription = _subscriptionResolver.GetSubscription(parseResult);
+        options.Subscription = _subscriptionResolver.ResolveSubscription(options.Subscription);
         return options;
     }
 }

--- a/core/Azure.Mcp.Core/src/Commands/Subscription/SubscriptionCommand`2.cs
+++ b/core/Azure.Mcp.Core/src/Commands/Subscription/SubscriptionCommand`2.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Microsoft.Mcp.Core.Commands;
+
+namespace Azure.Mcp.Core.Commands.Subscription;
+
+public abstract class SubscriptionCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions, TResult>
+     : AuthenticatedCommand<TOptions, TResult> where TOptions : class, ISubscriptionOption
+{
+    private readonly ISubscriptionResolver _subscriptionResolver;
+
+    protected SubscriptionCommand(ISubscriptionResolver subscriptionResolver)
+    {
+        _subscriptionResolver = subscriptionResolver;
+    }
+
+    public override void ValidateOptions(TOptions options, ValidationResult validationResult)
+    {
+        base.ValidateOptions(options, validationResult);
+
+        if (string.IsNullOrEmpty(options.Subscription))
+        {
+            validationResult.Errors.Add("Missing Required options: --subscription");
+        }
+    }
+
+    public override TOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        // Always post-process subscription via resolver (env var / CLI profile fallback)
+        options.Subscription = _subscriptionResolver.GetSubscription(parseResult);
+        return options;
+    }
+}

--- a/core/Azure.Mcp.Core/src/Options/ISubscriptionOption.cs
+++ b/core/Azure.Mcp.Core/src/Options/ISubscriptionOption.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Core.Options;
+
+public interface ISubscriptionOption
+{
+    string? Subscription { get; set; }
+}

--- a/core/Azure.Mcp.Core/src/Options/OptionDescriptions.cs
+++ b/core/Azure.Mcp.Core/src/Options/OptionDescriptions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Core.Options;
+
+/// <summary>
+/// Description constants for global options shared across all Azure MCP commands.
+/// Used with <see cref="Microsoft.Mcp.Core.Options.OptionAttribute"/> on options classes.
+/// </summary>
+public static class OptionDescriptions
+{
+    public const string Subscription =
+        "Specifies the Azure subscription to use. Accepts either a subscription ID (GUID) or display name. " +
+        "If not specified, the AZURE_SUBSCRIPTION_ID environment variable will be used instead.";
+
+    public const string Tenant =
+        "The Microsoft Entra ID tenant ID or name. " +
+        "This can be either the GUID identifier or the display name of your Entra ID tenant.";
+
+    public const string AuthMethod =
+        "Authentication method to use. " +
+        "Options: 'credential' (Azure CLI/managed identity), 'key' (access key), or 'connectionString'.";
+
+    public const string ResourceGroup =
+        "The name of the Azure resource group. This is a logical container for Azure resources.";
+
+    public const string Scope =
+        "Scope at which the role assignment or definition applies to, " +
+        "e.g., /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333, " +
+        "/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup, " +
+        "or /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM.";
+}

--- a/core/Azure.Mcp.Core/src/Options/RetryOptionsExtensions.cs
+++ b/core/Azure.Mcp.Core/src/Options/RetryOptionsExtensions.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Azure.Core;
+using Microsoft.Mcp.Core.Options;
+
+namespace Azure.Mcp.Core.Options
+{
+    public static class RetryOptionsExtensions
+    {
+        public static void ConfigureRetryOptions(this ClientOptions clientOptions, RetryPolicyOptions? retryPolicy)
+        {
+            if (retryPolicy == null)
+            {
+                return;
+            }
+
+            if (retryPolicy.MaxRetries.HasValue)
+            {
+                clientOptions.Retry.MaxRetries = retryPolicy.MaxRetries.Value;
+            }
+
+            if (retryPolicy.Mode.HasValue)
+            {
+                clientOptions.Retry.Mode = retryPolicy.Mode.Value;
+            }
+
+            if (retryPolicy.DelaySeconds.HasValue)
+            {
+                clientOptions.Retry.Delay = TimeSpan.FromSeconds(retryPolicy.DelaySeconds.Value);
+            }
+
+            if (retryPolicy.MaxDelaySeconds.HasValue)
+            {
+                clientOptions.Retry.MaxDelay = TimeSpan.FromSeconds(retryPolicy.MaxDelaySeconds.Value);
+            }
+
+            if (retryPolicy.NetworkTimeoutSeconds.HasValue)
+            {
+                clientOptions.Retry.NetworkTimeout = TimeSpan.FromSeconds(retryPolicy.NetworkTimeoutSeconds.Value);
+            }
+        }
+    }
+}

--- a/core/Azure.Mcp.Core/src/Options/RetryOptionsExtensions.cs
+++ b/core/Azure.Mcp.Core/src/Options/RetryOptionsExtensions.cs
@@ -8,6 +8,7 @@ using Azure.Core;
 using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Core.Options;
+
 public static class RetryOptionsExtensions
 {
     public static void ConfigureRetryOptions(this ClientOptions clientOptions, RetryPolicyOptions? retryPolicy)

--- a/core/Azure.Mcp.Core/src/Options/RetryOptionsExtensions.cs
+++ b/core/Azure.Mcp.Core/src/Options/RetryOptionsExtensions.cs
@@ -1,44 +1,45 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Azure.Core;
 using Microsoft.Mcp.Core.Options;
 
-namespace Azure.Mcp.Core.Options
+namespace Azure.Mcp.Core.Options;
+public static class RetryOptionsExtensions
 {
-    public static class RetryOptionsExtensions
+    public static void ConfigureRetryOptions(this ClientOptions clientOptions, RetryPolicyOptions? retryPolicy)
     {
-        public static void ConfigureRetryOptions(this ClientOptions clientOptions, RetryPolicyOptions? retryPolicy)
+        if (retryPolicy == null)
         {
-            if (retryPolicy == null)
-            {
-                return;
-            }
+            return;
+        }
 
-            if (retryPolicy.MaxRetries.HasValue)
-            {
-                clientOptions.Retry.MaxRetries = retryPolicy.MaxRetries.Value;
-            }
+        if (retryPolicy.MaxRetries.HasValue)
+        {
+            clientOptions.Retry.MaxRetries = retryPolicy.MaxRetries.Value;
+        }
 
-            if (retryPolicy.Mode.HasValue)
-            {
-                clientOptions.Retry.Mode = retryPolicy.Mode.Value;
-            }
+        if (retryPolicy.Mode.HasValue)
+        {
+            clientOptions.Retry.Mode = retryPolicy.Mode.Value;
+        }
 
-            if (retryPolicy.DelaySeconds.HasValue)
-            {
-                clientOptions.Retry.Delay = TimeSpan.FromSeconds(retryPolicy.DelaySeconds.Value);
-            }
+        if (retryPolicy.DelaySeconds.HasValue)
+        {
+            clientOptions.Retry.Delay = TimeSpan.FromSeconds(retryPolicy.DelaySeconds.Value);
+        }
 
-            if (retryPolicy.MaxDelaySeconds.HasValue)
-            {
-                clientOptions.Retry.MaxDelay = TimeSpan.FromSeconds(retryPolicy.MaxDelaySeconds.Value);
-            }
+        if (retryPolicy.MaxDelaySeconds.HasValue)
+        {
+            clientOptions.Retry.MaxDelay = TimeSpan.FromSeconds(retryPolicy.MaxDelaySeconds.Value);
+        }
 
-            if (retryPolicy.NetworkTimeoutSeconds.HasValue)
-            {
-                clientOptions.Retry.NetworkTimeout = TimeSpan.FromSeconds(retryPolicy.NetworkTimeoutSeconds.Value);
-            }
+        if (retryPolicy.NetworkTimeoutSeconds.HasValue)
+        {
+            clientOptions.Retry.NetworkTimeout = TimeSpan.FromSeconds(retryPolicy.NetworkTimeoutSeconds.Value);
         }
     }
 }

--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
@@ -214,33 +214,33 @@ public abstract class BaseAzureService
     {
         if (retryPolicy != null)
         {
-            if (retryPolicy.HasDelaySeconds)
+            if (retryPolicy.DelaySeconds is { } delaySeconds)
             {
                 clientOptions.Retry.Delay = s_retryLimitsDisabled
-                    ? TimeSpan.FromSeconds(retryPolicy.DelaySeconds)
-                    : TimeSpan.FromSeconds(Math.Clamp(retryPolicy.DelaySeconds, MinAllowedDelaySeconds, MaxAllowedDelaySeconds));
+                    ? TimeSpan.FromSeconds(delaySeconds)
+                    : TimeSpan.FromSeconds(Math.Clamp(delaySeconds, MinAllowedDelaySeconds, MaxAllowedDelaySeconds));
             }
-            if (retryPolicy.HasMaxDelaySeconds)
+            if (retryPolicy.MaxDelaySeconds is { } maxDelaySeconds)
             {
                 clientOptions.Retry.MaxDelay = s_retryLimitsDisabled
-                    ? TimeSpan.FromSeconds(retryPolicy.MaxDelaySeconds)
-                    : TimeSpan.FromSeconds(Math.Clamp(retryPolicy.MaxDelaySeconds, MinAllowedDelaySeconds, MaxAllowedDelaySeconds));
+                    ? TimeSpan.FromSeconds(maxDelaySeconds)
+                    : TimeSpan.FromSeconds(Math.Clamp(maxDelaySeconds, MinAllowedDelaySeconds, MaxAllowedDelaySeconds));
             }
-            if (retryPolicy.HasMaxRetries)
+            if (retryPolicy.MaxRetries is { } maxRetries)
             {
                 clientOptions.Retry.MaxRetries = s_retryLimitsDisabled
-                    ? retryPolicy.MaxRetries
-                    : Math.Min(MaxAllowedRetries, retryPolicy.MaxRetries);
+                    ? maxRetries
+                    : Math.Min(MaxAllowedRetries, maxRetries);
             }
-            if (retryPolicy.HasMode)
+            if (retryPolicy.Mode is { } mode)
             {
-                clientOptions.Retry.Mode = retryPolicy.Mode;
+                clientOptions.Retry.Mode = mode;
             }
-            if (retryPolicy.HasNetworkTimeoutSeconds)
+            if (retryPolicy.NetworkTimeoutSeconds is { } networkTimeoutSeconds)
             {
                 clientOptions.Retry.NetworkTimeout = s_retryLimitsDisabled
-                    ? TimeSpan.FromSeconds(retryPolicy.NetworkTimeoutSeconds)
-                    : TimeSpan.FromSeconds(Math.Min(MaxAllowedNetworkTimeoutSeconds, retryPolicy.NetworkTimeoutSeconds));
+                    ? TimeSpan.FromSeconds(networkTimeoutSeconds)
+                    : TimeSpan.FromSeconds(Math.Min(MaxAllowedNetworkTimeoutSeconds, networkTimeoutSeconds));
             }
         }
 

--- a/core/Azure.Mcp.Core/src/Services/Azure/Subscription/ISubscriptionResolver.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Subscription/ISubscriptionResolver.cs
@@ -12,10 +12,10 @@ namespace Azure.Mcp.Core.Services.Azure.Subscription;
 public interface ISubscriptionResolver
 {
     /// <summary>
-    /// Resolves the subscription from the parse result, falling back to Azure CLI profile
+    /// Resolves the subscription from the provided value, falling back to Azure CLI profile
     /// or AZURE_SUBSCRIPTION_ID environment variable.
     /// </summary>
-    string? GetSubscription(ParseResult parseResult);
+    string? ResolveSubscription(string? subscription);
 
     /// <summary>
     /// Checks if a subscription is available from the command option, Azure CLI profile,

--- a/core/Azure.Mcp.Core/src/Services/Azure/Subscription/ISubscriptionResolver.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Subscription/ISubscriptionResolver.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+
+namespace Azure.Mcp.Core.Services.Azure.Subscription;
+
+/// <summary>
+/// Resolves subscription values from command-line arguments, environment variables,
+/// and Azure CLI profile, providing a testable seam for subscription resolution.
+/// </summary>
+public interface ISubscriptionResolver
+{
+    /// <summary>
+    /// Resolves the subscription from the parse result, falling back to Azure CLI profile
+    /// or AZURE_SUBSCRIPTION_ID environment variable.
+    /// </summary>
+    string? GetSubscription(ParseResult parseResult);
+
+    /// <summary>
+    /// Checks if a subscription is available from the command option, Azure CLI profile,
+    /// or AZURE_SUBSCRIPTION_ID environment variable.
+    /// </summary>
+    bool HasSubscriptionAvailable(CommandResult commandResult);
+}

--- a/core/Azure.Mcp.Core/src/Services/Azure/Subscription/SubscriptionResolver.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Subscription/SubscriptionResolver.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using Microsoft.Mcp.Core.Helpers;
+
+namespace Azure.Mcp.Core.Services.Azure.Subscription;
+
+/// <summary>
+/// Default implementation that resolves subscriptions from command-line arguments,
+/// Azure CLI profile, and the AZURE_SUBSCRIPTION_ID environment variable.
+/// </summary>
+public sealed class SubscriptionResolver : ISubscriptionResolver
+{
+    public static SubscriptionResolver Instance { get; } = new();
+
+    public string? GetSubscription(ParseResult parseResult)
+    {
+        string? subscription = CommandHelper.GetSubscription(parseResult);
+
+        if (!string.IsNullOrEmpty(subscription))
+        {
+            subscription = subscription.Trim('"', '\'');
+        }
+
+        return subscription;
+    }
+
+    public bool HasSubscriptionAvailable(CommandResult commandResult) =>
+        CommandHelper.HasSubscriptionAvailable(commandResult);
+}

--- a/core/Azure.Mcp.Core/src/Services/Azure/Subscription/SubscriptionResolver.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Subscription/SubscriptionResolver.cs
@@ -12,17 +12,10 @@ namespace Azure.Mcp.Core.Services.Azure.Subscription;
 /// </summary>
 public sealed class SubscriptionResolver : ISubscriptionResolver
 {
-    public static SubscriptionResolver Instance { get; } = new();
-
-    public string? GetSubscription(ParseResult parseResult)
+    public string? ResolveSubscription(string? subscription)
     {
-        string? subscription = CommandHelper.GetSubscription(parseResult);
-
-        if (!string.IsNullOrEmpty(subscription))
-        {
-            subscription = subscription.Trim('"', '\'');
-        }
-
+        subscription = subscription?.Trim('"', '\'');
+        subscription = CommandHelper.GetSubscription(subscription);
         return subscription;
     }
 

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/CommandFactoryHelpers.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/CommandFactoryHelpers.cs
@@ -181,7 +181,8 @@ internal class CommandFactoryHelpers
             .AddSingleton(Substitute.For<IDateTimeProvider>())
             .AddSingleton(Substitute.For<IExternalProcessService>())
             .AddSingleton(Substitute.For<IAzureTokenCredentialProvider>())
-            .AddSingleton(Substitute.For<IAzureCloudConfiguration>());
+            .AddSingleton(Substitute.For<IAzureCloudConfiguration>())
+            .AddSingleton(Substitute.For<ISubscriptionResolver>());
 
         foreach (var area in areaSetups)
         {

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Options/RetryPolicyOptionsTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Options/RetryPolicyOptionsTests.cs
@@ -44,21 +44,20 @@ public class RetryPolicyOptionsTests
     }
 
     [Fact]
-    public void Policies_With_DifferentValues_But_UnsetFlags_AreEqual()
+    public void Policies_With_AllNullValues_AreEqual()
     {
-        // Create two policies differing in values but with no flags set (simulate deserialization or manual construction without flags)
-        var p1 = new RetryPolicyOptions { MaxRetries = 3, Mode = RetryMode.Exponential, DelaySeconds = 1, MaxDelaySeconds = 5, NetworkTimeoutSeconds = 30 };
-        var p2 = new RetryPolicyOptions { MaxRetries = 999, Mode = RetryMode.Fixed, DelaySeconds = 10, MaxDelaySeconds = 50, NetworkTimeoutSeconds = 0 };
-        // Since no Has* flags are set, differences are ignored.
+        // Policies with no values set are equal — both are "use SDK defaults"
+        var p1 = new RetryPolicyOptions();
+        var p2 = new RetryPolicyOptions();
         Assert.True(RetryPolicyOptions.AreEqual(p1, p2));
         Assert.True(p1 == p2);
     }
 
     [Fact]
-    public void Policies_With_Mismatched_Flags_NotEqual()
+    public void Policies_With_SomeValuesSet_VsNone_NotEqual()
     {
-        var pSpecified = GetPolicy(3, RetryMode.Exponential, 1, 5, 30); // flags set
-        var pUnspecified = new RetryPolicyOptions { MaxRetries = 3, Mode = RetryMode.Exponential, DelaySeconds = 1, MaxDelaySeconds = 5, NetworkTimeoutSeconds = 30 }; // flags unset
+        var pSpecified = GetPolicy(3, RetryMode.Exponential, 1, 5, 30);
+        var pUnspecified = new RetryPolicyOptions();
         Assert.False(RetryPolicyOptions.AreEqual(pSpecified, pUnspecified));
         Assert.True(pSpecified != pUnspecified);
     }
@@ -72,11 +71,6 @@ public class RetryPolicyOptionsTests
             DelaySeconds = delay,
             MaxDelaySeconds = maxDelay,
             NetworkTimeoutSeconds = timeout,
-            HasMaxRetries = true,
-            HasMode = true,
-            HasDelaySeconds = true,
-            HasMaxDelaySeconds = true,
-            HasNetworkTimeoutSeconds = true
         };
     }
 }

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Services/Azure/BaseAzureServiceRetryLimitsTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Services/Azure/BaseAzureServiceRetryLimitsTests.cs
@@ -45,13 +45,9 @@ public class BaseAzureServiceRetryLimitsTests
             var retryPolicy = new RetryPolicyOptions
             {
                 MaxRetries = 100,
-                HasMaxRetries = true,
                 DelaySeconds = 200,
-                HasDelaySeconds = true,
                 MaxDelaySeconds = 500,
-                HasMaxDelaySeconds = true,
                 NetworkTimeoutSeconds = 1000,
-                HasNetworkTimeoutSeconds = true
             };
             var clientOptions = new ArmClientOptions();
 
@@ -80,9 +76,7 @@ public class BaseAzureServiceRetryLimitsTests
             var retryPolicy = new RetryPolicyOptions
             {
                 DelaySeconds = 0.001,
-                HasDelaySeconds = true,
                 MaxDelaySeconds = 0.005,
-                HasMaxDelaySeconds = true
             };
             var clientOptions = new ArmClientOptions();
 

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Services/Azure/BaseAzureServiceTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Services/Azure/BaseAzureServiceTests.cs
@@ -219,11 +219,11 @@ public class BaseAzureServiceTests
     [InlineData(5, true, 5)]   // below cap, should remain unchanged
     [InlineData(10, true, 10)] // at cap, should remain unchanged
     [InlineData(20, true, 10)] // above cap, should be capped
-    [InlineData(20, false, null)] // HasMaxRetries = false, should not override default
+    [InlineData(20, false, null)] // null MaxRetries, should not override default
     public void ConfigureRetryPolicy_RespectsAndCapsMaxRetries(int maxRetries, bool hasMaxRetries, int? expectedMaxRetries)
     {
         // Arrange
-        var retryPolicy = new RetryPolicyOptions { MaxRetries = maxRetries, HasMaxRetries = hasMaxRetries };
+        var retryPolicy = new RetryPolicyOptions { MaxRetries = hasMaxRetries ? maxRetries : null };
         var clientOptions = new ArmClientOptions();
         var defaultClientOptions = new ArmClientOptions();
         // Act
@@ -239,11 +239,11 @@ public class BaseAzureServiceTests
     [InlineData(0.1, true, 0.1)]    // at lower cap, should remain unchanged
     [InlineData(120.0, true, 60.0)]      // above upper cap, should be capped to 60
     [InlineData(0.01, true, 0.1)]   // below lower cap, should be raised to 0.1
-    [InlineData(120.0, false, null)]   // HasDelaySeconds = false, should not override default
+    [InlineData(120.0, false, null)]   // null DelaySeconds, should not override default
     public void ConfigureRetryPolicy_RespectsAndClampsDelay(double delaySeconds, bool hasDelay, double? expectedDelay)
     {
         // Arrange
-        var retryPolicy = new RetryPolicyOptions { DelaySeconds = delaySeconds, HasDelaySeconds = hasDelay };
+        var retryPolicy = new RetryPolicyOptions { DelaySeconds = hasDelay ? delaySeconds : null };
         var clientOptions = new ArmClientOptions();
         var defaultClientOptions = new ArmClientOptions();
         // Act
@@ -259,11 +259,11 @@ public class BaseAzureServiceTests
     [InlineData(0.1, true, 0.1)]    // at lower cap, should remain unchanged
     [InlineData(120.0, true, 60.0)]      // above upper cap, should be capped to 60
     [InlineData(0.01, true, 0.1)]   // below lower cap, should be raised to 0.1
-    [InlineData(120.0, false, null)]   // HasMaxDelaySeconds = false, should not override default
+    [InlineData(120.0, false, null)]   // null MaxDelaySeconds, should not override default
     public void ConfigureRetryPolicy_RespectsAndClampsMaxDelay(double maxDelaySeconds, bool hasMaxDelay, double? expectedMaxDelay)
     {
         // Arrange
-        var retryPolicy = new RetryPolicyOptions { MaxDelaySeconds = maxDelaySeconds, HasMaxDelaySeconds = hasMaxDelay };
+        var retryPolicy = new RetryPolicyOptions { MaxDelaySeconds = hasMaxDelay ? maxDelaySeconds : null };
         var clientOptions = new ArmClientOptions();
         var defaultClientOptions = new ArmClientOptions();
         // Act
@@ -277,11 +277,11 @@ public class BaseAzureServiceTests
     [InlineData(30.0, true, 30.0)]       // within bounds, should remain unchanged
     [InlineData(300.0, true, 300.0)]     // at cap, should remain unchanged
     [InlineData(600.0, true, 300.0)]     // above cap, should be capped to 300
-    [InlineData(600.0, false, null)]   // HasNetworkTimeoutSeconds = false, should not override default
+    [InlineData(600.0, false, null)]   // null NetworkTimeoutSeconds, should not override default
     public void ConfigureRetryPolicy_RespectsAndCapsNetworkTimeout(double networkTimeoutSeconds, bool hasNetworkTimeout, double? expectedTimeout)
     {
         // Arrange
-        var retryPolicy = new RetryPolicyOptions { NetworkTimeoutSeconds = networkTimeoutSeconds, HasNetworkTimeoutSeconds = hasNetworkTimeout };
+        var retryPolicy = new RetryPolicyOptions { NetworkTimeoutSeconds = hasNetworkTimeout ? networkTimeoutSeconds : null };
         var clientOptions = new ArmClientOptions();
         var defaultClientOptions = new ArmClientOptions();
         // Act

--- a/core/Microsoft.Mcp.Core/src/Commands/AuthenticatedCommand`2.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/AuthenticatedCommand`2.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using Azure;
+using Azure.Identity;
+using Microsoft.Identity.Client;
+
+namespace Microsoft.Mcp.Core.Commands;
+
+public abstract class AuthenticatedCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions, TResult> : BaseCommand<TOptions, TResult>
+    where TOptions : class
+{
+    protected override string GetErrorMessage(Exception ex) => ex switch
+    {
+        AuthenticationFailedException authEx =>
+            $"Authentication failed. Please run 'az login' to sign in to Azure. Details: {authEx.Message}",
+        RequestFailedException rfEx => HandleRequestFailedException(rfEx),
+        HttpRequestException httpEx =>
+            $"Service unavailable or network connectivity issues. Details: {httpEx.Message}",
+        TimeoutException timeoutEx =>
+            $"The operation timed out. Details: {timeoutEx.Message.TrimEnd('.')}",
+        TaskCanceledException canceledEx =>
+            $"The operation timed out or was canceled. Details: {canceledEx.Message.TrimEnd('.')}",
+        _ => ex.Message  // Just return the actual exception message
+    };
+
+    protected override HttpStatusCode GetStatusCode(Exception ex) => ex switch
+    {
+        ArgumentException => HttpStatusCode.BadRequest,
+        KeyNotFoundException => HttpStatusCode.NotFound,
+        AuthenticationFailedException => HttpStatusCode.Unauthorized,
+        RequestFailedException rfEx => (HttpStatusCode)rfEx.Status,
+        MsalServiceException msalServiceEx => (HttpStatusCode)msalServiceEx.StatusCode,
+        HttpRequestException httpEx => httpEx.StatusCode ?? HttpStatusCode.ServiceUnavailable,
+        InvalidOperationException => HttpStatusCode.UnprocessableEntity,
+        TimeoutException => HttpStatusCode.GatewayTimeout,
+        TaskCanceledException => HttpStatusCode.GatewayTimeout,
+        _ => HttpStatusCode.InternalServerError
+    };
+
+    private static string HandleRequestFailedException(RequestFailedException ex)
+    {
+        string message = ex.Message ?? string.Empty;
+
+        if (ex.Status == 401 && message.Contains("InvalidAuthenticationTokenTenant", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Authentication failed due to a tenant mismatch. " +
+            "Your credential is authenticated to a different Azure tenant than the one required by this subscription. " +
+            "To resolve: " +
+            "1. Authenticate to the target tenant using one of the supported credential types: " +
+            "   - Azure CLI: Run 'az login --tenant <tenant_id>' and set AZURE_TOKEN_CREDENTIALS=AzureCliCredential, " +
+            "   - Azure PowerShell: Run 'Connect-AzAccount -Tenant <tenant_id>' and set AZURE_TOKEN_CREDENTIALS=AzurePowerShellCredential, " +
+            "   - Azure Developer CLI: Run 'azd auth login --tenant-id <tenant_id>' and set AZURE_TOKEN_CREDENTIALS=AzureDeveloperCliCredential, " +
+            "2. Restart the MCP Server. " +
+            "For the complete list of supported credentials, see: https://aka.ms/azmcp/auth";
+        }
+
+        return message;
+    }
+}

--- a/core/Microsoft.Mcp.Core/src/Commands/BaseCommand`2.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/BaseCommand`2.cs
@@ -1,0 +1,233 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Azure;
+using Azure.Mcp.Core.Areas.Server;
+using Microsoft.Identity.Client;
+using Microsoft.Mcp.Core.Extensions;
+using Microsoft.Mcp.Core.Helpers;
+using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Core.Options;
+
+namespace Microsoft.Mcp.Core.Commands;
+
+public abstract class BaseCommand<[DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions, TResult> : IBaseCommand where TOptions : class
+{
+    private const string MissingRequiredOptionsPrefix = "Missing Required options: ";
+    private const string TroubleshootingUrl = "https://aka.ms/azmcp/troubleshooting";
+
+    private readonly Command _command;
+
+    [UnconditionalSuppressMessage("Trimming", "IL2075:UnrecognizedReflectionPattern",
+        Justification = "CommandMetadataAttribute is only applied to concrete command types that are rooted by DI service registration.")]
+    protected BaseCommand()
+    {
+        var attr = GetType().GetCustomAttribute<CommandMetadataAttribute>();
+        if (attr is not null)
+        {
+            Id = attr.Id;
+            Name = attr.Name;
+            Description = attr.Description;
+            Title = attr.Title;
+            Metadata = attr.ToToolMetadata();
+        }
+
+        ValidateMetadataConfiguration();
+
+        _command = new ExtendedCommand(this, Name, Description);
+        OptionBinder.RegisterOptions<TOptions>(_command);
+    }
+
+    public string Id { get; protected set; } = null!;
+    public string Name { get; protected set; } = null!;
+    public string Description { get; protected set; } = null!;
+    public string Title { get; protected set; } = null!;
+    public ToolMetadata Metadata { get; protected set; } = null!;
+
+    public Command GetCommand() => _command;
+
+    public virtual TOptions BindOptions(ParseResult parseResult)
+    {
+        return OptionBinder.BindOptions<TOptions>(parseResult);
+    }
+
+    public virtual void ValidateOptions(TOptions options, ValidationResult validationResult)
+    {
+    }
+
+    public abstract Task<CommandResponse> ExecuteAsync(CommandContext context, TOptions options, CancellationToken cancellationToken);
+
+    async Task<CommandResponse> IBaseCommand.ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        TOptions options;
+        try
+        {
+            options = BindOptions(parseResult);
+        }
+        catch (CommandValidationException ex)
+        {
+            HandleException(context, ex);
+            return context.Response;
+        }
+
+        var validationResult = new ValidationResult();
+        ValidateOptions(options, validationResult);
+
+        if (!validationResult.IsValid)
+        {
+            var errorMessage = string.Join('\n', validationResult.Errors);
+            SetValidationError(context.Response, errorMessage, HttpStatusCode.BadRequest);
+            return context.Response!;
+        }
+
+        CommandResponse response = await ExecuteAsync(context, options, cancellationToken);
+        return response;
+    }
+
+    protected virtual void HandleException(CommandContext context, Exception ex)
+    {
+        context.Activity?.SetStatus(ActivityStatusCode.Error)
+            ?.SetTag(TagName.ExceptionType, ex.GetType().ToString())
+            ?.SetTag(TagName.ExceptionStackTrace, ex.StackTrace);
+
+        var response = context.Response;
+
+        // Handle structured validation errors first
+        if (ex is CommandValidationException cve)
+        {
+            response.Status = cve.StatusCode;
+            // If specific missing options are provided, format a consistent message
+            if (cve.MissingOptions is { Count: > 0 })
+            {
+                response.Message = $"{MissingRequiredOptionsPrefix}{string.Join(", ", cve.MissingOptions)}";
+            }
+            else
+            {
+                response.Message = cve.Message;
+            }
+            // Include the command validation exception message as it should be safe. Requires custom validators to
+            // exclude any sensitive information from their error messages.
+            context.Activity?.SetTag(TagName.ExceptionMessage, response.Message);
+            response.Results = null;
+            return;
+        }
+
+        // Start with adding the status code of the exception.
+        var exceptionDetails = new JsonObject([new("StatusCode", (int)GetStatusCode(ex))]);
+        if (ex is RequestFailedException failedException)
+        {
+            // For RequestFailedException, we can include the error code and request ID.
+            exceptionDetails.Add("ErrorCode", failedException.ErrorCode);
+            exceptionDetails.Add("RequestId", failedException.GetRawResponse()?.ClientRequestId);
+        }
+        else if (ex is MsalServiceException msalServiceException)
+        {
+            // For MsalServiceException, we can include the error code and correlation ID.
+            exceptionDetails.Add("ErrorCode", msalServiceException.ErrorCode);
+            exceptionDetails.Add("CorrelationId", msalServiceException.CorrelationId);
+        }
+        else if (ex is MsalClientException msalClientException)
+        {
+            // For MsalClientException, we can include the error code and correlation ID.
+            exceptionDetails.Add("ErrorCode", msalClientException.ErrorCode);
+            exceptionDetails.Add("CorrelationId", msalClientException.CorrelationId);
+        }
+
+        context.Activity?.SetTag(TagName.ExceptionMessage, exceptionDetails);
+
+        var result = new ExceptionResult(
+            Message: ex.Message ?? string.Empty,
+#if DEBUG
+            StackTrace: ex.StackTrace,
+#else
+            StackTrace: null,
+#endif
+            Type: ex.GetType().Name);
+
+        response.Status = GetStatusCode(ex);
+        response.Message = GetErrorMessage(ex) + $". To mitigate this issue, please refer to the troubleshooting guidelines here at {TroubleshootingUrl}.";
+        response.Results = ResponseResult.Create(result, CoreJsonContext.Default.ExceptionResult);
+    }
+
+    protected virtual string GetErrorMessage(Exception ex) => ex.Message;
+
+    protected virtual HttpStatusCode GetStatusCode(Exception ex) => ex switch
+    {
+        ArgumentException => HttpStatusCode.BadRequest,  // Bad Request for invalid arguments
+        InvalidOperationException => HttpStatusCode.UnprocessableEntity,  // Unprocessable Entity for configuration errors
+        HttpRequestException httpEx => httpEx.StatusCode ?? HttpStatusCode.ServiceUnavailable,
+        RequestFailedException reqFailedEx => (HttpStatusCode)reqFailedEx.Status,
+        MsalServiceException msalServiceEx => (HttpStatusCode)msalServiceEx.StatusCode,
+        _ => HttpStatusCode.InternalServerError  // Internal Server Error for unexpected errors
+    };
+
+    ValidationResult IBaseCommand.Validate(CommandResult commandResult, CommandResponse? commandResponse)
+    {
+        var result = new ValidationResult();
+
+        // First, check for missing required options
+        var missingOptions = commandResult.Command.Options
+            .Where(o => o.Required && !o.HasDefaultValue && !commandResult.HasOptionResult(o))
+            .Select(o => $"--{NameNormalization.NormalizeOptionName(o.Name)}")
+            .ToList();
+
+        var missingOptionsJoined = string.Join(", ", missingOptions);
+
+        if (!string.IsNullOrEmpty(missingOptionsJoined))
+        {
+            result.Errors.Add($"{MissingRequiredOptionsPrefix}{missingOptionsJoined}");
+        }
+
+        // Check for parser/validator errors
+        if (commandResult.Errors != null && commandResult.Errors.Any())
+        {
+            result.Errors.Add(string.Join(", ", commandResult.Errors.Select(e => e.Message)));
+        }
+
+        if (!result.IsValid && commandResponse != null)
+        {
+            commandResponse.Status = HttpStatusCode.BadRequest;
+            commandResponse.Message = string.Join('\n', result.Errors);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Sets validation error details on the command response with a custom status code.
+    /// </summary>
+    /// <param name="response">The command response to update.</param>
+    /// <param name="errorMessage">The error message.</param>
+    /// <param name="statusCode">The HTTP status code (defaults to ValidationErrorStatusCode).</param>
+    protected static void SetValidationError(CommandResponse? response, string errorMessage, HttpStatusCode statusCode)
+    {
+        if (response != null)
+        {
+            response.Status = statusCode;
+            response.Message = errorMessage;
+        }
+    }
+
+    private void ValidateMetadataConfiguration()
+    {
+        if (!string.IsNullOrWhiteSpace(Id) &&
+            !string.IsNullOrWhiteSpace(Name) &&
+            !string.IsNullOrWhiteSpace(Description) &&
+            !string.IsNullOrWhiteSpace(Title) &&
+            Metadata is not null)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Command type '{GetType().FullName}' is missing required command metadata. " +
+            "Apply [CommandMetadata] to the command class or override Id, Name, Description, Title, and Metadata " +
+            "with non-null values that are available during BaseCommand construction.");
+    }
+}

--- a/core/Microsoft.Mcp.Core/src/Commands/GlobalCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/GlobalCommand.cs
@@ -84,20 +84,20 @@ public abstract class GlobalCommand<
         {
             var policy = new RetryPolicyOptions();
 
-            policy.HasMaxRetries = parseResult.TryGetValue(OptionDefinitions.RetryPolicy.MaxRetries.Name, out int maxRetries);
-            policy.MaxRetries = maxRetries;
+            if (parseResult.TryGetValue(OptionDefinitions.RetryPolicy.MaxRetries.Name, out int maxRetries))
+                policy.MaxRetries = maxRetries;
 
-            policy.HasDelaySeconds = parseResult.TryGetValue(OptionDefinitions.RetryPolicy.Delay.Name, out double delaySeconds);
-            policy.DelaySeconds = delaySeconds;
+            if (parseResult.TryGetValue(OptionDefinitions.RetryPolicy.Delay.Name, out double delaySeconds))
+                policy.DelaySeconds = delaySeconds;
 
-            policy.HasMaxDelaySeconds = parseResult.TryGetValue(OptionDefinitions.RetryPolicy.MaxDelay.Name, out double maxDelaySeconds);
-            policy.MaxDelaySeconds = maxDelaySeconds;
+            if (parseResult.TryGetValue(OptionDefinitions.RetryPolicy.MaxDelay.Name, out double maxDelaySeconds))
+                policy.MaxDelaySeconds = maxDelaySeconds;
 
-            policy.HasMode = parseResult.TryGetValue(OptionDefinitions.RetryPolicy.Mode.Name, out RetryMode mode);
-            policy.Mode = mode;
+            if (parseResult.TryGetValue(OptionDefinitions.RetryPolicy.Mode.Name, out RetryMode mode))
+                policy.Mode = mode;
 
-            policy.HasNetworkTimeoutSeconds = parseResult.TryGetValue(OptionDefinitions.RetryPolicy.NetworkTimeout.Name, out double networkTimeoutSeconds);
-            policy.NetworkTimeoutSeconds = networkTimeoutSeconds;
+            if (parseResult.TryGetValue(OptionDefinitions.RetryPolicy.NetworkTimeout.Name, out double networkTimeoutSeconds))
+                policy.NetworkTimeoutSeconds = networkTimeoutSeconds;
 
             // Only assign if at least one flag set (defensive)
             if (policy.HasMaxRetries || policy.HasDelaySeconds || policy.HasMaxDelaySeconds || policy.HasMode || policy.HasNetworkTimeoutSeconds)

--- a/core/Microsoft.Mcp.Core/src/Helpers/CommandHelper.cs
+++ b/core/Microsoft.Mcp.Core/src/Helpers/CommandHelper.cs
@@ -33,6 +33,13 @@ public static class CommandHelper
         // Get subscription from command line option or fallback to default subscription
         var subscriptionValue = parseResult.GetValueOrDefault(OptionDefinitions.Common.Subscription);
 
+        return GetSubscription(subscriptionValue);
+    }
+
+    public static string? GetSubscription(string? subscriptionValue)
+    {
+        subscriptionValue = subscriptionValue?.Trim('"', '\'');
+
         if (!string.IsNullOrEmpty(subscriptionValue) && !IsPlaceholder(subscriptionValue))
         {
             return subscriptionValue;

--- a/core/Microsoft.Mcp.Core/src/Options/OptionAttribute.cs
+++ b/core/Microsoft.Mcp.Core/src/Options/OptionAttribute.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Mcp.Core.Options;
+
+/// <summary>
+/// Overrides the implicit option definition derived from a public property on an options POCO.
+/// <para>
+/// By convention, every public property on the options class becomes a CLI option:
+/// <list type="bullet">
+///   <item><b>Name</b>: derived from the property name in kebab-case (e.g., <c>VaultName</c> → <c>--vault-name</c>).</item>
+///   <item><b>Required</b>: determined by nullability — non-nullable = required, nullable = optional.</item>
+///   <item><b>Type</b>: derived from the property's CLR type.</item>
+/// </list>
+/// Apply this attribute to override any of these defaults.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+public sealed class OptionAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance with default values.
+    /// Use named properties to override: <c>[Option(Name = "x", Description = "y", Hidden = true)]</c>.
+    /// </summary>
+    public OptionAttribute() { }
+
+    /// <summary>
+    /// Initializes a new instance with a description.
+    /// Shorthand for <c>[Option(Description = "...")]</c>.
+    /// </summary>
+    /// <param name="description">A description of what the option controls.</param>
+    public OptionAttribute(string description)
+    {
+        Description = description;
+    }
+
+    /// <summary>
+    /// Override the CLI option name (without the "--" prefix).
+    /// When null, the name is derived from the property name in kebab-case.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// A description of what the option controls. Used in help text and by AI agents.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Whether the option is hidden from help output.
+    /// </summary>
+    public bool Hidden { get; init; }
+}

--- a/core/Microsoft.Mcp.Core/src/Options/OptionBinder.cs
+++ b/core/Microsoft.Mcp.Core/src/Options/OptionBinder.cs
@@ -144,7 +144,7 @@ public static class OptionBinder
 
         // For array/collection types, allow multiple values after a single option token
         // e.g., --modules RedisBloom RedisJSON instead of --modules RedisBloom --modules RedisJSON
-        if (descriptor.Type.IsArray || descriptor.Type.IsAssignableTo(typeof(System.Collections.IEnumerable)) && descriptor.Type != typeof(string))
+        if (descriptor.Type.IsArray || (descriptor.Type != typeof(string) && descriptor.Type.IsAssignableTo(typeof(System.Collections.IEnumerable))))
         {
             option.Arity = ArgumentArity.OneOrMore;
             option.AllowMultipleArgumentsPerToken = true;

--- a/core/Microsoft.Mcp.Core/src/Options/OptionBinder.cs
+++ b/core/Microsoft.Mcp.Core/src/Options/OptionBinder.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Reflection;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
+
+namespace Microsoft.Mcp.Core.Options;
+
+/// <summary>
+/// Provides static methods for registering System.CommandLine options from TOptions POCOs
+/// and binding ParseResult values back to TOptions instances.
+/// </summary>
+public static class OptionBinder
+{
+    private static readonly MethodInfo GetValueOrDefaultMethod =
+        typeof(ParseResultExtensions)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m => m.Name == nameof(ParseResultExtensions.GetValueOrDefault)
+                && m.IsGenericMethodDefinition
+                && m.GetParameters().Length == 2
+                && m.GetParameters()[1].ParameterType == typeof(string));
+
+    /// <summary>
+    /// Registers System.CommandLine options on a command based on the public properties of <typeparamref name="TOptions"/>.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2055:MakeGenericType",
+        Justification = "Option<T> is used with property types rooted by the application.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Option<T> generic instantiation uses types rooted by the application.")]
+    public static void RegisterOptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TOptions>(Command command)
+        where TOptions : class
+    {
+        var descriptors = OptionDescriptor.FromType<TOptions>();
+        foreach (var descriptor in descriptors)
+        {
+            var option = CreateOption(descriptor);
+            command.Options.Add(option);
+        }
+    }
+
+    /// <summary>
+    /// Creates a new <typeparamref name="TOptions"/> instance and populates its properties
+    /// from the parsed command-line values.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2060:MakeGenericMethod",
+        Justification = "GetValueOrDefault<T> is called with property types rooted by the application.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Generic method instantiation uses types rooted by the application.")]
+    public static TOptions BindOptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TOptions>(ParseResult parseResult)
+        where TOptions : class
+    {
+        var instance = (TOptions)CreateInstance(typeof(TOptions));
+        var descriptors = OptionDescriptor.FromType<TOptions>();
+        List<string> missingOptions = [];
+        List<string> errors = [];
+        Dictionary<PropertyInfo, object>? parentInstances = null;
+
+        foreach (var descriptor in descriptors)
+        {
+            var optionName = $"--{descriptor.Name}";
+            var method = GetValueOrDefaultMethod.MakeGenericMethod(descriptor.Type);
+
+            object? value;
+            try
+            {
+                value = method.Invoke(null, [parseResult, optionName]);
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is InvalidOperationException or FormatException or OverflowException)
+            {
+                errors.Add($"Invalid value for '{optionName}': {ex.InnerException.Message}");
+                continue;
+            }
+
+            if (value is null)
+            {
+                if (descriptor.Required)
+                {
+                    missingOptions.Add(optionName);
+                }
+                continue;
+            }
+
+            if (descriptor.ParentProperty is not null)
+            {
+                parentInstances ??= [];
+                if (!parentInstances.TryGetValue(descriptor.ParentProperty, out var parent))
+                {
+                    parent = CreateInstance(descriptor.ParentProperty.PropertyType);
+                    parentInstances[descriptor.ParentProperty] = parent;
+                }
+                descriptor.TargetProperty.SetValue(parent, value);
+            }
+            else
+            {
+                descriptor.TargetProperty.SetValue(instance, value);
+            }
+        }
+
+        // Set any nested parent objects that had at least one child value provided
+        if (parentInstances is not null)
+        {
+            foreach (var (parentProp, parentObj) in parentInstances)
+            {
+                parentProp.SetValue(instance, parentObj);
+            }
+        }
+
+        if (missingOptions.Count > 0 || errors.Count > 0)
+        {
+            var messages = new List<string>();
+            if (missingOptions.Count > 0)
+            {
+                messages.Add($"Missing Required options: {string.Join(", ", missingOptions)}");
+            }
+            if (errors.Count > 0)
+            {
+                messages.AddRange(errors);
+            }
+
+            throw new CommandValidationException(
+                string.Join('\n', messages),
+                HttpStatusCode.BadRequest,
+                missingOptions: missingOptions);
+        }
+
+        return instance;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2055:MakeGenericType",
+        Justification = "Option<T> is used with property types rooted by the application.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Option<T> generic instantiation uses types rooted by the application.")]
+    private static Option CreateOption(OptionDescriptor descriptor)
+    {
+        var optionType = typeof(Option<>).MakeGenericType(descriptor.Type);
+        var option = (Option)Activator.CreateInstance(optionType, $"--{descriptor.Name}")!;
+        option.Description = descriptor.Description;
+        option.Required = descriptor.Required;
+        option.Hidden = descriptor.Hidden;
+
+        // For array/collection types, allow multiple values after a single option token
+        // e.g., --modules RedisBloom RedisJSON instead of --modules RedisBloom --modules RedisJSON
+        if (descriptor.Type.IsArray || descriptor.Type.IsAssignableTo(typeof(System.Collections.IEnumerable)) && descriptor.Type != typeof(string))
+        {
+            option.Arity = ArgumentArity.OneOrMore;
+            option.AllowMultipleArgumentsPerToken = true;
+        }
+
+        return option;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2067:UnrecognizedReflectionPattern",
+        Justification = "Nested option types are rooted by the application via property references.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Nested option types use parameterless constructors rooted by the application.")]
+    private static object CreateInstance(Type type)
+    {
+        return Activator.CreateInstance(type)
+            ?? throw new InvalidOperationException($"Failed to create instance of nested options type '{type.Name}'. Ensure it has a public parameterless constructor.");
+    }
+}

--- a/core/Microsoft.Mcp.Core/src/Options/OptionDescriptor.cs
+++ b/core/Microsoft.Mcp.Core/src/Options/OptionDescriptor.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.Mcp.Core.Commands;
+
+namespace Microsoft.Mcp.Core.Options;
+
+public class OptionDescriptor
+{
+    public required string Name { get; init; }
+    public string? Description { get; init; }
+    public bool Required { get; init; }
+    public bool Hidden { get; init; }
+    public required PropertyInfo TargetProperty { get; init; }
+    public required Type Type { get; init; }
+    public PropertyInfo? ParentProperty { get; init; }
+
+    public static OptionDescriptor[] FromType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>() where T : class
+    {
+        List<OptionDescriptor> optionDescriptors = [];
+        NullabilityInfoContext nullabilityContext = new();
+        CollectDescriptors(typeof(T), prefix: null, optionDescriptors, nullabilityContext);
+        return [.. optionDescriptors];
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070:UnrecognizedReflectionPattern",
+        Justification = "Nested option types are rooted by the application.")]
+    private static void CollectDescriptors(Type type, string? prefix, List<OptionDescriptor> descriptors, NullabilityInfoContext nullabilityContext, bool parentOptional = false, PropertyInfo? parentProperty = null)
+    {
+        PropertyInfo[] allProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        // When a derived class hides a base property with 'new', GetProperties returns both.
+        // Keep only the most-derived version (the one whose DeclaringType is closest to 'type').
+        Dictionary<string, PropertyInfo> deduped = new(StringComparer.Ordinal);
+        foreach (PropertyInfo p in allProperties)
+        {
+            if (!deduped.TryGetValue(p.Name, out PropertyInfo? existing) ||
+                (existing.DeclaringType is not null && p.DeclaringType is not null && existing.DeclaringType.IsAssignableFrom(p.DeclaringType)))
+            {
+                deduped[p.Name] = p;
+            }
+        }
+
+        foreach (PropertyInfo property in deduped.Values)
+        {
+            // Skip read-only properties (no setter) — they can't be bound from command-line args
+            if (!property.CanWrite)
+            {
+                continue;
+            }
+
+            OptionAttribute? optionAttribute = property.GetCustomAttribute<OptionAttribute>();
+            string name = optionAttribute?.Name ?? OptionNameConvention.ToKebabCase(property.Name);
+
+            if (!string.IsNullOrEmpty(prefix))
+            {
+                name = $"{prefix}-{name}";
+            }
+
+            if (IsComplexType(property.PropertyType))
+            {
+                bool isOptionalGroup = IsNullable(property, nullabilityContext);
+
+                // Flatten nested complex types with a prefix.
+                CollectDescriptors(property.PropertyType, name, descriptors, nullabilityContext, parentOptional: isOptionalGroup, parentProperty: property);
+            }
+            else
+            {
+                bool isNullable = IsNullable(property, nullabilityContext);
+
+                if (parentOptional && !isNullable)
+                {
+                    throw new InvalidOperationException(
+                        $"Optional group contains required member '{property.Name}'. " +
+                        "All properties within a nullable complex type must be nullable. " +
+                        "Either make the parent property required or make all child properties nullable.");
+                }
+
+
+                descriptors.Add(new OptionDescriptor
+                {
+                    Name = name,
+                    Description = optionAttribute?.Description,
+                    Type = property.PropertyType,
+                    Required = !isNullable,
+                    Hidden = optionAttribute?.Hidden ?? false,
+                    TargetProperty = property,
+                    ParentProperty = parentProperty
+                });
+            }
+        }
+    }
+
+    private static bool IsComplexType(Type type)
+    {
+        // Unwrap Nullable<T>
+        Type underlying = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (IsScalarType(underlying))
+        {
+            return false;
+        }
+
+        // Arrays and collections are leaf types, but only when their element type is scalar
+        // String is an IEnumerable<char>, but we treat it as a scalar type, so it will be handled above.
+        if (underlying.IsArray || underlying.IsAssignableTo(typeof(System.Collections.IEnumerable)))
+        {
+            Type? elementType = GetCollectionElementType(underlying);
+            if (elementType is not null && !IsScalarType(elementType))
+            {
+                throw new InvalidOperationException(
+                    $"Collection property with non-scalar element type '{elementType.Name}' is not supported. " +
+                    "Only collections of scalar types (string, int, enum, etc.) can be used as command options.");
+            }
+            return false;
+        }
+
+        // Everything else (classes, complex structs) is considered nested/complex
+        return true;
+    }
+
+    private static bool IsScalarType(Type type)
+    {
+        Type underlying = Nullable.GetUnderlyingType(type) ?? type;
+        return underlying.IsPrimitive ||
+               underlying.IsEnum ||
+               underlying == typeof(string) ||
+               underlying == typeof(decimal) ||
+               underlying == typeof(DateTime) ||
+               underlying == typeof(DateTimeOffset) ||
+               underlying == typeof(TimeSpan) ||
+               underlying == typeof(Guid) ||
+               underlying == typeof(Uri);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070:UnrecognizedReflectionPattern",
+        Justification = "Collection types used in option properties are rooted by the application.")]
+    private static Type? GetCollectionElementType(Type type)
+    {
+        if (type.IsArray)
+        {
+            return type.GetElementType();
+        }
+
+        // Look for IEnumerable<T>
+        return type.GetInterfaces()
+            .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            .Select(i => i.GetGenericArguments()[0])
+            .FirstOrDefault();
+    }
+
+    private static bool IsNullable(PropertyInfo property, NullabilityInfoContext nullabilityContext)
+    {
+        // Nullable value types (e.g., TimeSpan?)
+        if (Nullable.GetUnderlyingType(property.PropertyType) is not null)
+        {
+            return true;
+        }
+
+        // Nullable reference types (e.g., string?)
+        NullabilityInfo nullabilityInfo = nullabilityContext.Create(property);
+        return nullabilityInfo.WriteState == NullabilityState.Nullable;
+    }
+}

--- a/core/Microsoft.Mcp.Core/src/Options/OptionNameConvention.cs
+++ b/core/Microsoft.Mcp.Core/src/Options/OptionNameConvention.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+
+namespace Microsoft.Mcp.Core.Commands;
+
+/// <summary>
+/// Derives CLI option names from C# property names using kebab-case convention.
+/// Splits on PascalCase word boundaries and lowercases the result.
+/// Use <see cref="OptionAttribute.Name"/> to override when the convention doesn't produce the desired name.
+/// <example>
+///   <c>VaultName</c> → <c>vault-name</c>,
+///   <c>ResourceGroup</c> → <c>resource-group</c>,
+///   <c>Subscription</c> → <c>subscription</c>,
+///   <c>MaxRetries</c> → <c>max-retries</c>,
+///   <c>HTTPSOnly</c> → <c>https-only</c>.
+/// </example>
+/// </summary>
+public static class OptionNameConvention
+{
+    /// <summary>
+    /// Converts a PascalCase property name to a kebab-case option name (without "--" prefix).
+    /// </summary>
+    public static string ToKebabCase(string propertyName)
+    {
+        if (string.IsNullOrEmpty(propertyName))
+        {
+            return propertyName;
+        }
+
+        var sb = new StringBuilder(propertyName.Length + 4);
+
+        for (int i = 0; i < propertyName.Length; i++)
+        {
+            char c = propertyName[i];
+
+            if (char.IsUpper(c))
+            {
+                if (i > 0 && !char.IsUpper(propertyName[i - 1]))
+                {
+                    // camelCase boundary: "vaultName" → "vault-n"
+                    sb.Append('-');
+                }
+                else if (i > 0 && i + 1 < propertyName.Length
+                    && char.IsUpper(propertyName[i - 1]) && char.IsLower(propertyName[i + 1]))
+                {
+                    // Acronym-to-word boundary: "HTTPSOnly" → "https-only"
+                    sb.Append('-');
+                }
+
+                sb.Append(char.ToLowerInvariant(c));
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Returns the full CLI option flag (e.g., "--vault-name") for a property name.
+    /// </summary>
+    public static string ToOptionFlag(string propertyName) =>
+        $"--{ToKebabCase(propertyName)}";
+}

--- a/core/Microsoft.Mcp.Core/src/Options/RetryPolicyOptions.cs
+++ b/core/Microsoft.Mcp.Core/src/Options/RetryPolicyOptions.cs
@@ -8,38 +8,43 @@ using Microsoft.Mcp.Core.Models.Option;
 namespace Microsoft.Mcp.Core.Options;
 
 /// <summary>
-/// Represents retry policy configuration for Azure SDK clients
+/// Represents retry policy configuration for Azure SDK clients.
+/// All value properties are nullable — null means "use SDK default."
 /// </summary>
 public class RetryPolicyOptions : IComparable<RetryPolicyOptions>, IEquatable<RetryPolicyOptions>
 {
     [JsonPropertyName(OptionDefinitions.RetryPolicy.DelayName)]
-    public double DelaySeconds { get; set; }
+    [Option(Name = "delay", Description = "Initial delay in seconds between retry attempts. For exponential backoff, this value is used as the base.")]
+    public double? DelaySeconds { get; set; }
 
     [JsonPropertyName(OptionDefinitions.RetryPolicy.MaxDelayName)]
-    public double MaxDelaySeconds { get; set; }
+    [Option(Name = "max-delay", Description = "Maximum delay in seconds between retries, regardless of the retry strategy.")]
+    public double? MaxDelaySeconds { get; set; }
 
     [JsonPropertyName(OptionDefinitions.RetryPolicy.MaxRetriesName)]
-    public int MaxRetries { get; set; }
+    [Option(Name = "max-retries", Description = "Maximum number of retry attempts before giving up.")]
+    public int? MaxRetries { get; set; }
 
     [JsonPropertyName(OptionDefinitions.RetryPolicy.ModeName)]
-    public RetryMode Mode { get; set; }
+    [Option(Name = "mode", Description = "Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts.")]
+    public RetryMode? Mode { get; set; }
 
     [JsonPropertyName(OptionDefinitions.RetryPolicy.NetworkTimeoutName)]
-    public double NetworkTimeoutSeconds { get; set; }
+    [Option(Name = "network-timeout", Description = "Network operation timeout in seconds. Operations taking longer than this will be cancelled.")]
+    public double? NetworkTimeoutSeconds { get; set; }
 
-    // Flags indicating which options were explicitly provided by the caller.
-    // This allows us to only override the Azure SDK defaults for the specified settings.
-    public bool HasDelaySeconds { get; set; }
-    public bool HasMaxDelaySeconds { get; set; }
-    public bool HasMaxRetries { get; set; }
-    public bool HasMode { get; set; }
-    public bool HasNetworkTimeoutSeconds { get; set; }
+    // Derived flags indicating which options were explicitly provided by the caller.
+    [JsonIgnore]
+    public bool HasDelaySeconds => DelaySeconds.HasValue;
+    [JsonIgnore]
+    public bool HasMaxDelaySeconds => MaxDelaySeconds.HasValue;
+    [JsonIgnore]
+    public bool HasMaxRetries => MaxRetries.HasValue;
+    [JsonIgnore]
+    public bool HasMode => Mode.HasValue;
+    [JsonIgnore]
+    public bool HasNetworkTimeoutSeconds => NetworkTimeoutSeconds.HasValue;
 
-    /// <summary>
-    /// Compares this retry policy with another policy to check if all settings match
-    /// </summary>
-    /// <param name="other">The retry policy to compare with</param>
-    /// <returns>True if both policies have identical settings or are both null, false otherwise</returns>
     public static bool AreEqual(RetryPolicyOptions? policy1, RetryPolicyOptions? policy2)
     {
         if (ReferenceEquals(policy1, policy2))
@@ -52,11 +57,11 @@ public class RetryPolicyOptions : IComparable<RetryPolicyOptions>, IEquatable<Re
             return false;
         }
 
-        return policy1.HasMaxRetries == policy2.HasMaxRetries && (!policy1.HasMaxRetries || policy1.MaxRetries == policy2.MaxRetries) &&
-            policy1.HasMode == policy2.HasMode && (!policy1.HasMode || policy1.Mode == policy2.Mode) &&
-            policy1.HasDelaySeconds == policy2.HasDelaySeconds && (!policy1.HasDelaySeconds || policy1.DelaySeconds == policy2.DelaySeconds) &&
-            policy1.HasMaxDelaySeconds == policy2.HasMaxDelaySeconds && (!policy1.HasMaxDelaySeconds || policy1.MaxDelaySeconds == policy2.MaxDelaySeconds) &&
-            policy1.HasNetworkTimeoutSeconds == policy2.HasNetworkTimeoutSeconds && (!policy1.HasNetworkTimeoutSeconds || policy1.NetworkTimeoutSeconds == policy2.NetworkTimeoutSeconds);
+        return policy1.MaxRetries == policy2.MaxRetries &&
+            policy1.Mode == policy2.Mode &&
+            policy1.DelaySeconds == policy2.DelaySeconds &&
+            policy1.MaxDelaySeconds == policy2.MaxDelaySeconds &&
+            policy1.NetworkTimeoutSeconds == policy2.NetworkTimeoutSeconds;
     }
 
     public int CompareTo(RetryPolicyOptions? other)
@@ -64,54 +69,30 @@ public class RetryPolicyOptions : IComparable<RetryPolicyOptions>, IEquatable<Re
         if (other == null)
             return 1;
 
-        // Compare by whether MaxRetries was specified, then value
-        var retryComparison = HasMaxRetries.CompareTo(other.HasMaxRetries);
-        if (retryComparison != 0)
-            return retryComparison;
-        retryComparison = MaxRetries.CompareTo(other.MaxRetries);
-        if (retryComparison != 0)
-            return retryComparison;
+        var cmp = Nullable.Compare(MaxRetries, other.MaxRetries);
+        if (cmp != 0)
+            return cmp;
 
-        // Then by Mode specification
-        var modeComparison = HasMode.CompareTo(other.HasMode);
-        if (modeComparison != 0)
-            return modeComparison;
-        modeComparison = Mode.CompareTo(other.Mode);
-        if (modeComparison != 0)
-            return modeComparison;
+        cmp = Nullable.Compare(Mode, other.Mode);
+        if (cmp != 0)
+            return cmp;
 
-        // Then by delay settings (specified flag then value)
-        var delayFlagComparison = HasDelaySeconds.CompareTo(other.HasDelaySeconds);
-        if (delayFlagComparison != 0)
-            return delayFlagComparison;
-        var delayComparison = DelaySeconds.CompareTo(other.DelaySeconds);
-        if (delayComparison != 0)
-            return delayComparison;
+        cmp = Nullable.Compare(DelaySeconds, other.DelaySeconds);
+        if (cmp != 0)
+            return cmp;
 
-        var maxDelayFlagComparison = HasMaxDelaySeconds.CompareTo(other.HasMaxDelaySeconds);
-        if (maxDelayFlagComparison != 0)
-            return maxDelayFlagComparison;
-        var maxDelayComparison = MaxDelaySeconds.CompareTo(other.MaxDelaySeconds);
-        if (maxDelayComparison != 0)
-            return maxDelayComparison;
+        cmp = Nullable.Compare(MaxDelaySeconds, other.MaxDelaySeconds);
+        if (cmp != 0)
+            return cmp;
 
-        // Finally by network timeout flag then value
-        var networkTimeoutFlagComparison = HasNetworkTimeoutSeconds.CompareTo(other.HasNetworkTimeoutSeconds);
-        if (networkTimeoutFlagComparison != 0)
-            return networkTimeoutFlagComparison;
-        return NetworkTimeoutSeconds.CompareTo(other.NetworkTimeoutSeconds);
+        return Nullable.Compare(NetworkTimeoutSeconds, other.NetworkTimeoutSeconds);
     }
 
     public bool Equals(RetryPolicyOptions? other) => AreEqual(this, other);
 
     public override bool Equals(object? obj) => obj is RetryPolicyOptions other && Equals(other);
 
-    public override int GetHashCode()
-    {
-        var h1 = HashCode.Combine(HasMaxRetries, MaxRetries, HasMode, Mode, HasDelaySeconds);
-        var h2 = HashCode.Combine(DelaySeconds, HasMaxDelaySeconds, MaxDelaySeconds, HasNetworkTimeoutSeconds, NetworkTimeoutSeconds);
-        return HashCode.Combine(h1, h2);
-    }
+    public override int GetHashCode() => HashCode.Combine(MaxRetries, Mode, DelaySeconds, MaxDelaySeconds, NetworkTimeoutSeconds);
 
     public static bool operator ==(RetryPolicyOptions? left, RetryPolicyOptions? right) => AreEqual(left, right);
 

--- a/servers/Azure.Mcp.Server/src/Program.cs
+++ b/servers/Azure.Mcp.Server/src/Program.cs
@@ -7,6 +7,7 @@ using Azure.Mcp.Core.Services.Azure.ResourceGroup;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -322,6 +323,7 @@ internal class Program
         services.AddSingleton<IResourceGroupService, ResourceGroupService>();
         services.AddSingleton<ISubscriptionService, SubscriptionService>();
         services.AddSingleton<ICommandFactory, CommandFactory>();
+        services.AddSingleton<ISubscriptionResolver, SubscriptionResolver>();
 
         // !!! WARNING !!!
         // stdio-transport-specific implementations of ITenantService and ICacheService.

--- a/tools/Azure.Mcp.Tools.AppConfig/src/AppConfigSetup.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/AppConfigSetup.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.AppConfig.Commands.Account;
 using Azure.Mcp.Tools.AppConfig.Commands.KeyValue;
 using Azure.Mcp.Tools.AppConfig.Commands.KeyValue.Lock;
 using Azure.Mcp.Tools.AppConfig.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Mcp.Core.Areas;
 using Microsoft.Mcp.Core.Commands;
 

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/Lock/KeyValueLockSetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/Lock/KeyValueLockSetCommand.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Tools.AppConfig.Options;
+using Azure.Mcp.Core.Commands.Subscription;
+using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.AppConfig.Options.KeyValue.Lock;
 using Azure.Mcp.Tools.AppConfig.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
-using Microsoft.Mcp.Core.Extensions;
 using Microsoft.Mcp.Core.Models.Command;
 
 namespace Azure.Mcp.Tools.AppConfig.Commands.KeyValue.Lock;
@@ -28,47 +28,27 @@ namespace Azure.Mcp.Tools.AppConfig.Commands.KeyValue.Lock;
     ReadOnly = false,
     Secret = false,
     LocalRequired = false)]
-public sealed class KeyValueLockSetCommand(ILogger<KeyValueLockSetCommand> logger, IAppConfigService appConfigService)
-    : BaseKeyValueCommand<KeyValueLockSetOptions>()
+public sealed class KeyValueLockSetCommand(ILogger<KeyValueLockSetCommand> logger, IAppConfigService appConfigService, ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<KeyValueLockSetOptions, KeyValueLockSetCommand.KeyValueLockSetCommandResult>(subscriptionResolver)
 {
     private readonly ILogger<KeyValueLockSetCommand> _logger = logger;
     private readonly IAppConfigService _appConfigService = appConfigService;
 
-    protected override void RegisterOptions(Command command)
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, KeyValueLockSetOptions options, CancellationToken cancellationToken)
     {
-        base.RegisterOptions(command);
-        command.Options.Add(AppConfigOptionDefinitions.Lock);
-    }
-
-    protected override KeyValueLockSetOptions BindOptions(ParseResult parseResult)
-    {
-        var options = base.BindOptions(parseResult);
-        options.Lock = parseResult.GetValueOrDefault(AppConfigOptionDefinitions.Lock);
-        return options;
-    }
-
-    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
-        {
-            return context.Response;
-        }
-
-        var options = BindOptions(parseResult);
-
         try
         {
             await _appConfigService.SetKeyValueLockState(
-                options.Account!,
-                options.Key!,
-                options.Lock,
+                options.Account,
+                options.Key,
+                options.Lock ?? false,
                 options.Subscription!,
                 options.Tenant,
                 options.RetryPolicy,
                 options.Label,
                 cancellationToken);
 
-            context.Response.Results = ResponseResult.Create(new(options.Key!, options.Label, options.Lock), AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
+            context.Response.Results = ResponseResult.Create(new(options.Key, options.Label, options.Lock ?? false), AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
         }
         catch (Exception ex)
         {
@@ -80,5 +60,5 @@ public sealed class KeyValueLockSetCommand(ILogger<KeyValueLockSetCommand> logge
         return context.Response;
     }
 
-    internal record KeyValueLockSetCommandResult(string Key, string? Label, bool Locked);
+    public record KeyValueLockSetCommandResult(string Key, string? Label, bool Locked);
 }

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Options/KeyValue/Lock/KeyValueLockSetOptions.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Options/KeyValue/Lock/KeyValueLockSetOptions.cs
@@ -1,12 +1,31 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Text.Json.Serialization;
+using Azure.Mcp.Core.Options;
+using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.AppConfig.Options.KeyValue.Lock;
 
-public class KeyValueLockSetOptions : BaseKeyValueOptions
+public class KeyValueLockSetOptions : ISubscriptionOption
 {
-    [JsonPropertyName(AppConfigOptionDefinitions.LockName)]
-    public bool Lock { get; set; }
+    [Option(OptionDescriptions.Subscription)]
+    public string? Subscription { get; set; }
+
+    [Option("Whether a key-value will be locked (set to read-only) or unlocked (read-only removed).")]
+    public bool? Lock { get; set; }
+
+    [Option("The name of the App Configuration store (e.g., my-appconfig).")]
+    public required string Account { get; set; }
+
+    [Option("The name of the key to access within the App Configuration store.")]
+    public required string Key { get; set; }
+
+    [Option("The label to apply to the configuration key. Labels are used to group and organize settings.")]
+    public string? Label { get; set; }
+
+    [Option(OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
+    [Option(Name = "retry")]
+    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Mcp.Tools.AppConfig.UnitTests.KeyValue.Lock;
 
 public class KeyValueLockSetCommandTests : CommandUnitTestsBase<KeyValueLockSetCommand, IAppConfigService>
 {
-    ISubscriptionResolver _subscriptionResolver;
+    private readonly ISubscriptionResolver _subscriptionResolver;
 
     public KeyValueLockSetCommandTests()
     {

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.CommandLine;
 using System.Net;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.AppConfig.Commands;
@@ -17,9 +18,13 @@ namespace Azure.Mcp.Tools.AppConfig.UnitTests.KeyValue.Lock;
 
 public class KeyValueLockSetCommandTests : CommandUnitTestsBase<KeyValueLockSetCommand, IAppConfigService>
 {
+    ISubscriptionResolver _subscriptionResolver;
+    
     public KeyValueLockSetCommandTests()
     {
-        Services.AddSingleton<ISubscriptionResolver>(SubscriptionResolver.Instance);
+        _subscriptionResolver = Substitute.For<ISubscriptionResolver>();
+        _subscriptionResolver.ResolveSubscription(Arg.Any<string?>()).Returns(args => args[0]); // Return the input subscription for testing
+        Services.AddSingleton(_subscriptionResolver);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
@@ -19,11 +19,12 @@ namespace Azure.Mcp.Tools.AppConfig.UnitTests.KeyValue.Lock;
 public class KeyValueLockSetCommandTests : CommandUnitTestsBase<KeyValueLockSetCommand, IAppConfigService>
 {
     ISubscriptionResolver _subscriptionResolver;
-    
+
     public KeyValueLockSetCommandTests()
     {
         _subscriptionResolver = Substitute.For<ISubscriptionResolver>();
-        _subscriptionResolver.ResolveSubscription(Arg.Any<string?>()).Returns(args => args[0]); // Return the input subscription for testing
+        // Return the input subscription for testing
+        _subscriptionResolver.ResolveSubscription(Arg.Any<string?>()).Returns(args => args[0]);
         Services.AddSingleton(_subscriptionResolver);
     }
 

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.UnitTests/KeyValue/Lock/KeyValueLockSetCommandTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 using System.Net;
+using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.AppConfig.Commands;
 using Azure.Mcp.Tools.AppConfig.Commands.KeyValue.Lock;
 using Azure.Mcp.Tools.AppConfig.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
@@ -15,6 +17,11 @@ namespace Azure.Mcp.Tools.AppConfig.UnitTests.KeyValue.Lock;
 
 public class KeyValueLockSetCommandTests : CommandUnitTestsBase<KeyValueLockSetCommand, IAppConfigService>
 {
+    public KeyValueLockSetCommandTests()
+    {
+        Services.AddSingleton<ISubscriptionResolver>(SubscriptionResolver.Instance);
+    }
+
     [Fact]
     public async Task ExecuteAsync_LocksKeyValue_WhenValidParametersProvided()
     {

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
@@ -69,8 +69,10 @@ public sealed class CosmosService(ISubscriptionService subscriptionService, ITen
 
         if (retryPolicy != null)
         {
-            clientOptions.MaxRetryAttemptsOnRateLimitedRequests = retryPolicy.MaxRetries;
-            clientOptions.MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(retryPolicy.MaxDelaySeconds);
+            if (retryPolicy.MaxRetries is { } maxRetries)
+                clientOptions.MaxRetryAttemptsOnRateLimitedRequests = maxRetries;
+            if (retryPolicy.MaxDelaySeconds is { } maxDelaySeconds)
+                clientOptions.MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(maxDelaySeconds);
         }
 
         clientOptions.HttpClientFactory = () => _httpClientFactory.CreateClient();

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorService.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Nodes;
 using Azure.Core;
 using Azure.Core.Pipeline;
+using Azure.Mcp.Core.Options;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Core.Services.Azure.ResourceGroup;
 using Azure.Mcp.Core.Services.Azure.Subscription;
@@ -15,6 +16,7 @@ using Azure.Monitor.Query.Logs;
 using Azure.Monitor.Query.Logs.Models;
 using Azure.ResourceManager.OperationalInsights;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Azure.Authentication;
@@ -52,14 +54,7 @@ public class MonitorService(
         var options = AddDefaultPolicies(new LogsQueryClientOptions());
         options.Audience = GetLogsQueryAudience();
 
-        if (retryPolicy != null)
-        {
-            options.Retry.Delay = TimeSpan.FromSeconds(retryPolicy.DelaySeconds);
-            options.Retry.MaxDelay = TimeSpan.FromSeconds(retryPolicy.MaxDelaySeconds);
-            options.Retry.MaxRetries = retryPolicy.MaxRetries;
-            options.Retry.Mode = retryPolicy.Mode;
-            options.Retry.NetworkTimeout = TimeSpan.FromSeconds(retryPolicy.NetworkTimeoutSeconds);
-        }
+        options.ConfigureRetryOptions(retryPolicy);
         options.Transport = new HttpClientTransport(_httpClientFactory.CreateClient());
         var client = new LogsQueryClient(credential, options);
         var timeRange = new LogsQueryTimeRange(TimeSpan.FromHours(hours ?? 24));
@@ -117,14 +112,7 @@ public class MonitorService(
         var options = AddDefaultPolicies(new LogsQueryClientOptions());
         options.Audience = GetLogsQueryAudience();
 
-        if (retryPolicy != null)
-        {
-            options.Retry.Delay = TimeSpan.FromSeconds(retryPolicy.DelaySeconds);
-            options.Retry.MaxDelay = TimeSpan.FromSeconds(retryPolicy.MaxDelaySeconds);
-            options.Retry.MaxRetries = retryPolicy.MaxRetries;
-            options.Retry.Mode = retryPolicy.Mode;
-            options.Retry.NetworkTimeout = TimeSpan.FromSeconds(retryPolicy.NetworkTimeoutSeconds);
-        }
+        options.ConfigureRetryOptions(retryPolicy);
         options.Transport = new HttpClientTransport(_httpClientFactory.CreateClient());
         var client = new LogsQueryClient(credential, options);
 
@@ -259,14 +247,7 @@ public class MonitorService(
             var options = AddDefaultPolicies(new LogsQueryClientOptions());
             options.Audience = GetLogsQueryAudience();
 
-            if (retryPolicy != null)
-            {
-                options.Retry.Delay = TimeSpan.FromSeconds(retryPolicy.DelaySeconds);
-                options.Retry.MaxDelay = TimeSpan.FromSeconds(retryPolicy.MaxDelaySeconds);
-                options.Retry.MaxRetries = retryPolicy.MaxRetries;
-                options.Retry.Mode = retryPolicy.Mode;
-                options.Retry.NetworkTimeout = TimeSpan.FromSeconds(retryPolicy.NetworkTimeoutSeconds);
-            }
+            options.ConfigureRetryOptions(retryPolicy);
             options.Transport = new HttpClientTransport(_httpClientFactory.CreateClient());
             var client = new LogsQueryClient(credential, options);
             var timeRange = new LogsQueryTimeRange(TimeSpan.FromHours(hours ?? 24));

--- a/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
@@ -392,18 +392,6 @@ public sealed partial class SearchService(
         return results;
     }
 
-    private static void ConfigureRetryPolicy(SearchClientOptions options, RetryPolicyOptions? retryPolicy)
-    {
-        if (retryPolicy != null)
-        {
-            options.Retry.MaxRetries = retryPolicy.MaxRetries;
-            options.Retry.Mode = retryPolicy.Mode;
-            options.Retry.Delay = TimeSpan.FromSeconds(retryPolicy.DelaySeconds);
-            options.Retry.MaxDelay = TimeSpan.FromSeconds(retryPolicy.MaxDelaySeconds);
-            options.Retry.NetworkTimeout = TimeSpan.FromSeconds(retryPolicy.NetworkTimeoutSeconds);
-        }
-    }
-
     private static IndexInfo MapToIndexInfo(SearchIndex index)
         => new(index.Name, index.Description, [.. index.Fields.Select(MapToFieldInfo)]);
 

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/UpdateWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.UnitTests/UpdateWorkbooksCommandTests.cs
@@ -491,7 +491,7 @@ public class UpdateWorkbooksCommandTests : CommandUnitTestsBase<UpdateWorkbooksC
             Arg.Is(workbookId),
             Arg.Is("Test Workbook"),
             Arg.Is((string?)null),
-            Arg.Is<RetryPolicyOptions?>(x => x != null && x.MaxRetries == 5 && System.Math.Abs(x.DelaySeconds - 2.5) < 1e-6),
+            Arg.Is<RetryPolicyOptions?>(x => x != null && x.MaxRetries == 5 && System.Math.Abs(x.DelaySeconds.GetValueOrDefault() - 2.5) < 1e-6),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
## What does this PR do?
This pull request introduces significant refactoring to the Azure MCP command and options infrastructure, primarily to simplify option binding and validation, and to improve consistency across commands. The changes also include updates to retry policy configuration, test adjustments, and new project references.

- Removed SearchService's ConfigureRetryPolicy in favor of the common base class method

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
