### PR TITLE
Fix runtime options binding failures

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Commands/TrimAnnotations.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/TrimAnnotations.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Mcp.Core.Commands;
 public static class TrimAnnotations
 {
     public const DynamicallyAccessedMemberTypes CommandAnnotations =
+    DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
+    |
         DynamicallyAccessedMemberTypes.PublicProperties
         | DynamicallyAccessedMemberTypes.NonPublicProperties;
 }

--- a/core/Microsoft.Mcp.Core/src/Options/OptionBinder.cs
+++ b/core/Microsoft.Mcp.Core/src/Options/OptionBinder.cs
@@ -17,6 +17,10 @@ namespace Microsoft.Mcp.Core.Options;
 /// </summary>
 public static class OptionBinder
 {
+    private const DynamicallyAccessedMemberTypes OptionBindingMembers =
+        DynamicallyAccessedMemberTypes.PublicProperties |
+        DynamicallyAccessedMemberTypes.PublicParameterlessConstructor;
+
     /// <summary>
     /// To prevent native AOT builds from trimming away the filled generic Options<T> methods, we have to maintain a
     /// centralized factory pattern. Each entry provides both the option factory (for registration) and value binder
@@ -118,7 +122,7 @@ public static class OptionBinder
     /// <summary>
     /// Registers System.CommandLine options on a command based on the public properties of <typeparamref name="TOptions"/>.
     /// </summary>
-    public static void RegisterOptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TOptions>(Command command)
+    public static void RegisterOptions<[DynamicallyAccessedMembers(OptionBindingMembers)] TOptions>(Command command)
         where TOptions : class
     {
         var descriptors = OptionDescriptor.FromType<TOptions>();
@@ -133,7 +137,7 @@ public static class OptionBinder
     /// Creates a new <typeparamref name="TOptions"/> instance and populates its properties
     /// from the parsed command-line values.
     /// </summary>
-    public static TOptions BindOptions<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TOptions>(ParseResult parseResult)
+    public static TOptions BindOptions<[DynamicallyAccessedMembers(OptionBindingMembers)] TOptions>(ParseResult parseResult)
         where TOptions : class
     {
         var instance = (TOptions)CreateInstance(typeof(TOptions));

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Options/OptionBinderTests.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Options/OptionBinderTests.cs
@@ -3,6 +3,9 @@
 
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Options;
 using Xunit;
 
@@ -440,6 +443,39 @@ public sealed class OptionBinderTests
         Assert.NotNull(options.Required);
         Assert.Equal("primary", options.Required.Name);
         Assert.Equal(5432, options.Required.Port);
+    }
+
+    #endregion
+
+    #region Trimming Annotation Tests
+
+    [Fact]
+    public void OptionBinder_GenericMethods_PreservePublicPropertiesAndParameterlessConstructor()
+    {
+        var registerMethod = typeof(OptionBinder).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m => m.Name == nameof(OptionBinder.RegisterOptions) && m.IsGenericMethodDefinition);
+        var bindMethod = typeof(OptionBinder).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m => m.Name == nameof(OptionBinder.BindOptions) && m.IsGenericMethodDefinition);
+
+        AssertHasRequiredMemberAnnotations(registerMethod.GetGenericArguments()[0]);
+        AssertHasRequiredMemberAnnotations(bindMethod.GetGenericArguments()[0]);
+    }
+
+    [Fact]
+    public void TrimAnnotations_CommandAnnotations_IncludePublicPropertiesAndParameterlessConstructor()
+    {
+        var annotations = TrimAnnotations.CommandAnnotations;
+
+        Assert.True(annotations.HasFlag(DynamicallyAccessedMemberTypes.PublicProperties));
+        Assert.True(annotations.HasFlag(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor));
+    }
+
+    private static void AssertHasRequiredMemberAnnotations(MemberInfo member)
+    {
+        var attribute = member.GetCustomAttribute<DynamicallyAccessedMembersAttribute>();
+        Assert.NotNull(attribute);
+        Assert.True(attribute!.MemberTypes.HasFlag(DynamicallyAccessedMemberTypes.PublicProperties));
+        Assert.True(attribute.MemberTypes.HasFlag(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor));
     }
 
     #endregion

--- a/servers/Azure.Mcp.Server/changelog-entries/1780078930062.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1780078930062.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed trimmed/package runtime option binding failures (e.g., Kusto query/sample) by preserving public parameterless constructors required for reflection-based option activation."

--- a/tools/Azure.Mcp.Tools.Communication/src/Commands/BaseCommunicationCommand.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Commands/BaseCommunicationCommand.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.Communication.Options;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Extensions;
 
 namespace Azure.Mcp.Tools.Communication.Commands;
 
 public abstract class BaseCommunicationCommand<
-    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)]
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)]
 TOptions> : GlobalCommand<TOptions>
     where TOptions : BaseCommunicationOptions, new()
 {

--- a/tools/Azure.Mcp.Tools.Communication/src/Commands/BaseCommunicationCommand.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Commands/BaseCommunicationCommand.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Tools.Communication.Options;
 using System.Diagnostics.CodeAnalysis;
+using Azure.Mcp.Tools.Communication.Options;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Extensions;
 


### PR DESCRIPTION
Fixed trimmed/package runtime option binding failures (e.g., Kusto query/sample) by preserving public parameterless constructors required for reflection-based option activation.