### PR TITLE
Update new-command.md to two-generic options pattern

### DIFF
--- a/servers/Azure.Mcp.Server/docs/new-command.md
+++ b/servers/Azure.Mcp.Server/docs/new-command.md
@@ -535,7 +535,7 @@ The `[Option]` attribute drives automatic option registration and binding via `O
 
 **Conventions:**
 - **Name**: Derived automatically from the property name in kebab-case (e.g., `LocalFilePath` → `--local-file-path`). Only use `[Option(Name = "...")]` when the convention doesn't produce the desired name (e.g., `RetryPolicy` → `--retry` instead of `--retry-policy`). **Do not** specify `Name =` when it matches the default.
-- **Required**: Determined by nullability. Use `required` keyword or non-nullable types for required options. Use `?` for optional.
+- **Required**: Determined by nullability. Use non-nullable types for required options. Use `?` for optional.  Use the `required` keyword to suppress compiler warnings about uninitialized non-nullable reference properties.
 - **Description**: Pass as the constructor argument `[Option("description")]` or via `[Option(Description = "...")]`.
 - **Shared descriptions**: Use constants from `OptionDescriptions` (e.g., `OptionDescriptions.Subscription`, `OptionDescriptions.Tenant`).
 - **Nested objects**: Use `[Option(Name = "prefix")]` on a property of a complex type. Its child properties become `--prefix-child-name`. Example: `RetryPolicyOptions` with `[Option(Name = "retry")]` produces `--retry-delay`, `--retry-max-retries`, etc.

--- a/servers/Azure.Mcp.Server/docs/new-command.md
+++ b/servers/Azure.Mcp.Server/docs/new-command.md
@@ -528,7 +528,7 @@ The `[Option]` attribute drives automatic option registration and binding via `O
 - `OptionBinder` discovers all `[Option]`-attributed properties on the concrete class and handles both registration (adding to the CLI parser) and binding (populating from parse results) automatically.
 - **Required vs optional** is determined entirely by nullability: `required` keyword or non-nullable types = required; `?` = optional. No `.AsRequired()`/`.AsOptional()` calls needed.
 - **No shared state**: Each command gets its own options instance per request — thread-safe by design.
-- **Implement `ISubscriptionOption`** if the command needs `Subscription`/`Tenant`. This enables `ISubscriptionResolver` post-processing.
+- **Implement `ISubscriptionOption`** if the command needs optional `string? Subscription`. This enables post-processing by `SubscriptionCommand` and `ISubscriptionResolver`.
 - **Implement additional option interfaces** (e.g., `IStorageAccountOption`) only when base command classes need type-safe access to specific properties for shared behavior like validation.
 - **Validation** is done via `ValidateOptions(TOptions, ValidationResult)` override in the command class — not via `Command.Validators.Add`.
 - **No manual registration or binding**: Remove all `RegisterOptions`/`BindOptions` overrides. If you find yourself writing these, you're using the old pattern.

--- a/servers/Azure.Mcp.Server/docs/new-command.md
+++ b/servers/Azure.Mcp.Server/docs/new-command.md
@@ -482,246 +482,252 @@ var client = new BlobServiceClient(new(endpoint), credential, options);
 
 ### 3. Options Class
 
+Options classes are flat POCOs with `[Option]` attributes. Registration and binding are handled automatically by `OptionBinder` — no manual `RegisterOptions` or `BindOptions` overrides needed.
+
 ```csharp
-public class {Resource}{Operation}Options : Base{Toolset}Options
+public class {Resource}{Operation}Options : ISubscriptionOption
 {
-    // Only add properties not in base class
-    public string? NewOption { get; set; }
+    [Option("Description of the required option.")]
+    public required string RequiredOption { get; set; }
+
+    [Option("Description of the optional option.")]
+    public string? OptionalOption { get; set; }
+
+    [Option(OptionDescriptions.Subscription)]
+    public string? Subscription { get; set; }
+
+    [Option(OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
+    [Option(Name = "retry")]
+    public RetryPolicyOptions? RetryPolicy { get; set; }
 }
 ```
 
 IMPORTANT:
-- Inherit from appropriate base class (Base{Toolset}Options, GlobalOptions, etc.)
-- Only define properties that aren't in the base classes
-- Make properties nullable if not required
+- Options classes are **flat** — no inheritance hierarchy. Implement `ISubscriptionOption` if the command needs subscription/tenant.
+- Use `[Option]` attributes to declare each option. `OptionBinder` handles registration and binding automatically.
+- Use `required` keyword or non-nullable types for required options. Use `?` for optional options.
+- Only define properties that correspond to actually exposed CLI options for that specific command.
 - Use consistent parameter names across services:
-  - **CRITICAL**: Always use `subscription` (never `subscriptionId`) for subscription parameters - this allows the parameter to accept both subscription IDs and subscription names, which are resolved internally by `ISubscriptionService.GetSubscription()`
+  - **CRITICAL**: Always use `subscription` (never `subscriptionId`) for subscription parameters - this allows the parameter to accept both subscription IDs and subscription names, which are resolved internally by `ISubscriptionResolver`
   - Use `resourceGroup` instead of `resourceGroupName`
   - Use singular nouns for resource names (e.g., `server` not `serverName`)
   - **Remove unnecessary "-name" suffixes**: Use `--account` instead of `--account-name`, `--container` instead of `--container-name`, etc. Only keep "-name" when it provides necessary disambiguation (e.g., `--subscription-name` to distinguish from global `--subscription`)
   - Keep parameter names consistent with Azure SDK parameters when possible
   - If services share similar operations (e.g., ListDatabases), use the same parameter order and names
 
-### Option Handling Pattern
+### Option Attribute Conventions
 
-Commands explicitly register options as required or optional using extension methods. This pattern provides explicit, per-command control over option requirements.
+The `[Option]` attribute drives automatic option registration and binding via `OptionBinder`:
 
-**Extension Methods (available on any `OptionDefinition<T>` or `Option<T>`):**
+**Key Principles:**
+- Options classes are **flat POCOs** — no class inheritance. Each command has its own options class.
+- `OptionBinder` discovers all `[Option]`-attributed properties on the concrete class and handles both registration (adding to the CLI parser) and binding (populating from parse results) automatically.
+- **Required vs optional** is determined entirely by nullability: `required` keyword or non-nullable types = required; `?` = optional. No `.AsRequired()`/`.AsOptional()` calls needed.
+- **No shared state**: Each command gets its own options instance per request — thread-safe by design.
+- **Implement `ISubscriptionOption`** if the command needs `Subscription`/`Tenant`. This enables `ISubscriptionResolver` post-processing.
+- **Implement additional option interfaces** (e.g., `IStorageAccountOption`) only when base command classes need type-safe access to specific properties for shared behavior like validation.
+- **Validation** is done via `ValidateOptions(TOptions, ValidationResult)` override in the command class — not via `Command.Validators.Add`.
+- **No manual registration or binding**: Remove all `RegisterOptions`/`BindOptions` overrides. If you find yourself writing these, you're using the old pattern.
+
+**Conventions:**
+- **Name**: Derived automatically from the property name in kebab-case (e.g., `LocalFilePath` → `--local-file-path`). Only use `[Option(Name = "...")]` when the convention doesn't produce the desired name (e.g., `RetryPolicy` → `--retry` instead of `--retry-policy`). **Do not** specify `Name =` when it matches the default.
+- **Required**: Determined by nullability. Use `required` keyword or non-nullable types for required options. Use `?` for optional.
+- **Description**: Pass as the constructor argument `[Option("description")]` or via `[Option(Description = "...")]`.
+- **Shared descriptions**: Use constants from `OptionDescriptions` (e.g., `OptionDescriptions.Subscription`, `OptionDescriptions.Tenant`).
+- **Nested objects**: Use `[Option(Name = "prefix")]` on a property of a complex type. Its child properties become `--prefix-child-name`. Example: `RetryPolicyOptions` with `[Option(Name = "retry")]` produces `--retry-delay`, `--retry-max-retries`, etc.
+- **Property ordering**: List command-specific options first, then sink common/infrastructure options to the bottom in this order: `ResourceGroup`, `Subscription`, `Tenant`, `AuthMethod`, `RetryPolicy`. This keeps the most relevant options visible at a glance.
+
+### Usage Patterns
+
+**Pattern 1: Standard command with required and optional options**
+
+The most common pattern — a command that needs some required parameters and some optional ones:
 
 ```csharp
-.AsRequired()    // Makes the option required for this command
-.AsOptional()    // Makes the option optional for this command
-```
-
-**Key principles:**
-- Commands explicitly register options when needed using extension methods
-- Each command controls whether each option is required or optional
-- Binding is explicit using `parseResult.GetValueOrDefault(Option<T>)`
-- No shared state between commands - each gets its own option instance
-- Only use `.AsRequired()` and `.AsOptional()` if they will change the `Required` setting.
-- Use `Command.Validators.Add` to add unique option validation.
-
-**Usage patterns:**
-
-**For commands that require specific options:**
-```csharp
-protected override void RegisterOptions(Command command)
+public class {Resource}{Operation}Options : ISubscriptionOption
 {
-    base.RegisterOptions(command);
-    // Make commonly optional options required for this command
-    command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsRequired());
-    command.Options.Add(ServiceOptionDefinitions.Account.AsRequired());
-    // Use default requirement from definition
-    command.Options.Add(ServiceOptionDefinitions.Database);
-}
+    [Option("The name of the Azure Storage account.")]
+    public required string Account { get; set; }
 
-protected override MyCommandOptions BindOptions(ParseResult parseResult)
-{
-    var options = base.BindOptions(parseResult);
-    // Use ??= for options that might be set by base classes
-    options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
-    // Direct assignment for command-specific options
-    options.Account = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Account);
-    options.Database = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Database);
-    return options;
-}
-```
+    [Option("The name of the container within the storage account.")]
+    public required string Container { get; set; }
 
-**For commands that use options optionally:**
-```csharp
-protected override void RegisterOptions(Command command)
-{
-    base.RegisterOptions(command);
-    // Make typically required options optional for this command
-    command.Options.Add(ServiceOptionDefinitions.Account.AsOptional());
-    command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsOptional());
-}
+    [Option("Optional filter expression.")]
+    public string? Filter { get; set; }
 
-protected override MyCommandOptions BindOptions(ParseResult parseResult)
-{
-    var options = base.BindOptions(parseResult);
-    options.Account = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Account);
-    options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
-    return options;
+    [Option(OptionDescriptions.ResourceGroup)]
+    public string? ResourceGroup { get; set; }
+
+    [Option(OptionDescriptions.Subscription)]
+    public string? Subscription { get; set; }
+
+    [Option(OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
+    [Option(Name = "retry")]
+    public RetryPolicyOptions? RetryPolicy { get; set; }
 }
 ```
 
-**For commands with unique option requirements:**
+**Pattern 2: Command with mutually exclusive options**
+
+When options are mutually exclusive, make them both optional in the POCO and validate in the command via `ValidateOptions`:
+
 ```csharp
-protected override void RegisterOptions(Command command)
+public class MyCommandOptions : ISubscriptionOption
 {
-    base.RegisterOptions(command);
-    // Simple options.
-    command.Options.Add(ServiceOptionDefinitions.Account);
-    command.Options.Add(OptionDefinitions.Common.ResourceGroup);
-    // Exclusive or options
-    command.Options.Add(ServiceOptionDefinitions.EitherThis);
-    command.Options.Add(ServiceOptionDefinitions.OrThat);
-    // Validate that only 'EitherThis' or 'OrThat' were used individually.
-    command.Validators.Add(commandResult =>
+    [Option("First exclusive option.")]
+    public string? EitherThis { get; set; }
+
+    [Option("Second exclusive option.")]
+    public string? OrThat { get; set; }
+
+    [Option(OptionDescriptions.Subscription)]
+    public string? Subscription { get; set; }
+
+    [Option(OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
+    [Option(Name = "retry")]
+    public RetryPolicyOptions? RetryPolicy { get; set; }
+}
+
+// In the command class:
+public override void ValidateOptions(MyCommandOptions options, ValidationResult validationResult)
+{
+    base.ValidateOptions(options, validationResult);
+
+    var hasEitherThis = !string.IsNullOrWhiteSpace(options.EitherThis);
+    var hasOrThat = !string.IsNullOrWhiteSpace(options.OrThat);
+
+    if (!hasEitherThis && !hasOrThat)
     {
-        // Retrieve values once and infer presence from non-empty values
-        var eitherThis = commandResult.GetOrDefaultValue(ServiceOptionDefinitions.EitherThis);
-        var orThat = commandResult.GetOrDefaultValue(ServiceOptionDefinitions.OrThat);
+        validationResult.Errors.Add("Either --either-this or --or-that must be provided.");
+    }
 
-        var hasEitherThis = !string.IsNullOrWhiteSpace(eitherThis);
-        var hasOrThat = !string.IsNullOrWhiteSpace(orThat);
-
-        // Validate that either either-this or or-that is provided, but not both
-        if (!hasEitherThis && !hasOrThat)
-        {
-            commandResult.AddError("Either --either-this or --or-that must be provided.");
-        }
-
-        if (hasEitherThis && hasOrThat)
-        {
-            commandResult.AddError("Cannot specify both --either-this and --or-that. Use only one.");
-        }
-    });
-}
-
-protected override MyCommandOptions BindOptions(ParseResult parseResult)
-{
-    var options = base.BindOptions(parseResult);
-    options.Account = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Account);
-    options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
-    options.EitherThis = parseResult.GetValueOrDefault(ServiceOptionDefinitions.EitherThis);
-    options.OrThat = parseResult.GetValueOrDefault(ServiceOptionDefinitions.OrThat);
-    return options;
-}
-```
-
-**Important binding patterns:**
-- Use `??=` assignment for options that might be set by base classes (like global options)
-- Use direct assignment for command-specific options
-- Use `parseResult.GetValueOrDefault(Option<T>)`
-- The extension methods handle the required/optional logic at the parser level
-
-**Benefits of the new pattern:**
-- **Explicit**: Clear what options each command uses
-- **Flexible**: Each command controls option requirements independently
-- **No shared state**: Extension methods create new option instances
-- **Consistent**: Same pattern works for all options
-- **Maintainable**: Easy to see option dependencies in RegisterOptions method
-
-### Option Extension Methods Pattern
-
-The option pattern is built on extension methods that provide flexible, per-command control over option requirements. This eliminates shared state issues and makes option dependencies explicit.
-
-**Available Extension Methods:**
-
-```csharp
-// For OptionDefinition<T> instances
-.AsRequired()              // Creates a required option instance
-.AsOptional()              // Creates an optional option instance
-
-// For existing Option<T> instances
-.AsRequired()              // Creates a new required version
-.AsOptional()              // Creates a new optional version
-```
-
-**Usage Examples:**
-
-```csharp
-// Using OptionDefinitions with extension methods
-protected override void RegisterOptions(Command command)
-{
-    base.RegisterOptions(command);
-
-    // Global option - required for this command
-    command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsRequired());
-
-    // Service account - optional for this command
-    command.Options.Add(ServiceOptionDefinitions.Account.AsOptional());
-
-    // Database - required (override default from definition)
-    command.Options.Add(ServiceOptionDefinitions.Database.AsRequired());
-
-    // Filter - use default requirement from definition
-    command.Options.Add(ServiceOptionDefinitions.Filter);
-}
-
-// When you need a custom option (e.g., making a required option optional for a specific command)
-protected override void RegisterOptions(Command command)
-{
-    base.RegisterOptions(command);
-    command.Options.Remove(ComputeOptionDefinitions.ResourceGroup);
-
-    // ✅ Correct: Use string parameters for Option constructor
-    var optionalRg = new Option<string>(
-        "--resource-group",
-        "-g")
+    if (hasEitherThis && hasOrThat)
     {
-        Description = "The name of the resource group (optional)"
-    };
-    command.Options.Add(optionalRg);
-
-    // ❌ Wrong: Don't use array for aliases in constructor
-    var wrongOption = new Option<string>(
-        ComputeOptionDefinitions.ResourceGroup.Aliases.ToArray(),
-        "Description");
-    // Error CS1503: Argument 1: cannot convert from 'string[]' to 'string'
+        validationResult.Errors.Add("Cannot specify both --either-this and --or-that. Use only one.");
+    }
 }
 ```
 
-**Option-Based Binding Pattern:**
+**Pattern 3: Command with enum/constrained options**
 
-With the new pattern, option binding uses the option-based `GetValueOrDefault(Option<T>)` method:
+For options with a fixed set of valid values:
 
 ```csharp
-protected override MyCommandOptions BindOptions(ParseResult parseResult)
+public class MyCommandOptions : ISubscriptionOption
 {
-    var options = base.BindOptions(parseResult);
+    [Option("The output format.")]
+    public required string Format { get; set; }  // Validated in ValidateOptions
 
-    // Use ??= for options that might be set by base classes
-    options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
+    [Option(OptionDescriptions.Subscription)]
+    public string? Subscription { get; set; }
 
-    // Use direct assignment for command-specific options
-    options.Account = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Account);
-    options.Database = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Database);
-    options.Filter = parseResult.GetValueOrDefault(ServiceOptionDefinitions.Filter);
+    [Option(OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
 
-    return options;
+    [Option(Name = "retry")]
+    public RetryPolicyOptions? RetryPolicy { get; set; }
+}
+
+// In the command class:
+public override void ValidateOptions(MyCommandOptions options, ValidationResult validationResult)
+{
+    base.ValidateOptions(options, validationResult);
+
+    if (!new[] { "json", "table", "csv" }.Contains(options.Format, StringComparer.OrdinalIgnoreCase))
+    {
+        validationResult.Errors.Add("--format must be one of: json, table, csv");
+    }
+}
+```
+
+**Pattern 4: Options with interface constraints for shared base command behavior**
+
+When base commands need type-safe access to specific options, define small interfaces:
+
+```csharp
+public interface IStorageAccountOption
+{
+    string Account { get; }
+}
+
+public interface IContainerOption : IStorageAccountOption
+{
+    string Container { get; }
+}
+```
+
+The concrete options class implements these interfaces while remaining flat:
+
+```csharp
+public class BlobUploadOptions : ISubscriptionOption, IBlobOption
+{
+    [Option("The name of the Azure Storage account.")]
+    public required string Account { get; set; }
+
+    [Option("The name of the container within the storage account.")]
+    public required string Container { get; set; }
+
+    [Option("The blob name/path within the container.")]
+    public required string Blob { get; set; }
+
+    [Option("The local file path to read content from.")]
+    public required string LocalFilePath { get; set; }
+
+    [Option(OptionDescriptions.Subscription)]
+    public string? Subscription { get; set; }
+
+    [Option(OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
+    [Option(Name = "retry")]
+    public RetryPolicyOptions? RetryPolicy { get; set; }
+}
+```
+
+**Pattern 5: Options for list/query commands with optional filtering**
+
+Commands that list resources with optional narrowing:
+
+```csharp
+public class StorageAccountListOptions : ISubscriptionOption
+{
+    [Option(OptionDescriptions.ResourceGroup)]
+    public string? ResourceGroup { get; set; }
+
+    [Option(OptionDescriptions.Subscription)]
+    public string? Subscription { get; set; }
+
+    [Option(OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
+    [Option(Name = "retry")]
+    public RetryPolicyOptions? RetryPolicy { get; set; }
 }
 ```
 
 **Key Benefits:**
-- **Type Safety**: Generic `GetValueOrDefault(Option<T>)` provides compile-time type checking
-- **No Field References**: Eliminates need for readonly option fields in commands
-- **Flexible Requirements**: Each command controls which options are required/optional
-- **Clear Dependencies**: All option usage visible in `RegisterOptions` method
-- **No Shared State**: Extension methods create new option instances per command
+- **Flat and readable**: All options visible in one file — no hunting through a class hierarchy
+- **Composable**: Options can implement multiple interfaces without rigid single-inheritance trees
+- **Automatic**: `OptionBinder` handles registration and binding — no manual `RegisterOptions`/`BindOptions`
+- **Type-safe**: `required` keyword enforces required options at compile time; `OptionBinder` validates presence at runtime
+- **Consistent**: Same pattern as `SubscriptionCommand` using `ISubscriptionOption`
+- **Per-command accuracy**: Each options class declares exactly what that command needs — nullability reflects actual usage, not shared base class compromises
 
 ### 4. Command Class
 
 **CRITICAL: Using Statements**
-Ensure all necessary using statements are included, especially for option definitions:
+Ensure all necessary using statements are included:
 
 ```csharp
 using System.Net;
 using Azure.Mcp.Tools.{Toolset}.Models;
-using Azure.Mcp.Tools.{Toolset}.Options;  // REQUIRED: For {Toolset}OptionDefinitions
-using Azure.Mcp.Tools.{Toolset}.Options.{Resource};  // For resource-specific options
+using Azure.Mcp.Tools.{Toolset}.Options;  // REQUIRED: For options classes
 using Azure.Mcp.Tools.{Toolset}.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
@@ -744,52 +750,38 @@ using Microsoft.Mcp.Core.Models.Command;
     ReadOnly = true,        // Set to false for tools that modify resources
     Secret = false,         // Set to true for tools that may return sensitive information
     LocalRequired = false)] // Set to true for tools requiring local execution/resources
-public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Command> logger, I{Toolset}Service service)
-    : Base{Toolset}Command<{Resource}{Operation}Options>
+public sealed class {Resource}{Operation}Command(
+    ILogger<{Resource}{Operation}Command> logger,
+    I{Toolset}Service service,
+    ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<{Resource}{Operation}Options, {Resource}{Operation}Command.{Resource}{Operation}CommandResult>(subscriptionResolver)
 {
     private readonly ILogger<{Resource}{Operation}Command> _logger = logger;
     private readonly I{Toolset}Service _service = service;
 
-    protected override void RegisterOptions(Command command)
+    // No RegisterOptions or BindOptions overrides needed — OptionBinder handles this via [Option] attributes
+
+    // Optional: Override ValidateOptions for custom validation beyond required/optional checks
+    public override void ValidateOptions({Resource}{Operation}Options options, ValidationResult validationResult)
     {
-        base.RegisterOptions(command);
-        // Add options as needed (use AsRequired() or AsOptional() to override defaults)
-        command.Options.Add({Toolset}OptionDefinitions.RequiredOption.AsRequired());
-        command.Options.Add({Toolset}OptionDefinitions.OptionalOption.AsOptional());
-        // Use default requirement from OptionDefinitions
-        command.Options.Add({Toolset}OptionDefinitions.StandardOption);
+        base.ValidateOptions(options, validationResult);  // checks --subscription
+        // Add custom validation if needed
     }
 
-    protected override {Resource}{Operation}Options BindOptions(ParseResult parseResult)
+    public override async Task<CommandResponse> ExecuteAsync(
+        CommandContext context, {Resource}{Operation}Options options, CancellationToken cancellationToken)
     {
-        var options = base.BindOptions(parseResult);
-        // Bind options using GetValueOrDefault(Option<T>)
-        options.RequiredOption = parseResult.GetValueOrDefault({Toolset}OptionDefinitions.RequiredOption);
-        options.OptionalOption = parseResult.GetValueOrDefault({Toolset}OptionDefinitions.OptionalOption);
-        options.StandardOption = parseResult.GetValueOrDefault({Toolset}OptionDefinitions.StandardOption;
-        return options;
-    }
-
-    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        // Required validation step
-        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
-        {
-            return context.Response;
-        }
-
-        var options = BindOptions(parseResult);
-
+        // Options are already bound and validated — just use them directly
         try
         {
             context.Activity?.WithSubscriptionTag(options);
 
             // Call service operation(s) with required parameters
             var results = await _service.{Operation}(
-                options.RequiredParam!,  // Required parameters end with !
-                options.OptionalParam,   // Optional parameters are nullable
-                options.Subscription!,   // From SubscriptionCommand
-                options.RetryPolicy,     // From GlobalCommand
+                options.RequiredOption,   // Required options are non-nullable (no ! needed)
+                options.OptionalOption,   // Optional options are nullable
+                options.Subscription!,   // From ISubscriptionOption (resolved by ISubscriptionResolver)
+                options.RetryPolicy,     // From options POCO
                 cancellationToken);      // Passed in ExecuteAsync
 
             // Set results if any were returned
@@ -800,7 +792,7 @@ public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Co
         {
             // Log error with all relevant context
             _logger.LogError(ex, "Error in {Operation}. Required: {Required}, Optional: {Optional}",
-                Name, options.RequiredParam, options.OptionalParam);
+                Name, options.RequiredOption, options.OptionalOption);
             HandleException(context, ex);
         }
 
@@ -829,6 +821,13 @@ public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Co
     internal record {Resource}{Operation}CommandResult(List<ResultType> Results);
 }
 ```
+
+Key differences from the old pattern:
+- **Base class**: `SubscriptionCommand<TOptions, TResult>` (two generics) instead of `Base{Toolset}Command<TOptions>`
+- **Constructor**: Inject `ISubscriptionResolver` and pass to base
+- **No `RegisterOptions`/`BindOptions`**: `OptionBinder` handles this automatically via `[Option]` attributes
+- **`ExecuteAsync` signature**: Takes `TOptions` directly instead of `ParseResult` — options are pre-bound and pre-validated
+- **No `Validate()` call**: Validation is handled before `ExecuteAsync` is called. Use `ValidateOptions` override for custom validation.
 
 ### Tool ID
 
@@ -1060,7 +1059,11 @@ var result = await Service.GetResourceAsync(
 
 ### 6. Base Service Command Classes
 
-Each toolset has its own hierarchy of base command classes that inherit from `GlobalCommand` or `SubscriptionCommand`. Service classes that work with Azure resources should inject `ISubscriptionService` for subscription resolution. For example:
+Each toolset may have base command classes that provide shared behavior (validation, error handling, etc.) across related commands. In the new two-generic pattern, these use **interface constraints** on `TOptions` instead of options class inheritance.
+
+**If a base command class only existed to add `RegisterOptions`/`BindOptions`**, remove it entirely. The concrete command directly extends `SubscriptionCommand<TOptions, TResult>`.
+
+**If a base command class provides real shared behavior** (validation, error handling, etc.), keep it and use the interface constraint pattern:
 
 ```csharp
 // Copyright (c) Microsoft Corporation.
@@ -1071,56 +1074,46 @@ using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Tools.{Toolset}.Options;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Extensions;
-using Microsoft.Mcp.Core.Models.Option;
 
 namespace Azure.Mcp.Tools.{Toolset}.Commands;
 
-// Base command for all service commands (if no members needed, use concise syntax)
-public abstract class Base{Toolset}Command<
-    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions>
-    : SubscriptionCommand<TOptions> where TOptions : Base{Toolset}Options, new();
-
-// Base command for all service commands (if members are needed, use full syntax)
-public abstract class Base{Toolset}Command<
-    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions>
-    : SubscriptionCommand<TOptions> where TOptions : Base{Toolset}Options, new()
+// Option interfaces for shared concerns
+public interface I{Toolset}AccountOption
 {
-    protected override void RegisterOptions(Command command)
-    {
-        base.RegisterOptions(command);
-        // Register common options for all toolset commands
-        command.Options.Add({Toolset}OptionDefinitions.CommonOption);
-    }
+    string Account { get; }
+}
 
-    protected override TOptions BindOptions(ParseResult parseResult)
+public interface I{Resource}Option : I{Toolset}AccountOption
+{
+    string {Resource}Name { get; }
+}
+
+// Base command with interface constraint — provides shared behavior
+public abstract class Base{Toolset}Command<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions, TResult>(
+    ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<TOptions, TResult>(subscriptionResolver)
+    where TOptions : class, ISubscriptionOption, I{Toolset}AccountOption
+{
+    // Shared validation using options.Account with type safety
+    public override void ValidateOptions(TOptions options, ValidationResult validationResult)
     {
-        var options = base.BindOptions(parseResult);
-        // Bind common options using GetValueOrDefault(Option<T>)
-        options.CommonOption = parseResult.GetValueOrDefault({Toolset}OptionDefinitions.CommonOption);
-        return options;
+        base.ValidateOptions(options, validationResult);
+        // Shared validation logic using options.Account
     }
 }
 
-// Example: Resource-specific base command with common options
+// Deeper layer with additional interface constraint
 public abstract class Base{Resource}Command<
-    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions>
-    : Base{Toolset}Command<TOptions> where TOptions : Base{Resource}Options, new()
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions, TResult>(
+    ISubscriptionResolver subscriptionResolver)
+    : Base{Toolset}Command<TOptions, TResult>(subscriptionResolver)
+    where TOptions : class, ISubscriptionOption, I{Resource}Option
 {
-    protected override void RegisterOptions(Command command)
+    public override void ValidateOptions(TOptions options, ValidationResult validationResult)
     {
-        base.RegisterOptions(command);
-        // Add resource-specific options that all resource commands need
-        command.Options.Add({Toolset}OptionDefinitions.{Resource}Name);
-        command.Options.Add({Toolset}OptionDefinitions.{Resource}Type.AsOptional());
-    }
-
-    protected override TOptions BindOptions(ParseResult parseResult)
-    {
-        var options = base.BindOptions(parseResult);
-        // Bind resource-specific options
-        options.{Resource}Name = parseResult.GetValueOrDefault({Toolset}OptionDefinitions.{Resource}Name);
-        options.{Resource}Type = parseResult.GetValueOrDefault({Toolset}OptionDefinitions.{Resource}Type);
-        return options;
+        base.ValidateOptions(options, validationResult);
+        // Shared resource-level validation using options.{Resource}Name
     }
 }
 
@@ -1148,12 +1141,25 @@ public class {Toolset}Service(ISubscriptionService subscriptionService, ITenantS
 }
 ```
 
+Key differences from the old pattern:
+- **Two-generic base classes**: `Base{Toolset}Command<TOptions, TResult>` instead of `Base{Toolset}Command<TOptions>`
+- **Interface constraints**: `where TOptions : class, ISubscriptionOption, I{Toolset}AccountOption` instead of `where TOptions : Base{Toolset}Options, new()`
+- **No `RegisterOptions`/`BindOptions`**: Shared behavior is expressed through `ValidateOptions` overrides
+- **Constructor injects `ISubscriptionResolver`**: Passed to the base `SubscriptionCommand`
+- **Options stay flat**: Concrete options implement interfaces but don't use class inheritance
+
 ### 7. Unit Tests
 
-Unit tests follow a standardized pattern that tests initialization, validation, and execution:
+Unit tests follow a standardized pattern that tests initialization, validation, and execution.
+
+**IMPORTANT**: Tests for commands that extend `SubscriptionCommand<TOptions, TResult>` must inherit from `SubscriptionCommandUnitTestsBase<TCommand, TService>` instead of `CommandUnitTestsBase`. This base class automatically registers a mock `ISubscriptionResolver` in DI.
+
+> **Without `SubscriptionCommandUnitTestsBase`**, DI will fail at runtime with "Unable to resolve service for type `ISubscriptionResolver`".
+
+> **Prefer string args over constructing options directly.** Using `ExecuteCommandAsync("--account", ...)` tests the full pipeline: `[Option]` attribute registration, `OptionBinder` parsing, and `SubscriptionResolver` post-processing.
 
 ```csharp
-public class {Resource}{Operation}CommandTests : CommandUnitTestsBase<{Resource}{Operation}Command, I{Toolset}Service>
+public class {Resource}{Operation}CommandTests : SubscriptionCommandUnitTestsBase<{Resource}{Operation}Command, I{Toolset}Service>
 {
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
@@ -1238,20 +1244,6 @@ public class {Resource}{Operation}CommandTests : CommandUnitTestsBase<{Resource}
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.Contains("Test error", response.Message);
         Assert.Contains("troubleshooting", response.Message);
-    }
-
-    [Fact]
-    public void BindOptions_BindsOptionsCorrectly()
-    {
-        // Arrange
-        var parseResult = CommandDefinition.Parse(["--subscription", "test-sub", "--required", "value"]);
-
-        // Act
-        var options = Command.BindOptions(parseResult);
-
-        // Assert
-        Assert.Equal("test-sub", options.Subscription);
-        Assert.Equal("value", options.RequiredParam);
     }
 }
 ```
@@ -2002,26 +1994,43 @@ var subscriptionResource = await _subscriptionService.GetSubscription(subscripti
 
 ### Command Option Patterns
 
-**Issue: Using readonly option fields in commands**
-- **Problem**: Commands define readonly `Option<T>` fields and use `parseResult.GetValue()` without type parameters.
-- **Solution**: Remove readonly fields; use `OptionDefinitions` directly in `RegisterOptions` and name-based binding in `BindOptions`.
+**Issue: Using readonly option fields or manual RegisterOptions/BindOptions**
+- **Problem**: Commands define readonly `Option<T>` fields, manual `RegisterOptions`/`BindOptions` overrides, or use the old one-generic `BaseCommand<TOptions>` pattern.
+- **Solution**: Use flat options POCOs with `[Option]` attributes and the two-generic `SubscriptionCommand<TOptions, TResult>` base class. `OptionBinder` handles registration and binding automatically.
 - **Pattern**:
 ```csharp
-protected override void RegisterOptions(Command command)
+// Options are a flat POCO with [Option] attributes
+public class MyOptions : ISubscriptionOption
 {
-    base.RegisterOptions(command);
-    // Use extension methods for flexible requirements
-    command.Options.Add(OptionDefinitions.Common.ResourceGroup.AsRequired());
-    command.Options.Add(ServiceOptionDefinitions.ServiceOption);
+    [Option("The resource group name.")]
+    public required string ResourceGroup { get; set; }
+
+    [Option("The service-specific option.")]
+    public string? ServiceOption { get; set; }
+
+    [Option(OptionDescriptions.Subscription)]
+    public string? Subscription { get; set; }
+
+    [Option(OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
+    [Option(Name = "retry")]
+    public RetryPolicyOptions? RetryPolicy { get; set; }
 }
 
-protected override MyOptions BindOptions(ParseResult parseResult)
+// Command uses two-generic base class — no RegisterOptions/BindOptions needed
+public sealed class MyCommand(ILogger<MyCommand> logger, IMyService service, ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<MyOptions, MyCommand.MyResult>(subscriptionResolver)
 {
-    var options = base.BindOptions(parseResult);
-    // Use name-based binding with generic type parameters
-    options.ResourceGroup ??= parseResult.GetValueOrDefault(OptionDefinitions.Common.ResourceGroup);
-    options.ServiceOption = parseResult.GetValueOrDefault(ServiceOptionDefinitions.ServiceOption);
-    return options;
+    public override async Task<CommandResponse> ExecuteAsync(
+        CommandContext context, MyOptions options, CancellationToken cancellationToken)
+    {
+        // options are pre-bound and validated — use directly
+        var result = await service.DoWork(options.ResourceGroup, options.ServiceOption, cancellationToken);
+        // ...
+    }
+
+    internal record MyResult(string Value);
 }
 ```
 
@@ -2058,7 +2067,9 @@ catch (Exception ex)
    - Make command classes sealed
    - Use primary constructors
    - Follow exact namespace hierarchy
-   - Register all options in RegisterOptions
+   - Use flat options POCOs with `[Option]` attributes — no `RegisterOptions`/`BindOptions` overrides
+   - Extend `SubscriptionCommand<TOptions, TResult>` (two-generic pattern)
+   - Inject `ISubscriptionResolver` in the constructor
    - Handle all exceptions
    - Include CancellationToken parameter as final argument in all async methods
 
@@ -2165,12 +2176,12 @@ catch (Exception ex)
 
 1. Do not:
    - **CRITICAL**: Use `subscriptionId` as parameter name - Always use `subscription` to support both IDs and names
-   - **CRITICAL**: Define readonly option fields in commands - Use `OptionDefinitions` directly in `RegisterOptions` and `BindOptions`
-   - **CRITICAL**: Use the old `UseResourceGroup()` or `RequireResourceGroup()` pattern - These methods no longer exist. Use extension methods like `.AsRequired()` or `.AsOptional()` instead
+   - **CRITICAL**: Use the old one-generic `BaseCommand<TOptions>` pattern - Use two-generic `SubscriptionCommand<TOptions, TResult>` with `[Option]` attributes
+   - **CRITICAL**: Define manual `RegisterOptions`/`BindOptions` overrides - Use `[Option]` attributes on a flat options POCO; `OptionBinder` handles this automatically
+   - **CRITICAL**: Use options class inheritance hierarchies - Options classes should be flat POCOs implementing `ISubscriptionOption`
    - **CRITICAL**: Skip live test infrastructure for Azure service commands - Create `test-resources.bicep` template early in development
-   - **CRITICAL**: Use `parseResult.GetValue()` without the generic type parameter - Use `parseResult.GetValueOrDefault(Option<T>)` instead
-   - Redefine base class properties in Options classes
-   - Skip base.RegisterOptions() call
+   - **CRITICAL**: Use `CommandUnitTestsBase` for subscription commands - Use `SubscriptionCommandUnitTestsBase` to register `ISubscriptionResolver`
+   - Use readonly option fields in commands
    - Skip base.Dispose() call
    - Use hardcoded option strings
    - Return different response formats
@@ -2183,13 +2194,13 @@ catch (Exception ex)
    - Use dashes in command group names
 
 2. Always:
-   - Create a static `{Toolset}OptionDefinitions` class for the toolset
-   - **For option handling**: Use extension methods like `.AsRequired()` or `.AsOptional()` to control option requirements per command. Register explicitly in `RegisterOptions` and bind explicitly in `BindOptions`
-   - **For option binding**: Use `parseResult.GetValueOrDefault(Option<T>)` pattern for all options
+   - **For options**: Use flat POCOs with `[Option]` attributes implementing `ISubscriptionOption`
+   - **For commands**: Extend `SubscriptionCommand<TOptions, TResult>` and inject `ISubscriptionResolver`
+   - **For `ExecuteAsync`**: Use the `(CommandContext, TOptions, CancellationToken)` signature — options are pre-bound
+   - **For validation**: Override `ValidateOptions(TOptions, ValidationResult)` for custom validation
+   - **For tests**: Inherit from `SubscriptionCommandUnitTestsBase<TCommand, TService>`
    - **For Azure service commands**: Create test infrastructure (`test-resources.bicep`) before implementing live tests
-   - Use OptionDefinitions for options
    - Follow exact file structure
-   - Implement all base members
    - Add both unit and integration tests
    - Register in toolset setup RegisterCommands method
    - Handle all error cases
@@ -2468,24 +2479,20 @@ Commands should be **transport-agnostic** - they work identically in stdio and H
 
 **Good:**
 ```csharp
-public sealed class StorageAccountGetCommand(IStorageService storageService, ILogger<StorageAccountGetCommand> logger)
-    : SubscriptionCommand<StorageAccountGetOptions>
+public sealed class StorageAccountGetCommand(
+    IStorageService storageService,
+    ILogger<StorageAccountGetCommand> logger,
+    ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<StorageAccountGetOptions, StorageAccountGetCommand.StorageAccountGetResult>(subscriptionResolver)
 {
     private readonly IStorageService _storageService = storageService;
     private readonly ILogger<StorageAccountGetCommand> _logger = logger;
 
     public override async Task<CommandResponse> ExecuteAsync(
         CommandContext context,
-        ParseResult parseResult,
+        StorageAccountGetOptions options,
         CancellationToken cancellationToken)
     {
-        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
-        {
-            return context.Response;
-        }
-
-        var options = BindOptions(parseResult);
-
         // Authentication provider handles both stdio and HTTP scenarios
         var accounts = await _storageService.GetStorageAccountsAsync(
             options.Subscription!,
@@ -2500,6 +2507,8 @@ public sealed class StorageAccountGetCommand(IStorageService storageService, ILo
 
         return context.Response;
     }
+
+    internal record StorageAccountGetResult(List<StorageAccount> Accounts);
 }
 ```
 
@@ -2567,25 +2576,21 @@ Remote HTTP mode supports **multiple concurrent users**:
 
 **Good:**
 ```csharp
-public sealed class SqlDatabaseListCommand(ISqlService sqlService, ILogger<SqlDatabaseListCommand> logger)
-    : SubscriptionCommand<SqlDatabaseListOptions>
+public sealed class SqlDatabaseListCommand(
+    ISqlService sqlService,
+    ILogger<SqlDatabaseListCommand> logger,
+    ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<SqlDatabaseListOptions, SqlDatabaseListCommand.SqlDatabaseListResult>(subscriptionResolver)
 {
     private readonly ISqlService _sqlService = sqlService;  // ✅ Singleton service, thread-safe
     private readonly ILogger<SqlDatabaseListCommand> _logger = logger;
 
     public override async Task<CommandResponse> ExecuteAsync(
         CommandContext context,
-        ParseResult parseResult,
+        SqlDatabaseListOptions options,
         CancellationToken cancellationToken)
     {
-        if (!Validate(parseResult.CommandResult, context.Response).IsValid)
-        {
-            return context.Response;
-        }
-
-        // ✅ Options created per-request, no shared state
-        var options = BindOptions(parseResult);
-
+        // ✅ Options are pre-bound per-request, no shared state
         // ✅ Service calls are async and don't store request state
         var databases = await _sqlService.ListDatabasesAsync(
             options.Subscription!,
@@ -2595,12 +2600,15 @@ public sealed class SqlDatabaseListCommand(ISqlService sqlService, ILogger<SqlDa
 
         return context.Response;
     }
+
+    internal record SqlDatabaseListResult(List<SqlDatabase> Databases);
 }
 ```
 
 **Bad:**
 ```csharp
-public sealed class BadCommand : SubscriptionCommand<BadCommandOptions>
+public sealed class BadCommand(ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<BadCommandOptions, BadCommand.BadResult>(subscriptionResolver)
 {
     // ❌ Don't store per-request state in command fields
     private CommandContext? _currentContext;
@@ -2608,16 +2616,19 @@ public sealed class BadCommand : SubscriptionCommand<BadCommandOptions>
 
     public override async Task<CommandResponse> ExecuteAsync(
         CommandContext context,
-        ParseResult parseResult)
+        BadCommandOptions options,
+        CancellationToken cancellationToken)
     {
         // ❌ Race condition with multiple concurrent requests
         _currentContext = context;
-        _currentOptions = BindOptions(parseResult);
+        _currentOptions = options;
 
         // ❌ Another request might overwrite these before we use them
         await Task.Delay(100);
         return _currentContext.Response;
     }
+
+    internal record BadResult(string Value);
 }
 ```
 

--- a/servers/Azure.Mcp.Server/docs/new-command.md
+++ b/servers/Azure.Mcp.Server/docs/new-command.md
@@ -505,9 +505,9 @@ public class {Resource}{Operation}Options : ISubscriptionOption
 ```
 
 IMPORTANT:
-- Options classes are **flat** — no inheritance hierarchy. Implement `ISubscriptionOption` if the command needs subscription/tenant.
-- Use `[Option]` attributes to declare each option. `OptionBinder` handles registration and binding automatically.
-- Use `required` keyword or non-nullable types for required options. Use `?` for optional options.
+- Options classes are **flat** — no inheritance hierarchy. Implement `ISubscriptionOption` if the command needs subscription support.
+- `OptionBinder` discovers all public writable properties on the options class and handles registration and binding automatically. The `[Option]` attribute is used to override name, description, or hidden — but properties are discovered regardless of whether `[Option]` is present.
+- **Required vs optional** is determined entirely by nullability: non-nullable types = required; `?` = optional. The `required` keyword is a C# compile-time aid to suppress uninitialized warnings but does not affect CLI validation.
 - Only define properties that correspond to actually exposed CLI options for that specific command.
 - Use consistent parameter names across services:
   - **CRITICAL**: Always use `subscription` (never `subscriptionId`) for subscription parameters - this allows the parameter to accept both subscription IDs and subscription names, which are resolved internally by `ISubscriptionResolver`
@@ -525,17 +525,17 @@ The `[Option]` attribute drives automatic option registration and binding via `O
 
 **Key Principles:**
 - Options classes are **flat POCOs** — no class inheritance. Each command has its own options class.
-- `OptionBinder` discovers all `[Option]`-attributed properties on the concrete class and handles both registration (adding to the CLI parser) and binding (populating from parse results) automatically.
-- **Required vs optional** is determined entirely by nullability: `required` keyword or non-nullable types = required; `?` = optional. No `.AsRequired()`/`.AsOptional()` calls needed.
+- `OptionBinder` discovers **all public writable properties** on the concrete class and handles both registration (adding to the CLI parser) and binding (populating from parse results) automatically. The `[Option]` attribute is only needed to override name, description, or hidden status — un-attributed properties are still discovered and bound.
+- **Required vs optional** is determined entirely by nullability: non-nullable types = required; `?` = optional. The `required` keyword suppresses C# compiler warnings about uninitialized non-nullable reference properties but does **not** drive CLI validation — only nullability matters to `OptionBinder`.
 - **No shared state**: Each command gets its own options instance per request — thread-safe by design.
-- **Implement `ISubscriptionOption`** if the command needs optional `string? Subscription`. This enables post-processing by `SubscriptionCommand` and `ISubscriptionResolver`.
+- **Implement `ISubscriptionOption`** if the command needs optional `string? Subscription`. This enables post-processing by `SubscriptionCommand` and `ISubscriptionResolver`. Note: `ISubscriptionOption` only provides `Subscription` — add a separate `Tenant` property if the command accepts `--tenant`.
 - **Implement additional option interfaces** (e.g., `IStorageAccountOption`) only when base command classes need type-safe access to specific properties for shared behavior like validation.
 - **Validation** is done via `ValidateOptions(TOptions, ValidationResult)` override in the command class — not via `Command.Validators.Add`.
 - **No manual registration or binding**: Remove all `RegisterOptions`/`BindOptions` overrides. If you find yourself writing these, you're using the old pattern.
 
 **Conventions:**
 - **Name**: Derived automatically from the property name in kebab-case (e.g., `LocalFilePath` → `--local-file-path`). Only use `[Option(Name = "...")]` when the convention doesn't produce the desired name (e.g., `RetryPolicy` → `--retry` instead of `--retry-policy`). **Do not** specify `Name =` when it matches the default.
-- **Required**: Determined by nullability. Use non-nullable types for required options. Use `?` for optional.  Use the `required` keyword to suppress compiler warnings about uninitialized non-nullable reference properties.
+- **Required**: Determined by nullability. Use non-nullable types for required options. Use `?` for optional. Use the `required` keyword to suppress compiler warnings about uninitialized non-nullable reference properties.
 - **Description**: Pass as the constructor argument `[Option("description")]` or via `[Option(Description = "...")]`.
 - **Shared descriptions**: Use constants from `OptionDescriptions` (e.g., `OptionDescriptions.Subscription`, `OptionDescriptions.Tenant`).
 - **Nested objects**: Use `[Option(Name = "prefix")]` on a property of a complex type. Its child properties become `--prefix-child-name`. Example: `RetryPolicyOptions` with `[Option(Name = "retry")]` produces `--retry-delay`, `--retry-max-retries`, etc.
@@ -667,7 +667,7 @@ public interface IContainerOption : IStorageAccountOption
 The concrete options class implements these interfaces while remaining flat:
 
 ```csharp
-public class BlobUploadOptions : ISubscriptionOption, IBlobOption
+public class BlobUploadOptions : ISubscriptionOption, IContainerOption
 {
     [Option("The name of the Azure Storage account.")]
     public required string Account { get; set; }
@@ -728,12 +728,13 @@ Ensure all necessary using statements are included:
 
 ```csharp
 using System.Net;
+using Azure.Mcp.Core.Commands.Subscription;       // REQUIRED: For SubscriptionCommand<TOptions, TResult>
+using Azure.Mcp.Core.Services.Azure.Subscription;  // REQUIRED: For ISubscriptionResolver
 using Azure.Mcp.Tools.{Toolset}.Models;
-using Azure.Mcp.Tools.{Toolset}.Options;  // REQUIRED: For options classes
+using Azure.Mcp.Tools.{Toolset}.Options;           // REQUIRED: For options classes
 using Azure.Mcp.Tools.{Toolset}.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
-using Microsoft.Mcp.Core.Extensions;
 using Microsoft.Mcp.Core.Models.Command;
 
 [CommandMetadata(

--- a/servers/Azure.Mcp.Server/docs/new-command.md
+++ b/servers/Azure.Mcp.Server/docs/new-command.md
@@ -512,6 +512,8 @@ IMPORTANT:
 - Use consistent parameter names across services:
   - **CRITICAL**: Always use `subscription` (never `subscriptionId`) for subscription parameters - this allows the parameter to accept both subscription IDs and subscription names, which are resolved internally by `ISubscriptionResolver`
   - Use `resourceGroup` instead of `resourceGroupName`
+  - Use constants on `OptionDescriptions` for commonly defined options
+  - Create a similar constants class ,e.g. `KeyVaultOptionDescriptions` in the tools project if options appear on multiple commands
   - Use singular nouns for resource names (e.g., `server` not `serverName`)
   - **Remove unnecessary "-name" suffixes**: Use `--account` instead of `--account-name`, `--container` instead of `--container-name`, etc. Only keep "-name" when it provides necessary disambiguation (e.g., `--subscription-name` to distinguish from global `--subscription`)
   - Keep parameter names consistent with Azure SDK parameters when possible


### PR DESCRIPTION
Replace the legacy one-generic BaseCommand<TOptions> pattern with the new two-generic SubscriptionCommand<TOptions, TResult> pattern using [Option] attribute-driven binding throughout new-command.md.

Key changes:
- Options Class section: flat POCOs with [Option] attributes instead of inheritance hierarchies
- Added Key Principles and Usage Patterns subsections covering 5 patterns (standard, mutually exclusive, enum/constrained, interface constraints, list/query)
- Command Class section: two-generic base class, ISubscriptionResolver injection, ExecuteAsync takes TOptions directly
- Base Service Command Classes: interface constraint pattern instead of RegisterOptions/BindOptions overrides
- Unit Tests: SubscriptionCommandUnitTestsBase instead of CommandUnitTestsBase
- Common Pitfalls and Best Practices: updated guidance

## What does this PR do?
`[Provide a clear, concise description of the changes]`

`[Add additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
