### PR TITLE
azurebackup: Fix KQL classification order and update bug tracker in telemetry skill

### DIFF
--- a/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-telemetry-report/SKILL.md
+++ b/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-telemetry-report/SKILL.md
@@ -152,19 +152,24 @@ For the Outlook version, apply these rules:
 
 ## Error Classification Decision Tree
 
+> **Important:** MCP bug exception types must be checked **before** StatusCode.
+> The `HandleException` base class maps `ArgumentNullException` (inherits `ArgumentException`)
+> to HTTP 400, which would incorrectly classify MCP bugs as "Customer" errors if StatusCode
+> is checked first.
+
 ```
 Is success == true?
   └─ YES → "Success"
   └─ NO →
-      Is StatusCode 400/403/404?
-        └─ YES → "Customer (4xx)"
+      Is ExceptionType FormatException / ArgumentNullException / ArgumentException / InvalidOperationException?
+        └─ YES → "MCP Tool Bug"
         └─ NO →
+            Is StatusCode 400/403/404?
+              └─ YES → "Customer (4xx)"
             Is ExceptionType Azure.RequestFailedException with 5xx?
               └─ YES → "Azure Service"
             Is ExceptionType System.AggregateException?
               └─ YES → "Azure Service"
-            Is ExceptionType FormatException / ArgumentNullException / ArgumentException / InvalidOperationException?
-              └─ YES → "MCP Tool Bug"
             Otherwise → "Unknown" (investigate)
 ```
 
@@ -174,18 +179,21 @@ These are the bugs triaged from the original telemetry analysis (April 2026):
 
 | Bug | Tool | Description | Fix PR | Release |
 |-----|------|-------------|--------|---------|
-| BUG-1 | backup_status | ArgumentNullException on null ResourceType | #2518 (code included, not in PR title) | beta.7 |
+| BUG-1 | backup_status, protecteditem_get | ArgumentNullException on null ResourceType in MapArmResourceTypeToBackupDataSourceType | #2518 (partial), #2621 (defense-in-depth) | beta.7 (partial), beta.11 (pending) |
 | BUG-2 | protecteditem_protect | VM pre-discovery loop timeout | #2470 | beta.6 |
-| BUG-3 | protectableitem_list | Workload normalization ArgumentException | #2518 | beta.7 |
+| BUG-3 | protectableitem_list, find-unprotected | Workload normalization ArgumentException in ValidateAndParseResourceTypeFilter | #2518 (partial), #2621 (relaxed regex) | beta.7 (partial), beta.11 (pending) |
 | BUG-4 | soft-delete | Deprecated BackupResourceVaultConfig API | #2518 | beta.7 |
 | BUG-5 | enable-crr | Deprecated BackupResourceConfig API | #2518 | beta.7 |
 | BUG-6 | vault_get | FormatException on subscription name (non-GUID) | #2518 | beta.7 |
 | BUG-7 | protecteditem_protect | DPP vault missing managed identity | #2470 | beta.6 |
 | BUG-8 | recoverypoint_get | Null container in resolution | #2518 | beta.7 |
 | NEW-1 | vault_get | AggregateException — pre-existing auth race (Azure Service, not MCP bug) | Not filed | — |
+| NEW-2 | job_get | FormatException in DPP SDK — XmlConvert.ToTimeSpan fails during DataProtectionBackupJobProperties.Deserialize (Azure SDK bug, not MCP code) | #2621 (workaround catch), [azure-sdk#59306](https://github.com/Azure/azure-sdk-for-net/issues/59306) (upstream) | beta.11 (pending) |
 
 > **Note:** PR #2518 title says "Fix 5 telemetry-triaged bugs (BUG-3,4,5,6,8)" but the
-> actual merged code also includes the BUG-1 fix. Always verify the diff, not just the title.
+> actual merged code also includes the BUG-1 fix. However, the #2518 fixes for BUG-1 and
+> BUG-3 were **incomplete** — confirmed by telemetry on beta.8/beta.9. PR #2621 adds
+> defense-in-depth fixes for both. Always verify the diff, not just the title.
 
 When new errors appear, assign the next sequential ID (NEW-2, NEW-3, etc.) and add to this table.
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-telemetry-report/SKILL.md
+++ b/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-telemetry-report/SKILL.md
@@ -166,11 +166,12 @@ Is success == true?
         └─ NO →
             Is StatusCode 400/403/404?
               └─ YES → "Customer (4xx)"
-            Is ExceptionType Azure.RequestFailedException with 5xx?
-              └─ YES → "Azure Service"
-            Is ExceptionType System.AggregateException?
-              └─ YES → "Azure Service"
-            Otherwise → "Unknown" (investigate)
+              └─ NO →
+                  Is ExceptionType Azure.RequestFailedException with 5xx?
+                    └─ YES → "Azure Service"
+                  Is ExceptionType System.AggregateException?
+                    └─ YES → "Azure Service"
+                  Otherwise → "Unknown" (investigate)
 ```
 
 ## Known Bug IDs
@@ -179,16 +180,16 @@ These are the bugs triaged from the original telemetry analysis (April 2026):
 
 | Bug | Tool | Description | Fix PR | Release |
 |-----|------|-------------|--------|---------|
-| BUG-1 | backup_status, protecteditem_get | ArgumentNullException on null ResourceType in MapArmResourceTypeToBackupDataSourceType | #2518 (partial), #2621 (defense-in-depth) | beta.7 (partial), beta.11 (pending) |
+| BUG-1 | backup_status, protecteditem_get | ArgumentNullException on null ResourceType in MapArmResourceTypeToBackupDataSourceType | #2518 (partial), #2621 (defense-in-depth) | beta.7 (partial), pending |
 | BUG-2 | protecteditem_protect | VM pre-discovery loop timeout | #2470 | beta.6 |
-| BUG-3 | protectableitem_list, find-unprotected | Workload normalization ArgumentException in ValidateAndParseResourceTypeFilter | #2518 (partial), #2621 (relaxed regex) | beta.7 (partial), beta.11 (pending) |
+| BUG-3 | protectableitem_list, find-unprotected | Workload normalization ArgumentException in ValidateAndParseResourceTypeFilter | #2518 (partial), #2621 (relaxed regex) | beta.7 (partial), pending |
 | BUG-4 | soft-delete | Deprecated BackupResourceVaultConfig API | #2518 | beta.7 |
 | BUG-5 | enable-crr | Deprecated BackupResourceConfig API | #2518 | beta.7 |
 | BUG-6 | vault_get | FormatException on subscription name (non-GUID) | #2518 | beta.7 |
 | BUG-7 | protecteditem_protect | DPP vault missing managed identity | #2470 | beta.6 |
 | BUG-8 | recoverypoint_get | Null container in resolution | #2518 | beta.7 |
 | NEW-1 | vault_get | AggregateException — pre-existing auth race (Azure Service, not MCP bug) | Not filed | — |
-| NEW-2 | job_get | FormatException in DPP SDK — XmlConvert.ToTimeSpan fails during DataProtectionBackupJobProperties.Deserialize (Azure SDK bug, not MCP code) | #2621 (workaround catch), [azure-sdk#59306](https://github.com/Azure/azure-sdk-for-net/issues/59306) (upstream) | beta.11 (pending) |
+| NEW-2 | job_get | FormatException in DPP SDK — XmlConvert.ToTimeSpan fails during DataProtectionBackupJobProperties.Deserialize (Azure SDK bug, not MCP code) | #2621 (workaround catch), [azure-sdk#59306](https://github.com/Azure/azure-sdk-for-net/issues/59306) (upstream) | pending |
 
 > **Note:** PR #2518 title says "Fix 5 telemetry-triaged bugs (BUG-3,4,5,6,8)" but the
 > actual merged code also includes the BUG-1 fix. However, the #2518 fixes for BUG-1 and

--- a/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-telemetry-report/references/kql-queries.md
+++ b/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-telemetry-report/references/kql-queries.md
@@ -24,11 +24,11 @@ getAzureMcpEvents_ToolCalls(ago(7d), now())
 | extend StatusCode = toint(extract(@"StatusCode.*?(\d+)", 1, ExMsg))
 | extend ErrorCategory = case(
     success == true, "Success",
+    ExType in ("System.FormatException", "System.ArgumentNullException", "System.ArgumentException", "System.InvalidOperationException"), "McpToolBug",
     StatusCode >= 400 and StatusCode < 500, "Customer",
     ExType == "System.Collections.Generic.KeyNotFoundException", "Customer",
     ExType == "Azure.RequestFailedException" and StatusCode >= 500, "AzureService",
     ExType == "System.AggregateException", "AzureService",
-    ExType in ("System.FormatException", "System.ArgumentNullException", "System.ArgumentException", "System.InvalidOperationException"), "McpToolBug",
     "Unknown")
 | summarize
     Total = count(),
@@ -62,11 +62,11 @@ getAzureMcpEvents_ToolCalls(TwoWeeksAgo, now())
 | extend StatusCode = toint(extract(@"StatusCode.*?(\d+)", 1, ExMsg))
 | extend ErrorCategory = case(
     success == true, "Success",
+    ExType in ("System.FormatException", "System.ArgumentNullException", "System.ArgumentException", "System.InvalidOperationException"), "McpToolBug",
     StatusCode >= 400 and StatusCode < 500, "Customer",
     ExType == "System.Collections.Generic.KeyNotFoundException", "Customer",
     ExType == "Azure.RequestFailedException" and StatusCode >= 500, "AzureService",
     ExType == "System.AggregateException", "AzureService",
-    ExType in ("System.FormatException", "System.ArgumentNullException", "System.ArgumentException", "System.InvalidOperationException"), "McpToolBug",
     "Unknown")
 | summarize
     Total = count(),
@@ -111,11 +111,11 @@ getAzureMcpEvents_ToolCalls(ago(7d), now())
     ExType = tostring(customDimensions["exception.type"])
 | extend StatusCode = toint(extract(@"StatusCode.*?(\d+)", 1, ExMsg))
 | extend ErrorCategory = case(
+    ExType in ("System.FormatException", "System.ArgumentNullException", "System.ArgumentException", "System.InvalidOperationException"), "McpToolBug",
     StatusCode >= 400 and StatusCode < 500, "Customer",
     ExType == "System.Collections.Generic.KeyNotFoundException", "Customer",
     ExType == "Azure.RequestFailedException" and StatusCode >= 500, "AzureService",
     ExType == "System.AggregateException", "AzureService",
-    ExType in ("System.FormatException", "System.ArgumentNullException", "System.ArgumentException", "System.InvalidOperationException"), "McpToolBug",
     "Unknown")
 | summarize Count = count()
     by ToolName, StatusCode, ErrorCategory, ExType


### PR DESCRIPTION
## Summary

Fix incorrect error classification in telemetry KQL queries that masked MCP tool bugs as "Customer" errors. Update the SKILL.md decision tree and bug tracker to reflect current state.

## Problem

The KQL `case()` expression in `kql-queries.md` checked `StatusCode 400-499` **before** exception type. When our `HandleException` base class maps `ArgumentNullException` (inherits `ArgumentException`) to HTTP 400, the KQL classified it as "Customer" instead of "MCP Tool Bug". This caused the May 11-17 weekly report to undercount MCP bugs by ~33x (reported 1 instead of 34).

## Changes

### kql-queries.md (queries 1, 2, 4)
- Reorder `case()` to check MCP bug exception types (`FormatException`, `ArgumentNullException`, `ArgumentException`, `InvalidOperationException`) **before** `StatusCode 400-499`

### SKILL.md
- Update decision tree to check exception type before status code, matching the classification table
- Add explanatory note about `HandleException` mapping `ArgumentNullException` → HTTP 400
- Update bug tracker:
  - BUG-1: Mark #2518 as partial fix, add #2621 as defense-in-depth (confirmed incomplete on beta.8/beta.9)
  - BUG-3: Mark #2518 as partial, add #2621 relaxed regex
  - Add NEW-2 (job_get `FormatException` in DPP SDK `XmlConvert.ToTimeSpan`, upstream [azure-sdk-for-net#59306](https://github.com/Azure/azure-sdk-for-net/issues/59306))

## Testing

No code changes — skill documentation and KQL query fixes only. Verified queries produce correct classification against May 11-17 telemetry data.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.