### PR TITLE
eventgrid: update TopicListCommand description

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1779915676984.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1779915676984.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "eventgrid: corrected the topic list command description to remove unsupported claims (access keys and required topic/subscription wording), and added unit-test coverage to prevent regression."

--- a/tools/Azure.Mcp.Tools.EventGrid/src/Commands/Topic/TopicListCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/src/Commands/Topic/TopicListCommand.cs
@@ -14,7 +14,7 @@ namespace Azure.Mcp.Tools.EventGrid.Commands.Topic;
     Id = "42390294-2856-4980-a057-095c91355650",
     Name = "list",
     Title = "List Event Grid Topics",
-    Description = "List or show all Event Grid topics in a subscription, optionally filtered by resource group, returning endpoints, access keys, provisioning state, and subscription details for event publishing and management. A subscription or topic name is required.",
+    Description = "List Event Grid topics in an Azure subscription or resource group. Returns topic names, endpoints, locations, and provisioning status.",
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,

--- a/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.Tests/Topic/TopicListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.Tests/Topic/TopicListCommandTests.cs
@@ -15,6 +15,13 @@ namespace Azure.Mcp.Tools.EventGrid.Tests.Topic;
 
 public class TopicListCommandTests : CommandUnitTestsBase<TopicListCommand, IEventGridService>
 {
+
+    [Fact]
+    public void Constructor_Description_DoesNotMentionAccessKeys()
+    {
+        Assert.DoesNotContain("access key", CommandDefinition.Description, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public async Task ExecuteAsync_NoParameters_ReturnsTopics()
     {


### PR DESCRIPTION
This pull request addresses a bug in the Event Grid topic listing command by correcting its description to remove references to unsupported features and by adding unit tests to prevent future regressions. The changes improve both the accuracy of the command's documentation and the reliability of the codebase.

**Bug fix and documentation update:**

* Updated the `Description` property in `TopicListCommand` to remove mentions of access keys and clarify the output, ensuring it reflects only supported features.
* Added a changelog entry summarizing the correction of the topic list command description and the addition of unit-test coverage.

**Test coverage improvements:**

* Added a unit test in `TopicListCommandTests` to assert that the command description does not mention "access keys," preventing regression on this issue.