### PR TITLE
Bump testing timeout to 45 minutes

### DIFF
--- a/eng/pipelines/templates/common.yml
+++ b/eng/pipelines/templates/common.yml
@@ -29,7 +29,7 @@ parameters:
   default: false
 - name: TestTimeoutInMinutes
   type: number
-  default: 30
+  default: 45
 - name: IsTestPipeline
   type: boolean
   default: false

--- a/servers/Azure.Mcp.Server/build.yml
+++ b/servers/Azure.Mcp.Server/build.yml
@@ -9,7 +9,7 @@ parameters:
 - name: TestTimeoutInMinutes
   displayName: Test Timeout In Minutes
   type: number
-  default: 30
+  default: 45
 - name: RunVSCodeIntegrationTests
   displayName: Run VS Code Integration Tests (Outerloop Playwright)
   type: boolean

--- a/servers/Fabric.Mcp.Server/build.yml
+++ b/servers/Fabric.Mcp.Server/build.yml
@@ -9,7 +9,7 @@ parameters:
 - name: TestTimeoutInMinutes
   displayName: Test Timeout In Minutes
   type: number
-  default: 30
+  default: 45
 
 trigger: none
 pr: none

--- a/servers/Template.Mcp.Server/build.yml
+++ b/servers/Template.Mcp.Server/build.yml
@@ -21,7 +21,7 @@ parameters:
 - name: TestTimeoutInMinutes
   displayName: Test Timeout In Minutes
   type: number
-  default: 30
+  default: 45
 
 trigger: none
 pr: none


### PR DESCRIPTION
## What does this PR do?

Increases timeout for testing steps to 45 minutes as we're intermittently hitting the 30-minute timeout. This issue explains more on why we're seeing that: https://github.com/microsoft/mcp/issues/2755

## GitHub issue number?

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
