### PR TITLE
Update App Lens Tool to handle resource not found scenarios as successful calls

### DIFF
--- a/tools/Azure.Mcp.Tools.AppLens/src/Services/AppLensService.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Services/AppLensService.cs
@@ -52,7 +52,7 @@ public class AppLensService(
 
         if (findResult is DidNotFindResourceResult notFound)
         {
-            throw new InvalidOperationException(notFound.Message);
+            return new DiagnosticResult([notFound.Message], [], string.Empty, string.Empty);
         }
 
         var foundResource = (FoundResourceResult)findResult;

--- a/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.Tests/Resource/ResourceDiagnoseCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.Tests/Resource/ResourceDiagnoseCommandTests.cs
@@ -271,7 +271,7 @@ public class ResourceDiagnoseCommandTests : CommandUnitTestsBase<ResourceDiagnos
     }
 
     [Fact]
-    public async Task ExecuteAsync_Returns400_WhenServiceThrowsInvalidOperationException()
+    public async Task ExecuteAsync_Returns422_WhenServiceThrowsInvalidOperationException()
     {
         // Arrange - this covers cases like AppLens session failure (not resource-not-found)
         Service.DiagnoseResourceAsync(

--- a/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.Tests/Resource/ResourceDiagnoseCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/tests/Azure.Mcp.Tools.AppLens.Tests/Resource/ResourceDiagnoseCommandTests.cs
@@ -236,9 +236,12 @@ public class ResourceDiagnoseCommandTests : CommandUnitTestsBase<ResourceDiagnos
     }
 
     [Fact]
-    public async Task ExecuteAsync_Returns400_WhenServiceThrowsInvalidOperationException()
+    public async Task ExecuteAsync_ReturnsSuccessWithMessage_WhenResourceNotFound()
     {
-        // Arrange
+        // Arrange - service returns a result with the not-found message in Insights (no exception thrown)
+        var notFoundMessage = "No resources found with name 'myapp'.";
+        var notFoundResult = new DiagnosticResult([notFoundMessage], [], string.Empty, string.Empty);
+
         Service.DiagnoseResourceAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -247,7 +250,39 @@ public class ResourceDiagnoseCommandTests : CommandUnitTestsBase<ResourceDiagnos
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("Resource not found"));
+            .Returns(notFoundResult);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--question", "Why is my app slow?",
+            "--resource", "myapp",
+            "--subscription", "sub123",
+            "--resource-group", "rg1",
+            "--resource-type", "Microsoft.Web/sites");
+
+        // Assert - resource not found is not a tool failure, so it should succeed
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        var result = ValidateAndDeserializeResponse(response, AppLensJsonContext.Default.ResourceDiagnoseCommandResult);
+        Assert.NotNull(result.Result);
+        Assert.Single(result.Result.Insights);
+        Assert.Contains(notFoundMessage, result.Result.Insights[0]);
+        Assert.Empty(result.Result.Solutions);
+        Assert.Empty(result.Result.ResourceId);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns400_WhenServiceThrowsInvalidOperationException()
+    {
+        // Arrange - this covers cases like AppLens session failure (not resource-not-found)
+        Service.DiagnoseResourceAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("AppLens session failed"));
 
         // Act
         var response = await ExecuteCommandAsync(
@@ -259,7 +294,7 @@ public class ResourceDiagnoseCommandTests : CommandUnitTestsBase<ResourceDiagnos
 
         // Assert
         Assert.Equal(HttpStatusCode.UnprocessableEntity, response.Status);
-        Assert.Contains("Resource not found", response.Message);
+        Assert.Contains("AppLens session failed", response.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?
Updated app lens so that in cases where a resource is not found due to there not being a resource available that matches the name given, the tool now returns a success response with message informing user that resource with name was not found, as opposed to throwing exception. This is to help with accurately tracking telemetry, as this scenario should not be reported as a tool failure given tool is responding appropriately given the input. 

<img width="575" height="821" alt="image" src="https://github.com/user-attachments/assets/0e5ee9fb-a348-4b2c-8d20-c3be66b18e39" />

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md) (Not necessary, this is an internal refactor)
- [x] For MCP tool changes:
    - [x] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
