### PR TITLE
Fix AVM module-not-found returning HTTP 422 instead of 400

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/yunliu1-fix-avm-module-not-found-status.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/yunliu1-fix-avm-module-not-found-status.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed AVM module-not-found errors returning HTTP 422 instead of 400 by using ArgumentException for invalid module names"

--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Services/AvmDocsService.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Services/AvmDocsService.cs
@@ -32,7 +32,7 @@ public sealed class AvmDocsService(IHttpClientFactory httpClientFactory) : IAvmD
     {
         var modules = await GetModuleCollectionAsync(cancellationToken).ConfigureAwait(false);
         var module = modules.Find(m => string.Equals(m.ModuleName, moduleName, StringComparison.OrdinalIgnoreCase))
-            ?? throw new InvalidOperationException($"Module '{moduleName}' not found in available modules.");
+            ?? throw new ArgumentException($"Module '{moduleName}' not found in available modules.", nameof(moduleName));
 
         var apiUrl = module.RepoUrl
             .Replace("github.com", "api.github.com/repos", StringComparison.OrdinalIgnoreCase) + "/releases";
@@ -67,7 +67,7 @@ public sealed class AvmDocsService(IHttpClientFactory httpClientFactory) : IAvmD
     {
         var modules = await GetModuleCollectionAsync(cancellationToken).ConfigureAwait(false);
         var module = modules.Find(m => string.Equals(m.ModuleName, moduleName, StringComparison.OrdinalIgnoreCase))
-            ?? throw new InvalidOperationException($"Module '{moduleName}' not found in available modules.");
+            ?? throw new ArgumentException($"Module '{moduleName}' not found in available modules.", nameof(moduleName));
 
         var cleanVersion = moduleVersion.TrimStart('v');
 

--- a/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.Tests/AvmDocumentationGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.Tests/AvmDocumentationGetCommandTests.cs
@@ -58,7 +58,7 @@ public class AvmDocumentationGetCommandTests : CommandUnitTestsBase<AvmDocumenta
     public async Task ExecuteAsync_ServiceThrows_HandlesException()
     {
         Service.GetDocumentationAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("Module not found"));
+            .ThrowsAsync(new ArgumentException("Module not found", "moduleName"));
 
         var response = await ExecuteCommandAsync("--module-name", "nonexistent", "--module-version", "1.0.0");
 

--- a/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.Tests/AvmVersionListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/tests/Azure.Mcp.Tools.AzureTerraform.Tests/AvmVersionListCommandTests.cs
@@ -55,7 +55,7 @@ public class AvmVersionListCommandTests : CommandUnitTestsBase<AvmVersionListCom
     public async Task ExecuteAsync_ServiceThrows_HandlesException()
     {
         Service.GetVersionsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("Module not found"));
+            .ThrowsAsync(new ArgumentException("Module not found", "moduleName"));
 
         var response = await ExecuteCommandAsync("--module-name", "nonexistent-module");
 


### PR DESCRIPTION
## What does this PR do?

Fixes `AvmDocsService.GetVersionsAsync` and `GetDocumentationAsync` throwing `InvalidOperationException` when a module name is not found, which `BaseCommand.GetStatusCode` mapped to HTTP 422 (Unprocessable Entity). Since an invalid user-supplied module name is bad input rather than a configuration error, the exception type is changed to `ArgumentException`, which maps to HTTP 400 (Bad Request).

### Changes
- **`AvmDocsService.cs`**: Changed both "module not found" throws from `InvalidOperationException` to `ArgumentException` with proper `nameof(moduleName)` parameter
- **`AvmVersionListCommandTests.cs`** / **`AvmDocumentationGetCommandTests.cs`**: Updated test mocks to throw `ArgumentException` to match the new service behavior

## GitHub issue number
N/A — discovered during troubleshooting of HTTP 422 `System.InvalidOperationException` at `AvmDocsService.GetVersionsAsync`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [x] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] ~~Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation~~ (not applicable — no tool description or behavior changes visible to users)
    - [ ] ~~Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`~~ (not applicable)
    - [ ] ~~For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md)~~ (not applicable — no tool description changes)
    - [ ] ~~For tools with new names, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)~~ (not applicable)
    - [ ] ~~For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md)~~ (not applicable)
    - [ ] ~~For new tools associated with Azure services, add URL to documentation in the PR description~~ (not applicable)