### PR TITLE
Rename MCP server configuration property names to prevent collisions

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
@@ -270,28 +270,29 @@ public static partial class ServiceCollectionExtensions
             .Configure<IConfiguration, IOptions<ServiceStartOptions>>((options, rootConfiguration, serviceStartOptions) =>
             {
                 // Manually bind configuration values to avoid reflection-based binding for AOT compatibility
-                options.RootCommandGroupName = rootConfiguration["Microsoft.Mcp.RootCommandGroupName"]
-                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp.RootCommandGroupName' is required.");
-                options.Name = rootConfiguration["Microsoft.Mcp.Name"]
-                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp.Name' is required.");
-                options.DisplayName = rootConfiguration["Microsoft.Mcp.DisplayName"]
-                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp.DisplayName' is required.");
+                var mcpConfiguration = rootConfiguration.GetRequiredSection("MicrosoftMcp");
+                options.RootCommandGroupName = mcpConfiguration[nameof(McpServerConfiguration.RootCommandGroupName)]
+                    ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.RootCommandGroupName)}' is required.");
+                options.Name = mcpConfiguration[nameof(McpServerConfiguration.Name)]
+                    ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.Name)}' is required.");
+                options.DisplayName = mcpConfiguration[nameof(McpServerConfiguration.DisplayName)]
+                    ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.DisplayName)}' is required.");
 
-                options.ShortName = rootConfiguration["Microsoft.Mcp.ShortName"]
-                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp.ShortName' is required.");
+                options.ShortName = mcpConfiguration[nameof(McpServerConfiguration.ShortName)]
+                    ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.ShortName)}' is required.");
                 options.ShortName = options.ShortName.Trim();
                 if (!ShortNamePattern().IsMatch(options.ShortName))
                 {
                     throw new InvalidOperationException(
-                        "Configuration value 'Microsoft.Mcp.ShortName' must contain only letters, digits, '_', or '-'.");
+                        $"Configuration value '{nameof(McpServerConfiguration.ShortName)}' must contain only letters, digits, '_', or '-'.");
                 }
 
-                options.Description = rootConfiguration["Microsoft.Mcp.Description"]
-                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp.Description' is required.");
+                options.Description = mcpConfiguration[nameof(McpServerConfiguration.Description)]
+                    ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.Description)}' is required.");
                 if (string.IsNullOrWhiteSpace(options.Description))
                 {
                     throw new InvalidOperationException(
-                        "Configuration value 'Microsoft.Mcp.Description' must not be empty or whitespace.");
+                        $"Configuration value '{nameof(McpServerConfiguration.Description)}' must not be empty or whitespace.");
                 }
 
                 // Assembly.GetEntryAssembly is used to retrieve the version of the server application as that is

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Mcp.Core.Areas.Server.Commands.Discovery;
@@ -270,28 +271,28 @@ public static partial class ServiceCollectionExtensions
             .Configure<IConfiguration, IOptions<ServiceStartOptions>>((options, rootConfiguration, serviceStartOptions) =>
             {
                 // Manually bind configuration values to avoid reflection-based binding for AOT compatibility
-                options.RootCommandGroupName = rootConfiguration[nameof(McpServerConfiguration.RootCommandGroupName)]
-                    ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.RootCommandGroupName)}' is required.");
-                options.Name = rootConfiguration[nameof(McpServerConfiguration.Name)]
-                    ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.Name)}' is required.");
-                options.DisplayName = rootConfiguration[nameof(McpServerConfiguration.DisplayName)]
-                    ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.DisplayName)}' is required.");
+                options.RootCommandGroupName = rootConfiguration["Microsoft.Mcp.RootCommandName"]
+                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp.RootCommandGroupName' is required.");
+                options.Name = rootConfiguration["Microsoft.Mcp.Name"]
+                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp..Name' is required.");
+                options.DisplayName = rootConfiguration["Microsoft.Mcp.DisplayName"]
+                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp..DisplayName' is required.");
 
-                options.ShortName = rootConfiguration[nameof(McpServerConfiguration.ShortName)]
-                    ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.ShortName)}' is required.");
+                options.ShortName = rootConfiguration["Microsoft.Mcp.ShortName"]
+                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp.ShortName' is required.");
                 options.ShortName = options.ShortName.Trim();
                 if (!ShortNamePattern().IsMatch(options.ShortName))
                 {
                     throw new InvalidOperationException(
-                        $"Configuration value '{nameof(McpServerConfiguration.ShortName)}' must contain only letters, digits, '_', or '-'.");
+                        "Configuration value 'Microsoft.Mcp.ShortName' must contain only letters, digits, '_', or '-'.");
                 }
 
-                options.Description = rootConfiguration[nameof(McpServerConfiguration.Description)]
-                    ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.Description)}' is required.");
+                options.Description = rootConfiguration["Microsoft.Mcp.Description"]
+                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp.Description' is required.");
                 if (string.IsNullOrWhiteSpace(options.Description))
                 {
                     throw new InvalidOperationException(
-                        $"Configuration value '{nameof(McpServerConfiguration.Description)}' must not be empty or whitespace.");
+                        "Configuration value 'Microsoft.Mcp.Description' must not be empty or whitespace.");
                 }
 
                 // Assembly.GetEntryAssembly is used to retrieve the version of the server application as that is

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Mcp.Core.Areas.Server.Commands.Discovery;
@@ -271,12 +270,12 @@ public static partial class ServiceCollectionExtensions
             .Configure<IConfiguration, IOptions<ServiceStartOptions>>((options, rootConfiguration, serviceStartOptions) =>
             {
                 // Manually bind configuration values to avoid reflection-based binding for AOT compatibility
-                options.RootCommandGroupName = rootConfiguration["Microsoft.Mcp.RootCommandName"]
+                options.RootCommandGroupName = rootConfiguration["Microsoft.Mcp.RootCommandGroupName"]
                     ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp.RootCommandGroupName' is required.");
                 options.Name = rootConfiguration["Microsoft.Mcp.Name"]
-                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp..Name' is required.");
+                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp.Name' is required.");
                 options.DisplayName = rootConfiguration["Microsoft.Mcp.DisplayName"]
-                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp..DisplayName' is required.");
+                    ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp.DisplayName' is required.");
 
                 options.ShortName = rootConfiguration["Microsoft.Mcp.ShortName"]
                     ?? throw new InvalidOperationException("Configuration value 'Microsoft.Mcp.ShortName' is required.");

--- a/servers/Azure.Mcp.Server/changelog-entries/1780345675706.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1780345675706.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Breaking Changes"
+    description: "Changed appsetting.json property names to be scope to MicrosoftMcp instead of direct property names."

--- a/servers/Azure.Mcp.Server/src/appsettings.json
+++ b/servers/Azure.Mcp.Server/src/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
-    "RootCommandGroupName": "azmcp",
-    "Name": "Azure.Mcp.Server",
-    "ShortName": "azure",
-    "DisplayName": "Azure MCP Server",
-    "Description": "This server/tool provides real-time, programmatic access to all Azure products, services, and resources, as well as all interactions with the Azure Developer CLI (azd). Use this tool for any Azure control plane or data plane operation, including resource management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Azure or \"azd\" related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
+    "Microsoft.Mcp.RootCommandGroupName": "azmcp",
+    "Microsoft.Mcp.Name": "Azure.Mcp.Server",
+    "Microsoft.Mcp.ShortName": "azure",
+    "Microsoft.Mcp.DisplayName": "Azure MCP Server",
+    "Microsoft.Mcp.Description": "This server/tool provides real-time, programmatic access to all Azure products, services, and resources, as well as all interactions with the Azure Developer CLI (azd). Use this tool for any Azure control plane or data plane operation, including resource management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Azure or \"azd\" related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
 }

--- a/servers/Azure.Mcp.Server/src/appsettings.json
+++ b/servers/Azure.Mcp.Server/src/appsettings.json
@@ -1,7 +1,9 @@
 ﻿{
-    "Microsoft.Mcp.RootCommandGroupName": "azmcp",
-    "Microsoft.Mcp.Name": "Azure.Mcp.Server",
-    "Microsoft.Mcp.ShortName": "azure",
-    "Microsoft.Mcp.DisplayName": "Azure MCP Server",
-    "Microsoft.Mcp.Description": "This server/tool provides real-time, programmatic access to all Azure products, services, and resources, as well as all interactions with the Azure Developer CLI (azd). Use this tool for any Azure control plane or data plane operation, including resource management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Azure or \"azd\" related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
+    "MicrosoftMcp": {
+        "RootCommandGroupName": "azmcp",
+        "Name": "Azure.Mcp.Server",
+        "ShortName": "azure",
+        "DisplayName": "Azure MCP Server",
+        "Description": "This server/tool provides real-time, programmatic access to all Azure products, services, and resources, as well as all interactions with the Azure Developer CLI (azd). Use this tool for any Azure control plane or data plane operation, including resource management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Azure or \"azd\" related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
+    }
 }

--- a/servers/Fabric.Mcp.Server/changelog-entries/1780345683191.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1780345683191.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Breaking Changes"
+    description: "Changed appsetting.json property names to be scope to MicrosoftMcp instead of direct property names."

--- a/servers/Fabric.Mcp.Server/src/appsettings.json
+++ b/servers/Fabric.Mcp.Server/src/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
-    "RootCommandGroupName": "fabmcp",
-    "Name": "Fabric.Mcp.Server",
-    "ShortName": "fabric",
-    "DisplayName": "Fabric MCP Server",
-    "Description": "This server/tool provides real-time, programmatic access to all Microsoft Fabric workspaces, items, and data platform capabilities. Use this tool for any Microsoft Fabric operation, including workspace, item, and data platform management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Microsoft Fabric related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
+    "Microsoft.Mcp.RootCommandGroupName": "fabmcp",
+    "Microsoft.Mcp.Name": "Fabric.Mcp.Server",
+    "Microsoft.Mcp.ShortName": "fabric",
+    "Microsoft.Mcp.DisplayName": "Fabric MCP Server",
+    "Microsoft.Mcp.Description": "This server/tool provides real-time, programmatic access to all Microsoft Fabric workspaces, items, and data platform capabilities. Use this tool for any Microsoft Fabric operation, including workspace, item, and data platform management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Microsoft Fabric related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
 }

--- a/servers/Fabric.Mcp.Server/src/appsettings.json
+++ b/servers/Fabric.Mcp.Server/src/appsettings.json
@@ -1,7 +1,9 @@
 ﻿{
-    "Microsoft.Mcp.RootCommandGroupName": "fabmcp",
-    "Microsoft.Mcp.Name": "Fabric.Mcp.Server",
-    "Microsoft.Mcp.ShortName": "fabric",
-    "Microsoft.Mcp.DisplayName": "Fabric MCP Server",
-    "Microsoft.Mcp.Description": "This server/tool provides real-time, programmatic access to all Microsoft Fabric workspaces, items, and data platform capabilities. Use this tool for any Microsoft Fabric operation, including workspace, item, and data platform management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Microsoft Fabric related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
+    "MicrosoftMcp": {
+        "RootCommandGroupName": "fabmcp",
+        "Name": "Fabric.Mcp.Server",
+        "ShortName": "fabric",
+        "DisplayName": "Fabric MCP Server",
+        "Description": "This server/tool provides real-time, programmatic access to all Microsoft Fabric workspaces, items, and data platform capabilities. Use this tool for any Microsoft Fabric operation, including workspace, item, and data platform management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Microsoft Fabric related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
+    }
 }

--- a/servers/Template.Mcp.Server/src/appsettings.json
+++ b/servers/Template.Mcp.Server/src/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
-    "RootCommandGroupName": "mcptmp",
-    "Name": "Template.Mcp.Server",
-    "ShortName": "template",
-    "DisplayName": "Template MCP Server",
-    "Description": "This server/tool provides real-time, programmatic access to the Template MCP Server capabilities. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always include the \"intent\" parameter to specify the operation you want to perform."
+    "Microsoft.Mcp.RootCommandGroupName": "mcptmp",
+    "Microsoft.Mcp.Name": "Template.Mcp.Server",
+    "Microsoft.Mcp.ShortName": "template",
+    "Microsoft.Mcp.DisplayName": "Template MCP Server",
+    "Microsoft.Mcp.Description": "This server/tool provides real-time, programmatic access to the Template MCP Server capabilities. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always include the \"intent\" parameter to specify the operation you want to perform."
 }

--- a/servers/Template.Mcp.Server/src/appsettings.json
+++ b/servers/Template.Mcp.Server/src/appsettings.json
@@ -1,7 +1,9 @@
 ﻿{
-    "Microsoft.Mcp.RootCommandGroupName": "mcptmp",
-    "Microsoft.Mcp.Name": "Template.Mcp.Server",
-    "Microsoft.Mcp.ShortName": "template",
-    "Microsoft.Mcp.DisplayName": "Template MCP Server",
-    "Microsoft.Mcp.Description": "This server/tool provides real-time, programmatic access to the Template MCP Server capabilities. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always include the \"intent\" parameter to specify the operation you want to perform."
+    "MicrosoftMcp": {
+        "RootCommandGroupName": "mcptmp",
+        "Name": "Template.Mcp.Server",
+        "ShortName": "template",
+        "DisplayName": "Template MCP Server",
+        "Description": "This server/tool provides real-time, programmatic access to the Template MCP Server capabilities. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always include the \"intent\" parameter to specify the operation you want to perform."
+    }
 }


### PR DESCRIPTION
## What does this PR do?

The property names used in `appsettings.json` used generic names for a few things, which could result in collisions with existing settings. Renaming those configurations to prefix with `Microsoft.Mcp.` to reduce collisions.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
