### PR TITLE
Add customer adoption KQL queries to Azure Backup telemetry skill

### DIFF
--- a/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-telemetry-report/SKILL.md
+++ b/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-telemetry-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: azurebackup-telemetry-report
 description: 'Generate weekly telemetry reports and customer adoption reports for Azure Backup MCP tools. Runs KQL queries against the Kusto telemetry cluster, analyzes error patterns with 3-way classification (Customer/Azure Service/MCP Tool Bug), identifies customers via P360/C360 cross-cluster joins, compares week-over-week metrics, correlates with merged PRs and releases, and produces an Outlook-compatible HTML report. USE WHEN: weekly telemetry report, Azure Backup MCP telemetry, error analysis, telemetry bugs, weekly report, MCP tool success rate, backup telemetry, error classification, customer usage report, who is using Azure Backup MCP, backup adoption, customer report.'
-argument-hint: 'Generate the Azure Backup MCP weekly telemetry report'
+argument-hint: 'Generate an Azure Backup MCP telemetry or customer adoption report'
 ---
 
 # Azure Backup MCP — Weekly Telemetry & Customer Report Generator
@@ -157,7 +157,7 @@ For the Outlook version, apply these rules:
 
 > **Customer Report Queries:** For customer identification, tool adoption, client distribution,
 > and version analysis, refer to [`kql-customer-queries.md`](https://github.com/microsoft/mcp/blob/main/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-telemetry-report/references/kql-customer-queries.md)
-> (queries 14–24). These queries use cross-cluster joins to `mabprod1` (P360) and `icmdataro` (C360)
+> (queries 14–24). These queries use cross-cluster joins to `mabprod1` (P360) and `icmdataro.centralus` (C360)
 > for customer name resolution and external/internal classification.
 >
 > **Key rule:** Always use `P360_CustomerName` (not `CustomerName`) from the P360 table.

--- a/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-telemetry-report/references/kql-customer-queries.md
+++ b/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-telemetry-report/references/kql-customer-queries.md
@@ -8,6 +8,11 @@ All queries use the `getAzureMcpEvents_ToolCalls` function from the Azure MCP te
 
 Replace `{DAYS}` with the desired time range (e.g., `15` for 15 days).
 
+> **Note on field casing:** Lowercase bag access (e.g., `customDimensions.toolname`) works because
+> `getAzureMcpEvents_ToolCalls` normalizes keys. If queries return empty results, try PascalCase
+> variants (`customDimensions.ClientName`, `customDimensions.Version`). See the full note in
+> [`kql-queries.md`](https://github.com/microsoft/mcp/blob/main/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-telemetry-report/references/kql-queries.md).
+
 > **Critical:** Always use `P360_CustomerName` instead of `CustomerName` in P360. The `CustomerName`
 > field contains generic tenant names (e.g., "Denis" for all Prometeia SpA subs). `P360_CustomerName`
 > has the actual company name.


### PR DESCRIPTION
## Summary

Adds customer adoption and usage analysis KQL queries (14-24) to the existing Azure Backup telemetry report skill.

## Changes

### New file: \kql-customer-queries.md\
- **Query 14:** Overall summary (calls, success, users, sub tag coverage)
- **Query 15:** Subscription breakdown with call/user/tool counts
- **Query 16:** Customer name resolution via P360 (\P360_CustomerName\)
- **Query 17:** External vs Internal classification via C360
- **Query 18:** Non-GUID subscription name resolution
- **Query 19:** Tool usage ranking with success rates
- **Query 20:** Per-customer tool breakdown
- **Query 21:** Client/editor distribution
- **Query 22:** MCP server version distribution
- **Query 23:** Daily trend for dashboards
- **Query 24:** Version-by-client matrix
- Customer aggregation rules and known data quirks

### Updated: \SKILL.md\
- Expanded description to cover customer reports
- Added customer report use cases
- Added cross-reference to customer queries file
- Documented \P360_CustomerName\ vs \CustomerName\ guidance

## Key Learnings Captured
- Always use \P360_CustomerName\ (not \CustomerName\) — the latter is generic tenant name (e.g., 'Denis' for all Prometeia SpA subs)
- \zsubscriptionguid\ only emitted since beta.14 (~74% of calls lack it)
- Non-GUID subscription values need resolution via \SubscriptionName\ in P360
- Cross-cluster joins: \mabprod1\ (P360) and \icmdataro\ (C360)

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with \write\ access to the repo need to validate the contents of this PR before leaving a comment with the text \/azp run mcp - pullrequest - live\. This will trigger the necessary livetest workflows to complete required validation.