### PR TITLE
Fix ServiceBus Tools Issues

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1779255080548.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1779255080548.yaml
@@ -1,0 +1,7 @@
+changes:
+  - section: "Bugs Fixed"
+    description: |
+      Fixed multiple issues in Azure Service Bus commands:
+      - `--subscription` option was incorrectly required on `queue details`, `topic details`, and `topic subscription details` commands; the option has been removed since the namespace FQDN is sufficient for authentication.
+      - `topic details` returned "Subscription not found" when a topic did not exist; the error message now correctly reads "Topic not found".
+      - Malformed namespace names (containing path separators or other invalid characters) raised a `SecurityException`; they now raise an `ArgumentException` to correctly signal invalid input rather than a security violation.

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3542,20 +3542,17 @@ azmcp resourcehealth health-events list --subscription <subscription> \
 ```bash
 # Returns runtime and details about the Service Bus queue
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp servicebus queue details --subscription <subscription> \
-                               --namespace <service-bus-namespace> \
+azmcp servicebus queue details --namespace <service-bus-namespace> \
                                --queue <queue>
 
 # Gets runtime details a Service Bus topic
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp servicebus topic details --subscription <subscription> \
-                               --namespace <service-bus-namespace> \
+azmcp servicebus topic details --namespace <service-bus-namespace> \
                                --topic <topic>
 
 # Gets runtime details and message counts for a Service Bus subscription
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp servicebus topic subscription details --subscription <subscription> \
-                                            --namespace <service-bus-namespace> \
+azmcp servicebus topic subscription details --namespace <service-bus-namespace> \
                                             --topic <topic> \
                                             --subscription-name <subscription-name>
 ```

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Queue/QueueDetailsCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Queue/QueueDetailsCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Tools.ServiceBus.Models;
 using Azure.Mcp.Tools.ServiceBus.Options;
 using Azure.Mcp.Tools.ServiceBus.Options.Queue;
@@ -33,7 +32,7 @@ namespace Azure.Mcp.Tools.ServiceBus.Commands.Queue;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class QueueDetailsCommand(ILogger<QueueDetailsCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<BaseQueueOptions>
+public sealed class QueueDetailsCommand(ILogger<QueueDetailsCommand> logger, IServiceBusService serviceBusService) : GlobalCommand<BaseQueueOptions>
 {
     private readonly ILogger<QueueDetailsCommand> _logger = logger;
     private readonly IServiceBusService _serviceBusService = serviceBusService;

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Queue/QueuePeekCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Queue/QueuePeekCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Tools.ServiceBus.Options;
 using Azure.Mcp.Tools.ServiceBus.Options.Queue;
 using Azure.Mcp.Tools.ServiceBus.Services;
@@ -35,7 +34,7 @@ namespace Azure.Mcp.Tools.ServiceBus.Commands.Queue;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class QueuePeekCommand(ILogger<QueuePeekCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<QueuePeekOptions>
+public sealed class QueuePeekCommand(ILogger<QueuePeekCommand> logger, IServiceBusService serviceBusService) : GlobalCommand<QueuePeekOptions>
 {
     private readonly ILogger<QueuePeekCommand> _logger = logger;
     private readonly IServiceBusService _serviceBusService = serviceBusService;

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/SubscriptionDetailsCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/SubscriptionDetailsCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Tools.ServiceBus.Models;
 using Azure.Mcp.Tools.ServiceBus.Options;
 using Azure.Mcp.Tools.ServiceBus.Options.Topic;
@@ -33,7 +32,7 @@ namespace Azure.Mcp.Tools.ServiceBus.Commands.Topic;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class SubscriptionDetailsCommand(ILogger<SubscriptionDetailsCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<SubscriptionDetailsOptions>
+public sealed class SubscriptionDetailsCommand(ILogger<SubscriptionDetailsCommand> logger, IServiceBusService serviceBusService) : GlobalCommand<SubscriptionDetailsOptions>
 {
     private readonly ILogger<SubscriptionDetailsCommand> _logger = logger;
     private readonly IServiceBusService _serviceBusService = serviceBusService;

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/SubscriptionPeekCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/SubscriptionPeekCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Tools.ServiceBus.Options;
 using Azure.Mcp.Tools.ServiceBus.Options.Topic;
 using Azure.Mcp.Tools.ServiceBus.Services;
@@ -36,7 +35,7 @@ namespace Azure.Mcp.Tools.ServiceBus.Commands.Topic;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class SubscriptionPeekCommand(ILogger<SubscriptionPeekCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<SubscriptionPeekOptions>
+public sealed class SubscriptionPeekCommand(ILogger<SubscriptionPeekCommand> logger, IServiceBusService serviceBusService) : GlobalCommand<SubscriptionPeekOptions>
 {
     private readonly ILogger<SubscriptionPeekCommand> _logger = logger;
     private readonly IServiceBusService _serviceBusService = serviceBusService;

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/TopicDetailsCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Commands/Topic/TopicDetailsCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Tools.ServiceBus.Models;
 using Azure.Mcp.Tools.ServiceBus.Options;
 using Azure.Mcp.Tools.ServiceBus.Options.Topic;
@@ -30,7 +29,7 @@ namespace Azure.Mcp.Tools.ServiceBus.Commands.Topic;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class TopicDetailsCommand(ILogger<TopicDetailsCommand> logger, IServiceBusService serviceBusService) : SubscriptionCommand<BaseTopicOptions>
+public sealed class TopicDetailsCommand(ILogger<TopicDetailsCommand> logger, IServiceBusService serviceBusService) : GlobalCommand<BaseTopicOptions>
 {
     private readonly ILogger<TopicDetailsCommand> _logger = logger;
     private readonly IServiceBusService _serviceBusService = serviceBusService;
@@ -82,7 +81,7 @@ public sealed class TopicDetailsCommand(ILogger<TopicDetailsCommand> logger, ISe
     protected override string GetErrorMessage(Exception ex) => ex switch
     {
         ServiceBusException exception when exception.Reason == ServiceBusFailureReason.MessagingEntityNotFound =>
-            $"Subscription not found. Please check the topic and subscription name and try again.",
+            $"Topic not found. Please check the topic name and try again.",
         _ => base.GetErrorMessage(ex)
     };
 

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Options/Queue/BaseQueueOptions.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Options/Queue/BaseQueueOptions.cs
@@ -5,7 +5,7 @@ using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.ServiceBus.Options.Queue
 {
-    public class BaseQueueOptions : SubscriptionOptions
+    public class BaseQueueOptions : GlobalOptions
     {
         /// <summary>
         /// Service Bus namespace.

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Options/Topic/BaseTopicOptions.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Options/Topic/BaseTopicOptions.cs
@@ -5,7 +5,7 @@ using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.ServiceBus.Options.Topic;
 
-public class BaseTopicOptions : SubscriptionOptions
+public class BaseTopicOptions : GlobalOptions
 {
     /// <summary>
     /// Service Bus namespace.

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/ServiceBusSetup.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/ServiceBusSetup.cs
@@ -21,10 +21,10 @@ public class ServiceBusSetup : IAreaSetup
         services.AddSingleton<IServiceBusService, ServiceBusService>();
 
         services.AddSingleton<QueueDetailsCommand>();
-        services.AddSingleton<QueuePeekCommand>();
+        // services.AddSingleton<QueuePeekCommand>();  // Not yet exposed; enable when ready
         services.AddSingleton<TopicDetailsCommand>();
         services.AddSingleton<SubscriptionDetailsCommand>();
-        services.AddSingleton<SubscriptionPeekCommand>();
+        // services.AddSingleton<SubscriptionPeekCommand>();  // Not yet exposed; enable when ready
     }
 
     public CommandGroup RegisterCommands(IServiceProvider serviceProvider)
@@ -32,14 +32,14 @@ public class ServiceBusSetup : IAreaSetup
         var serviceBus = new CommandGroup(Name, "Service Bus operations - Commands to manage Azure Service Bus queues, topics, and subscriptions for reliable asynchronous messaging and enterprise integration. Supports point-to-point and publish-subscribe patterns, dead-letter handling, and decoupled architectures. Not intended for real-time communication, direct API calls, or database operations. Uses a hierarchical MCP command model with command, parameters, and learn=true.", Title);
 
         var queue = new CommandGroup("queue", "Queue operations - Commands for using Azure Service Bus queues.");
-        // queue.AddCommand<QueuePeekCommand>(serviceProvider);
+        // queue.AddCommand<QueuePeekCommand>(serviceProvider);  // Not yet exposed; enable when ready
         queue.AddCommand<QueueDetailsCommand>(serviceProvider);
 
         var topic = new CommandGroup("topic", "Topic operations - Commands for using Azure Service Bus topics and subscriptions.");
         topic.AddCommand<TopicDetailsCommand>(serviceProvider);
 
         var subscription = new CommandGroup("subscription", "Subscription operations - Commands for using subscriptions within a Service Bus topic.");
-        // subscription.AddCommand<SubscriptionPeekCommand>(serviceProvider);
+        // subscription.AddCommand<SubscriptionPeekCommand>(serviceProvider);  // Not yet exposed; enable when ready
         subscription.AddCommand<SubscriptionDetailsCommand>(serviceProvider);
 
         serviceBus.AddSubGroup(queue);

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Services/IServiceBusService.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Services/IServiceBusService.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Messaging.ServiceBus;
 using Azure.Mcp.Tools.ServiceBus.Models;
+using Azure.Messaging.ServiceBus;
 using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.ServiceBus.Services;

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Services/IServiceBusService.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Services/IServiceBusService.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Tools.ServiceBus.Models;
 using Azure.Messaging.ServiceBus;
+using Azure.Mcp.Tools.ServiceBus.Models;
 using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.ServiceBus.Services;

--- a/tools/Azure.Mcp.Tools.ServiceBus/src/Services/ServiceBusService.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/Services/ServiceBusService.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Security;
 using Azure.Core.Pipeline;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Core.Services.Azure.Tenant;
@@ -13,7 +12,7 @@ using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.ServiceBus.Services;
 
-public class ServiceBusService(ITenantService tenantService) : BaseAzureService(tenantService), IServiceBusService
+public sealed class ServiceBusService(ITenantService tenantService) : BaseAzureService(tenantService), IServiceBusService
 {
     private void ValidateNamespace(string namespaceName)
     {
@@ -21,8 +20,9 @@ public class ServiceBusService(ITenantService tenantService) : BaseAzureService(
         // A fully-qualified namespace must be a bare hostname (e.g. "mynamespace.servicebus.windows.net").
         if (namespaceName.AsSpan().IndexOfAny("/:?#@") >= 0)
         {
-            throw new SecurityException(
-                "Service Bus namespace must be a host name only, without scheme, port, path, query, or fragment components.");
+            throw new ArgumentException(
+                $"Namespace name contains invalid characters. A fully-qualified namespace must be a bare hostname (e.g. 'mynamespace.servicebus.windows.net'). Received: '{namespaceName}'.",
+                nameof(namespaceName));
         }
 
         EndpointValidator.ValidateAzureServiceEndpoint(

--- a/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.Tests/Queue/QueueDetailsCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.Tests/Queue/QueueDetailsCommandTests.cs
@@ -18,7 +18,6 @@ namespace Azure.Mcp.Tools.ServiceBus.Tests.Queue;
 public class QueueDetailsCommandTests : CommandUnitTestsBase<QueueDetailsCommand, IServiceBusService>
 {
     // Test constants
-    private const string SubscriptionId = "sub123";
     private const string QueueName = "testQueue";
     private const string NamespaceName = "test.servicebus.windows.net";
 
@@ -49,7 +48,6 @@ public class QueueDetailsCommandTests : CommandUnitTestsBase<QueueDetailsCommand
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", SubscriptionId,
             "--namespace", NamespaceName,
             "--queue", QueueName);
 
@@ -77,7 +75,6 @@ public class QueueDetailsCommandTests : CommandUnitTestsBase<QueueDetailsCommand
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", SubscriptionId,
             "--namespace", NamespaceName,
             "--queue", QueueName);
 
@@ -103,7 +100,6 @@ public class QueueDetailsCommandTests : CommandUnitTestsBase<QueueDetailsCommand
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", SubscriptionId,
             "--namespace", NamespaceName,
             "--queue", QueueName);
 
@@ -114,10 +110,9 @@ public class QueueDetailsCommandTests : CommandUnitTestsBase<QueueDetailsCommand
     }
 
     [Theory]
-    [InlineData("--subscription sub123 --namespace test.servicebus.windows.net --queue testQueue", true)]
-    [InlineData("--namespace test.servicebus.windows.net --queue testQueue", false)]  // Missing subscription
-    [InlineData("--subscription sub123 --queue testQueue", false)]   // Missing namespace
-    [InlineData("--subscription sub123 --namespace test.servicebus.windows.net", false)] // Missing queue
+    [InlineData("--namespace test.servicebus.windows.net --queue testQueue", true)]
+    [InlineData("--queue testQueue", false)]   // Missing namespace
+    [InlineData("--namespace test.servicebus.windows.net", false)] // Missing queue
     [InlineData("", false)]  // Missing all required options
     public async Task ExecuteAsync_ValidatesRequiredParameters(string args, bool shouldSucceed)
     {

--- a/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.Tests/Services/ServiceBusServiceNamespaceValidationTests.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.Tests/Services/ServiceBusServiceNamespaceValidationTests.cs
@@ -89,21 +89,21 @@ public class ServiceBusServiceNamespaceValidationTests
     [InlineData("test.servicebus.windows.net:443")]
     [InlineData("test.servicebus.windows.net?q=1")]
     [InlineData("https://test.servicebus.windows.net")]
-    public async Task GetQueueDetails_RejectsNonHostNamespaceValues(string namespaceName)
+    public async Task GetQueueDetails_RejectsMalformedNamespace(string namespaceName)
     {
-        var ex = await Assert.ThrowsAsync<SecurityException>(
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
             () => _service.GetQueueDetails(namespaceName, "testQueue", cancellationToken: TestContext.Current.CancellationToken));
-        Assert.Contains("host name only", ex.Message);
+        Assert.Contains("Namespace name contains invalid characters", ex.Message);
     }
 
     [Theory]
     [InlineData("ns#fragment.servicebus.windows.net")]
     [InlineData("test.servicebus.windows.net/extraPath")]
     [InlineData("test.servicebus.windows.net:443")]
-    public async Task PeekQueueMessages_RejectsNonHostNamespaceValues(string namespaceName)
+    public async Task PeekQueueMessages_RejectsMalformedNamespace(string namespaceName)
     {
-        var ex = await Assert.ThrowsAsync<SecurityException>(
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
             () => _service.PeekQueueMessages(namespaceName, "testQueue", 1, cancellationToken: TestContext.Current.CancellationToken));
-        Assert.Contains("host name only", ex.Message);
+        Assert.Contains("Namespace name contains invalid characters", ex.Message);
     }
 }

--- a/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.Tests/Topic/SubscriptionDetailsCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.Tests/Topic/SubscriptionDetailsCommandTests.cs
@@ -18,7 +18,6 @@ namespace Azure.Mcp.Tools.ServiceBus.Tests.Topic;
 public class SubscriptionDetailsCommandTests : CommandUnitTestsBase<SubscriptionDetailsCommand, IServiceBusService>
 {
     // Test constants
-    private const string SubscriptionId = "sub123";
     private const string TopicName = "testTopic";
     private const string SubscriptionName = "testSubscription";
     private const string NamespaceName = "test.servicebus.windows.net";
@@ -50,7 +49,6 @@ public class SubscriptionDetailsCommandTests : CommandUnitTestsBase<Subscription
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", SubscriptionId,
             "--namespace", NamespaceName,
             "--topic", TopicName,
             "--subscription-name", SubscriptionName);
@@ -80,7 +78,6 @@ public class SubscriptionDetailsCommandTests : CommandUnitTestsBase<Subscription
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", SubscriptionId,
             "--namespace", NamespaceName,
             "--topic", TopicName,
             "--subscription-name", SubscriptionName);
@@ -108,7 +105,6 @@ public class SubscriptionDetailsCommandTests : CommandUnitTestsBase<Subscription
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", SubscriptionId,
             "--namespace", NamespaceName,
             "--topic", TopicName,
             "--subscription-name", SubscriptionName);
@@ -120,11 +116,10 @@ public class SubscriptionDetailsCommandTests : CommandUnitTestsBase<Subscription
     }
 
     [Theory]
-    [InlineData("--subscription sub123 --namespace test.servicebus.windows.net --topic testTopic --subscription-name testSubscription", true)]
-    [InlineData("--namespace test.servicebus.windows.net --topic testTopic --subscription-name testSubscription", false)]  // Missing subscription
-    [InlineData("--subscription sub123 --topic testTopic --subscription-name testSubscription", false)]   // Missing namespace
-    [InlineData("--subscription sub123 --namespace test.servicebus.windows.net --subscription-name testSubscription", false)] // Missing topic
-    [InlineData("--subscription sub123 --namespace test.servicebus.windows.net --topic testTopic", false)] // Missing subscription-name
+    [InlineData("--namespace test.servicebus.windows.net --topic testTopic --subscription-name testSubscription", true)]
+    [InlineData("--topic testTopic --subscription-name testSubscription", false)]   // Missing namespace
+    [InlineData("--namespace test.servicebus.windows.net --subscription-name testSubscription", false)] // Missing topic
+    [InlineData("--namespace test.servicebus.windows.net --topic testTopic", false)] // Missing subscription-name
     [InlineData("", false)]  // Missing all required options
     public async Task ExecuteAsync_ValidatesRequiredParameters(string args, bool shouldSucceed)
     {

--- a/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.Tests/Topic/TopicDetailsCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.Tests/Topic/TopicDetailsCommandTests.cs
@@ -18,7 +18,6 @@ namespace Azure.Mcp.Tools.ServiceBus.Tests.Topic;
 public class TopicDetailsCommandTests : CommandUnitTestsBase<TopicDetailsCommand, IServiceBusService>
 {
     // Test constants
-    private const string SubscriptionId = "sub123";
     private const string TopicName = "testTopic";
     private const string NamespaceName = "test.servicebus.windows.net";
 
@@ -49,7 +48,6 @@ public class TopicDetailsCommandTests : CommandUnitTestsBase<TopicDetailsCommand
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", SubscriptionId,
             "--namespace", NamespaceName,
             "--topic", TopicName);
 
@@ -77,13 +75,13 @@ public class TopicDetailsCommandTests : CommandUnitTestsBase<TopicDetailsCommand
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", SubscriptionId,
             "--namespace", NamespaceName,
             "--topic", TopicName);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.NotFound, response.Status);
+        Assert.Contains("Topic not found", response.Message);
     }
 
     [Fact]
@@ -102,7 +100,6 @@ public class TopicDetailsCommandTests : CommandUnitTestsBase<TopicDetailsCommand
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", SubscriptionId,
             "--namespace", NamespaceName,
             "--topic", TopicName);
 
@@ -113,10 +110,9 @@ public class TopicDetailsCommandTests : CommandUnitTestsBase<TopicDetailsCommand
     }
 
     [Theory]
-    [InlineData("--subscription sub123 --namespace test.servicebus.windows.net --topic testTopic", true)]
-    [InlineData("--namespace test.servicebus.windows.net --topic testTopic", false)]  // Missing subscription
-    [InlineData("--subscription sub123 --topic testTopic", false)]   // Missing namespace
-    [InlineData("--subscription sub123 --namespace test.servicebus.windows.net", false)] // Missing topic
+    [InlineData("--namespace test.servicebus.windows.net --topic testTopic", true)]
+    [InlineData("--topic testTopic", false)]   // Missing namespace
+    [InlineData("--namespace test.servicebus.windows.net", false)] // Missing topic
     [InlineData("", false)]  // Missing all required options
     public async Task ExecuteAsync_ValidatesRequiredParameters(string args, bool shouldSucceed)
     {


### PR DESCRIPTION
Fixed multiple issues in Azure Service Bus commands:
      - `--subscription` option was incorrectly required on `queue details`, `topic details`, and `topic subscription details` commands; the option has been removed since the namespace FQDN is sufficient for authentication.
      - `topic details` returned "Subscription not found" when a topic did not exist; the error message now correctly reads "Topic not found".
      - Malformed namespace names (containing path separators or other invalid characters) raised a `SecurityException`; they now raise an `ArgumentException` to correctly signal invalid input rather than a security violation.