### PR TITLE
azurebackup: emit AzSubscriptionGuid telemetry tag from each tool

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1779814991354.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1779814991354.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Other Changes"
+    description: "AzureBackup: emit AzSubscriptionGuid telemetry tag from each tool so per-subscription telemetry works in namespace server mode."

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Backup/BackupStatusCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Backup/BackupStatusCommand.cs
@@ -60,6 +60,7 @@ public sealed class BackupStatusCommand(ILogger<BackupStatusCommand> logger, IAz
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         context.Activity?.AddTag(AzureBackupTelemetryTags.OperationScope, "status-check");
 
         try

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/DisasterRecovery/DisasterRecoveryEnableCrrCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/DisasterRecovery/DisasterRecoveryEnableCrrCommand.cs
@@ -38,6 +38,7 @@ public sealed class DisasterRecoveryEnableCrrCommand(ILogger<DisasterRecoveryEna
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
 
         try

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceFindUnprotectedCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceFindUnprotectedCommand.cs
@@ -59,6 +59,7 @@ public sealed class GovernanceFindUnprotectedCommand(ILogger<GovernanceFindUnpro
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         context.Activity?.AddTag(AzureBackupTelemetryTags.OperationScope, "scan");
 
         try

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceImmutabilityCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceImmutabilityCommand.cs
@@ -69,6 +69,7 @@ public sealed class GovernanceImmutabilityCommand(ILogger<GovernanceImmutability
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
 
         try

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceSoftDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceSoftDeleteCommand.cs
@@ -82,6 +82,7 @@ public sealed class GovernanceSoftDeleteCommand(ILogger<GovernanceSoftDeleteComm
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
 
         try

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Job/JobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Job/JobGetCommand.cs
@@ -60,6 +60,7 @@ public sealed class JobGetCommand(ILogger<JobGetCommand> logger, IAzureBackupSer
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
         context.Activity?.AddTag(AzureBackupTelemetryTags.OperationScope, string.IsNullOrEmpty(options.Job) ? "list" : "single");
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyCreateCommand.cs
@@ -147,6 +147,7 @@ public sealed class PolicyCreateCommand(ILogger<PolicyCreateCommand> logger, IAz
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultAndWorkloadTags(context.Activity, options.VaultType, options.WorkloadType);
 
         var validation = Services.Policy.PolicyCreateValidator.Validate(options);

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyGetCommand.cs
@@ -60,6 +60,7 @@ public sealed class PolicyGetCommand(ILogger<PolicyGetCommand> logger, IAzureBac
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
         context.Activity?.AddTag(AzureBackupTelemetryTags.OperationScope, string.IsNullOrEmpty(options.Policy) ? "list" : "single");
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyUpdateCommand.cs
@@ -56,6 +56,7 @@ public sealed class PolicyUpdateCommand(ILogger<PolicyUpdateCommand> logger, IAz
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
 
         try

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectableItem/ProtectableItemListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectableItem/ProtectableItemListCommand.cs
@@ -58,6 +58,7 @@ public sealed class ProtectableItemListCommand(ILogger<ProtectableItemListComman
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultAndWorkloadTags(context.Activity, options.VaultType ?? "rsv", options.WorkloadType);
 
         try

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemGetCommand.cs
@@ -63,6 +63,7 @@ public sealed class ProtectedItemGetCommand(ILogger<ProtectedItemGetCommand> log
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
         context.Activity?.AddTag(AzureBackupTelemetryTags.OperationScope, string.IsNullOrEmpty(options.ProtectedItem) ? "list" : "single");
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemProtectCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemProtectCommand.cs
@@ -77,6 +77,7 @@ public sealed class ProtectedItemProtectCommand(ILogger<ProtectedItemProtectComm
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
         context.Activity?.AddTag(AzureBackupTelemetryTags.DatasourceType, AzureBackupTelemetryTags.NormalizeWorkloadType(options.DatasourceType));
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemUndeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemUndeleteCommand.cs
@@ -61,6 +61,7 @@ public sealed class ProtectedItemUndeleteCommand(ILogger<ProtectedItemUndeleteCo
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
 
         try

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/RecoveryPoint/RecoveryPointGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/RecoveryPoint/RecoveryPointGetCommand.cs
@@ -60,6 +60,7 @@ public sealed class RecoveryPointGetCommand(ILogger<RecoveryPointGetCommand> log
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
         context.Activity?.AddTag(AzureBackupTelemetryTags.OperationScope, string.IsNullOrEmpty(options.RecoveryPoint) ? "list" : "single");
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityConfigureEncryptionCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityConfigureEncryptionCommand.cs
@@ -112,6 +112,7 @@ public sealed class SecurityConfigureEncryptionCommand(ILogger<SecurityConfigure
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
         _lastVaultType = options.VaultType;
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityConfigureMuaCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityConfigureMuaCommand.cs
@@ -69,6 +69,7 @@ public sealed class SecurityConfigureMuaCommand(ILogger<SecurityConfigureMuaComm
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
 
         try

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultCreateCommand.cs
@@ -95,6 +95,7 @@ public sealed class VaultCreateCommand(ILogger<VaultCreateCommand> logger, IAzur
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
 
         try

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultGetCommand.cs
@@ -85,6 +85,7 @@ public sealed class VaultGetCommand(ILogger<VaultGetCommand> logger, IAzureBacku
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
         context.Activity?.AddTag(AzureBackupTelemetryTags.OperationScope, string.IsNullOrEmpty(options.Vault) ? "list" : "single");
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultUpdateCommand.cs
@@ -103,6 +103,7 @@ public sealed class VaultUpdateCommand(ILogger<VaultUpdateCommand> logger, IAzur
 
         var options = BindOptions(parseResult);
 
+        AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);
         AzureBackupTelemetryTags.AddVaultTags(context.Activity, options.VaultType);
 
         try

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Models/AzureBackupTelemetryTags.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Models/AzureBackupTelemetryTags.cs
@@ -14,6 +14,27 @@ public static class AzureBackupTelemetryTags
     public static readonly string DatasourceType = AddPrefix("DatasourceType");
     public static readonly string OperationScope = AddPrefix("OperationScope");
 
+    // Unprefixed tag name shared with Microsoft.Mcp.Core's AzureTagName.SubscriptionGuid.
+    // Duplicated here as a string literal because AzureTagName is internal to that assembly.
+    // Emitted directly from each AzureBackup tool to ensure per-subscription telemetry is
+    // captured even in namespace server mode, where the central McpRuntime tag emission
+    // does not see the nested `subscription` parameter.
+    public const string SubscriptionGuid = "AzSubscriptionGuid";
+
+    /// <summary>
+    /// Adds the AzSubscriptionGuid tag to the activity. Matches McpRuntime.CallToolHandler
+    /// behavior by emitting any non-null subscription value (including empty string).
+    /// </summary>
+    public static void AddSubscriptionTag(Activity? activity, string? subscription)
+    {
+        if (activity is null || subscription is null)
+        {
+            return;
+        }
+
+        activity.SetTag(SubscriptionGuid, subscription);
+    }
+
     /// <summary>
     /// Normalizes the vault type to canonical lowercase values (rsv/dpp).
     /// Returns "auto" when the input is null or empty (user didn't specify --vault-type).

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Models/AzureBackupTelemetryTagsTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Models/AzureBackupTelemetryTagsTests.cs
@@ -107,4 +107,58 @@ public class AzureBackupTelemetryTagsTests
         Assert.Equal("azurebackup/DatasourceType", AzureBackupTelemetryTags.DatasourceType);
         Assert.Equal("azurebackup/OperationScope", AzureBackupTelemetryTags.OperationScope);
     }
+
+    [Fact]
+    public void SubscriptionGuid_MatchesGlobalAzureTagName()
+    {
+        // Must stay in sync with Microsoft.Mcp.Core's internal AzureTagName.SubscriptionGuid.
+        Assert.Equal("AzSubscriptionGuid", AzureBackupTelemetryTags.SubscriptionGuid);
+    }
+
+    [Fact]
+    public void AddSubscriptionTag_NullActivity_DoesNotThrow()
+    {
+        AzureBackupTelemetryTags.AddSubscriptionTag(null, "00000000-0000-0000-0000-000000000000");
+    }
+
+    [Fact]
+    public void AddSubscriptionTag_NullSubscription_DoesNotEmitTag()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var source = new ActivitySource("test");
+        using var activity = source.StartActivity("test-op");
+        Assert.NotNull(activity);
+
+        AzureBackupTelemetryTags.AddSubscriptionTag(activity, null);
+
+        Assert.Null(activity.GetTagItem(AzureBackupTelemetryTags.SubscriptionGuid));
+    }
+
+    [Theory]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    [InlineData("my-subscription-name")]
+    [InlineData("")]
+    public void AddSubscriptionTag_NonNullValue_EmitsTag(string subscription)
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var source = new ActivitySource("test");
+        using var activity = source.StartActivity("test-op");
+        Assert.NotNull(activity);
+
+        AzureBackupTelemetryTags.AddSubscriptionTag(activity, subscription);
+
+        Assert.Equal(subscription, activity.GetTagItem(AzureBackupTelemetryTags.SubscriptionGuid));
+    }
 }


### PR DESCRIPTION
## Summary

Per reviewer feedback on #2725, set the `AzSubscriptionGuid` Activity telemetry tag directly in each AzureBackup tool alongside existing `OperationScope`/`VaultType` tags, instead of relying on a central emission path in `McpRuntime`/`NamespaceToolLoader`. This restores per-subscription telemetry for AzureBackup tools in both namespace and standard server modes.

## Changes

- Add `SubscriptionGuid` constant + `AddSubscriptionTag` helper to `AzureBackupTelemetryTags`.
  - The literal `"AzSubscriptionGuid"` is duplicated here because the canonical constant in `Microsoft.Mcp.Core` (`AzureTagName.SubscriptionGuid`) is `internal` and not visible to the AzureBackup tool assembly. A code comment notes this.
- Insert `AzureBackupTelemetryTags.AddSubscriptionTag(context.Activity, options.Subscription);` near the top of `ExecuteAsync` in **18 AzureBackup command classes**, immediately before the existing `AddVaultTags` / scope-tagging calls.
- Add **5 unit tests** in `AzureBackupTelemetryTagsTests` covering:
  - Constant value matches the global `AzSubscriptionGuid` tag name.
  - `AddSubscriptionTag` is a safe no-op when `Activity` is `null`.
  - `AddSubscriptionTag` emits no tag when `subscription` is `null`.
  - `AddSubscriptionTag` emits the tag for GUID, name, and empty-string inputs (theory).

## Validation

- `dotnet build tools/Azure.Mcp.Tools.AzureBackup/src` — 0 warnings, 0 errors.
- `dotnet test tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests --filter "FullyQualifiedName~AzureBackupTelemetryTagsTests"` — 23 passed, 0 failed.

## Files changed

- `tools/Azure.Mcp.Tools.AzureBackup/src/Models/AzureBackupTelemetryTags.cs`
- 18 command files under `tools/Azure.Mcp.Tools.AzureBackup/src/Commands/**`
- `tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.UnitTests/Models/AzureBackupTelemetryTagsTests.cs`
- `servers/Azure.Mcp.Server/changelog-entries/1779814991354.yaml`

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
