### PR TITLE
Add namespace declaration linter to Analyze-Code pipeline

### DIFF
--- a/eng/scripts/Analyze-Code.ps1
+++ b/eng/scripts/Analyze-Code.ps1
@@ -84,6 +84,17 @@ try {
         Write-Host "✅ Tool id validation passed."
     }
 
+    # Run namespace validation
+    $namespaceResult = & "$PSScriptRoot/Test-Namespace.ps1"
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "❌ Namespace validation failed"
+        Write-Host "$($namespaceResult.ViolationCount) file(s) missing namespace declarations. Review the above output for details."
+        $hasErrors = $true
+    } else {
+        Write-Host "✅ Namespace validation passed."
+    }
+
     if($hasErrors) {
         exit 1
     }

--- a/eng/scripts/Test-Namespace.ps1
+++ b/eng/scripts/Test-Namespace.ps1
@@ -1,0 +1,90 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7
+
+<#
+.SYNOPSIS
+    Validates that all C# class files have a namespace declaration.
+
+.DESCRIPTION
+    Scans all .cs files under core/, servers/, and tools/ directories (excluding
+    obj/, bin/, and auto-generated files) and ensures each file contains a
+    namespace declaration. Files without a namespace cause compilation issues
+    and pollute the global namespace.
+
+.PARAMETER Path
+    Root directory to scan. Defaults to the repository root.
+
+.OUTPUTS
+    Returns an object with ViolationCount property. Sets exit code 1 if violations found.
+#>
+
+param(
+    [string]$Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot/../common/scripts/common.ps1"
+
+if (-not $Path) {
+    $Path = $RepoRoot
+}
+
+$rootPath = (Resolve-Path $Path).Path.TrimEnd('\', '/')
+
+$searchDirs = @(
+    Join-Path $rootPath "core"
+    Join-Path $rootPath "servers"
+    Join-Path $rootPath "tools"
+)
+
+$violations = @()
+
+foreach ($dir in $searchDirs) {
+    if (-not (Test-Path $dir)) {
+        continue
+    }
+
+    $csFiles = Get-ChildItem -Path $dir -Filter "*.cs" -Recurse | Where-Object {
+        $_.FullName -notmatch '[/\\](obj|bin)[/\\]' -and
+        $_.FullName -notmatch '\.g\.cs$' -and
+        $_.FullName -notmatch '\.generated\.cs$' -and
+        $_.FullName -notmatch 'GlobalUsings\.cs$' -and
+        $_.FullName -notmatch 'AssemblyInfo\.cs$' -and
+        $_.FullName -notmatch 'AssemblyAttributes\.cs$' -and
+        $_.Name -ne 'Program.cs' -and
+        $_.Name -ne 'Usings.cs' -and
+        $_.FullName -notmatch '[/\\]templates[/\\]'
+    }
+
+    foreach ($file in $csFiles) {
+        $content = Get-Content $file.FullName -Raw
+
+        if ([string]::IsNullOrWhiteSpace($content)) {
+            continue
+        }
+
+        if ($content -notmatch '(?m)^\s*namespace\s+[A-Za-z_][A-Za-z0-9_.]*\s*;') {
+            $relativePath = [System.IO.Path]::GetRelativePath($rootPath, $file.FullName)
+            $violations += $relativePath
+        }
+    }
+}
+
+if ($violations.Count -gt 0) {
+    Write-Host "❌ Found $($violations.Count) C# file(s) missing a namespace declaration:"
+    Write-Host ""
+    foreach ($v in $violations) {
+        Write-Host "  - $v"
+    }
+    Write-Host ""
+    Write-Host "All C# class files must declare a namespace. Use file-scoped namespaces:"
+    Write-Host "  namespace Azure.Mcp.Tools.MyToolset.Commands;"
+    Write-Host ""
+
+    $result = [PSCustomObject]@{ ViolationCount = $violations.Count }
+    Write-Output $result
+    exit 1
+} else {
+    Write-Output ([PSCustomObject]@{ ViolationCount = 0 })
+}

--- a/tools/Azure.Mcp.Tools.Speech/src/Commands/SpeechJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Commands/SpeechJsonContext.cs
@@ -8,6 +8,8 @@ using Azure.Mcp.Tools.Speech.Models;
 using Azure.Mcp.Tools.Speech.Models.FastTranscription;
 using Azure.Mcp.Tools.Speech.Models.Realtime;
 
+namespace Azure.Mcp.Tools.Speech.Commands;
+
 [JsonSerializable(typeof(RealtimeRecognitionContinuousResult))]
 [JsonSerializable(typeof(RealtimeRecognitionDetailedResult))]
 [JsonSerializable(typeof(RealtimeRecognitionNBestResult))]

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/BlobGetCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/BlobGetCommand.cs
@@ -14,6 +14,8 @@ using Microsoft.Mcp.Core.Extensions;
 using Microsoft.Mcp.Core.Models.Option;
 using Microsoft.Mcp.Core.Options;
 
+namespace Fabric.Mcp.Tools.OneLake.Commands.File;
+
 [CommandMetadata(
     Id = "75d6cb4c-4e81-4e69-a4ec-eca53a7dacd9",
     Name = "download_file",


### PR DESCRIPTION
## What does this PR do?
 Adds a new Test-Namespace.ps1 linter that validates all C# class files under core/, servers/, and tools/ contain a namespace declaration. Files without namespaces pollute the global namespace and can cause compilation issues.

## GitHub issue number?
https://github.com/microsoft/mcp/issues/2530

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
