### PR TITLE
Fix azureterraform_azapi_get to return 400 BadRequest for invalid resource type or API version

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/yunliu1-azapi-get-bad-request.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/yunliu1-azapi-get-bad-request.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed `azureterraform_azapi_get` returning `500 InternalServerError` for invalid resource type or API version inputs. The tool now returns `400 BadRequest` with an actionable message, enabling agents to auto-correct and retry with valid inputs."

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AzApiDocsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Commands/AzApiDocsGetCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.IO;
 using System.Net;
 using Azure.Mcp.Tools.AzureTerraform.Models;
 using Azure.Mcp.Tools.AzureTerraform.Options;
@@ -54,6 +55,12 @@ public sealed class AzApiDocsGetCommand(
             ApiVersion = parseResult.GetValueOrDefault<string>(AzureTerraformOptionDefinitions.ApiVersion.Name)
         };
     }
+
+    protected override HttpStatusCode GetStatusCode(Exception ex) => ex switch
+    {
+        InvalidDataException => HttpStatusCode.BadRequest,
+        _ => base.GetStatusCode(ex)
+    };
 
     public override async Task<CommandResponse> ExecuteAsync(
         CommandContext context,

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Services/AzApiDocsService.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Services/AzApiDocsService.cs
@@ -21,7 +21,19 @@ public sealed class AzApiDocsService : IAzApiDocsService
     public AzApiDocsResult GetDocumentation(string resourceTypeName, string? apiVersion = null)
     {
         var serviceProvider = s_schemaServiceProvider.Value;
-        TypesDefinitionResult typesResult = SchemaGenerator.GetResourceTypeDefinitions(serviceProvider, resourceTypeName, apiVersion);
+        TypesDefinitionResult typesResult;
+        try
+        {
+            typesResult = SchemaGenerator.GetResourceTypeDefinitions(serviceProvider, resourceTypeName, apiVersion);
+        }
+        catch (InvalidDataException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidDataException(ex.Message, ex);
+        }
         List<ComplexType> complexTypes = SchemaGenerator.GetResponse(typesResult);
 
         string resolvedApiVersion = typesResult.ApiVersion;

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Services/AzApiDocsService.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Services/AzApiDocsService.cs
@@ -21,19 +21,7 @@ public sealed class AzApiDocsService : IAzApiDocsService
     public AzApiDocsResult GetDocumentation(string resourceTypeName, string? apiVersion = null)
     {
         var serviceProvider = s_schemaServiceProvider.Value;
-        TypesDefinitionResult typesResult;
-        try
-        {
-            typesResult = SchemaGenerator.GetResourceTypeDefinitions(serviceProvider, resourceTypeName, apiVersion);
-        }
-        catch (InvalidDataException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidDataException(ex.Message, ex);
-        }
+        TypesDefinitionResult typesResult = SchemaGenerator.GetResourceTypeDefinitions(serviceProvider, resourceTypeName, apiVersion);
         List<ComplexType> complexTypes = SchemaGenerator.GetResponse(typesResult);
 
         string resolvedApiVersion = typesResult.ApiVersion;

--- a/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.Tests/AzApiDocsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.Tests/AzApiDocsGetCommandTests.cs
@@ -136,7 +136,7 @@ public class AzApiDocsGetCommandTests : CommandUnitTestsBase<AzApiDocsGetCommand
 
         var response = await ExecuteCommandAsync("--resource-type", "Microsoft.Fake/nonexistent");
 
-        Assert.NotEqual(HttpStatusCode.OK, response.Status);
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
     }
 
     [Theory]

--- a/tools/Azure.Mcp.Tools.BicepSchema/src/Services/ResourceProperties/ResourceVisitor.cs
+++ b/tools/Azure.Mcp.Tools.BicepSchema/src/Services/ResourceProperties/ResourceVisitor.cs
@@ -86,12 +86,13 @@ public class ResourceVisitor
     {
         (string providerName, _, _) = ResourceParser.ParseResourceType(resourceTypeName);
 
-        if (!GetAllResourceTypesAndVersionsByProvider().TryGetValue(providerName, out ProviderResourceTypes? provider))
+        if (!GetAllResourceTypesAndVersionsByProvider().TryGetValue(providerName, out ProviderResourceTypes? provider)
+            || !provider.ResourceTypes.TryGetValue(resourceTypeName.ToLowerInvariant(), out UniqueResourceType? uniqueResourceType))
         {
-            throw new Exception($"Resource type {resourceTypeName} not found.");
+            throw new InvalidDataException($"Resource type {resourceTypeName} not found.");
         }
 
-        return [.. provider.ResourceTypes[resourceTypeName.ToLowerInvariant()].ApiVersions];
+        return [.. uniqueResourceType.ApiVersions];
     }
 
     public TypesDefinitionResult LoadSingleResource(string resourceTypeName, string apiVersion)

--- a/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.Tests/GetSchemaTests.cs
+++ b/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.Tests/GetSchemaTests.cs
@@ -33,7 +33,7 @@ public class GetSchemaTests(ITestOutputHelper output)
         SchemaGenerator.ConfigureServices(serviceCollection);
         IServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
 
-        var exception = Assert.Throws<Exception>(() =>
+        var exception = Assert.Throws<InvalidDataException>(() =>
         {
             TypesDefinitionResult result = SchemaGenerator.GetResourceTypeDefinitions(serviceProvider, "Microsoft.Unknown/virtualRandom");
             _ = SchemaGenerator.GetResponse(result);


### PR DESCRIPTION
## What does this PR do?

When `azureterraform_azapi_get` is called with an invalid resource type or API version, the tool previously returned `500 InternalServerError`. This caused AI agents to interpret the failure as a server-side problem rather than a correctable input error, preventing auto-correction.

This PR fixes the issue by:
- **`AzApiDocsService`**: Wraps the schema lookup in a try/catch that normalizes any non-`InvalidDataException` from the BicepSchema layer (e.g., the generic `Exception` thrown when a resource type isn't found and `--api-version` is omitted) into `InvalidDataException`, ensuring consistent exception surfacing.
- **`AzApiDocsGetCommand`**: Overrides `GetStatusCode` to map `InvalidDataException → 400 BadRequest`, scoping the change strictly to this tool without touching shared core infrastructure.

With these changes, agents receive `400 BadRequest` with an actionable message (e.g., `"Resource type X does not have an apiVersion "Y". Available versions are: ..."`) and can retry with corrected input.

## GitHub issue number?
N/A

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [x] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*