### PR TITLE
[PROTOTYPE] Support ability to select return fields in listing operations

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Commands/CommandResponseSelectProperties.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/CommandResponseSelectProperties.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization.Metadata;
+
+namespace Microsoft.Mcp.Core.Commands;
+
+public sealed class CommandResponseSelectProperties(string[]? selectedFields, IJsonTypeInfoResolver originalResolver, Type typeToTrim) : IJsonTypeInfoResolver
+{
+    private readonly IJsonTypeInfoResolver _trimmingResolver = originalResolver.WithAddedModifier(typeInfo =>
+        {
+            if (typeInfo.Type == typeToTrim)
+            {
+                foreach (var property in typeInfo.Properties)
+                {
+                    property.ShouldSerialize = (obj, value) =>
+                        selectedFields != null && selectedFields.Any(field => property.Name.Equals(field, StringComparison.OrdinalIgnoreCase));
+                }
+            }
+        });
+
+    public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options) => _trimmingResolver.GetTypeInfo(type, options);
+}

--- a/core/Microsoft.Mcp.Core/src/Models/Command/CommandResponse.cs
+++ b/core/Microsoft.Mcp.Core/src/Models/Command/CommandResponse.cs
@@ -36,10 +36,8 @@ public sealed class ResponseResult
         _typeInfo = typeInfo;
     }
 
-    public static ResponseResult Create<T>(T result, JsonTypeInfo<T> typeInfo)
-    {
-        return new ResponseResult(result, typeInfo);
-    }
+    public static ResponseResult Create<T>(T result, JsonTypeInfo<T> typeInfo) => new(result, typeInfo);
+    public static ResponseResult Create(object? result, JsonTypeInfo typeInfo) => new(result, typeInfo);
 
     public void Write(Utf8JsonWriter writer)
     {

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobGetCommand.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.Storage.Models;
@@ -19,13 +21,11 @@ namespace Azure.Mcp.Tools.Storage.Commands.Blob;
     Description = """
         List/get/show blobs in a blob container in Storage account. Use this tool to list the blobs in a container or
         get details for a specific blob. If no blob specified, lists all blobs present in the container, optionally
-        filtering on a prefix. The prefix is ignored if a blob is specified.
-
-        Required: --account, --container, --subscription
-        Optional: --blob, --tenant, --prefix
-
-        Returns: blob name, size, lastModified, contentType, contentHash, metadata, and blob properties.
-        Do not use this tool to list containers in the storage account.
+        filtering on a prefix. The prefix is ignored if a blob is specified. The results may also be filtered by
+        selecting which fields to include in the output. If no fields are selected, all fields will be included.
+        The details returned include blob name, size, last modified time, content type, content hash, metadata, and
+        blob properties. This tool is not intended to list containers in the storage account; use the appropriate
+        command for that operation.
         """,
     Destructive = false,
     Idempotent = true,
@@ -54,7 +54,21 @@ public sealed class BlobGetCommand(ILogger<BlobGetCommand> logger, IStorageServi
                 cancellationToken
             );
 
-            context.Response.Results = ResponseResult.Create(new BlobGetCommandResult(details ?? []), StorageJsonContext.Default.BlobGetCommandResult);
+            if (!string.IsNullOrEmpty(options.SelectedFields))
+            {
+                var dynamicOptions = new JsonSerializerOptions()
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+                    TypeInfoResolver = new CommandResponseSelectProperties(options.SelectedFields.Split(','), StorageJsonContext.Default, typeof(BlobInfo))
+                };
+                context.Response.Results = ResponseResult.Create(new BlobGetCommandResult(details ?? []), dynamicOptions.GetTypeInfo(typeof(BlobGetCommandResult)));
+            }
+            else
+            {
+                context.Response.Results = ResponseResult.Create(new(details ?? []), StorageJsonContext.Default.BlobGetCommandResult);
+            }
+
             return context.Response;
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/BlobGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/BlobGetOptions.cs
@@ -27,6 +27,9 @@ public class BlobGetOptions : ISubscriptionOption
     [Option(OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
+    [Option("Comma-separated list of specific fields to include in the output. If not specified, all fields will be included.")]
+    public string? SelectedFields { get; set; }
+
     // TODO: Remove unused option — registered and visible to the user but never consumed by the command
     [Option(OptionDescriptions.AuthMethod)]
     public AuthMethod? AuthMethod { get; set; }


### PR DESCRIPTION
## What does this PR do?

This PR is a prototype which adds the ability to `select-fields` when running operations, allowing the agent to restrict response data to a subset of what would normally be returned. This allows for listing operations to reduce their size, which reduces token usage and reduces the chances an agent misinterprets response data due to pressure on its context window.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
