### PR TITLE
Login to GitHub with Microsoft as TokenOwners

### DIFF
--- a/eng/common/pipelines/templates/steps/login-to-github.yml
+++ b/eng/common/pipelines/templates/steps/login-to-github.yml
@@ -16,6 +16,7 @@ parameters:
 
 steps:
 - task: AzureCLI@2
+  name: GenerateGitHubToken
   displayName: "Login to GitHub"
   inputs:
     azureSubscription: 'AzureSDKEngKeyVault Secrets'

--- a/eng/common/pipelines/templates/steps/login-to-github.yml
+++ b/eng/common/pipelines/templates/steps/login-to-github.yml
@@ -8,6 +8,9 @@ parameters:
 - name: VariableNamePrefix
   type: string 
   default: GH_TOKEN
+- name: ExportAsOutputVariable
+  type: boolean 
+  default: false
 - name: ScriptDirectory
   default: eng/common/scripts
 
@@ -22,4 +25,4 @@ steps:
     arguments: >
      -InstallationTokenOwners '${{ join(''',''', parameters.TokenOwners) }}'
      -VariableNamePrefix '${{ parameters.VariableNamePrefix }}'
-     
+     -ExportAsOutputVariable:$${{ parameters.ExportAsOutputVariable }}

--- a/eng/common/scripts/login-to-github.ps1
+++ b/eng/common/scripts/login-to-github.ps1
@@ -22,6 +22,10 @@
   Prefix for the exported variable name (default: GH_TOKEN).
   With a single owner, exports as GH_TOKEN. With multiple owners, exports as GH_TOKEN_<Owner>.
 
+.PARAMETER ExportAsOutputVariable
+  When set in Azure DevOps, also exports the variable as an output variable
+  (##vso[task.setvariable ...;isOutput=true]) for downstream jobs/stages.
+
 .OUTPUTS
   Sets environment variables in the current process and exports them to the CI system:
   - Azure DevOps: sets secret pipeline variables via ##vso logging commands
@@ -34,7 +38,8 @@ param(
   [string] $KeyName = "azure-sdk-automation",
   [string] $GitHubAppId = '1086291', # Azure SDK Automation App ID
   [string[]] $InstallationTokenOwners = @("Azure"),
-  [string] $VariableNamePrefix = "GH_TOKEN"
+  [string] $VariableNamePrefix = "GH_TOKEN",
+  [switch] $ExportAsOutputVariable
 )
 
 $ErrorActionPreference = 'Stop'
@@ -177,6 +182,11 @@ foreach ($InstallationTokenOwner in $InstallationTokenOwners)
   if ($null -ne $env:SYSTEM_TEAMPROJECTID) {
     Write-Host "##vso[task.setvariable variable=$variableName;issecret=true]$installationToken"
     Write-Host "Azure DevOps variable '$variableName' has been set (secret)."
+
+    if ($ExportAsOutputVariable) {
+      Write-Host "##vso[task.setvariable variable=$variableName;issecret=true;isOutput=true]$installationToken"
+      Write-Host "Azure DevOps output variable '$variableName' has been set (secret)."
+    }
   }
 
   # GitHub Actions: mask the token and export to GITHUB_ENV

--- a/eng/pipelines/templates/jobs/mcpb/release-mcpb.yml
+++ b/eng/pipelines/templates/jobs/mcpb/release-mcpb.yml
@@ -20,6 +20,8 @@ jobs:
   displayName: "Publish MCPB to GitHub Release"
   dependsOn: ${{ parameters.DependsOn }}
   condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
+  variables:
+    GH_TOKEN: $[ dependencies.TagRepository.outputs['ExportGitHubToken.GitHubToken'] ]
   templateContext:
     type: releaseJob
     isProduction: true
@@ -108,4 +110,4 @@ jobs:
             Write-Host "`n✓ All MCPB files uploaded successfully"
           displayName: "Upload MCPB to GitHub Release"
           env:
-            GH_TOKEN: $(azuresdk-github-pat)
+            GH_TOKEN: $(GH_TOKEN)

--- a/eng/pipelines/templates/jobs/mcpb/release-mcpb.yml
+++ b/eng/pipelines/templates/jobs/mcpb/release-mcpb.yml
@@ -21,7 +21,7 @@ jobs:
   dependsOn: ${{ parameters.DependsOn }}
   condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
   variables:
-    GH_TOKEN: $[ dependencies.TagRepository.outputs['ExportGitHubToken.GitHubToken'] ]
+    GH_TOKEN: $[ dependencies.TagRepository.outputs['GenerateGitHubToken.GH_TOKEN'] ]
   templateContext:
     type: releaseJob
     isProduction: true

--- a/eng/pipelines/templates/jobs/release.yml
+++ b/eng/pipelines/templates/jobs/release.yml
@@ -31,6 +31,12 @@ jobs:
 
   - template: /eng/common/pipelines/templates/steps/retain-run.yml
 
+  - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+    parameters:
+      TokenOwners:
+        - Microsoft
+      ExportAsOutputVariable: true
+
   - pwsh: |
       $buildInfoPath = "$(Pipeline.Workspace)/build_info/build_info.json"
       $buildInfo = Get-Content -Raw -Path $buildInfoPath | ConvertFrom-Json
@@ -49,7 +55,7 @@ jobs:
       gh release upload $tag $(Pipeline.Workspace)/binaries_signed_zipped/*.zip
     displayName: Create GitHub Release and upload artifacts
     env:
-      GH_TOKEN: $(azuresdk-github-pat)
+      GH_TOKEN: $(GH_TOKEN)
 
 - template: /eng/pipelines/templates/jobs/publish-symbols.yml
 


### PR DESCRIPTION
This pull request updates the release pipeline templates to standardize GitHub authentication and improve security by switching to a common login step and environment variable for the GitHub token. The main changes are the addition of a shared login step and the replacement of a specific token variable with a more generic one.

**Authentication improvements:**

* Added the `login-to-github.yml` step to both `release.yml` and `release-mcpb.yml` to standardize GitHub authentication using the `TokenOwners` parameter set to `Microsoft`. [[1]](diffhunk://#diff-8fe374fde7326850473c26bd48ac7f3aca23be86d92f0b06fbb69d747930442aR43-R47) [[2]](diffhunk://#diff-d9cb815966a57d5f892d6c63b81b63a61d4cc7ac25e3ec9540414778de77b18cR34-R38)

**Environment variable updates:**

* Changed the environment variable for the GitHub token from `azuresdk-github-pat` to `GH_TOKEN` in both `release.yml` and `release-mcpb.yml` to align with the new authentication approach. [[1]](diffhunk://#diff-8fe374fde7326850473c26bd48ac7f3aca23be86d92f0b06fbb69d747930442aL111-R116) [[2]](diffhunk://#diff-d9cb815966a57d5f892d6c63b81b63a61d4cc7ac25e3ec9540414778de77b18cL52-R57)

Related to Azure/azure-sdk-tools#9842

[mcp - Template.Mcp.Server](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6397731&view=results)