### PR TITLE
Set `SslMode` to `Require` in all PostgreSQL tools

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1779913735497.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1779913735497.yaml
@@ -1,0 +1,4 @@
+pr: 2749
+changes:
+  - section: "Other Changes"
+    description: "Changed the `SslMode` in PostgreSQL tools to `Require` instead of the default `Prefer` to align with other tools like those in the MySQL namespace."

--- a/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
@@ -346,7 +346,8 @@ public class PostgresService(
             Host = host,
             Database = database,
             Username = user,
-            Password = password
+            Password = password,
+            SslMode = SslMode.Require
         };
         return builder.ConnectionString;
     }

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceConnectionStringInjectionTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceConnectionStringInjectionTests.cs
@@ -135,7 +135,7 @@ public class PostgresServiceConnectionStringInjectionTests
     }
 
     [Fact]
-    public async Task ExecuteQueryAsync_WithSslDowngradeInDatabase_DoesNotDisableSsl()
+    public async Task ExecuteQueryAsync_WithSslDowngradeInDatabase_EnforcesSslRequire()
     {
         // Arrange — attacker tries to inject SSL Mode=Disable via the database parameter
         const string maliciousDatabase = "postgres;SSL Mode=Disable";
@@ -150,7 +150,24 @@ public class PostgresServiceConnectionStringInjectionTests
         Assert.NotNull(_capturedConnectionString);
         var parsed = new NpgsqlConnectionStringBuilder(_capturedConnectionString!);
 
-        // SSL Mode should not be Disable — the builder escapes the value in the Database field
-        Assert.NotEqual(SslMode.Disable, parsed.SslMode);
+        // SSL Mode must be Require — the builder escapes the injected value in the Database field
+        // and BuildConnectionString explicitly sets SslMode.Require to prevent silent downgrade.
+        Assert.Equal(SslMode.Require, parsed.SslMode);
+    }
+
+    [Fact]
+    public async Task ExecuteQueryAsync_NormalInputs_EnforcesSslRequire()
+    {
+        // Act — exercise the normal (non-injection) code path
+        await _postgresService.ExecuteQueryAsync(
+            "test-sub", "test-rg", AuthTypes.MicrosoftEntra, "test-user", null,
+            "safe-server", "mydb", "SELECT 1",
+            TestContext.Current.CancellationToken);
+
+        // Assert — BuildConnectionString must enforce SslMode.Require so connections
+        // cannot silently downgrade to unencrypted (the Npgsql default is Prefer).
+        Assert.NotNull(_capturedConnectionString);
+        var parsed = new NpgsqlConnectionStringBuilder(_capturedConnectionString!);
+        Assert.Equal(SslMode.Require, parsed.SslMode);
     }
 }


### PR DESCRIPTION
## What does this PR do?
Update the `SslMode` in PostgreSQL connection settings to `Require` instead of the default `Prefer`, ensuring consistency with other database tools like those in the MySQL namespace.

## GitHub issue number?
[#468](https://github.com/microsoft/mcp-pr/issues/468)

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    


