### PR TITLE
Update build perf test script

### DIFF
--- a/eng/scripts/Test-BuildPerformance.ps1
+++ b/eng/scripts/Test-BuildPerformance.ps1
@@ -4,8 +4,7 @@
 param(
     [parameter(Mandatory)]
     [string] $ServerName,
-    [int] $RunCount = 3,
-    [int] $InvocationsPerRun = 10
+    [int] $RunCount = 10
 )
 
 . "$PSScriptRoot/../common/scripts/common.ps1"
@@ -17,12 +16,12 @@ $combinations += @{
 }
 
 $combinations += @{
-    Name = "trimmed/no-self"
+    Name = "single/no-self"
+    SingleFile = $true
 }
 
 $combinations += @{
-    Name = "trimmed r2r/no-self"
-    Trimmed = $true
+    Name = "r2r/no-self"
     ReadyToRun = $true
 }
 
@@ -55,19 +54,27 @@ $combinations += @{
 }
 
 function SaveResults() {
-    $csv = @("Name,Compilation,First Run,Average Run,Package Size")
+    $csv = @("Name,Self Contained,Trimmed,Single File,Ready To Run,Native,Compilation,First Run,Average Run,Package Size")
 
     foreach($combination in $combinations) {
-        $result = $results[$combination.Name]
+        $name = $combination.Name
+        $singleFile = !!$combination.SingleFile
+        $trimmed = !!$combination.Trimmed
+        $selfContained = !!$combination.SelfContained
+        $readyToRun = !!$combination.ReadyToRun
+        $native = !!$combination.Native
 
-        $compilation = ($result | Measure-Object -Property Compilation -Average).Average
-        $firstRun = ($result | Measure-Object -Property FirstRun -Average).Average
-        $averageRun = ($result | Measure-Object -Property AverageRun -Average).Average
-        $packageSize = ($result | Measure-Object -Property PackageSize -Average).Average
+        $result = $results[$name]
 
-        $csv += "$($combination.Name),$compilation,$firstRun,$averageRun,$packageSize"
+        $compilation = $result.Compilation
+        $firstRun = $result.FirstRun
+        $averageRun = $result.AverageRun
+        $packageSize = $result.PackageSize
+
+        $csv += "$name,$selfContained,$trimmed,$singleFile,$readyToRun,$native,$compilation,$firstRun,$averageRun,$packageSize"
     }
 
+    New-Item -ItemType Directory -Path .work -Force
     $csv | Out-File -FilePath .work/results.csv -Encoding utf8 -Force
 }
 
@@ -84,12 +91,24 @@ try {
         Write-Host "Building '$($combination.Name)' to '$outputPath' ..."
         Write-Host "-----------------------------------------------------------------------------------"
 
-        Remove-Item -Path .work -Recurse -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
-        Remove-Item -Path .dist -Recurse -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
-        Remove-Item -Path ./src/bin -Recurse -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
-        Remove-Item -Path ./src/obj -Recurse -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
+        Remove-Item -Path .work/build -Recurse -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
+
+        # Remove bin and obj directories anywhere in the repo
+        Get-ChildItem . -Directory -Recurse
+        | Where-Object Name -Match '^(bin|obj)$'
+        | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
 
         $start = Get-Date
+
+        Write-Host @"
+./eng/scripts/Build-Code.ps1 ``
+    -ServerName '$ServerName' ``
+    -SelfContained:`$$(!!$combination.SelfContained) ``
+    -Trimmed:`$$(!!$combination.Trimmed) ``
+    -ReadyToRun:`$$(!!$combination.ReadyToRun) ``
+    -SingleFile:`$$(!!$combination.SingleFile) ``
+    -Native:`$$(!!$combination.Native)
+"@
 
         ./eng/scripts/Build-Code.ps1 `
             -ServerName $ServerName `
@@ -101,6 +120,10 @@ try {
 
         $compilation = ((Get-Date) - $start).TotalMilliseconds
 
+        # Remove pdb files
+        Get-ChildItem -Path $outputPath -Filter "*.pdb"
+        | Remove-Item -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
+
         $executable = Get-ChildItem -Path $outputPath -Filter "*.exe" | Select-Object -First 1
 
         if(-not $executable) {
@@ -110,31 +133,29 @@ try {
 
         $command = "$($executable.FullName) tools list"
 
-        for($i = 1; $i -le $RunCount; $i++) {
-            Write-Host "Running '$($combination.Name)' - Round $i"
-            Write-Host "----------------------------------------"
+        Write-Host "Running '$($combination.Name)' - Round $i"
+        Write-Host "----------------------------------------"
 
+        $start = Get-Date
+
+        $runs = @()
+        Write-Host "Running $command"
+        foreach($x in 1..$RunCount) {
             $start = Get-Date
-
-            $runs = @()
-            Write-Host "Running $command"
-            foreach($x in 1..$InvocationsPerRun) {
-                $start = Get-Date
-                Invoke-Expression $command | Out-Null
-                if ($LASTEXITCODE -ne 0) {
-                    Write-Warning "$($combination.Name) failed with exit code $LASTEXITCODE"
-                }
-                $runs += ((Get-Date) - $start).TotalMilliseconds
+            Invoke-Expression $command | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning "$($combination.Name) failed with exit code $LASTEXITCODE"
             }
+            $runs += ((Get-Date) - $start).TotalMilliseconds
+        }
 
-            $packageSize = (Get-ChildItem -Path $executable.DirectoryName -File -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB
+        $packageSize = (Get-ChildItem -Path $executable.DirectoryName -File -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB
 
-            $results[$combination.Name] += @{
-                Compilation = $compilation
-                FirstRun = $runs[0]
-                AverageRun = ($runs | Select-Object -Skip 2 | Measure-Object -Average).Average
-                PackageSize = $packageSize
-            }
+        $results[$combination.Name] = @{
+            Compilation = $compilation
+            FirstRun = $runs[0]
+            AverageRun = ($runs | Select-Object -Skip 2 | Measure-Object -Average).Average
+            PackageSize = $packageSize
         }
 
         SaveResults

--- a/eng/scripts/Test-BuildPerformance.ps1
+++ b/eng/scripts/Test-BuildPerformance.ps1
@@ -2,12 +2,41 @@
 #Requires -Version 7
 
 param(
-    [string] $Command = 'azmcp tools list'
+    [parameter(Mandatory)]
+    [string] $ServerName,
+    [int] $RunCount = 3,
+    [int] $InvocationsPerRun = 10
 )
 
 . "$PSScriptRoot/../common/scripts/common.ps1"
 
 $combinations = @()
+
+$combinations += @{
+    Name = "plain/no-self"
+}
+
+$combinations += @{
+    Name = "trimmed/no-self"
+}
+
+$combinations += @{
+    Name = "trimmed r2r/no-self"
+    Trimmed = $true
+    ReadyToRun = $true
+}
+
+$combinations += @{
+    Name = "native"
+    Native = $true
+}
+
+$combinations += @{
+    Name = "native r2r"
+    Native = $true
+    ReadyToRun = $true
+}
+
 @($false, $true) | ForEach-Object {
     $SingleFile = $_
     @($false, $true) | ForEach-Object {
@@ -15,7 +44,8 @@ $combinations = @()
         @($false, $true) | ForEach-Object {
             $ReadyToRun = $_
             $combinations += @{
-                Name = "$($Trimmed ? 'aot' : 'no-aot')/$($ReadyToRun ? 'r2r' : 'no-r2r')"
+                Name = "$($Trimmed ? 'trim' : 'no-trim')/$($ReadyToRun ? 'r2r' : 'no-r2r')/$($SingleFile ? 'single' : 'no-single')"
+                SelfContained = $true
                 Trimmed = $Trimmed
                 ReadyToRun = $ReadyToRun
                 SingleFile = $SingleFile
@@ -25,19 +55,17 @@ $combinations = @()
 }
 
 function SaveResults() {
-    $csv = @("Trimmed,ReadyToRun,Compilation,Installation,First Run,Average Run,Tgz Size,Package Size")
+    $csv = @("Name,Compilation,First Run,Average Run,Package Size")
 
     foreach($combination in $combinations) {
         $result = $results[$combination.Name]
 
         $compilation = ($result | Measure-Object -Property Compilation -Average).Average
-        $installation = ($result | Measure-Object -Property Installation -Average).Average
         $firstRun = ($result | Measure-Object -Property FirstRun -Average).Average
         $averageRun = ($result | Measure-Object -Property AverageRun -Average).Average
-        $tgzSize = ($result | Measure-Object -Property TgzSize -Average).Average
         $packageSize = ($result | Measure-Object -Property PackageSize -Average).Average
 
-        $csv += "$($combination.Trimmed),$($combination.ReadyToRun),$compilation,$installation,$firstRun,$averageRun,$tgzSize,$packageSize"
+        $csv += "$($combination.Name),$compilation,$firstRun,$averageRun,$packageSize"
     }
 
     $csv | Out-File -FilePath .work/results.csv -Encoding utf8 -Force
@@ -47,15 +75,14 @@ $results = @{};
 
 Push-Location $RepoRoot
 try {
-    $version = & "./eng/scripts/Get-Version.ps1"
     $rid = [System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier
-    $nodeRid = $rid.Replace('win', 'win32').Replace('osx', 'darwin')
+    $platformName = $rid.Replace('win', 'windows').Replace('osx', 'macos')
 
     foreach($combination in $combinations) {
         $results[$combination.Name] = @()
-
-        Write-Host "Building '$($combination.Name)'"
-        Write-Host "-------------------------------"
+        $outputPath = ".work/build/$ServerName/$platformName"
+        Write-Host "Building '$($combination.Name)' to '$outputPath' ..."
+        Write-Host "-----------------------------------------------------------------------------------"
 
         Remove-Item -Path .work -Recurse -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
         Remove-Item -Path .dist -Recurse -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
@@ -63,39 +90,49 @@ try {
         Remove-Item -Path ./src/obj -Recurse -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
 
         $start = Get-Date
-        ./eng/scripts/Build-Local.ps1 -SelfContained:$true -Trimmed:$combination.Trimmed -ReadyToRun:$combination.ReadyToRun -UsePaths:$true -AllPlatforms:$false
+
+        ./eng/scripts/Build-Code.ps1 `
+            -ServerName $ServerName `
+            -SelfContained:(!!$combination.SelfContained) `
+            -Trimmed:(!!$combination.Trimmed) `
+            -ReadyToRun:(!!$combination.ReadyToRun) `
+            -SingleFile:(!!$combination.SingleFile) `
+            -Native:(!!$combination.Native)
+
         $compilation = ((Get-Date) - $start).TotalMilliseconds
 
-        for($i = 1; $i -le 3; $i++) {
+        $executable = Get-ChildItem -Path $outputPath -Filter "*.exe" | Select-Object -First 1
+
+        if(-not $executable) {
+            Write-Warning "No executable found for '$($combination.Name)' in '$outputPath'"
+            continue
+        }
+
+        $command = "$($executable.FullName) tools list"
+
+        for($i = 1; $i -le $RunCount; $i++) {
             Write-Host "Running '$($combination.Name)' - Round $i"
             Write-Host "----------------------------------------"
-            npm uninstall -g azmcp | Out-Null
 
             $start = Get-Date
-            Write-Host "> npm install -g .dist/wrapper/azure-mcp-$version.tgz"
-            npm install -g ".dist/wrapper/azure-mcp-$version.tgz" | Out-Null
-            $installation = ((Get-Date) - $start).TotalMilliseconds
 
             $runs = @()
-            Write-Host "Running ..."
-            foreach($x in 1..6) {
+            Write-Host "Running $command"
+            foreach($x in 1..$InvocationsPerRun) {
                 $start = Get-Date
-                Invoke-Expression $Command | Out-Null
+                Invoke-Expression $command | Out-Null
                 if ($LASTEXITCODE -ne 0) {
                     Write-Warning "$($combination.Name) failed with exit code $LASTEXITCODE"
                 }
                 $runs += ((Get-Date) - $start).TotalMilliseconds
             }
 
-            $tgzSize = (Get-Item -Path ".dist/platform/azure-mcp-$nodeRid-$version.tgz").Length / 1MB
-            $packageSize = (Get-ChildItem -Path ".work/platform/$rid" -File -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB
+            $packageSize = (Get-ChildItem -Path $executable.DirectoryName -File -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB
 
             $results[$combination.Name] += @{
                 Compilation = $compilation
-                Installation = $installation
                 FirstRun = $runs[0]
-                AverageRun = ($runs | Select-Object -Skip 3 | Measure-Object -Average).Average
-                TgzSize = $tgzSize
+                AverageRun = ($runs | Select-Object -Skip 2 | Measure-Object -Average).Average
                 PackageSize = $packageSize
             }
         }

--- a/eng/scripts/Test-BuildPerformance.ps1
+++ b/eng/scripts/Test-BuildPerformance.ps1
@@ -3,8 +3,7 @@
 
 param(
     [parameter(Mandatory)]
-    [string] $ServerName,
-    [int] $RunCount = 10
+    [string] $ServerName
 )
 
 . "$PSScriptRoot/../common/scripts/common.ps1"
@@ -12,36 +11,42 @@ param(
 $combinations = @()
 
 $combinations += @{
-    Name = "plain/no-self"
+    Name = "dependent/no-r2r/no-single"
 }
 
 $combinations += @{
-    Name = "single/no-self"
+    Name = "dependent/no-r2r/single"
     SingleFile = $true
 }
 
 $combinations += @{
-    Name = "r2r/no-self"
+    Name = "dependent/r2r/no-single"
     ReadyToRun = $true
 }
 
 $combinations += @{
-    Name = "native"
+    Name = "dependent/r2r/single"
+    ReadyToRun = $true
+    SingleFile = $true
+}
+
+$combinations += @{
+    Name = "native/no-r2r"
     Native = $true
 }
 
 $combinations += @{
-    Name = "native r2r"
+    Name = "native/r2r"
     Native = $true
     ReadyToRun = $true
 }
 
 @($false, $true) | ForEach-Object {
-    $SingleFile = $_
+    $Trimmed = $_
     @($false, $true) | ForEach-Object {
-        $Trimmed = $_
+        $ReadyToRun = $_
         @($false, $true) | ForEach-Object {
-            $ReadyToRun = $_
+            $SingleFile = $_
             $combinations += @{
                 Name = "$($Trimmed ? 'trim' : 'no-trim')/$($ReadyToRun ? 'r2r' : 'no-r2r')/$($SingleFile ? 'single' : 'no-single')"
                 SelfContained = $true
@@ -54,7 +59,7 @@ $combinations += @{
 }
 
 function SaveResults() {
-    $csv = @("Name,Self Contained,Trimmed,Single File,Ready To Run,Native,Compilation,First Run,Average Run,Package Size")
+    $csv = @("Name,Self Contained,Trimmed,Single File,Ready To Run,Native,Compilation,Cold Run,Warm Run,Package Size")
 
     foreach($combination in $combinations) {
         $name = $combination.Name
@@ -67,23 +72,49 @@ function SaveResults() {
         $result = $results[$name]
 
         $compilation = $result.Compilation
-        $firstRun = $result.FirstRun
-        $averageRun = $result.AverageRun
+        $coldRun = $result.ColdRun
+        $warmRun = $result.WarmRun
         $packageSize = $result.PackageSize
 
-        $csv += "$name,$selfContained,$trimmed,$singleFile,$readyToRun,$native,$compilation,$firstRun,$averageRun,$packageSize"
+        $csv += "$name,$selfContained,$trimmed,$singleFile,$readyToRun,$native,$compilation,$coldRun,$warmRun,$packageSize"
     }
 
-    New-Item -ItemType Directory -Path .work -Force
+    New-Item -ItemType Directory -Path .work -Force | Out-Null
     $csv | Out-File -FilePath .work/results.csv -Encoding utf8 -Force
 }
 
 $results = @{};
 
+$ballastSize = 1gb
+$ballastFile = ".work/ballast.txt"
+function Write-ballastFile {
+    New-Item -ItemType Directory -Path .work -Force | Out-Null
+    Remove-Item -Path $ballastFile -Force -ErrorAction SilentlyContinue
+    # Create a large ballast file to clear the io cache
+    $ballastRemaining = $ballastSize
+    $gitPackFiles = Get-ChildItem .git/objects/pack -File
+    while ($ballastRemaining -gt 0) {
+        foreach ($file in $gitPackFiles) {
+            $chunk = [IO.File]::ReadAllBytes($file.FullName)
+            # trim the chunk if necessary
+            if ($ballastRemaining -lt $chunk.Length) {
+                [Array]::Resize([ref]$chunk, [int]$ballastRemaining)
+            }
+            [IO.File]::AppendAllBytes($ballastFile, $chunk)
+            $ballastRemaining -= $chunk.Length
+            if ($ballastRemaining -le 0) {
+                break
+            }
+        }
+    }
+}
+
 Push-Location $RepoRoot
 try {
     $rid = [System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier
     $platformName = $rid.Replace('win', 'windows').Replace('osx', 'macos')
+
+    Write-ballastFile
 
     foreach($combination in $combinations) {
         $results[$combination.Name] = @()
@@ -91,7 +122,7 @@ try {
         Write-Host "Building '$($combination.Name)' to '$outputPath' ..."
         Write-Host "-----------------------------------------------------------------------------------"
 
-        Remove-Item -Path .work/build -Recurse -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
+        Remove-Item -Path $outputPath -Recurse -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
 
         # Remove bin and obj directories anywhere in the repo
         Get-ChildItem . -Directory -Recurse
@@ -102,6 +133,7 @@ try {
 
         Write-Host @"
 ./eng/scripts/Build-Code.ps1 ``
+    -ReleaseBuild ``
     -ServerName '$ServerName' ``
     -SelfContained:`$$(!!$combination.SelfContained) ``
     -Trimmed:`$$(!!$combination.Trimmed) ``
@@ -111,6 +143,7 @@ try {
 "@
 
         ./eng/scripts/Build-Code.ps1 `
+            -ReleaseBuild `
             -ServerName $ServerName `
             -SelfContained:(!!$combination.SelfContained) `
             -Trimmed:(!!$combination.Trimmed) `
@@ -133,32 +166,63 @@ try {
 
         $command = "$($executable.FullName) tools list"
 
-        Write-Host "Running '$($combination.Name)' - Round $i"
+        Write-Host "Running '$($combination.Name)'"
         Write-Host "----------------------------------------"
 
         $start = Get-Date
 
-        $runs = @()
-        Write-Host "Running $command"
-        foreach($x in 1..$RunCount) {
+        function measureRun {
             $start = Get-Date
-            Invoke-Expression $command | Out-Null
+            & $executable 'tools' 'list' | Out-Null
             if ($LASTEXITCODE -ne 0) {
                 Write-Warning "$($combination.Name) failed with exit code $LASTEXITCODE"
+                return $null
             }
-            $runs += ((Get-Date) - $start).TotalMilliseconds
+            return ((Get-Date) - $start).TotalMilliseconds
+        }
+
+        $coldRuns = @()
+        $warmRuns = @()
+        foreach($i in 1..3) {
+            # Read the ballast file to clear the io cache
+            Write-Host "Reading ballast file..."
+            [IO.File]::ReadAllBytes($ballastFile) | Out-Null
+            Write-Host "Cold run $i.0`: $command"
+            $coldRun = measureRun
+            if (!$coldRun) {
+                Write-Warning "Failed to measure first run for $($combination.Name)"
+                break
+            }
+            $coldRuns += $coldRun
+
+            foreach($x in 1..5) {
+                Write-Host "Warm run $i.$x`: $command"
+                $warmRun = measureRun
+                if (!$warmRun) {
+                    Write-Warning "Failed to measure warm run for $($combination.Name)"
+                    break
+                }
+                $warmRuns += $warmRun
+            }
         }
 
         $packageSize = (Get-ChildItem -Path $executable.DirectoryName -File -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB
 
         $results[$combination.Name] = @{
             Compilation = $compilation
-            FirstRun = $runs[0]
-            AverageRun = ($runs | Select-Object -Skip 2 | Measure-Object -Average).Average
+            ColdRun = ($coldRuns | Measure-Object -Average).Average
+            WarmRun = ($warmRuns | Measure-Object -Average).Average
             PackageSize = $packageSize
         }
 
         SaveResults
+
+        # rename the output path to preserve it
+        $newOutputPath = ".work/build-old/$($combination.Name -replace '\W', '_')"
+        Remove-Item $newOutputPath -Recurse -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
+        New-Item -ItemType Directory -Path $newOutputPath -Force | Out-Null
+        Move-Item -Path $outputPath/* -Destination $newOutputPath
+        Remove-Item $outputPath -Recurse -Force -ErrorAction SilentlyContinue -ProgressAction SilentlyContinue
     }
 }
 finally {


### PR DESCRIPTION
## What does this PR do?
This pull request significantly refactors the `Test-BuildPerformance.ps1` script to improve build performance testing by expanding configuration options, enhancing cleanup and output, and streamlining the results reporting. The script now supports more build combinations, provides more detailed CSV output, and uses a more robust process for building and running test executables.

Key improvements and changes:

**Expanded build configuration and parameterization:**
- Added mandatory `ServerName` parameter and a configurable `RunCount` parameter to allow more flexible test execution. The script now defines a broader set of build combinations, including new options for `Native`, `SingleFile`, `ReadyToRun`, and `SelfContained` builds, and uses more descriptive names for each combination.

**Improved CSV output and results reporting:**
- Enhanced the results CSV to include more columns (`Name`, `Self Contained`, `Trimmed`, `Single File`, `Ready To Run`, `Native`, `Compilation`, `First Run`, `Average Run`, `Package Size`), providing a more comprehensive summary of each build/test run.

**Better cleanup and build output handling:**
- Improved the cleanup process by recursively removing all `bin` and `obj` directories throughout the repository before each build, ensuring a clean environment for every test.
- Updated the output directory structure and executable discovery logic to better organize build artifacts and reliably locate test executables.

**Streamlined build and test execution:**
- Switched from using `Build-Local.ps1` to `Build-Code.ps1` for building, and now constructs the command line for each test dynamically based on the discovered executable. The script also removes PDB files after building to reduce artifact size.
- Refined the run measurement logic to allow for a configurable number of runs per test, and simplified the calculation of average run times.

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
