### PR TITLE
Fix CS8629 errors in AppService Live tests

### DIFF
--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Deployment/DeploymentGetCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Deployment/DeploymentGetCommandLiveTests.cs
@@ -43,7 +43,7 @@ public class DeploymentGetCommandLiveTests(ITestOutputHelper output, TestProxyFi
                 { "app", webappName }
             });
 
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
 
         var getResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.DeploymentGetResult);
         Assert.NotNull(getResult);
@@ -68,7 +68,7 @@ public class DeploymentGetCommandLiveTests(ITestOutputHelper output, TestProxyFi
                 { "app", webappName },
                 { "deployment-id", deploymentId }
             });
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
 
         var getResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.DeploymentGetResult);
         Assert.NotNull(getResult);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Deployment/DeploymentGetCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Deployment/DeploymentGetCommandLiveTests.cs
@@ -43,6 +43,8 @@ public class DeploymentGetCommandLiveTests(ITestOutputHelper output, TestProxyFi
                 { "app", webappName }
             });
 
+        Assert.NotNull(result);
+
         var getResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.DeploymentGetResult);
         Assert.NotNull(getResult);
         Assert.NotEmpty(getResult.Deployments);
@@ -66,6 +68,7 @@ public class DeploymentGetCommandLiveTests(ITestOutputHelper output, TestProxyFi
                 { "app", webappName },
                 { "deployment-id", deploymentId }
             });
+        Assert.NotNull(result);
 
         var getResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.DeploymentGetResult);
         Assert.NotNull(getResult);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Diagnostic/DetectorDiagnoseCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Diagnostic/DetectorDiagnoseCommandLiveTests.cs
@@ -30,6 +30,7 @@ public class DetectorDiagnoseCommandLiveTests(ITestOutputHelper output, TestProx
                 { "app", webappName },
                 { "detector-id", "LinuxMemoryDrillDown"}
             });
+        Assert.NotNull(result);
 
         var detectorsResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.DetectorDiagnoseResult);
         Assert.NotNull(detectorsResult);
@@ -56,6 +57,7 @@ public class DetectorDiagnoseCommandLiveTests(ITestOutputHelper output, TestProx
                 { "end-time", DateTimeOffset.UtcNow.ToString("o") },
                 { "time-grain", "PT10M" }
             });
+        Assert.NotNull(result);
 
         var detectorsResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.DetectorDiagnoseResult);
         Assert.NotNull(detectorsResult);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Diagnostic/DetectorDiagnoseCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Diagnostic/DetectorDiagnoseCommandLiveTests.cs
@@ -30,7 +30,7 @@ public class DetectorDiagnoseCommandLiveTests(ITestOutputHelper output, TestProx
                 { "app", webappName },
                 { "detector-id", "LinuxMemoryDrillDown"}
             });
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
 
         var detectorsResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.DetectorDiagnoseResult);
         Assert.NotNull(detectorsResult);
@@ -57,7 +57,7 @@ public class DetectorDiagnoseCommandLiveTests(ITestOutputHelper output, TestProx
                 { "end-time", DateTimeOffset.UtcNow.ToString("o") },
                 { "time-grain", "PT10M" }
             });
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
 
         var detectorsResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.DetectorDiagnoseResult);
         Assert.NotNull(detectorsResult);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Diagnostic/DetectorListCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Diagnostic/DetectorListCommandLiveTests.cs
@@ -29,7 +29,7 @@ public class DetectorListCommandLiveTests(ITestOutputHelper output, TestProxyFix
                 { "resource-group", resourceGroupName },
                 { "app", webappName }
             });
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
 
         var detectorsResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.DetectorListResult);
         Assert.NotNull(detectorsResult);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Diagnostic/DetectorListCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Diagnostic/DetectorListCommandLiveTests.cs
@@ -29,6 +29,7 @@ public class DetectorListCommandLiveTests(ITestOutputHelper output, TestProxyFix
                 { "resource-group", resourceGroupName },
                 { "app", webappName }
             });
+        Assert.NotNull(result);
 
         var detectorsResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.DetectorListResult);
         Assert.NotNull(detectorsResult);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Settings/AppSettingsGetCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Settings/AppSettingsGetCommandLiveTests.cs
@@ -29,6 +29,7 @@ public class AppSettingsGetCommandLiveTests(ITestOutputHelper output, TestProxyF
                 { "resource-group", resourceGroupName },
                 { "app", webappName }
             });
+        Assert.NotNull(result);
 
         var getResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.AppSettingsGetResult);
         Assert.NotNull(getResult);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Settings/AppSettingsGetCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Settings/AppSettingsGetCommandLiveTests.cs
@@ -29,7 +29,7 @@ public class AppSettingsGetCommandLiveTests(ITestOutputHelper output, TestProxyF
                 { "resource-group", resourceGroupName },
                 { "app", webappName }
             });
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
 
         var getResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.AppSettingsGetResult);
         Assert.NotNull(getResult);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Settings/AppSettingsUpdateCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Settings/AppSettingsUpdateCommandLiveTests.cs
@@ -33,6 +33,7 @@ public class AppSettingsUpdateCommandLiveTests(ITestOutputHelper output, TestPro
                 { "setting-value", "SomeValue" },
                 { "setting-update-type", "add" }
             });
+        Assert.NotNull(result);
 
         var updateResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.AppSettingsUpdateResult);
         Assert.NotNull(updateResult);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Settings/AppSettingsUpdateCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/Settings/AppSettingsUpdateCommandLiveTests.cs
@@ -33,7 +33,7 @@ public class AppSettingsUpdateCommandLiveTests(ITestOutputHelper output, TestPro
                 { "setting-value", "SomeValue" },
                 { "setting-update-type", "add" }
             });
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
 
         var updateResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.AppSettingsUpdateResult);
         Assert.NotNull(updateResult);
@@ -60,6 +60,7 @@ public class AppSettingsUpdateCommandLiveTests(ITestOutputHelper output, TestPro
                 { "setting-value", "SomeValue" },
                 { "setting-update-type", "add" }
             });
+        Assert.True(result.HasValue);
 
         var updateResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.AppSettingsUpdateResult);
         Assert.NotNull(updateResult);
@@ -77,6 +78,7 @@ public class AppSettingsUpdateCommandLiveTests(ITestOutputHelper output, TestPro
                 { "setting-value", "SomeValue" },
                 { "setting-update-type", "add" }
             });
+        Assert.True(result.HasValue);
 
         updateResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.AppSettingsUpdateResult);
         Assert.NotNull(updateResult);
@@ -104,6 +106,7 @@ public class AppSettingsUpdateCommandLiveTests(ITestOutputHelper output, TestPro
                 { "setting-update-type", "set" }
             });
 
+        Assert.True(result.HasValue);
         var updateResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.AppSettingsUpdateResult);
         Assert.NotNull(updateResult);
         Assert.NotEmpty(updateResult.UpdateStatus);
@@ -121,6 +124,7 @@ public class AppSettingsUpdateCommandLiveTests(ITestOutputHelper output, TestPro
                 { "setting-update-type", "set" }
             });
 
+        Assert.True(result.HasValue);
         updateResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.AppSettingsUpdateResult);
         Assert.NotNull(updateResult);
         Assert.NotEmpty(updateResult.UpdateStatus);
@@ -147,6 +151,7 @@ public class AppSettingsUpdateCommandLiveTests(ITestOutputHelper output, TestPro
                 { "setting-update-type", "set" }
             });
 
+        Assert.True(result.HasValue);
         var updateResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.AppSettingsUpdateResult);
         Assert.NotNull(updateResult);
         Assert.NotEmpty(updateResult.UpdateStatus);
@@ -163,6 +168,7 @@ public class AppSettingsUpdateCommandLiveTests(ITestOutputHelper output, TestPro
                 { "setting-update-type", "delete" }
             });
 
+        Assert.True(result.HasValue);
         updateResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.AppSettingsUpdateResult);
         Assert.NotNull(updateResult);
         Assert.NotEmpty(updateResult.UpdateStatus);
@@ -188,6 +194,7 @@ public class AppSettingsUpdateCommandLiveTests(ITestOutputHelper output, TestPro
                 { "setting-update-type", "delete" }
             });
 
+        Assert.True(result.HasValue);
         var updateResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.AppSettingsUpdateResult);
         Assert.NotNull(updateResult);
         Assert.NotEmpty(updateResult.UpdateStatus);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/WebappGetCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/WebappGetCommandLiveTests.cs
@@ -26,7 +26,7 @@ public class WebappGetCommandLiveTests(ITestOutputHelper output, TestProxyFixtur
             {
                 { "subscription", Settings.SubscriptionId }
             });
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
 
         var getResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.WebappGetResult);
         Assert.NotNull(getResult);
@@ -48,7 +48,7 @@ public class WebappGetCommandLiveTests(ITestOutputHelper output, TestProxyFixtur
                 { "subscription", Settings.SubscriptionId },
                 { "resource-group", resourceGroupName }
             });
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
 
         var getResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.WebappGetResult);
         Assert.NotNull(getResult);
@@ -72,7 +72,7 @@ public class WebappGetCommandLiveTests(ITestOutputHelper output, TestProxyFixtur
                 { "resource-group", resourceGroupName },
                 { "app", webappName }
             });
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
 
         var getResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.WebappGetResult);
         Assert.NotNull(getResult);

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/WebappGetCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Webapp/WebappGetCommandLiveTests.cs
@@ -26,6 +26,7 @@ public class WebappGetCommandLiveTests(ITestOutputHelper output, TestProxyFixtur
             {
                 { "subscription", Settings.SubscriptionId }
             });
+        Assert.NotNull(result);
 
         var getResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.WebappGetResult);
         Assert.NotNull(getResult);
@@ -47,6 +48,7 @@ public class WebappGetCommandLiveTests(ITestOutputHelper output, TestProxyFixtur
                 { "subscription", Settings.SubscriptionId },
                 { "resource-group", resourceGroupName }
             });
+        Assert.NotNull(result);
 
         var getResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.WebappGetResult);
         Assert.NotNull(getResult);
@@ -70,6 +72,7 @@ public class WebappGetCommandLiveTests(ITestOutputHelper output, TestProxyFixtur
                 { "resource-group", resourceGroupName },
                 { "app", webappName }
             });
+        Assert.NotNull(result);
 
         var getResult = JsonSerializer.Deserialize(result.Value, AppServiceJsonContext.Default.WebappGetResult);
         Assert.NotNull(getResult);

--- a/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.LiveTests/SpeechCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.LiveTests/SpeechCommandTests.cs
@@ -106,6 +106,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
                 { "file", testAudioFile },
                 { "language", language },
             });
+        Assert.NotNull(result);
 
         // Assert
         using var doc = JsonDocument.Parse(result.Value.GetRawText());
@@ -150,6 +151,8 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
             });
 
         // Assert
+        Assert.NotNull(result);
+    
         using var doc = JsonDocument.Parse(result.Value.GetRawText());
         var inner = doc.RootElement.GetProperty("result").GetRawText();
         var resultObj = JsonSerializer.Deserialize<SpeechRecognitionResult>(inner);
@@ -207,6 +210,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
                 { "profanity", profanityOption }
             });
 
+        Assert.NotNull(result);
         using var doc = JsonDocument.Parse(result.Value.GetRawText());
         var inner = doc.RootElement.GetProperty("result").GetRawText();
         var resultObj = JsonSerializer.Deserialize<SpeechRecognitionResult>(inner);
@@ -247,6 +251,8 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
             });
 
         // Assert
+        Assert.NotNull(result);
+
         using var doc = JsonDocument.Parse(result.Value.GetRawText());
         var inner = doc.RootElement.GetProperty("result").GetRawText();
         var resultObj = JsonSerializer.Deserialize<SpeechRecognitionResult>(inner);
@@ -309,6 +315,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
                 });
 
             // Assert
+            Assert.NotNull(result);
             using var doc = JsonDocument.Parse(result.Value.GetRawText());
             var inner = doc.RootElement.GetProperty("result").GetRawText();
             var resultObj = JsonSerializer.Deserialize<SpeechRecognitionResult>(inner);
@@ -353,6 +360,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
                 });
 
             // Assert
+            Assert.NotNull(result);
             using var doc = JsonDocument.Parse(result.Value.GetRawText());
             var inner = doc.RootElement.GetProperty("result").GetRawText();
             var resultObj = JsonSerializer.Deserialize<SpeechRecognitionResult>(inner);
@@ -455,6 +463,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
             });
 
         // Assert
+        Assert.NotNull(result);
         using var doc = JsonDocument.Parse(result.Value.GetRawText());
         var inner = doc.RootElement.GetProperty("result").GetRawText();
         var resultObj = JsonSerializer.Deserialize<SpeechRecognitionResult>(inner);

--- a/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.LiveTests/SpeechCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.LiveTests/SpeechCommandTests.cs
@@ -106,7 +106,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
                 { "file", testAudioFile },
                 { "language", language },
             });
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
 
         // Assert
         using var doc = JsonDocument.Parse(result.Value.GetRawText());
@@ -151,7 +151,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
             });
 
         // Assert
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
     
         using var doc = JsonDocument.Parse(result.Value.GetRawText());
         var inner = doc.RootElement.GetProperty("result").GetRawText();
@@ -210,7 +210,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
                 { "profanity", profanityOption }
             });
 
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
         using var doc = JsonDocument.Parse(result.Value.GetRawText());
         var inner = doc.RootElement.GetProperty("result").GetRawText();
         var resultObj = JsonSerializer.Deserialize<SpeechRecognitionResult>(inner);
@@ -251,7 +251,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
             });
 
         // Assert
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
 
         using var doc = JsonDocument.Parse(result.Value.GetRawText());
         var inner = doc.RootElement.GetProperty("result").GetRawText();
@@ -286,7 +286,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
             });
 
         // Assert
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
 
         var resultText = result.ToString();
         Assert.NotNull(resultText);
@@ -315,7 +315,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
                 });
 
             // Assert
-            Assert.NotNull(result);
+            Assert.True(result.HasValue);
             using var doc = JsonDocument.Parse(result.Value.GetRawText());
             var inner = doc.RootElement.GetProperty("result").GetRawText();
             var resultObj = JsonSerializer.Deserialize<SpeechRecognitionResult>(inner);
@@ -360,7 +360,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
                 });
 
             // Assert
-            Assert.NotNull(result);
+            Assert.True(result.HasValue);
             using var doc = JsonDocument.Parse(result.Value.GetRawText());
             var inner = doc.RootElement.GetProperty("result").GetRawText();
             var resultObj = JsonSerializer.Deserialize<SpeechRecognitionResult>(inner);
@@ -410,7 +410,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
                 });
 
             // Assert
-            Assert.NotNull(result);
+            Assert.True(result.HasValue);
             var resultText = result.ToString();
             Assert.NotNull(resultText);
             Output.WriteLine("Recognition Result: " + resultText);
@@ -463,7 +463,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
             });
 
         // Assert
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
         using var doc = JsonDocument.Parse(result.Value.GetRawText());
         var inner = doc.RootElement.GetProperty("result").GetRawText();
         var resultObj = JsonSerializer.Deserialize<SpeechRecognitionResult>(inner);
@@ -505,7 +505,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
             });
 
         // Should handle empty file gracefully
-        Assert.NotNull(result);
+        Assert.True(result.HasValue);
         var resultText = result.ToString();
         Assert.NotNull(resultText);
 
@@ -550,7 +550,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
                 });
 
             // Verify successful response
-            Assert.NotNull(result);
+            Assert.True(result.HasValue);
             var resultText = result.ToString();
             Assert.NotNull(resultText);
 
@@ -605,7 +605,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
                     { "voice", voice }
                 });
 
-            Assert.NotNull(result);
+            Assert.True(result.HasValue);
             var resultText = result.ToString();
             Assert.NotNull(resultText);
 
@@ -658,7 +658,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
                     { "format", format }
                 });
 
-            Assert.NotNull(result);
+            Assert.True(result.HasValue);
             var resultText = result.ToString();
             Assert.NotNull(resultText);
 
@@ -773,7 +773,7 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
                     { "language", "en-US" }
                 });
 
-            Assert.NotNull(result);
+            Assert.True(result.HasValue);
             var resultText = result.ToString();
             Assert.NotNull(resultText);
 


### PR DESCRIPTION
## What does this PR do?

Fix CS8629 errors in AppService.LiveTests tests

Example:
DeploymentGetCommandLiveTests.cs(46,52): error CS8629: Nullable value type may be null. [/mnt/vss/_work/1/s/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.LiveTests/Azure.Mcp.Tools.AppService.LiveTests.csproj]

## GitHub issue number?

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
