### PR TITLE
Backport adding validations to compute create command

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1779993649921.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1779993649921.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Features Added"
+    description: "Adding validations to compute create command"

--- a/tools/Azure.Mcp.Tools.Compute/src/Services/ComputeService.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Services/ComputeService.cs
@@ -14,6 +14,8 @@ using Azure.ResourceManager.Compute.Models;
 using Azure.ResourceManager.Network;
 using Azure.ResourceManager.Network.Models;
 using Azure.ResourceManager.Resources;
+using Microsoft.Extensions.Options;
+using Microsoft.Mcp.Core.Areas.Server.Options;
 using Microsoft.Mcp.Core.Helpers;
 
 namespace Azure.Mcp.Tools.Compute.Services;
@@ -21,10 +23,12 @@ namespace Azure.Mcp.Tools.Compute.Services;
 public class ComputeService(
     ISubscriptionService subscriptionService,
     ITenantService tenantService,
-    ILogger<ComputeService> logger)
+    ILogger<ComputeService> logger,
+    IOptions<ServiceStartOptions> serviceStartOptions)
     : BaseAzureResourceService(subscriptionService, tenantService), IComputeService
 {
     private readonly ILogger<ComputeService> _logger = logger;
+    private readonly IOptions<ServiceStartOptions> _serviceStartOptions = serviceStartOptions;
 
     // Default VM size matching Azure CLI (az vm create --size default)
     private const string DefaultVmSize = "Standard_DS1_v2";
@@ -172,10 +176,7 @@ public class ComputeService(
             // Only add SSH key if explicitly provided
             if (!string.IsNullOrEmpty(sshPublicKey))
             {
-                // Check if it's a file path
-                var resolvedSshKey = File.Exists(sshPublicKey)
-                    ? File.ReadAllText(sshPublicKey).Trim()
-                    : sshPublicKey;
+                var resolvedSshKey = ResolveSshPublicKey(sshPublicKey);
 
                 vmData.OSProfile.LinuxConfiguration.SshPublicKeys.Add(new()
                 {
@@ -816,9 +817,7 @@ public class ComputeService(
 
             if (!string.IsNullOrEmpty(sshPublicKey))
             {
-                var resolvedSshKey = File.Exists(sshPublicKey)
-                    ? File.ReadAllText(sshPublicKey).Trim()
-                    : sshPublicKey;
+                var resolvedSshKey = ResolveSshPublicKey(sshPublicKey);
 
                 vmssData.VirtualMachineProfile.OSProfile.LinuxConfiguration.SshPublicKeys.Add(new()
                 {
@@ -1786,5 +1785,58 @@ public class ComputeService(
             // Return false to indicate the disk was not found (idempotent delete)
             return false;
         }
+    }
+
+    internal static readonly string[] s_validSshKeyPrefixes =
+    [
+        "ssh-rsa ",
+        "ssh-ed25519 ",
+        "ssh-dss ",
+        "ecdsa-sha2-nistp256 ",
+        "ecdsa-sha2-nistp384 ",
+        "ecdsa-sha2-nistp521 ",
+        "sk-ssh-ed25519@openssh.com ",
+        "sk-ecdsa-sha2-nistp256@openssh.com ",
+    ];
+
+    private string ResolveSshPublicKey(string sshPublicKey)
+    {
+        if (!_serviceStartOptions.Value.IsHttpMode)
+        {
+            // In stdio mode, allow resolving file paths for convenience
+            if (File.Exists(sshPublicKey))
+            {
+                return File.ReadAllText(sshPublicKey).Trim();
+            }
+        }
+        else
+        {
+            // In HTTP mode, file path resolution is not allowed for security
+            if (!IsValidSshPublicKeyContent(sshPublicKey))
+            {
+                var message = LooksLikeFilePath(sshPublicKey)
+                    ? "The provided SSH public key appears to be a file path. " +
+                      "In remote HTTP mode, file paths cannot be resolved on the server. " +
+                      "Please provide the SSH public key content directly (e.g., 'ssh-rsa AAAA...', 'ssh-ed25519 AAAA...')."
+                    : "The provided SSH public key does not appear to be valid key content. " +
+                      "Please provide the SSH public key content directly (e.g., 'ssh-rsa AAAA...', 'ssh-ed25519 AAAA...').";
+
+                throw new ArgumentException(message);
+            }
+        }
+
+        return sshPublicKey.Trim();
+    }
+
+    internal static bool LooksLikeFilePath(string value)
+    {
+        var trimmed = value.Trim();
+        return trimmed.Contains('/') || trimmed.Contains('\\') || trimmed.EndsWith(".pub", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static bool IsValidSshPublicKeyContent(string value)
+    {
+        var trimmed = value.Trim();
+        return Array.Exists(s_validSshKeyPrefixes, prefix => trimmed.StartsWith(prefix, StringComparison.Ordinal));
     }
 }

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/SshKeyValidationTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/SshKeyValidationTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Tools.Compute.Services;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Compute.Tests;
+
+public class SshKeyValidationTests
+{
+    [Theory]
+    [InlineData("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7... user@host")]
+    [InlineData("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGz... user@host")]
+    [InlineData("ssh-dss AAAAB3NzaC1kc3MAAACBAJ... user@host")]
+    [InlineData("ecdsa-sha2-nistp256 AAAAE2VjZHNh... user@host")]
+    [InlineData("ecdsa-sha2-nistp384 AAAAE2VjZHNh... user@host")]
+    [InlineData("ecdsa-sha2-nistp521 AAAAE2VjZHNh... user@host")]
+    [InlineData("sk-ssh-ed25519@openssh.com AAAAGnNrLXNz... user@host")]
+    [InlineData("sk-ecdsa-sha2-nistp256@openssh.com AAAAInNr... user@host")]
+    public void IsValidSshPublicKeyContent_ValidKeys_ReturnsTrue(string key)
+    {
+        Assert.True(ComputeService.IsValidSshPublicKeyContent(key));
+    }
+
+    [Theory]
+    [InlineData("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7...")] // No comment - still valid
+    [InlineData("  ssh-rsa AAAAB3NzaC1yc2EAAAA... user@host  ")] // Leading/trailing whitespace
+    public void IsValidSshPublicKeyContent_ValidKeysWithVariations_ReturnsTrue(string key)
+    {
+        Assert.True(ComputeService.IsValidSshPublicKeyContent(key));
+    }
+
+    [Theory]
+    [InlineData("ssh-rsaNotAKey")] // No space after prefix
+    [InlineData("ssh-ed25519NoSpace")] // No space after prefix
+    [InlineData("/home/user/.ssh/id_rsa.pub")] // File path
+    [InlineData("C:\\Users\\user\\.ssh\\id_rsa.pub")] // Windows file path
+    [InlineData("~/.ssh/id_rsa.pub")] // Relative file path
+    [InlineData("not-a-key-at-all")] // Random string
+    [InlineData("")] // Empty string
+    [InlineData("   ")] // Whitespace only
+    [InlineData("rsa-sha2-256 AAAA...")] // Wrong prefix format
+    [InlineData("SSH-RSA AAAA...")] // Case sensitive - uppercase should fail
+    public void IsValidSshPublicKeyContent_InvalidKeys_ReturnsFalse(string key)
+    {
+        Assert.False(ComputeService.IsValidSshPublicKeyContent(key));
+    }
+
+    [Theory]
+    [InlineData("/home/user/.ssh/id_rsa.pub")]
+    [InlineData("/etc/passwd")]
+    [InlineData("/etc/shadow")]
+    [InlineData("C:\\Users\\user\\.ssh\\id_rsa.pub")]
+    [InlineData("~/.ssh/id_rsa.pub")]
+    [InlineData("id_rsa.pub")] // .pub suffix
+    [InlineData("my-key.pub")] // .pub suffix
+    public void LooksLikeFilePath_FilePaths_ReturnsTrue(string value)
+    {
+        Assert.True(ComputeService.LooksLikeFilePath(value));
+    }
+
+    [Theory]
+    [InlineData("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7...")] // Valid key with / in base64
+    [InlineData("not-a-path")]
+    [InlineData("just-some-text")]
+    public void LooksLikeFilePath_NonPaths_ReturnsFalse(string value)
+    {
+        Assert.False(ComputeService.LooksLikeFilePath(value));
+    }
+
+    [Fact]
+    public void LooksLikeFilePath_ValidSshKeyWithSlashInBase64_ReturnsTrueButKeyIsStillValid()
+    {
+        // This demonstrates why prefix check must run BEFORE file path check:
+        // Valid SSH keys contain '/' in base64 content, which would trigger LooksLikeFilePath
+        var validKey = "ssh-rsa AAAAB3NzaC1yc2EAAA/DAQAB+AAABgQC7/abc user@host";
+
+        // The key contains '/' so it looks like a file path
+        Assert.True(ComputeService.LooksLikeFilePath(validKey));
+
+        // But it's still a valid SSH key by prefix check
+        Assert.True(ComputeService.IsValidSshPublicKeyContent(validKey));
+    }
+
+    [Fact]
+    public void ValidSshKeyPrefixes_ContainsExpectedPrefixes()
+    {
+        // Verify all standard SSH key types are covered
+        Assert.Contains(ComputeService.s_validSshKeyPrefixes, p => p.StartsWith("ssh-rsa", StringComparison.Ordinal));
+        Assert.Contains(ComputeService.s_validSshKeyPrefixes, p => p.StartsWith("ssh-ed25519", StringComparison.Ordinal));
+        Assert.Contains(ComputeService.s_validSshKeyPrefixes, p => p.StartsWith("ssh-dss", StringComparison.Ordinal));
+        Assert.Contains(ComputeService.s_validSshKeyPrefixes, p => p.StartsWith("ecdsa-sha2-nistp256", StringComparison.Ordinal));
+        Assert.Contains(ComputeService.s_validSshKeyPrefixes, p => p.StartsWith("ecdsa-sha2-nistp384", StringComparison.Ordinal));
+        Assert.Contains(ComputeService.s_validSshKeyPrefixes, p => p.StartsWith("ecdsa-sha2-nistp521", StringComparison.Ordinal));
+        Assert.Contains(ComputeService.s_validSshKeyPrefixes, p => p.StartsWith("sk-ssh-ed25519@openssh.com", StringComparison.Ordinal));
+        Assert.Contains(ComputeService.s_validSshKeyPrefixes, p => p.StartsWith("sk-ecdsa-sha2-nistp256@openssh.com", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidSshKeyPrefixes_AllEndWithSpace()
+    {
+        // Each prefix should end with a space to prevent partial matches like "ssh-rsaNotAKey"
+        foreach (var prefix in ComputeService.s_validSshKeyPrefixes)
+        {
+            Assert.True(prefix.EndsWith(' '), $"Prefix '{prefix}' should end with a space");
+        }
+    }
+}

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/SshKeyValidationTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.UnitTests/SshKeyValidationTests.cs
@@ -4,7 +4,7 @@
 using Azure.Mcp.Tools.Compute.Services;
 using Xunit;
 
-namespace Azure.Mcp.Tools.Compute.Tests;
+namespace Azure.Mcp.Tools.Compute.UnitTests;
 
 public class SshKeyValidationTests
 {


### PR DESCRIPTION
## Description
Cherry-pick of #2764 - Adding validations to compute create command onto release/azure/2.x branch.