### PR TITLE
Send clientType header in generate azcli request

### DIFF
--- a/tools/Azure.Mcp.Tools.Extension/src/Services/CliGenerateService.cs
+++ b/tools/Azure.Mcp.Tools.Extension/src/Services/CliGenerateService.cs
@@ -42,6 +42,7 @@ internal class CliGenerateService(IHttpClientFactory httpClientFactory, IAzureTo
             Content = content
         };
         requestMessage.Headers.Authorization = new("Bearer", accessToken.Token);
+        requestMessage.Headers.Add("clientType", "azuremcp");
         HttpResponseMessage responseMessage = await _httpClientFactory.CreateClient().SendAsync(requestMessage, cancellationToken);
         return responseMessage;
     }

--- a/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.Tests/CliGenerateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Extension/tests/Azure.Mcp.Tools.Extension.Tests/CliGenerateCommandTests.cs
@@ -3,9 +3,12 @@
 
 using System.CommandLine;
 using System.Net;
+using System.Net.Http;
+using Azure.Core;
 using Azure.Mcp.Tools.Extension.Commands;
 using Azure.Mcp.Tools.Extension.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Mcp.Core.Services.Azure.Authentication;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -90,5 +93,71 @@ public sealed class CliGenerateCommandTests : CommandUnitTestsBase<CliGenerateCo
         // Assert
         Assert.Equal([500], [(int)response.Status]);
         Assert.Contains("Test error", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SendsClientTypeHeader()
+    {
+        // Arrange
+        HttpRequestMessage? capturedRequest = null;
+
+        var handler = new HttpClientHandler();
+        var mockHttpMessageHandler = Substitute.ForPartsOf<MockHttpMessageHandler>();
+        mockHttpMessageHandler
+            .When(x => x.SendPublic(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>()))
+            .Do(callInfo =>
+            {
+                capturedRequest = callInfo.Arg<HttpRequestMessage>();
+            });
+        mockHttpMessageHandler
+            .SendPublic(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
+            .Returns(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("az storage account list") });
+
+        var httpClient = new HttpClient(mockHttpMessageHandler);
+        var httpClientFactory = new HttpClientFactoryStub(httpClient);
+
+        var tokenCredential = Substitute.For<TokenCredential>();
+        tokenCredential.GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(new AccessToken("mock-token", DateTimeOffset.UtcNow.AddHours(1)));
+
+        var tokenCredentialProvider = Substitute.For<IAzureTokenCredentialProvider>();
+        tokenCredentialProvider.GetTokenCredentialAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(tokenCredential);
+
+        var cloudConfiguration = Substitute.For<IAzureCloudConfiguration>();
+        cloudConfiguration.CloudType.Returns(AzureCloudConfiguration.AzureCloud.AzurePublicCloud);
+
+        var service = new CliGenerateService(httpClientFactory, tokenCredentialProvider, cloudConfiguration);
+
+        // Act
+        await service.GenerateAzureCLICommandAsync("list my storage accounts", CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(capturedRequest);
+        Assert.True(capturedRequest.Headers.Contains("clientType"), "Request should contain 'clientType' header");
+        var clientTypeValues = capturedRequest.Headers.GetValues("clientType").ToList();
+        Assert.Single(clientTypeValues);
+        Assert.Equal("azuremcp", clientTypeValues[0]);
+    }
+
+    /// <summary>
+    /// Helper class to expose protected Send method for testing.
+    /// </summary>
+    public abstract class MockHttpMessageHandler : HttpMessageHandler
+    {
+        public abstract Task<HttpResponseMessage> SendPublic(HttpRequestMessage request, CancellationToken cancellationToken);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => SendPublic(request, cancellationToken);
+    }
+
+    /// <summary>
+    /// Stub implementation of IHttpClientFactory that returns a fixed HttpClient.
+    /// </summary>
+    public sealed class HttpClientFactoryStub(HttpClient httpClient) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => httpClient;
+
+        public HttpClient CreateClient() => httpClient;
     }
 }


### PR DESCRIPTION
## What does this PR do?

Send a clientType header in requests to generate azcli API to help the service owner filter requests made from Azure MCP.

## GitHub issue number?
resolves: #1701 

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
