### PR TITLE
Update File Share and Storage Sync description to improve usability

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -2522,7 +2522,8 @@ azmcp fileshares fileshare delete --subscription <subscription> \
 # Check File Share name availability
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp fileshares fileshare check-name-availability --subscription <subscription> \
-                                                   --name <file-share-name>
+                                                   --name <file-share-name> \
+                                                   --location <location>
 ```
 
 ```bash

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -500,9 +500,9 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | fileshares_limits | Get the file share limits for subscription <subscription> in location <location> |
 | fileshares_limits | What are the file share limits in my subscription for location <location>? |
 | fileshares_limits | Show me the file share service limits in location <location> |
-| fileshares_fileshare_check-name-availability | Check if file share name <file_share_name> is available in subscription <subscription> |
-| fileshares_fileshare_check-name-availability | Is the file share name <file_share_name> available? |
-| fileshares_fileshare_check-name-availability | Verify availability of file share name <file_share_name> |
+| fileshares_fileshare_check-name-availability | Check if file share name <file_share_name> is available in <location> in subscription <subscription> |
+| fileshares_fileshare_check-name-availability | Is the file share name <file_share_name> available in <location>? |
+| fileshares_fileshare_check-name-availability | Verify availability of file share name <file_share_name> in <location> |
 | fileshares_rec | Get provisioning recommendations for file share <file_share_name> in resource group <resource_group_name> |
 | fileshares_rec | Show me provisioning recommendations for file share <file_share_name> |
 | fileshares_rec | What are the recommended provisioning settings for file share <file_share_name>? |

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCheckNameAvailabilityCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCheckNameAvailabilityCommand.cs
@@ -18,7 +18,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.FileShare;
     Id = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
     Name = "check-name-availability",
     Title = "Check File Share Name Availability",
-    Description = "Check if a file share name is available",
+    Description = "Check if a file share name is available in the specified location in the subscription.",
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/StorageSyncOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/StorageSyncOptionDefinitions.cs
@@ -39,7 +39,7 @@ public static class StorageSyncOptionDefinitions
 
         public static readonly Option<string> Tags = new($"--{TagsName}")
         {
-            Description = "Tags to assign to the service (space-separated key=value pairs)"
+            Description = "Tags to assign to the service, in the format 'tag1=value1 tag2=value2'."
         };
 
         public static readonly Option<string> IdentityType = new($"--{IdentityTypeName}")


### PR DESCRIPTION
## What does this PR do?

Updates descriptions used in File Share and Storage Sync tools so that an agent can consume them more efficiently.

Updated File Share `fileshares_fileshare_check-name-availability` tool to indicate location and subscription are needed to help guide an agent to get that information when using the tool. The File Share tools are particularly susceptible to issues as they are tools for what is effectively Storage File Share without the need to create a Storage service. So, an agent may eagerly attempt to call into Azure CLI with Storage File Share if the MCP tool call fails.

Updated Storage Sync `storagesync_service_update` tool parameter description to more clearly indicate the format of the parameter to prevent an agent from using the wrong format.

### fileshares_fileshare_check-name-availability

#### Before

```md
**Expected Tool:** `fileshares_fileshare_check-name-availability`  
**Prompt:** Check if file share name <file_share_name> is available in subscription <subscription>  

### Results

| Rank | Score | Tool | Status |
|------|-------|------|--------|
| 1 | 0.776032 | `fileshares_fileshare_check-name-availability` | ✅ **EXPECTED** |
| 2 | 0.580866 | `fileshares_fileshare_get` | ❌ |
| 3 | 0.564538 | `fileshares_usage` | ❌ |
| 4 | 0.560313 | `fileshares_limits` | ❌ |
| 5 | 0.494933 | `fileshares_fileshare_delete` | ❌ |

**Expected Tool:** `fileshares_fileshare_check-name-availability`  
**Prompt:** Is the file share name <file_share_name> available?  

### Results

| Rank | Score | Tool | Status |
|------|-------|------|--------|
| 1 | 0.827074 | `fileshares_fileshare_check-name-availability` | ✅ **EXPECTED** |
| 2 | 0.530271 | `fileshares_fileshare_delete` | ❌ |
| 3 | 0.513757 | `fileshares_fileshare_get` | ❌ |
| 4 | 0.431828 | `fileshares_fileshare_create` | ❌ |
| 5 | 0.422226 | `fileshares_rec` | ❌ |

**Expected Tool:** `fileshares_fileshare_check-name-availability`  
**Prompt:** Verify availability of file share name <file_share_name>  

### Results

| Rank | Score | Tool | Status |
|------|-------|------|--------|
| 1 | 0.798254 | `fileshares_fileshare_check-name-availability` | ✅ **EXPECTED** |
| 2 | 0.598886 | `fileshares_fileshare_get` | ❌ |
| 3 | 0.561309 | `fileshares_fileshare_delete` | ❌ |
| 4 | 0.473476 | `fileshares_fileshare_snapshot_get` | ❌ |
| 5 | 0.452526 | `fileshares_fileshare_create` | ❌ |
```

#### After

```md
**Expected Tool:** `fileshares_fileshare_check-name-availability`  
**Prompt:** Check if file share name <file_share_name> is available in <location> in subscription <subscription>  

### Results

| Rank | Score | Tool | Status |
|------|-------|------|--------|
| 1 | 0.915053 | `fileshares_fileshare_check-name-availability` | ✅ **EXPECTED** |
| 2 | 0.607195 | `fileshares_usage` | ❌ |
| 3 | 0.606970 | `fileshares_limits` | ❌ |
| 4 | 0.560621 | `fileshares_fileshare_get` | ❌ |
| 5 | 0.469603 | `fileshares_fileshare_delete` | ❌ |

**Expected Tool:** `fileshares_fileshare_check-name-availability`  
**Prompt:** Is the file share name <file_share_name> available in <location>?  

### Results

| Rank | Score | Tool | Status |
|------|-------|------|--------|
| 1 | 0.769407 | `fileshares_fileshare_check-name-availability` | ✅ **EXPECTED** |
| 2 | 0.490046 | `fileshares_fileshare_get` | ❌ |
| 3 | 0.472655 | `fileshares_limits` | ❌ |
| 4 | 0.464175 | `fileshares_fileshare_delete` | ❌ |
| 5 | 0.459727 | `fileshares_usage` | ❌ |

**Expected Tool:** `fileshares_fileshare_check-name-availability`  
**Prompt:** Verify availability of file share name <file_share_name> in <location>  

### Results

| Rank | Score | Tool | Status |
|------|-------|------|--------|
| 1 | 0.783516 | `fileshares_fileshare_check-name-availability` | ✅ **EXPECTED** |
| 2 | 0.554444 | `fileshares_fileshare_get` | ❌ |
| 3 | 0.508047 | `fileshares_fileshare_delete` | ❌ |
| 4 | 0.482742 | `fileshares_usage` | ❌ |
| 5 | 0.479560 | `fileshares_limits` | ❌ |
```

### storagesync_service_update

#### Before

```md
**Expected Tool:** `storagesync_service_update`  
**Prompt:** Update Storage Sync Service <service-name> with new tags  

### Results

| Rank | Score | Tool | Status |
|------|-------|------|--------|
| 1 | 0.592932 | `storagesync_service_update` | ✅ **EXPECTED** |
| 2 | 0.474416 | `storagesync_service_get` | ❌ |
| 3 | 0.470452 | `storagesync_service_create` | ❌ |
| 4 | 0.467140 | `storagesync_service_delete` | ❌ |
| 5 | 0.446901 | `storagesync_registeredserver_unregister` | ❌ |
```

#### After

```md
**Expected Tool:** `storagesync_service_update`  
**Prompt:** Update Storage Sync Service <service-name> with new tags  

### Results

| Rank | Score | Tool | Status |
|------|-------|------|--------|
| 1 | 0.592886 | `storagesync_service_update` | ✅ **EXPECTED** |
| 2 | 0.474433 | `storagesync_service_get` | ❌ |
| 3 | 0.470424 | `storagesync_service_create` | ❌ |
| 4 | 0.467130 | `storagesync_service_delete` | ❌ |
| 5 | 0.446884 | `storagesync_registeredserver_unregister` | ❌ |
```

## GitHub issue number?

Fixes #2793 
Fixes #2794 

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
