### PR TITLE
Fix Compute Tools Issues

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1779264486206.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1779264486206.yaml
@@ -1,7 +1,10 @@
 changes:
+  - section: "Breaking Changes"
+    description: |
+      `vm delete` now returns a not-found outcome (`Success: false`) when the target VM does not exist, instead of reporting a successful deletion.
+      This may affect automation that previously treated non-existent VM deletions as success.
   - section: "Bugs Fixed"
     description: |
       Fixed multiple bugs in Compute VM/VMSS commands:
-      - `vm delete` now correctly reports 'not found' when the target VM does not exist instead of always reporting success.
       - `vm update` and `vmss update` now correctly clear all tags when `--tags ''` is passed; fixed comma-separated tag delimiter mismatch between documentation and implementation.
       - `DetermineOsType` now uses word-boundary token matching: no longer misidentifies images with 'win' mid-word (e.g., 'twin-ubuntu') as Windows, and now correctly identifies Visual Studio on Windows images (e.g., 'vs-2022-comm-latest-win11-n-gen2') as Windows.

--- a/servers/Azure.Mcp.Server/changelog-entries/1779264486206.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1779264486206.yaml
@@ -1,0 +1,7 @@
+changes:
+  - section: "Bugs Fixed"
+    description: |
+      Fixed multiple bugs in Compute VM/VMSS commands:
+      - `vm delete` now correctly reports 'not found' when the target VM does not exist instead of always reporting success.
+      - `vm update` and `vmss update` now correctly clear all tags when `--tags ''` is passed; fixed comma-separated tag delimiter mismatch between documentation and implementation.
+      - `DetermineOsType` now uses word-boundary token matching: no longer misidentifies images with 'win' mid-word (e.g., 'twin-ubuntu') as Windows, and now correctly identifies Visual Studio on Windows images (e.g., 'vs-2022-comm-latest-win11-n-gen2') as Windows.

--- a/servers/Azure.Mcp.Server/changelog-entries/1779264486206.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1779264486206.yaml
@@ -1,8 +1,8 @@
 changes:
   - section: "Breaking Changes"
     description: |
-      `vm delete` now returns a not-found outcome (`Success: false`) when the target VM does not exist, instead of reporting a successful deletion.
-      This may affect automation that previously treated non-existent VM deletions as success.
+      `vm delete` and `vmss delete` now return a not-found outcome (`Success: false`) when the target resource does not exist, instead of reporting a successful deletion.
+      This may affect automation that previously treated non-existent VM/VMSS deletions as success.
   - section: "Bugs Fixed"
     description: |
       Fixed multiple bugs in Compute VM/VMSS commands:

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -1451,10 +1451,10 @@ azmcp compute vm update --subscription "my-subscription" \
 | `--resource-group`, `-g` | Yes | Resource group name |
 | `--vm-name` | Yes | Name of the virtual machine |
 | `--vm-size` | No | New VM size (may require VM to be deallocated) |
-| `--tags` | No | Tags in key=value,key2=value2 format |
+| `--tags` | No | Comma-separated tags in `key=value` format (e.g., `env=prod,team=compute`). Use `''` to clear all existing tags. |
 | `--license-type` | No | License type: 'Windows_Server', 'RHEL_BYOS', 'SLES_BYOS', 'None' |
 | `--boot-diagnostics` | No | Enable or disable boot diagnostics: 'true' or 'false' |
-| `--user-data` | No | Base64-encoded user data |
+| `--user-data` | No | Base64-encoded user data for the VM (e.g., a cloud-init or shell script). Must be Base64-encoded; the ARM API requires this format. |
 
 ```bash
 # Delete a Virtual Machine

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -1451,7 +1451,7 @@ azmcp compute vm update --subscription "my-subscription" \
 | `--resource-group`, `-g` | Yes | Resource group name |
 | `--vm-name` | Yes | Name of the virtual machine |
 | `--vm-size` | No | New VM size (may require VM to be deallocated) |
-| `--tags` | No | Comma-separated tags in `key=value` format (e.g., `env=prod,team=compute`). Use `''` to clear all existing tags. |
+| `--tags` | No | Comma-separated tags in `key=value` format (e.g., `env=prod,team=compute`). Use bare `--tags` or `--tags ''` to clear all existing tags. |
 | `--license-type` | No | License type: 'Windows_Server', 'RHEL_BYOS', 'SLES_BYOS', 'None' |
 | `--boot-diagnostics` | No | Enable or disable boot diagnostics: 'true' or 'false' |
 | `--user-data` | No | Base64-encoded user data for the VM (e.g., a cloud-init or shell script). Must be Base64-encoded; the ARM API requires this format. |
@@ -1742,7 +1742,7 @@ azmcp compute vmss update --subscription "my-subscription" \
 | `--overprovision` | No | Enable or disable overprovisioning |
 | `--enable-auto-os-upgrade` | No | Enable automatic OS image upgrades |
 | `--scale-in-policy` | No | Scale-in policy: 'Default', 'OldestVM', 'NewestVM' |
-| `--tags` | No | Tags in key=value,key2=value2 format |
+| `--tags` | No | Comma-separated tags in `key=value` format (e.g., `env=prod,team=compute`). Use bare `--tags` or `--tags ''` to clear all existing tags. |
 
 ```bash
 # Delete a Virtual Machine Scale Set

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmDeleteCommand.cs
@@ -68,7 +68,7 @@ public sealed class VmDeleteCommand(ILogger<VmDeleteCommand> logger, IComputeSer
         {
             context.Activity?.AddTag("subscription", options.Subscription);
 
-            await _computeService.DeleteVmAsync(
+            var deleted = await _computeService.DeleteVmAsync(
                 options.VmName!,
                 options.ResourceGroup!,
                 options.Subscription!,
@@ -77,10 +77,12 @@ public sealed class VmDeleteCommand(ILogger<VmDeleteCommand> logger, IComputeSer
                 options.RetryPolicy,
                 cancellationToken);
 
+            var message = deleted
+                ? $"Virtual machine '{options.VmName}' was successfully deleted from resource group '{options.ResourceGroup}'."
+                : $"Virtual machine '{options.VmName}' was not found in resource group '{options.ResourceGroup}'. Nothing was deleted.";
+
             context.Response.Results = ResponseResult.Create(
-                new VmDeleteCommandResult(
-                    $"Virtual machine '{options.VmName}' was successfully deleted from resource group '{options.ResourceGroup}'.",
-                    true),
+                new VmDeleteCommandResult(message, deleted),
                 ComputeJsonContext.Default.VmDeleteCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmUpdateCommand.cs
@@ -75,7 +75,9 @@ public sealed class VmUpdateCommand(ILogger<VmUpdateCommand> logger, IComputeSer
         var options = base.BindOptions(parseResult);
         options.VmName = parseResult.GetValueOrDefault<string>(ComputeOptionDefinitions.VmName.Name);
         options.VmSize = parseResult.GetValueOrDefault<string>(ComputeOptionDefinitions.VmSize.Name);
-        options.Tags = parseResult.GetValueOrDefault<string>(ComputeOptionDefinitions.Tags.Name);
+        var tagsProvided = parseResult.CommandResult.GetResult(ComputeOptionDefinitions.Tags) is not null;
+        var tagsValue = parseResult.GetValueOrDefault<string>(ComputeOptionDefinitions.Tags.Name);
+        options.Tags = tagsProvided && tagsValue is null ? string.Empty : tagsValue;
         options.LicenseType = parseResult.GetValueOrDefault<string>(ComputeOptionDefinitions.LicenseType.Name);
         options.BootDiagnostics = parseResult.GetValueOrDefault<string>(ComputeOptionDefinitions.BootDiagnostics.Name);
         options.UserData = parseResult.GetValueOrDefault<string>(ComputeOptionDefinitions.UserData.Name);

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmUpdateCommand.cs
@@ -53,9 +53,14 @@ public sealed class VmUpdateCommand(ILogger<VmUpdateCommand> logger, IComputeSer
         // Resource group is required for update
         command.Validators.Add(commandResult =>
         {
-            // Custom validation: At least one update property must be specified
+            // Custom validation: At least one update property must be specified.
+            // Note: Tags may be an empty string ("") to clear all tags — use GetResult to detect
+            // whether the option was explicitly passed even with an empty value, since HasOptionResult
+            // returns false for empty-string tokens.
+            var tagsProvided = commandResult.GetResult(ComputeOptionDefinitions.Tags) is not null;
+
             if (string.IsNullOrEmpty(commandResult.GetValueOrDefault<string>(ComputeOptionDefinitions.VmSize.Name)) &&
-                string.IsNullOrEmpty(commandResult.GetValueOrDefault<string>(ComputeOptionDefinitions.Tags.Name)) &&
+                !tagsProvided &&
                 string.IsNullOrEmpty(commandResult.GetValueOrDefault<string>(ComputeOptionDefinitions.LicenseType.Name)) &&
                 string.IsNullOrEmpty(commandResult.GetValueOrDefault<string>(ComputeOptionDefinitions.BootDiagnostics.Name)) &&
                 string.IsNullOrEmpty(commandResult.GetValueOrDefault<string>(ComputeOptionDefinitions.UserData.Name)))

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssDeleteCommand.cs
@@ -66,7 +66,7 @@ public sealed class VmssDeleteCommand(ILogger<VmssDeleteCommand> logger, IComput
         {
             context.Activity?.AddTag("subscription", options.Subscription);
 
-            await _computeService.DeleteVmssAsync(
+            var deleted = await _computeService.DeleteVmssAsync(
                 options.VmssName!,
                 options.ResourceGroup!,
                 options.Subscription!,
@@ -75,10 +75,14 @@ public sealed class VmssDeleteCommand(ILogger<VmssDeleteCommand> logger, IComput
                 options.RetryPolicy,
                 cancellationToken);
 
+            var message = deleted
+                ? $"Virtual machine scale set '{options.VmssName}' was successfully deleted from resource group '{options.ResourceGroup}'."
+                : $"Virtual machine scale set '{options.VmssName}' was not found in resource group '{options.ResourceGroup}'. Nothing was deleted.";
+
             context.Response.Results = ResponseResult.Create(
                 new VmssDeleteCommandResult(
-                    $"Virtual machine scale set '{options.VmssName}' was successfully deleted from resource group '{options.ResourceGroup}'.",
-                    true),
+                    message,
+                    deleted),
                 ComputeJsonContext.Default.VmssDeleteCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssUpdateCommand.cs
@@ -56,13 +56,15 @@ public sealed class VmssUpdateCommand(ILogger<VmssUpdateCommand> logger, IComput
         command.Validators.Add(commandResult =>
         {
             // Custom validation: At least one update property must be specified
+            var tagsProvided = commandResult.GetResult(ComputeOptionDefinitions.Tags) is not null;
+
             if (!commandResult.HasOptionResult(ComputeOptionDefinitions.UpgradePolicy) &&
                 !commandResult.HasOptionResult(ComputeOptionDefinitions.Capacity) &&
                 !commandResult.HasOptionResult(ComputeOptionDefinitions.VmSize) &&
                 !commandResult.HasOptionResult(ComputeOptionDefinitions.Overprovision) &&
                 !commandResult.HasOptionResult(ComputeOptionDefinitions.EnableAutoOsUpgrade) &&
                 !commandResult.HasOptionResult(ComputeOptionDefinitions.ScaleInPolicy) &&
-                !commandResult.HasOptionResult(ComputeOptionDefinitions.Tags))
+                !tagsProvided)
             {
                 commandResult.AddError(
                     "At least one update property must be specified: --upgrade-policy, --capacity, --vm-size, --overprovision, --enable-auto-os-upgrade, --scale-in-policy, or --tags.");
@@ -80,7 +82,9 @@ public sealed class VmssUpdateCommand(ILogger<VmssUpdateCommand> logger, IComput
         options.Overprovision = parseResult.GetValueOrDefault(ComputeOptionDefinitions.Overprovision);
         options.EnableAutoOsUpgrade = parseResult.GetValueOrDefault(ComputeOptionDefinitions.EnableAutoOsUpgrade);
         options.ScaleInPolicy = parseResult.GetValueOrDefault(ComputeOptionDefinitions.ScaleInPolicy);
-        options.Tags = parseResult.GetValueOrDefault(ComputeOptionDefinitions.Tags);
+        var tagsProvided = parseResult.CommandResult.GetResult(ComputeOptionDefinitions.Tags) is not null;
+        var tagsValue = parseResult.GetValueOrDefault(ComputeOptionDefinitions.Tags);
+        options.Tags = tagsProvided && tagsValue is null ? string.Empty : tagsValue;
         return options;
     }
 

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/ComputeOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/ComputeOptionDefinitions.cs
@@ -120,7 +120,8 @@ public static class ComputeOptionDefinitions
     public static readonly Option<string> Tags = new($"--{TagsName}")
     {
         Description = "Comma-separated tags in 'key=value' format (e.g., 'env=prod,team=compute'). Use '' to clear all existing tags.",
-        Required = false
+        Required = false,
+        Arity = ArgumentArity.ZeroOrOne
     };
 
     public static readonly Option<string> DiskEncryptionSet = new($"--{DiskEncryptionSetName}")

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/ComputeOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/ComputeOptionDefinitions.cs
@@ -119,7 +119,7 @@ public static class ComputeOptionDefinitions
 
     public static readonly Option<string> Tags = new($"--{TagsName}")
     {
-        Description = "Space-separated tags in 'key=value' format. Use '' to clear existing tags.",
+        Description = "Comma-separated tags in 'key=value' format (e.g., 'env=prod,team=compute'). Use '' to clear all existing tags.",
         Required = false
     };
 
@@ -386,7 +386,7 @@ public static class ComputeOptionDefinitions
 
     public static readonly Option<string> UserData = new($"--{UserDataName}")
     {
-        Description = "Base64-encoded user data for the VM. Use to update custom data scripts",
+        Description = "Base64-encoded user data for the VM (e.g., a cloud-init or shell script). The value must be Base64-encoded before passing; the ARM API requires this format.",
         Required = false
     };
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Services/ComputeService.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Services/ComputeService.cs
@@ -969,14 +969,22 @@ public class ComputeService(
 
         if (tags != null)
         {
-            // Parse tags in key=value,key2=value2 format
-            var tagPairs = tags.Split(',', StringSplitOptions.RemoveEmptyEntries);
-            foreach (var pair in tagPairs)
+            if (string.IsNullOrEmpty(tags))
             {
-                var keyValue = pair.Split('=', 2);
-                if (keyValue.Length == 2)
+                // Empty string explicitly clears all existing tags
+                patch.Tags.Clear();
+            }
+            else
+            {
+                // Parse tags in key=value,key2=value2 format
+                var tagPairs = tags.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                foreach (var pair in tagPairs)
                 {
-                    patch.Tags[keyValue[0].Trim()] = keyValue[1].Trim();
+                    var keyValue = pair.Split('=', 2);
+                    if (keyValue.Length == 2)
+                    {
+                        patch.Tags[keyValue[0].Trim()] = keyValue[1].Trim();
+                    }
                 }
             }
             needsUpdate = true;
@@ -1061,14 +1069,22 @@ public class ComputeService(
 
         if (tags != null)
         {
-            // Parse tags in key=value,key2=value2 format
-            var tagPairs = tags.Split(',', StringSplitOptions.RemoveEmptyEntries);
-            foreach (var pair in tagPairs)
+            if (string.IsNullOrEmpty(tags))
             {
-                var keyValue = pair.Split('=', 2);
-                if (keyValue.Length == 2)
+                // Empty string explicitly clears all existing tags
+                patch.Tags.Clear();
+            }
+            else
+            {
+                // Parse tags in key=value,key2=value2 format
+                var tagPairs = tags.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                foreach (var pair in tagPairs)
                 {
-                    patch.Tags[keyValue[0].Trim()] = keyValue[1].Trim();
+                    var keyValue = pair.Split('=', 2);
+                    if (keyValue.Length == 2)
+                    {
+                        patch.Tags[keyValue[0].Trim()] = keyValue[1].Trim();
+                    }
                 }
             }
             needsUpdate = true;

--- a/tools/Azure.Mcp.Tools.Compute/src/Utilities/ComputeUtilities.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Utilities/ComputeUtilities.cs
@@ -23,7 +23,13 @@ internal static class ComputeUtilities
         if (!string.IsNullOrEmpty(image))
         {
             var lowerImage = image.ToLowerInvariant();
-            if (lowerImage.Contains("win") || lowerImage.Contains("windows"))
+            // StartsWith("win"): alias-style names like "Win2022Datacenter", "Win11Pro"
+            // Contains("windows"): URN offer/publisher names like "MicrosoftWindowsServer:WindowsServer2022:..."
+            // Token StartsWith("win"): SKU components like "vs-2022-comm-latest-win11-n-gen2"
+            //   (split on URN/name separators so "twin-ubuntu" token "twin" does NOT match)
+            if (lowerImage.StartsWith("win") ||
+                lowerImage.Contains("windows") ||
+                lowerImage.Split(':', '-', '_', ' ').Any(t => t.StartsWith("win")))
             {
                 return "windows";
             }

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/ComputeUtilitiesTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/ComputeUtilitiesTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Tools.Compute.Utilities;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Compute.Tests;
+
+public class ComputeUtilitiesTests
+{
+    [Theory]
+    // Known Windows aliases (prefix-based matching)
+    [InlineData("Win2022Datacenter", "windows")]
+    [InlineData("Win11Pro", "windows")]
+    [InlineData("Win10Pro", "windows")]
+    [InlineData("Win2022Datacenter1P", "windows")]
+    // Windows URN / offer names (substring matching on "windows")
+    [InlineData("MicrosoftWindowsServer:WindowsServer2022:2022-datacenter-azure-edition:latest", "windows")]
+    [InlineData("MicrosoftWindowsDesktop:windows-11:win11-22h2-pro:latest", "windows")]
+    // Visual Studio on Windows — "win" only appears inside a SKU token (not at string start, no "windows" anywhere)
+    [InlineData("MicrosoftVisualStudio:visualstudio2022:vs-2022-comm-latest-win11-n-gen2:latest", "windows")]
+    [InlineData("MicrosoftVisualStudio:visualstudio2022:vs-2022-ent-latest-win10-n-gen2:latest", "windows")]
+    public void DetermineOsType_WindowsImages_ReturnsWindows(string image, string expected)
+    {
+        Assert.Equal(expected, ComputeUtilities.DetermineOsType(null, image));
+    }
+
+    [Theory]
+    // Linux aliases
+    [InlineData("Ubuntu2604", "linux")]
+    [InlineData("Ubuntu2404", "linux")]
+    [InlineData("Debian12", "linux")]
+    [InlineData("RHEL9", "linux")]
+    // Image names that contain "win" as a non-leading substring — original bug false-positive guard
+    [InlineData("twin-ubuntu-lts", "linux")]     // "twin" does not start with "win"
+    [InlineData("swingbench-linux", "linux")]    // "swingbench" does not start with "win"
+    // Linux URN
+    [InlineData("Canonical:ubuntu-24_04-lts:server:latest", "linux")]
+    public void DetermineOsType_LinuxImages_ReturnsLinux(string image, string expected)
+    {
+        Assert.Equal(expected, ComputeUtilities.DetermineOsType(null, image));
+    }
+
+    [Theory]
+    [InlineData("windows", "windows")]
+    [InlineData("linux", "linux")]
+    [InlineData("Windows", "Windows")]
+    [InlineData("Linux", "Linux")]
+    public void DetermineOsType_ExplicitOsType_ReturnsExplicitValue(string osType, string expected)
+    {
+        // Explicit osType overrides image-based detection
+        Assert.Equal(expected, ComputeUtilities.DetermineOsType(osType, "Ubuntu2404"));
+    }
+
+    [Fact]
+    public void DetermineOsType_NullImageAndNoOsType_DefaultsToLinux()
+    {
+        Assert.Equal("linux", ComputeUtilities.DetermineOsType(null, null));
+    }
+
+    [Fact]
+    public void DetermineOsType_EmptyImageAndNoOsType_DefaultsToLinux()
+    {
+        Assert.Equal("linux", ComputeUtilities.DetermineOsType(null, ""));
+    }
+}

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmDeleteCommandTests.cs
@@ -124,9 +124,9 @@ public class VmDeleteCommandTests : CommandUnitTestsBase<VmDeleteCommand, ICompu
     }
 
     [Fact]
-    public async Task ExecuteAsync_VmNotFound_ReturnsSuccess()
+    public async Task ExecuteAsync_VmNotFound_ReturnsNotFoundMessage()
     {
-        // Arrange - service returns false (VM was already gone / 404), but delete is idempotent
+        // Arrange - service returns false (VM was already gone / 404); delete is idempotent so HTTP 200
         Service.DeleteVmAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -143,9 +143,12 @@ public class VmDeleteCommandTests : CommandUnitTestsBase<VmDeleteCommand, ICompu
             "--resource-group", _knownResourceGroup,
             "--subscription", _knownSubscription);
 
-        // Assert - idempotent: 404 treated as success
+        // Assert - HTTP 200 (idempotent) but message says "not found"
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.VmDeleteCommandResult);
+        Assert.False(result.Success);
+        Assert.Contains("not found", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(_knownVmName, result.Message);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmUpdateCommandTests.cs
@@ -378,6 +378,18 @@ public class VmUpdateCommandTests : CommandUnitTestsBase<VmUpdateCommand, ICompu
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).UpdateVmAsync(
+            _knownVmName,
+            _knownResourceGroup,
+            _knownSubscription,
+            Arg.Any<string?>(),
+            string.Empty,
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -416,5 +428,17 @@ public class VmUpdateCommandTests : CommandUnitTestsBase<VmUpdateCommand, ICompu
             "--tags");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).UpdateVmAsync(
+            _knownVmName,
+            _knownResourceGroup,
+            _knownSubscription,
+            Arg.Any<string?>(),
+            string.Empty,
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmUpdateCommandTests.cs
@@ -379,4 +379,42 @@ public class VmUpdateCommandTests : CommandUnitTestsBase<VmUpdateCommand, ICompu
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_ClearTagsWithBareOption_PassesEmptyTagsToService()
+    {
+        var expectedResult = new VmUpdateResult(
+            Name: _knownVmName,
+            Id: "/subscriptions/sub123/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm",
+            Location: "eastus",
+            VmSize: "Standard_D2s_v5",
+            ProvisioningState: "Succeeded",
+            PowerState: "VM running",
+            OsType: "linux",
+            LicenseType: null,
+            Zones: null,
+            Tags: new Dictionary<string, string>());
+
+        Service.UpdateVmAsync(
+            Arg.Is(_knownVmName),
+            Arg.Is(_knownResourceGroup),
+            Arg.Is(_knownSubscription),
+            Arg.Any<string?>(),
+            Arg.Is(string.Empty),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedResult);
+
+        var response = await ExecuteCommandAsync(
+            "--vm-name", _knownVmName,
+            "--resource-group", _knownResourceGroup,
+            "--subscription", _knownSubscription,
+            "--tags");
+
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+    }
 }

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmUpdateCommandTests.cs
@@ -289,4 +289,94 @@ public class VmUpdateCommandTests : CommandUnitTestsBase<VmUpdateCommand, ICompu
         // Assert parse was successful
         Assert.Empty(parseResult.Errors);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_UpdatesVmWithUserData_PassesValueToService()
+    {
+        // The command passes the user-supplied value (expected to be Base64-encoded by the caller)
+        // directly to the service without modification (COMP-03: ARM requires Base64).
+        const string base64UserData = "IyEvYmluL2Jhc2gKZWNobyBoZWxsbw=="; // base64 of "#!/bin/bash\necho hello"
+
+        var expectedResult = new VmUpdateResult(
+            Name: _knownVmName,
+            Id: "/subscriptions/sub123/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm",
+            Location: "eastus",
+            VmSize: "Standard_D2s_v5",
+            ProvisioningState: "Succeeded",
+            PowerState: "VM running",
+            OsType: "linux",
+            LicenseType: null,
+            Zones: null,
+            Tags: null);
+
+        Service.UpdateVmAsync(
+            Arg.Is(_knownVmName),
+            Arg.Is(_knownResourceGroup),
+            Arg.Is(_knownSubscription),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Is(base64UserData),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedResult);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--vm-name", _knownVmName,
+            "--resource-group", _knownResourceGroup,
+            "--subscription", _knownSubscription,
+            "--user-data", base64UserData);
+
+        // Assert - command passes the value through as-is; caller is responsible for Base64 encoding
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).UpdateVmAsync(
+            _knownVmName, _knownResourceGroup, _knownSubscription,
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), base64UserData, Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ClearTagsWithEmptyString_PassesEmptyTagsToService()
+    {
+        // COMP-04: passing --tags "" should clear existing tags via the service
+        var expectedResult = new VmUpdateResult(
+            Name: _knownVmName,
+            Id: "/subscriptions/sub123/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm",
+            Location: "eastus",
+            VmSize: "Standard_D2s_v5",
+            ProvisioningState: "Succeeded",
+            PowerState: "VM running",
+            OsType: "linux",
+            LicenseType: null,
+            Zones: null,
+            Tags: new Dictionary<string, string>());
+
+        Service.UpdateVmAsync(
+            Arg.Is(_knownVmName),
+            Arg.Is(_knownResourceGroup),
+            Arg.Is(_knownSubscription),
+            Arg.Any<string?>(),
+            Arg.Is(string.Empty),  // empty string triggers tag clearing in service
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedResult);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--vm-name", _knownVmName,
+            "--resource-group", _knownResourceGroup,
+            "--subscription", _knownSubscription,
+            "--tags", "");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+    }
 }

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssDeleteCommandTests.cs
@@ -125,7 +125,7 @@ public class VmssDeleteCommandTests : CommandUnitTestsBase<VmssDeleteCommand, IC
     }
 
     [Fact]
-    public async Task ExecuteAsync_VmssNotFound_ReturnsSuccess()
+    public async Task ExecuteAsync_VmssNotFound_ReturnsNotFoundMessage()
     {
         // Arrange - service returns false (VMSS was already gone / 404), but delete is idempotent
         Service.DeleteVmssAsync(
@@ -144,9 +144,12 @@ public class VmssDeleteCommandTests : CommandUnitTestsBase<VmssDeleteCommand, IC
             "--resource-group", _knownResourceGroup,
             "--subscription", _knownSubscription);
 
-        // Assert - idempotent: 404 treated as success
+        // Assert - HTTP 200 (idempotent) but message says "not found"
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
+        var result = ValidateAndDeserializeResponse(response, ComputeJsonContext.Default.VmssDeleteCommandResult);
+        Assert.False(result.Success);
+        Assert.Contains("not found", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(_knownVmssName, result.Message);
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssUpdateCommandTests.cs
@@ -134,6 +134,45 @@ public class VmssUpdateCommandTests : CommandUnitTestsBase<VmssUpdateCommand, IC
     }
 
     [Fact]
+    public async Task ExecuteAsync_ClearTagsWithBareOption_PassesEmptyTagsToService()
+    {
+        var expectedResult = new VmssUpdateResult(
+            Name: _knownVmssName,
+            Id: "/subscriptions/sub123/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/test-vmss",
+            Location: "eastus",
+            VmSize: "Standard_D2s_v3",
+            ProvisioningState: "Succeeded",
+            Capacity: 5,
+            UpgradePolicy: "Manual",
+            Zones: null,
+            Tags: new Dictionary<string, string>());
+
+        Service.UpdateVmssAsync(
+            Arg.Is(_knownVmssName),
+            Arg.Is(_knownResourceGroup),
+            Arg.Is(_knownSubscription),
+            Arg.Any<string?>(),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<string?>(),
+            Arg.Is(string.Empty),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expectedResult);
+
+        var response = await ExecuteCommandAsync(
+            "--vmss-name", _knownVmssName,
+            "--resource-group", _knownResourceGroup,
+            "--subscription", _knownSubscription,
+            "--tags");
+
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_UpdatesVmssUpgradePolicy()
     {
         // Arrange

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssUpdateCommandTests.cs
@@ -170,6 +170,20 @@ public class VmssUpdateCommandTests : CommandUnitTestsBase<VmssUpdateCommand, IC
             "--tags");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).UpdateVmssAsync(
+            _knownVmssName,
+            _knownResourceGroup,
+            _knownSubscription,
+            Arg.Any<string?>(),
+            Arg.Any<int?>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<bool?>(),
+            Arg.Any<string?>(),
+            string.Empty,
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
Fixed multiple bugs in Compute VM/VMSS commands:
      - `vm delete` now correctly reports 'not found' when the target VM does not exist instead of always reporting success.
      - `vm update` and `vmss update` now correctly clear all tags when `--tags ''` is passed; fixed comma-separated tag delimiter mismatch between documentation and implementation.
      - `DetermineOsType` now uses word-boundary token matching: no longer misidentifies images with 'win' mid-word (e.g., 'twin-ubuntu') as Windows.