### PR TITLE
fix: Use KeyNotFoundException for not-found conditions in core Azure services

### DIFF
--- a/core/Azure.Mcp.Core/src/Services/Azure/ResourceGroup/ResourceGroupService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/ResourceGroup/ResourceGroupService.cs
@@ -94,7 +94,7 @@ public class ResourceGroupService(
         ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceGroupName), resourceGroupName));
 
         var resourceGroupResource = await GetResourceGroupResource(subscription, resourceGroupName, tenant, retryPolicy, cancellationToken)
-            ?? throw new Exception($"Resource group '{resourceGroupName}' not found");
+            ?? throw new KeyNotFoundException($"Resource group '{resourceGroupName}' not found");
 
         await foreach (var r in resourceGroupResource.GetGenericResourcesAsync(cancellationToken: cancellationToken))
         {

--- a/core/Azure.Mcp.Core/src/Services/Azure/Subscription/SubscriptionService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Subscription/SubscriptionService.cs
@@ -76,7 +76,7 @@ public class SubscriptionService(
         var response = await armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscriptionId)).GetAsync(cancellationToken);
         if (response?.Value == null)
         {
-            throw new Exception($"Could not retrieve subscription {subscription}");
+            throw new KeyNotFoundException($"Could not retrieve subscription {subscription}");
         }
 
         // Cache the result using subscription ID
@@ -95,7 +95,7 @@ public class SubscriptionService(
     {
         var subscriptions = await GetSubscriptions(tenant, retryPolicy, cancellationToken);
         var subscription = subscriptions.FirstOrDefault(s => s.DisplayName.Equals(subscriptionName, StringComparison.OrdinalIgnoreCase)) ??
-            throw new ArgumentException($"Could not find subscription with name {subscriptionName}", nameof(subscriptionName));
+            throw new KeyNotFoundException($"Could not find subscription with name {subscriptionName}");
 
         return subscription.SubscriptionId;
     }
@@ -104,7 +104,7 @@ public class SubscriptionService(
     {
         var subscriptions = await GetSubscriptions(tenant, retryPolicy, cancellationToken);
         var subscription = subscriptions.FirstOrDefault(s => s.SubscriptionId.Equals(subscriptionId, StringComparison.OrdinalIgnoreCase)) ??
-            throw new ArgumentException($"Could not find subscription with ID {subscriptionId}", nameof(subscriptionId));
+            throw new KeyNotFoundException($"Could not find subscription with ID {subscriptionId}");
 
         return subscription.DisplayName;
     }

--- a/core/Azure.Mcp.Core/src/Services/Azure/Tenant/TenantService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Tenant/TenantService.cs
@@ -95,7 +95,7 @@ public class TenantService : BaseAzureService, ITenantService
     {
         var tenants = await GetTenants(cancellationToken);
         var tenant = tenants.FirstOrDefault(t => t.Data.DisplayName?.Equals(tenantName, StringComparison.OrdinalIgnoreCase) == true) ??
-            throw new Exception($"Could not find tenant with name {tenantName}");
+            throw new KeyNotFoundException($"Could not find tenant with name {tenantName}");
 
         string? tenantId = tenant.Data.TenantId?.ToString() ??
             throw new InvalidOperationException($"Tenant {tenantName} has a null TenantId");
@@ -108,7 +108,7 @@ public class TenantService : BaseAzureService, ITenantService
     {
         var tenants = await GetTenants(cancellationToken);
         var tenant = tenants.FirstOrDefault(t => t.Data.TenantId?.ToString().Equals(tenantId, StringComparison.OrdinalIgnoreCase) == true) ??
-            throw new Exception($"Could not find tenant with ID {tenantId}");
+            throw new KeyNotFoundException($"Could not find tenant with ID {tenantId}");
 
         string? tenantName = tenant.Data.DisplayName ??
             throw new InvalidOperationException($"Tenant with ID {tenantId} has a null DisplayName");

--- a/servers/Azure.Mcp.Server/changelog-entries/1779392230582.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1779392230582.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed not-found conditions in SubscriptionService, TenantService, and ResourceGroupService returning HTTP 500/400 instead of HTTP 404"


### PR DESCRIPTION
## Summary

Replace plain `Exception` and `ArgumentException` with `KeyNotFoundException` in `SubscriptionService`, `TenantService`, and `ResourceGroupService` so that not-found conditions return HTTP 404 instead of 500/400.

## Changes

| File | Lines | Before | After |
|------|-------|--------|-------|
| `SubscriptionService.cs` | 79 | `Exception` (→500) | `KeyNotFoundException` (→404) |
| `SubscriptionService.cs` | 97-98 | `ArgumentException` (→400) | `KeyNotFoundException` (→404) |
| `SubscriptionService.cs` | 106-107 | `ArgumentException` (→400) | `KeyNotFoundException` (→404) |
| `TenantService.cs` | 98 | `Exception` (→500) | `KeyNotFoundException` (→404) |
| `TenantService.cs` | 111 | `Exception` (→500) | `KeyNotFoundException` (→404) |
| `ResourceGroupService.cs` | 97 | `Exception` (→500) | `KeyNotFoundException` (→404) |

## Why KeyNotFoundException?

`AuthenticatedCommand.GetStatusCode` already maps `KeyNotFoundException` → `HttpStatusCode.NotFound` (404). This is the same pattern used by `BaseAzureResourceService` and `AcrService` for not-found conditions.

## Validation

- **Build:** Clean ✅
- **Tests:** 1109 passed, 0 failed ✅

Fixes microsoft/mcp-pr#396
Fixes microsoft/mcp-pr#403
Fixes microsoft/mcp-pr#404

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.