### PR TITLE
Fix appconfig issues

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1779262158643.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1779262158643.yaml
@@ -3,6 +3,5 @@ changes:
     description: |
       Fixed multiple bugs in the App Configuration toolset:
       - Store lookup no longer passes subscription as both the store identifier and the error context argument; "store not found" messages now correctly name the missing store instead of echoing the subscription value
-      - Setting a key-value with a malformed tag (missing the required `key=value` separator) now returns a 400 validation error with a clear message instead of silently creating a tag with an empty value
       - The user-supplied retry policy is now applied to all data-plane key-value operations (get, set, delete, lock); previously it was only applied to the ARM store-discovery call, causing custom retry settings to have no effect on actual configuration reads and writes
-      - The `kv delete` command response now includes an `existed` field (`true` if the key was present and deleted, `false` if it was already absent), allowing callers to distinguish a successful deletion from a no-op on a non-existent key
+      - The `kv delete` command response now includes an `existed` field (`true` if the key was present and deleted, `false` if it was already absent) and a human-readable `message`, allowing callers to distinguish a successful deletion from a no-op on a non-existent key

--- a/servers/Azure.Mcp.Server/changelog-entries/1779262158643.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1779262158643.yaml
@@ -2,6 +2,6 @@ changes:
   - section: "Bugs Fixed"
     description: |
       Fixed multiple bugs in the App Configuration toolset:
-      - Store lookup no longer passes subscription as both the store identifier and the error context argument; "store not found" messages now correctly name the missing store instead of echoing the subscription value
+      - Store lookup no longer passes subscription as both subscription-based arguments when resolving the store by name
       - The user-supplied retry policy is now applied to all data-plane key-value operations (get, set, delete, lock); previously it was only applied to the ARM store-discovery call, causing custom retry settings to have no effect on actual configuration reads and writes
       - The `kv delete` command response now includes an `existed` field (`true` if the key was present and deleted, `false` if it was already absent) and a human-readable `message`, allowing callers to distinguish a successful deletion from a no-op on a non-existent key

--- a/servers/Azure.Mcp.Server/changelog-entries/1779262158643.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1779262158643.yaml
@@ -1,0 +1,8 @@
+changes:
+  - section: "Bugs Fixed"
+    description: |
+      Fixed multiple bugs in the App Configuration toolset:
+      - Store lookup no longer passes subscription as both the store identifier and the error context argument; "store not found" messages now correctly name the missing store instead of echoing the subscription value
+      - Setting a key-value with a malformed tag (missing the required `key=value` separator) now returns a 400 validation error with a clear message instead of silently creating a tag with an empty value
+      - The user-supplied retry policy is now applied to all data-plane key-value operations (get, set, delete, lock); previously it was only applied to the ARM store-discovery call, causing custom retry settings to have no effect on actual configuration reads and writes
+      - The `kv delete` command response now includes an `existed` field (`true` if the key was present and deleted, `false` if it was already absent), allowing callers to distinguish a successful deletion from a no-op on a non-existent key

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -484,7 +484,7 @@ azmcp appconfig account list --subscription <subscription> \
                             [--resource-group <resource-group>]
 
 # Delete a key-value setting
-# Returns: { key, label, existed } — 'existed' is true if the key was present and deleted, false if it was already absent
+# Returns: { key, label, existed, message } — 'existed' is true if the key was present and deleted, false if it was already absent
 # ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp appconfig kv delete --subscription <subscription> \
                           --account <account> \

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -509,7 +509,6 @@ azmcp appconfig kv lock set --subscription <subscription> \
                             [--lock]
 
 # Set a key-value setting
-# Note: --tags values must be in 'key=value' format (e.g., --tags env=prod team=backend)
 # ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp appconfig kv set --subscription <subscription> \
                        --account <account> \

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -484,6 +484,7 @@ azmcp appconfig account list --subscription <subscription> \
                             [--resource-group <resource-group>]
 
 # Delete a key-value setting
+# Returns: { key, label, existed } — 'existed' is true if the key was present and deleted, false if it was already absent
 # ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp appconfig kv delete --subscription <subscription> \
                           --account <account> \
@@ -508,6 +509,7 @@ azmcp appconfig kv lock set --subscription <subscription> \
                             [--lock]
 
 # Set a key-value setting
+# Note: --tags values must be in 'key=value' format (e.g., --tags env=prod team=backend)
 # ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp appconfig kv set --subscription <subscription> \
                        --account <account> \

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueDeleteCommand.cs
@@ -50,9 +50,10 @@ public sealed class KeyValueDeleteCommand(ILogger<KeyValueDeleteCommand> logger,
                 options.Label,
                 cancellationToken);
 
+            var labelSuffix = options.Label is null ? string.Empty : $" with label '{options.Label}'";
             var message = existed
-                ? $"Key '{options.Key}' deleted successfully."
-                : $"Key '{options.Key}' did not exist in store '{options.Account}'.";
+                ? $"Key '{options.Key}'{labelSuffix} deleted successfully."
+                : $"Key '{options.Key}'{labelSuffix} did not exist in store '{options.Account}'.";
             context.Response.Results = ResponseResult.Create(new(options.Key, options.Label, existed, message), AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueDeleteCommand.cs
@@ -50,7 +50,10 @@ public sealed class KeyValueDeleteCommand(ILogger<KeyValueDeleteCommand> logger,
                 options.Label,
                 cancellationToken);
 
-            context.Response.Results = ResponseResult.Create(new(options.Key, options.Label, existed), AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
+            var message = existed
+                ? $"Key '{options.Key}' deleted successfully."
+                : $"Key '{options.Key}' did not exist in store '{options.Account}'.";
+            context.Response.Results = ResponseResult.Create(new(options.Key, options.Label, existed, message), AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
         }
         catch (Exception ex)
         {
@@ -61,5 +64,5 @@ public sealed class KeyValueDeleteCommand(ILogger<KeyValueDeleteCommand> logger,
         return context.Response;
     }
 
-    internal record KeyValueDeleteCommandResult(string? Key, string? Label, bool Existed);
+    internal record KeyValueDeleteCommandResult(string? Key, string? Label, bool Existed, string Message);
 }

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueDeleteCommand.cs
@@ -41,7 +41,7 @@ public sealed class KeyValueDeleteCommand(ILogger<KeyValueDeleteCommand> logger,
 
         try
         {
-            await _appConfigService.DeleteKeyValue(
+            var existed = await _appConfigService.DeleteKeyValue(
                 options.Account!,
                 options.Key!,
                 options.Subscription!,
@@ -50,7 +50,7 @@ public sealed class KeyValueDeleteCommand(ILogger<KeyValueDeleteCommand> logger,
                 options.Label,
                 cancellationToken);
 
-            context.Response.Results = ResponseResult.Create(new(options.Key, options.Label), AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
+            context.Response.Results = ResponseResult.Create(new(options.Key, options.Label, existed), AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
         }
         catch (Exception ex)
         {
@@ -61,5 +61,5 @@ public sealed class KeyValueDeleteCommand(ILogger<KeyValueDeleteCommand> logger,
         return context.Response;
     }
 
-    internal record KeyValueDeleteCommandResult(string? Key, string? Label);
+    internal record KeyValueDeleteCommandResult(string? Key, string? Label, bool Existed);
 }

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
@@ -165,7 +165,12 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
         ValidateRequiredParameters((nameof(accountName), accountName), (nameof(key), key), (nameof(subscription), subscription));
         var client = await GetConfigurationClient(accountName, subscription, tenant, retryPolicy, cancellationToken);
         var response = await client.DeleteConfigurationSettingAsync(key, label, cancellationToken: cancellationToken);
-        return response.Status == 200;
+        return KeyValueExistedFromDeleteStatus(response.Status);
+    }
+
+    internal static bool KeyValueExistedFromDeleteStatus(int status)
+    {
+        return status == 200;
     }
 
     private async Task<ConfigurationClient> GetConfigurationClient(string accountName, string subscription, string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
@@ -180,16 +185,30 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
         EndpointValidator.ValidateAzureServiceEndpoint(endpoint, "appconfig", TenantService.CloudConfiguration.ArmEnvironment);
 
         var credential = await GetCredential(tenant, cancellationToken);
-        var options = new ConfigurationClientOptions();
-        options.Audience = GetAppConfigurationAudience();
-        ConfigureRetryPolicy(AddDefaultPolicies(options), retryPolicy);
 
         var endpointUri = new Uri(endpoint);
         var httpClient = _httpClientFactory.CreateClient();
-        httpClient.BaseAddress = endpointUri;
-        options.Transport = new HttpClientTransport(httpClient);
+        var options = CreateConfigurationClientOptions(GetAppConfigurationAudience(), retryPolicy, httpClient, endpointUri);
 
         return new ConfigurationClient(endpointUri, credential, options);
+    }
+
+    internal static ConfigurationClientOptions CreateConfigurationClientOptions(
+        AppConfigurationAudience audience,
+        RetryPolicyOptions? retryPolicy,
+        HttpClient httpClient,
+        Uri endpointUri)
+    {
+        var options = new ConfigurationClientOptions
+        {
+            Audience = audience
+        };
+
+        httpClient.BaseAddress = endpointUri;
+        options.Transport = new HttpClientTransport(httpClient);
+        ConfigureRetryPolicy(AddDefaultPolicies(options), retryPolicy);
+
+        return options;
     }
 
     private async Task<AppConfigurationAccount> FindAppConfigStore(

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
@@ -144,17 +144,18 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
                         setting.Tags[tagKey] = parts[1];
                     }
                 }
-                else if (parts.Length == 1 && !string.IsNullOrEmpty(parts[0]))
+                else
                 {
-                    // Handle tags that don't follow key=value format
-                    setting.Tags[parts[0]] = string.Empty;
+                    throw new ArgumentException(
+                        $"Invalid tag format '{tagPair}'. Tags must be in 'key=value' format.",
+                        nameof(tags));
                 }
             }
         }
 
         await client.SetConfigurationSettingAsync(setting, cancellationToken: cancellationToken);
     }
-    public async Task DeleteKeyValue(
+    public async Task<bool> DeleteKeyValue(
         string accountName,
         string key,
         string subscription,
@@ -165,12 +166,13 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
     {
         ValidateRequiredParameters((nameof(accountName), accountName), (nameof(key), key), (nameof(subscription), subscription));
         var client = await GetConfigurationClient(accountName, subscription, tenant, retryPolicy, cancellationToken);
-        await client.DeleteConfigurationSettingAsync(key, label, cancellationToken: cancellationToken);
+        var response = await client.DeleteConfigurationSettingAsync(key, label, cancellationToken: cancellationToken);
+        return response.Status == 200;
     }
 
     private async Task<ConfigurationClient> GetConfigurationClient(string accountName, string subscription, string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
     {
-        var configStore = await FindAppConfigStore(subscription, tenant, accountName, subscription, retryPolicy, cancellationToken);
+        var configStore = await FindAppConfigStore(subscription, tenant, accountName, retryPolicy, cancellationToken);
         var endpoint = configStore.Endpoint;
         if (string.IsNullOrEmpty(endpoint))
         {
@@ -182,7 +184,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
         var credential = await GetCredential(tenant, cancellationToken);
         var options = new ConfigurationClientOptions();
         options.Audience = GetAppConfigurationAudience();
-        AddDefaultPolicies(options);
+        ConfigureRetryPolicy(AddDefaultPolicies(options), retryPolicy);
 
         var endpointUri = new Uri(endpoint);
         var httpClient = _httpClientFactory.CreateClient();
@@ -196,7 +198,6 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
         string subscription,
         string? tenant,
         string accountName,
-        string subscriptionIdentifier,
         RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken)
     {
@@ -209,7 +210,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
             additionalFilter: $"name =~ '{EscapeKqlString(accountName)}'",
             tenant: tenant,
             cancellationToken: cancellationToken)
-            ?? throw new KeyNotFoundException($"App Configuration store '{accountName}' not found for subscription '{subscriptionIdentifier}'.");
+            ?? throw new KeyNotFoundException($"App Configuration store '{accountName}' not found for subscription '{subscription}'.");
     }
 
     /// <summary>

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
@@ -146,9 +146,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
                 }
                 else
                 {
-                    throw new ArgumentException(
-                        $"Invalid tag format '{tagPair}'. Tags must be in 'key=value' format.",
-                        nameof(tags));
+                    setting.Tags[parts[0]] = string.Empty;
                 }
             }
         }

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
@@ -144,7 +144,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
                         setting.Tags[tagKey] = parts[1];
                     }
                 }
-                else
+                else if (parts.Length == 1 && !string.IsNullOrEmpty(parts[0]))
                 {
                     setting.Tags[parts[0]] = string.Empty;
                 }

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/AppConfigService.cs
@@ -208,7 +208,7 @@ public sealed class AppConfigService(ISubscriptionService subscriptionService, I
             additionalFilter: $"name =~ '{EscapeKqlString(accountName)}'",
             tenant: tenant,
             cancellationToken: cancellationToken)
-            ?? throw new KeyNotFoundException($"App Configuration store '{accountName}' not found for subscription '{subscription}'.");
+            ?? throw new KeyNotFoundException($"App Configuration store '{accountName}' not found in subscription '{subscription}'.");
     }
 
     /// <summary>

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Services/IAppConfigService.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Services/IAppConfigService.cs
@@ -45,7 +45,7 @@ public interface IAppConfigService
         string? contentType = null,
         string[]? tags = null,
         CancellationToken cancellationToken = default);
-    Task DeleteKeyValue(
+    Task<bool> DeleteKeyValue(
         string accountName,
         string key,
         string subscription,

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/KeyValue/KeyValueDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/KeyValue/KeyValueDeleteCommandTests.cs
@@ -43,6 +43,7 @@ public class KeyValueDeleteCommandTests : CommandUnitTestsBase<KeyValueDeleteCom
 
         Assert.Equal("my-key", result.Key);
         Assert.True(result.Existed);
+        Assert.Equal("Key 'my-key' deleted successfully.", result.Message);
     }
 
     [Fact]
@@ -74,6 +75,7 @@ public class KeyValueDeleteCommandTests : CommandUnitTestsBase<KeyValueDeleteCom
         Assert.Equal("my-key", result.Key);
         Assert.Equal("prod", result.Label);
         Assert.True(result.Existed);
+        Assert.Equal("Key 'my-key' deleted successfully.", result.Message);
     }
 
     [Fact]
@@ -95,6 +97,7 @@ public class KeyValueDeleteCommandTests : CommandUnitTestsBase<KeyValueDeleteCom
 
         Assert.Equal("nonexistent-key", result.Key);
         Assert.False(result.Existed);
+        Assert.Equal("Key 'nonexistent-key' did not exist in store 'account1'.", result.Message);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/KeyValue/KeyValueDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/KeyValue/KeyValueDeleteCommandTests.cs
@@ -18,7 +18,12 @@ public class KeyValueDeleteCommandTests : CommandUnitTestsBase<KeyValueDeleteCom
     [Fact]
     public async Task ExecuteAsync_DeletesKeyValue_WhenValidParametersProvided()
     {
-        // Arrange & Act
+        // Arrange
+        Service.DeleteKeyValue(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--account", "account1",
@@ -37,12 +42,18 @@ public class KeyValueDeleteCommandTests : CommandUnitTestsBase<KeyValueDeleteCom
         var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
 
         Assert.Equal("my-key", result.Key);
+        Assert.True(result.Existed);
     }
 
     [Fact]
     public async Task ExecuteAsync_DeletesKeyValueWithLabel_WhenLabelProvided()
     {
-        // Arrange & Act
+        // Arrange
+        Service.DeleteKeyValue(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--account", "account1",
@@ -62,6 +73,28 @@ public class KeyValueDeleteCommandTests : CommandUnitTestsBase<KeyValueDeleteCom
 
         Assert.Equal("my-key", result.Key);
         Assert.Equal("prod", result.Label);
+        Assert.True(result.Existed);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsExistedFalse_WhenKeyWasAbsent()
+    {
+        // Arrange — service returns false indicating the key did not exist
+        Service.DeleteKeyValue(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub123",
+            "--account", "account1",
+            "--key", "nonexistent-key");
+
+        // Assert
+        var result = ValidateAndDeserializeResponse(response, AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
+
+        Assert.Equal("nonexistent-key", result.Key);
+        Assert.False(result.Existed);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/KeyValue/KeyValueDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/KeyValue/KeyValueDeleteCommandTests.cs
@@ -75,7 +75,7 @@ public class KeyValueDeleteCommandTests : CommandUnitTestsBase<KeyValueDeleteCom
         Assert.Equal("my-key", result.Key);
         Assert.Equal("prod", result.Label);
         Assert.True(result.Existed);
-        Assert.Equal("Key 'my-key' deleted successfully.", result.Message);
+        Assert.Equal("Key 'my-key' with label 'prod' deleted successfully.", result.Message);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/KeyValue/KeyValueSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/KeyValue/KeyValueSetCommandTests.cs
@@ -153,27 +153,4 @@ public class KeyValueSetCommandTests : CommandUnitTestsBase<KeyValueSetCommand, 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("required", response.Message.ToLower());
     }
-
-    [Fact]
-    public async Task ExecuteAsync_Returns400_WhenTagFormatIsInvalid()
-    {
-        // Arrange — service throws when a tag without '=' is supplied
-        Service.SetKeyValue(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<string>(),
-            Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new ArgumentException("Invalid tag format 'InvalidTag'. Tags must be in 'key=value' format.", "tags"));
-
-        // Act
-        var response = await ExecuteCommandAsync(
-            "--subscription", "sub123",
-            "--account", "account1",
-            "--key", "my-key",
-            "--value", "my-value",
-            "--tags", "InvalidTag");
-
-        // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
-        Assert.Contains("Invalid tag format", response.Message);
-    }
 }

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/KeyValue/KeyValueSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/KeyValue/KeyValueSetCommandTests.cs
@@ -153,4 +153,27 @@ public class KeyValueSetCommandTests : CommandUnitTestsBase<KeyValueSetCommand, 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("required", response.Message.ToLower());
     }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns400_WhenTagFormatIsInvalid()
+    {
+        // Arrange — service throws when a tag without '=' is supplied
+        Service.SetKeyValue(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ArgumentException("Invalid tag format 'InvalidTag'. Tags must be in 'key=value' format.", "tags"));
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub123",
+            "--account", "account1",
+            "--key", "my-key",
+            "--value", "my-value",
+            "--tags", "InvalidTag");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("Invalid tag format", response.Message);
+    }
 }

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/Services/AppConfigServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/Services/AppConfigServiceTests.cs
@@ -1,57 +1,47 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Reflection;
+using Azure.Core;
+using Azure.Data.AppConfiguration;
 using Azure.Mcp.Tools.AppConfig.Services;
+using Microsoft.Mcp.Core.Options;
 using Xunit;
 
 namespace Azure.Mcp.Tools.AppConfig.Tests.Services;
 
 public class AppConfigServiceTests
 {
-    /// <summary>
-    /// Regression guard (AC-01): ensures FindAppConfigStore does not have a redundant
-    /// subscriptionIdentifier parameter that duplicates subscription.
-    /// </summary>
     [Fact]
-    public void FindAppConfigStore_DoesNotHaveRedundantSubscriptionIdentifierParameter()
+    public void CreateConfigurationClientOptions_AppliesRetrySettings()
     {
-        var method = typeof(AppConfigService).GetMethod(
-            "FindAppConfigStore",
-            BindingFlags.NonPublic | BindingFlags.Instance);
-        Assert.NotNull(method);
+        var retryPolicy = new RetryPolicyOptions
+        {
+            DelaySeconds = 2,
+            MaxDelaySeconds = 10,
+            MaxRetries = 4,
+            Mode = RetryMode.Fixed,
+            NetworkTimeoutSeconds = 15
+        };
+        using var httpClient = new HttpClient();
+        var options = AppConfigService.CreateConfigurationClientOptions(
+            AppConfigurationAudience.AzurePublicCloud,
+            retryPolicy,
+            httpClient,
+            new Uri("https://example.azconfig.io"));
 
-        var paramNames = method!.GetParameters().Select(p => p.Name).ToArray();
-        Assert.DoesNotContain("subscriptionIdentifier", paramNames);
+        Assert.Equal(AppConfigurationAudience.AzurePublicCloud, options.Audience);
+        Assert.Equal(TimeSpan.FromSeconds(2), options.Retry.Delay);
+        Assert.Equal(TimeSpan.FromSeconds(10), options.Retry.MaxDelay);
+        Assert.Equal(4, options.Retry.MaxRetries);
+        Assert.Equal(RetryMode.Fixed, options.Retry.Mode);
+        Assert.Equal(TimeSpan.FromSeconds(15), options.Retry.NetworkTimeout);
     }
 
-    private static string ReadFindAppConfigStoreSource()
+    [Theory]
+    [InlineData(200, true)]
+    [InlineData(204, false)]
+    public void KeyValueExistedFromDeleteStatus_MapsKnownStatuses(int statusCode, bool expected)
     {
-        var sourceFile = Path.Combine(
-            AppContext.BaseDirectory,
-            "..", "..", "..", "..", "..",
-            "src", "Services", "AppConfigService.cs");
-
-        if (!File.Exists(sourceFile))
-        {
-            return string.Empty;
-        }
-
-        var source = File.ReadAllText(sourceFile);
-        var marker = "private async Task<AppConfigurationAccount> FindAppConfigStore";
-        var startIndex = source.IndexOf(marker, StringComparison.Ordinal);
-        if (startIndex < 0)
-        {
-            return source;
-        }
-
-        var snippet = source[startIndex..];
-        var nextMethodIndex = snippet.IndexOf("private", 1, StringComparison.Ordinal);
-        if (nextMethodIndex > 0)
-        {
-            snippet = snippet[..nextMethodIndex];
-        }
-
-        return snippet;
+        Assert.Equal(expected, AppConfigService.KeyValueExistedFromDeleteStatus(statusCode));
     }
 }

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/Services/AppConfigServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/Services/AppConfigServiceTests.cs
@@ -10,31 +10,6 @@ namespace Azure.Mcp.Tools.AppConfig.Tests.Services;
 public class AppConfigServiceTests
 {
     /// <summary>
-    /// Regression guard: ensures ExecuteSingleResourceQueryAsync continues to expose the optional
-    /// additionalFilter parameter and that AppConfigService calls it using a named argument.
-    /// If the base signature changes or the service reverts to positional arguments, this test fails.
-    /// </summary>
-    [Fact]
-    public void FindAppConfigStore_InvokesExecuteSingleResourceQueryAsyncWithNamedAdditionalFilter()
-    {
-        var baseType = typeof(AppConfigService).BaseType;
-        Assert.NotNull(baseType);
-
-        var executeMethod = baseType!.GetMethod(
-            "ExecuteSingleResourceQueryAsync",
-            BindingFlags.NonPublic | BindingFlags.Instance);
-        Assert.NotNull(executeMethod);
-
-        var parameters = executeMethod!.GetParameters();
-        Assert.True(parameters.Length >= 7, "ExecuteSingleResourceQueryAsync should expose the additionalFilter parameter");
-        Assert.Equal("additionalFilter", parameters[6].Name);
-
-        var methodSource = ReadFindAppConfigStoreSource();
-        Assert.Contains("ExecuteSingleResourceQueryAsync(", methodSource);
-        Assert.Contains("additionalFilter:", methodSource);
-    }
-
-    /// <summary>
     /// Regression guard (AC-01): ensures FindAppConfigStore does not have a redundant
     /// subscriptionIdentifier parameter that duplicates subscription.
     /// </summary>

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/Services/AppConfigServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/Services/AppConfigServiceTests.cs
@@ -34,6 +34,22 @@ public class AppConfigServiceTests
         Assert.Contains("additionalFilter:", methodSource);
     }
 
+    /// <summary>
+    /// Regression guard (AC-01): ensures FindAppConfigStore does not have a redundant
+    /// subscriptionIdentifier parameter that duplicates subscription.
+    /// </summary>
+    [Fact]
+    public void FindAppConfigStore_DoesNotHaveRedundantSubscriptionIdentifierParameter()
+    {
+        var method = typeof(AppConfigService).GetMethod(
+            "FindAppConfigStore",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+
+        var paramNames = method!.GetParameters().Select(p => p.Name).ToArray();
+        Assert.DoesNotContain("subscriptionIdentifier", paramNames);
+    }
+
     private static string ReadFindAppConfigStoreSource()
     {
         var sourceFile = Path.Combine(


### PR DESCRIPTION
Fixed multiple bugs in the App Configuration toolset:
      - Store lookup no longer passes subscription as both subscription-based arguments when resolving the store by name
      - The user-supplied retry policy is now applied to all data-plane key-value operations (get, set, delete, lock); previously it was only applied to the ARM store-discovery call, causing custom retry settings to have no effect on actual configuration reads and writes
      - The `kv delete` command response now includes an `existed` field (`true` if the key was present and deleted, `false` if it was already absent) and a human-readable `message`, allowing callers to distinguish a successful deletion from a no-op on a non-existent key