### PR TITLE
Fix Monitor Tools Issues

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1779260700545.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1779260700545.yaml
@@ -1,0 +1,10 @@
+changes:
+  - section: "Bug Fixes"
+    description: |
+      Fix several correctness, reliability, and performance issues in the Monitor toolset:
+      - Activity log level filtering now works correctly. The OData filter used the wrong field name ('levels' instead of 'level'), causing the API to silently ignore the filter and return all severity levels regardless of what was requested.
+      - Workspace log queries no longer require --resource-group. The option was incorrectly enforced on all Monitor commands, including workspace queries that never use it. It is now only required on the commands that actually need it.
+      - Table-type filtering is now case-insensitive. Passing 'customlog' instead of 'CustomLog' previously returned an empty list with no error. Filtering now matches regardless of casing.
+      - Query limit detection is now locale-safe. The 'limit' keyword check used a culture-sensitive comparison that could fail in Turkish locale, causing a duplicate limit clause and invalid KQL. This now uses ordinal comparison.
+      - QueryWorkspace now logs and classifies errors correctly. Exceptions previously propagated as bare stack traces; they are now caught, logged with context, and 404s are surfaced as a clear 'not found' error.
+      - Activity log pagination now stops as soon as the requested number of results is collected. Previously, all pages were fetched into memory before truncation, causing unnecessary ARM round-trips and potential timeouts on busy subscriptions.

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/BaseMonitorCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/BaseMonitorCommand.cs
@@ -18,7 +18,6 @@ public abstract class BaseMonitorCommand<
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
-        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsRequired());
     }
 
     protected override TOptions BindOptions(ParseResult parseResult)

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/HealthModels/BaseMonitorHealthModelsCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/HealthModels/BaseMonitorHealthModelsCommand.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using Azure.Mcp.Tools.Monitor.Options;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Extensions;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.HealthModels;
 
@@ -16,6 +17,7 @@ public abstract class BaseMonitorHealthModelsCommand<
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
+        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsRequired());
         command.Options.Add(MonitorOptionDefinitions.Health.Entity);
         command.Options.Add(MonitorOptionDefinitions.Health.HealthModel);
     }

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Table/TableListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Table/TableListCommand.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Extensions;
 using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.Table;
 
@@ -32,6 +33,7 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger, IMonitorS
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
+        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsRequired());
         command.Options.Add(MonitorOptionDefinitions.TableType);
     }
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/TableType/TableTypeListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/TableType/TableTypeListCommand.cs
@@ -5,7 +5,9 @@ using Azure.Mcp.Tools.Monitor.Options.TableType;
 using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
 using Microsoft.Mcp.Core.Models.Command;
+using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.Monitor.Commands.TableType;
 
@@ -24,6 +26,12 @@ public sealed class TableTypeListCommand(ILogger<TableTypeListCommand> logger, I
 {
     private readonly ILogger<TableTypeListCommand> _logger = logger;
     private readonly IMonitorService _monitorService = monitorService;
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsRequired());
+    }
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorService.cs
@@ -118,34 +118,46 @@ public class MonitorService(
 
         var (workspaceId, _) = await GetWorkspaceInfo(workspace, subscription, tenant, retryPolicy, cancellationToken);
 
-        var response = await client.QueryWorkspaceAsync(
-            workspaceId,
-            query,
-            new(TimeSpan.FromDays(timeSpanDays)),
-            options: null,
-            cancellationToken
-        );
-
-        var results = new List<JsonNode>();
-        if (response.Value.Table != null)
+        try
         {
-            var rows = response.Value.Table.Rows;
-            var columns = response.Value.Table.Columns;
+            var response = await client.QueryWorkspaceAsync(
+                workspaceId,
+                query,
+                new(TimeSpan.FromDays(timeSpanDays)),
+                options: null,
+                cancellationToken
+            );
 
-            if (rows != null && columns != null && rows.Any())
+            var results = new List<JsonNode>();
+            if (response.Value.Table != null)
             {
-                foreach (var row in rows)
+                var rows = response.Value.Table.Rows;
+                var columns = response.Value.Table.Columns;
+
+                if (rows != null && columns != null && rows.Any())
                 {
-                    var rowDict = new JsonObject();
-                    for (int i = 0; i < columns.Count; i++)
+                    foreach (var row in rows)
                     {
-                        rowDict[columns[i].Name] = JsonValue.Create(row[i]?.ToString() ?? "null");
+                        var rowDict = new JsonObject();
+                        for (int i = 0; i < columns.Count; i++)
+                        {
+                            rowDict[columns[i].Name] = JsonValue.Create(row[i]?.ToString() ?? "null");
+                        }
+                        results.Add(rowDict);
                     }
-                    results.Add(rowDict);
                 }
             }
+            return results;
         }
-        return results;
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            throw new KeyNotFoundException($"Workspace '{workspaceId}' not found.", ex);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error querying workspace '{WorkspaceId}'. Query: {Query}", workspaceId, query);
+            throw;
+        }
     }
 
     public async Task<List<string>> ListTables(
@@ -178,8 +190,9 @@ public class MonitorService(
             .ConfigureAwait(false);
 
         return [.. tables
-            .Where(table => string.IsNullOrEmpty(tableType) || table.Data.Schema.TableType.ToString() == tableType)
-            .Select(table => table.Data.Name ?? string.Empty) // ensure non-null
+            .Where(table => string.IsNullOrEmpty(tableType) ||
+                string.Equals(table.Data.Schema.TableType?.ToString(), tableType, StringComparison.OrdinalIgnoreCase))
+            .Select(table => table.Data.Name ?? string.Empty)
             .Where(name => !string.IsNullOrEmpty(name))
             .OrderBy(name => name)];
     }
@@ -277,15 +290,16 @@ public class MonitorService(
     }
 
     // Helper to build the query string with table and limit
-    private static string BuildQuery(string query, string table, int? limit)
+    // Helper to build the query string with table and limit; internal for testability
+    internal static string BuildQuery(string query, string table, int? limit)
     {
         if (!string.IsNullOrEmpty(query) && s_predefinedQueries.ContainsKey(query.Trim().ToLower()))
         {
             query = s_predefinedQueries[query.Trim().ToLower()];
             query = query.Replace(TablePlaceholder, KqlSanitizer.EscapeIdentifier(table));
         }
-        // Add limit if not present
-        if (limit.HasValue && !query.Contains("limit", StringComparison.CurrentCultureIgnoreCase))
+        // Add limit if not present; use OrdinalIgnoreCase to avoid locale-sensitive comparison (e.g. Turkish locale)
+        if (limit.HasValue && !query.Contains("limit", StringComparison.OrdinalIgnoreCase))
         {
             query = $"{query}\n| limit {limit}";
         }
@@ -379,11 +393,10 @@ public class MonitorService(
         string subscriptionId = resourceIdentifier.SubscriptionId
             ?? throw new ArgumentException($"Unable to extract subscription ID from resource ID: {resourceId}");
 
-        // Get the activity logs from the Azure Management API
-        var activityLogs = await CallActivityLogApiAsync(subscriptionId, resourceId, hours, eventLevel, tenant, retryPolicy, cancellationToken);
+        // Get the activity logs from the Azure Management API — top is passed to limit server-side pagination
+        var activityLogs = await CallActivityLogApiAsync(subscriptionId, resourceId, hours, eventLevel, top, tenant, retryPolicy, cancellationToken);
 
-        // Take only the requested number of logs
-        return activityLogs.Take(top).ToList();
+        return activityLogs;
     }
 
     private async Task<List<ActivityLogEventData>> CallActivityLogApiAsync(
@@ -391,6 +404,7 @@ public class MonitorService(
         string resourceId,
         double hours,
         ActivityLogEventLevel? eventLevel,
+        int top,
         string? tenant,
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken)
@@ -399,11 +413,9 @@ public class MonitorService(
 
         string endpoint = GetLogActivityEndpointString(subscriptionId);
 
-        // Build the query parameters
+        // Build the query parameters — include $top to constrain server-side results and reduce unnecessary pages
         var uriBuilder = new UriBuilder(endpoint);
-
-        // Build the query parameters
-        string query = $"api-version={ActivityLogApiVersion}";
+        string query = $"api-version={ActivityLogApiVersion}&$top={top}";
 
         // Create the time filter
         DateTimeOffset startDate = DateTimeOffset.UtcNow.AddHours(-hours).ToUniversalTime();
@@ -414,7 +426,7 @@ public class MonitorService(
 
         if (eventLevel != null)
         {
-            filter += $" and levels eq '{eventLevel}'";
+            filter += $" and level eq '{eventLevel}'";
         }
 
         query += $"&$filter={Uri.EscapeDataString(filter)}";
@@ -422,16 +434,20 @@ public class MonitorService(
 
         var accessToken = await GetArmAccessTokenAsync(tenant, cancellationToken);
 
-        // Make paginated requests
+        // Make paginated requests, stopping as soon as the requested count is reached
         string? nextRequestUrl = uriBuilder.Uri.ToString();
         do
         {
             ActivityLogListResponse listResponse = await MakeActivityLogRequestAsync(nextRequestUrl, accessToken.Token, cancellationToken);
             returnValue.AddRange(listResponse.Value);
+            if (returnValue.Count >= top)
+            {
+                break;
+            }
             nextRequestUrl = listResponse.NextLink;
         } while (!string.IsNullOrEmpty(nextRequestUrl));
 
-        return returnValue;
+        return returnValue.Take(top).ToList();
     }
 
     private async Task<ActivityLogListResponse> MakeActivityLogRequestAsync(string url, string token, CancellationToken cancellationToken)

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/Log/WorkspaceLogQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/Log/WorkspaceLogQueryCommandTests.cs
@@ -25,9 +25,8 @@ public sealed class WorkspaceLogQueryCommandTests : CommandUnitTestsBase<Workspa
     private const string _knownQuery = "| limit 10";
 
     [Theory]
-    [InlineData($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --resource-group {_knownResourceGroup} --table {_knownTable} --query \"{_knownQuery}\"", true)]
-    [InlineData($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --resource-group {_knownResourceGroup} --table {_knownTable} --query \"{_knownQuery}\" --hours {_knownHours} --limit {_knownLimit}", true)]
-    [InlineData($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --table {_knownTable} --query \"{_knownQuery}\"", false)] // missing resource-group
+    [InlineData($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --table {_knownTable} --query \"{_knownQuery}\"", true)]
+    [InlineData($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --table {_knownTable} --query \"{_knownQuery}\" --hours {_knownHours} --limit {_knownLimit}", true)]
     [InlineData($"--subscription {_knownSubscription}", false)]
     [InlineData("", false)]
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
@@ -95,7 +94,6 @@ public sealed class WorkspaceLogQueryCommandTests : CommandUnitTestsBase<Workspa
         var response = await ExecuteCommandAsync(
             "--subscription", _knownSubscription,
             "--workspace", _knownWorkspace,
-            "--resource-group", _knownResourceGroup,
             "--table", _knownTable,
             "--query", _knownQuery);
 
@@ -137,7 +135,6 @@ public sealed class WorkspaceLogQueryCommandTests : CommandUnitTestsBase<Workspa
         var response = await ExecuteCommandAsync(
             "--subscription", _knownSubscription,
             "--workspace", _knownWorkspace,
-            "--resource-group", _knownResourceGroup,
             "--table", _knownTable,
             "--query", _knownQuery,
             "--hours", _knownHours,
@@ -179,7 +176,6 @@ public sealed class WorkspaceLogQueryCommandTests : CommandUnitTestsBase<Workspa
         var response = await ExecuteCommandAsync(
             "--subscription", _knownSubscription,
             "--workspace", _knownWorkspace,
-            "--resource-group", _knownResourceGroup,
             "--table", _knownTable,
             "--query", _knownQuery);
 
@@ -217,7 +213,6 @@ public sealed class WorkspaceLogQueryCommandTests : CommandUnitTestsBase<Workspa
         var response = await ExecuteCommandAsync(
             "--subscription", _knownSubscription,
             "--workspace", _knownWorkspace,
-            "--resource-group", _knownResourceGroup,
             "--table", _knownTable,
             "--query", _knownQuery);
 

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/MonitorServiceBuildQueryTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/MonitorServiceBuildQueryTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Tools.Monitor.Services;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Monitor.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="MonitorService.BuildQuery"/>, focusing on correctness of
+/// limit injection and locale-safe string comparison (MON-02).
+/// </summary>
+public class MonitorServiceBuildQueryTests
+{
+    // ── Limit injection ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildQuery_NoExistingLimit_AppendsLimitClause()
+    {
+        var result = MonitorService.BuildQuery("Heartbeat", "Heartbeat", 50);
+
+        Assert.Contains("| limit 50", result);
+    }
+
+    [Fact]
+    public void BuildQuery_AlreadyContainsLimitLowercase_DoesNotAppendDuplicate()
+    {
+        const string query = "Heartbeat\n| limit 100";
+
+        var result = MonitorService.BuildQuery(query, "Heartbeat", 50);
+
+        // Only one "| limit" clause should appear
+        Assert.Equal(1, CountOccurrences(result, "| limit"));
+    }
+
+    [Fact]
+    public void BuildQuery_AlreadyContainsLimitUppercase_DoesNotAppendDuplicate()
+    {
+        // MON-02: OrdinalIgnoreCase must be used so "LIMIT" is recognised in all locales
+        const string query = "Heartbeat\n| LIMIT 100";
+
+        var result = MonitorService.BuildQuery(query, "Heartbeat", 50);
+
+        Assert.Equal(1, CountOccurrences(result, "limit", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void BuildQuery_AlreadyContainsLimitMixedCase_DoesNotAppendDuplicate()
+    {
+        const string query = "Heartbeat\n| Limit 100";
+
+        var result = MonitorService.BuildQuery(query, "Heartbeat", 50);
+
+        Assert.Equal(1, CountOccurrences(result, "limit", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void BuildQuery_NullLimit_DoesNotAppendLimitClause()
+    {
+        const string query = "Heartbeat";
+
+        var result = MonitorService.BuildQuery(query, "Heartbeat", null);
+
+        Assert.DoesNotContain("| limit", result);
+    }
+
+    // ── Predefined queries ───────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildQuery_PredefinedQueryRecent_ExpandsWithTableName()
+    {
+        var result = MonitorService.BuildQuery("recent", "Heartbeat", null);
+
+        Assert.Contains("Heartbeat", result);
+        Assert.Contains("order by TimeGenerated desc", result);
+    }
+
+    [Fact]
+    public void BuildQuery_PredefinedQueryErrors_ExpandsWithTableName()
+    {
+        var result = MonitorService.BuildQuery("errors", "AppExceptions", null);
+
+        Assert.Contains("AppExceptions", result);
+        Assert.Contains("where Level == \"ERROR\"", result);
+    }
+
+    [Fact]
+    public void BuildQuery_PredefinedQueryWithLimit_AppendLimit()
+    {
+        var result = MonitorService.BuildQuery("recent", "Heartbeat", 25);
+
+        Assert.Contains("| limit 25", result);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static int CountOccurrences(string source, string search,
+        StringComparison comparison = StringComparison.Ordinal)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = source.IndexOf(search, index, comparison)) >= 0)
+        {
+            count++;
+            index += search.Length;
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
Fix several correctness, reliability, and performance issues in the Monitor toolset:
      - Activity log level filtering now works correctly. The OData filter used the wrong field name ('levels' instead of 'level'), causing the API to silently ignore the filter and return all severity levels regardless of what was requested.
      - Workspace log queries no longer require --resource-group. The option was incorrectly enforced on all Monitor commands, including workspace queries that never use it. It is now only required on the commands that actually need it.
      - Table-type filtering is now case-insensitive. Passing 'customlog' instead of 'CustomLog' previously returned an empty list with no error. Filtering now matches regardless of casing.
      - Query limit detection is now locale-safe. The 'limit' keyword check used a culture-sensitive comparison that could fail in Turkish locale, causing a duplicate limit clause and invalid KQL. This now uses ordinal comparison.
      - QueryWorkspace now logs and classifies errors correctly. Exceptions previously propagated as bare stack traces; they are now caught, logged with context, and 404s are surfaced as a clear 'not found' error.
      - Activity log pagination now stops as soon as the requested number of results is collected. Previously, all pages were fetched into memory before truncation, causing unnecessary ARM round-trips and potential timeouts on busy subscriptions.