### PR TITLE
Filter IAreaSetups to namespaces / tools specified on start

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/CommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/CommandTests.cs
@@ -13,6 +13,11 @@ namespace Azure.Mcp.Core.Tests;
 public class CommandTests(ITestOutputHelper output, TestProxyFixture testProxyFixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, testProxyFixture, liveServerFixture)
 {
+    public override string[] Tools => [
+        "group_list",
+        "subscription_list"
+    ];
+
     [Fact]
     public async Task Should_list_groups_by_subscription()
     {
@@ -33,7 +38,7 @@ public class CommandTests(ITestOutputHelper output, TestProxyFixture testProxyFi
     {
         var result = await CallToolAsync(
             "subscription_list",
-            new Dictionary<string, object?>());
+            []);
 
         var subscriptionsArray = result.AssertProperty("subscriptions");
         Assert.Equal(JsonValueKind.Array, subscriptionsArray.ValueKind);

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceStartCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceStartCommand.cs
@@ -50,19 +50,19 @@ namespace Microsoft.Mcp.Core.Areas.Server.Commands;
     ReadOnly = true)]
 public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
 {
-    private static readonly string[] StdioHostBuilderArgs =
+    private static readonly string[] s_stdioHostBuilderArgs =
     [
         $"--contentRoot={AppContext.BaseDirectory}",
         "--hostBuilder:reloadConfigOnChange=false"
     ];
 
-    private static readonly WebApplicationOptions HttpWebApplicationOptions = new()
+    private static readonly WebApplicationOptions s_httpWebApplicationOptions = new()
     {
         ContentRootPath = AppContext.BaseDirectory
     };
 
+    public static List<IAreaSetup> Areas { get; set; } = [];
     public static Action<IServiceCollection> ConfigureServices { get; set; } = _ => { };
-
     public static Func<IServiceProvider, Task> InitializeServicesAsync { get; set; } = _ => Task.CompletedTask;
 
     /// <summary>
@@ -186,6 +186,23 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
 
         try
         {
+            // After binding options, see if any tool filters were applied (--namespace or --tool).
+            // If any were specified, filter Areas based on the IAreaSetup name (case-insensitive).
+            var hasNamespace = options.Namespace is { Length: > 0 };
+            var hasTool = options.Tool is { Length: > 0 };
+            if (hasNamespace || hasTool)
+            {
+                // --namespace and --tool are mutually exclusive. Setup the filter based on which was set.
+                // When --namespace is used, use the namespace as the filter, as that should already be the IAreaSetup name.
+                // When --tool is used, use the first part of each tool name (split by '_') as the filter, as that represents the area (e.g., 'storage_account_get' -> 'storage').
+                var areaNames = hasNamespace ?
+                    new HashSet<string>(options.Namespace!, StringComparer.OrdinalIgnoreCase)! :
+                    options.Tool?.Select(t => t.Split('_').First()).ToHashSet(StringComparer.OrdinalIgnoreCase)!;
+
+                // Filter the Areas that were setup by Program.cs.
+                Areas.RemoveAll(area => !areaNames.Contains(area.Name));
+            }
+
             using var tracerProvider = AddIncomingAndOutgoingHttpSpans(options);
 
             using var host = CreateHost(options);
@@ -403,7 +420,7 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
     /// <returns>An IHost instance configured for STDIO transport.</returns>
     private IHost CreateStdioHost(ServiceStartOptions serverOptions)
     {
-        return Host.CreateDefaultBuilder(StdioHostBuilderArgs)
+        return Host.CreateDefaultBuilder(s_stdioHostBuilderArgs)
             .ConfigureLogging(logging =>
             {
                 logging.ClearProviders();
@@ -453,7 +470,7 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
     /// <returns>An IHost instance configured for HTTP transport.</returns>
     private IHost CreateHttpHost(ServiceStartOptions serverOptions)
     {
-        WebApplicationBuilder builder = WebApplication.CreateBuilder(HttpWebApplicationOptions);
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(s_httpWebApplicationOptions);
 
         // Read once at host setup time — this env var is process-wide and effectively static,
         // so there is no need to re-read it on every incoming request.
@@ -645,7 +662,7 @@ public sealed class ServiceStartCommand : BaseCommand<ServiceStartOptions>
     /// <returns>An IHost instance configured for HTTP transport.</returns>
     private IHost CreateIncomingAuthDisabledHttpHost(ServiceStartOptions serverOptions)
     {
-        WebApplicationBuilder builder = WebApplication.CreateBuilder(HttpWebApplicationOptions);
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(s_httpWebApplicationOptions);
 
         InitializeListingUrls(builder, serverOptions);
 

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/CommandTestsBase.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/CommandTestsBase.cs
@@ -24,16 +24,19 @@ public abstract class CommandTestsBase(ITestOutputHelper output, LiveServerFixtu
     protected ITestOutputHelper Output { get; } = output;
     protected LiveServerFixture LiveServerFixture { get; } = liveServerFixture;
 
-    public string[]? CustomArguments;
+    public string[]? Tools;
     public TestMode TestMode = TestMode.Live;
 
     /// <summary>
-    /// Sets custom arguments for the MCP server. Call this before InitializeAsync().
+    /// Sets the tools that the MCP server will scope to. Call this before InitializeAsync().
+    /// <para>
+    /// This reduces the number of tools that the MCP server will load and initialize.
+    /// </para>
     /// </summary>
-    /// <param name="arguments">Custom arguments to pass to the server (e.g., ["server", "start", "--mode", "single"])</param>
-    public void SetArguments(params string[] arguments)
+    /// <param name="tools">Tools to pass to the server (e.g., "storage_blob_get", "appconfig_kv_get", etc.)</param>
+    public void SetTools(params string[] tools)
     {
-        CustomArguments = arguments;
+        Tools = tools;
     }
 
     public virtual async ValueTask InitializeAsync()
@@ -127,7 +130,7 @@ public abstract class CommandTestsBase(ITestOutputHelper output, LiveServerFixtu
         List<string> defaultArgs = enableDebug
             ? ["server", "start", "--mode", "all", "--debug", "--dangerously-disable-elicitation", "--disable-caching"]
             : ["server", "start", "--mode", "all", "--dangerously-disable-elicitation", "--disable-caching"];
-        var arguments = CustomArguments?.ToList() ?? defaultArgs;
+        var arguments = Tools?.ToList() ?? defaultArgs;
 
         LiveServerFixture.EnvironmentVariables = GetEnvironmentVariables(proxy);
         LiveServerFixture.Arguments = arguments;

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/CommandTestsBase.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/CommandTestsBase.cs
@@ -24,7 +24,6 @@ public abstract class CommandTestsBase(ITestOutputHelper output, LiveServerFixtu
     protected ITestOutputHelper Output { get; } = output;
     protected LiveServerFixture LiveServerFixture { get; } = liveServerFixture;
 
-    public string[]? Tools;
     public TestMode TestMode = TestMode.Live;
 
     /// <summary>
@@ -34,10 +33,7 @@ public abstract class CommandTestsBase(ITestOutputHelper output, LiveServerFixtu
     /// </para>
     /// </summary>
     /// <param name="tools">Tools to pass to the server (e.g., "storage_blob_get", "appconfig_kv_get", etc.)</param>
-    public void SetTools(params string[] tools)
-    {
-        Tools = tools;
-    }
+    public virtual string[] Tools => [];
 
     public virtual async ValueTask InitializeAsync()
     {
@@ -127,10 +123,21 @@ public abstract class CommandTestsBase(ITestOutputHelper output, LiveServerFixtu
         // Use custom arguments if provided, otherwise use standard mode (debug can be enabled via environment variable)
         var debugEnvVar = Environment.GetEnvironmentVariable("AZURE_MCP_TEST_DEBUG");
         var enableDebug = string.Equals(debugEnvVar, "true", StringComparison.OrdinalIgnoreCase) || Settings.DebugOutput;
-        List<string> defaultArgs = enableDebug
+
+        // Live testing uses '--mode all' as it doesn't require sampling and the way live tests are ran an agent isn't
+        // used to make the request, so sampling isn't available.
+        List<string> arguments = enableDebug
             ? ["server", "start", "--mode", "all", "--debug", "--dangerously-disable-elicitation", "--disable-caching"]
             : ["server", "start", "--mode", "all", "--dangerously-disable-elicitation", "--disable-caching"];
-        var arguments = Tools?.ToList() ?? defaultArgs;
+
+        if (Tools != null && Tools.Length > 0)
+        {
+            foreach (var tool in Tools)
+            {
+                arguments.Add("--tool");
+                arguments.Add(tool);
+            }
+        }
 
         LiveServerFixture.EnvironmentVariables = GetEnvironmentVariables(proxy);
         LiveServerFixture.Arguments = arguments;

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/Helpers/McpTestUtilities.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/Helpers/McpTestUtilities.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics;
+using System.Net;
 using System.Reflection;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
@@ -190,9 +191,9 @@ public static class McpTestUtilities
     /// <returns>An available port number.</returns>
     private static int GetAvailablePort()
     {
-        using var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        using var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
         listener.Start();
-        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
         listener.Stop();
         return port;
     }
@@ -261,7 +262,7 @@ public static class McpTestUtilities
                     id = Guid.NewGuid().ToString()
                 };
 
-                var content = new System.Net.Http.StringContent(
+                var content = new StringContent(
                     System.Text.Json.JsonSerializer.Serialize(request),
                     System.Text.Encoding.UTF8,
                     "application/json");
@@ -269,16 +270,14 @@ public static class McpTestUtilities
                 {
                     Content = content
                 };
-                requestMessage.Headers.Accept.Add(
-                    new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-                requestMessage.Headers.Accept.Add(
-                    new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/event-stream"));
+                requestMessage.Headers.Accept.Add(new("application/json"));
+                requestMessage.Headers.Accept.Add(new("text/event-stream"));
                 using var resp = await httpClient.SendAsync(requestMessage);
 
                 // If authentication is enabled, 401 Unauthorized means server is ready
                 // If authentication is disabled, we need a success status code
                 if (resp.IsSuccessStatusCode || (authenticationEnabled &&
-                    (resp.StatusCode == System.Net.HttpStatusCode.Unauthorized || resp.StatusCode == System.Net.HttpStatusCode.Forbidden)))
+                    (resp.StatusCode == HttpStatusCode.Unauthorized || resp.StatusCode == HttpStatusCode.Forbidden)))
                 {
                     return;
                 }

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/LiveServerFixture.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/LiveServerFixture.cs
@@ -16,7 +16,7 @@ public sealed class LiveServerFixture() : IAsyncLifetime
     private string? _serverUrl;
     private bool _started;
 
-    public Dictionary<string, string?> EnvironmentVariables { get; set; } = new();
+    public Dictionary<string, string?> EnvironmentVariables { get; set; } = [];
     public List<string> Arguments { get; set; } = [];
     public ITestOutputHelper? Output { get; set; }
     public LiveTestSettings? Settings { get; set; }
@@ -60,11 +60,7 @@ public sealed class LiveServerFixture() : IAsyncLifetime
 
     public McpClient GetMcpClient()
     {
-        if (_mcpClient == null)
-        {
-            throw new InvalidOperationException("MCP Client has not been initialized.");
-        }
-        return _mcpClient;
+        return _mcpClient ?? throw new InvalidOperationException("MCP Client has not been initialized.");
     }
 
     public async ValueTask DisposeAsync()

--- a/servers/Azure.Mcp.Server/src/Program.cs
+++ b/servers/Azure.Mcp.Server/src/Program.cs
@@ -32,11 +32,11 @@ namespace Azure.Mcp.Server;
 
 internal class Program
 {
-    private static readonly IAreaSetup[] Areas = RegisterAreas();
+    private static readonly List<IAreaSetup> s_areas = RegisterAreas();
 
     // Derived from the registered ServerSetup instance so the name stays in sync
     // with the actual area registration — no magic string duplication.
-    private static readonly string s_serverAreaName = Array.Find(Areas, static a => a is ServerSetup)?.Name ?? "server";
+    private static readonly string s_serverAreaName = s_areas.First(static a => a is ServerSetup)?.Name ?? "server";
 
     private static async Task<int> Main(string[] args)
     {
@@ -51,6 +51,7 @@ internal class Program
             }
 
             // The server start and plugin-telemetry containers always need full area registration.
+            ServiceStartCommand.Areas = s_areas;
             ServiceStartCommand.ConfigureServices = services => ConfigureServices(services);
             ServiceStartCommand.InitializeServicesAsync = InitializeServicesAsync;
 
@@ -63,7 +64,7 @@ internal class Program
 
             ServiceCollection services = new();
 
-            ConfigureServices(services, targetAreaName);
+            ConfigureServices(services, areaSetup => string.Equals(areaSetup.Name, targetAreaName, StringComparison.OrdinalIgnoreCase));
 
             services.AddLogging(builder =>
             {
@@ -167,17 +168,17 @@ internal class Program
         }
     }
 
-    private static IAreaSetup[] RegisterAreas()
+    private static List<IAreaSetup> RegisterAreas()
     {
 
         return [
             // Register core areas
+            new Microsoft.Mcp.Core.Areas.Server.ServerSetup(),
+            new Microsoft.Mcp.Core.Areas.Tools.ToolsSetup(),
             new Azure.Mcp.Tools.AzureBestPractices.AzureBestPracticesSetup(),
             new Azure.Mcp.Tools.Extension.ExtensionSetup(),
             new Azure.Mcp.Core.Areas.Group.GroupSetup(),
-            new Microsoft.Mcp.Core.Areas.Server.ServerSetup(),
             new Azure.Mcp.Core.Areas.Subscription.SubscriptionSetup(),
-            new Microsoft.Mcp.Core.Areas.Tools.ToolsSetup(),
             // Register Azure service areas
             new Azure.Mcp.Tools.Aks.AksSetup(),
             new Azure.Mcp.Tools.AppConfig.AppConfigSetup(),
@@ -309,7 +310,7 @@ internal class Program
     /// (those with <see cref="CommandCategory"/> other than <see cref="CommandCategory.AzureServices"/>)
     /// have their services registered. Pass <see langword="null"/> for full initialization.
     /// </param>
-    internal static void ConfigureServices(IServiceCollection services, string? areaFilter = null)
+    internal static void ConfigureServices(IServiceCollection services, Predicate<IAreaSetup>? areaFilter = null)
     {
         var thisAssembly = typeof(Program).Assembly;
 
@@ -332,27 +333,27 @@ internal class Program
         services.AddAzureTenantService();
         services.AddSingleUserCliCacheService(disabled: true);
 
-        foreach (var area in Areas)
+        bool configuredServerArea = false;
+        foreach (var area in s_areas)
         {
             // When areaFilter is set (CLI path), skip Azure service areas that don't match the target.
             // Non-Azure-service areas (Category != AzureServices) provide shared infrastructure
             // (command routing, server start, subscription listing, etc.) and must always be registered.
             // Any area whose Category is AzureServices and whose name doesn't match the filter is skipped;
             // this avoids registering services (HTTP clients, SDKs, etc.) for 60+ irrelevant services.
-            if (areaFilter != null &&
-                area.Category == CommandCategory.AzureServices &&
-                !string.Equals(area.Name, areaFilter, StringComparison.OrdinalIgnoreCase))
+            if (areaFilter != null && area.Category == CommandCategory.AzureServices && !areaFilter(area))
             {
                 continue;
             }
             services.AddSingleton(area);
             area.ConfigureServices(services);
+            configuredServerArea |= string.Equals(area.Name, s_serverAreaName, StringComparison.OrdinalIgnoreCase);
         }
 
         // Optimization: server-mode providers (registry, instructions, plugin allowlists) are only
         // used when running as an MCP server. For CLI area invocations they are never resolved, so
         // register lightweight stubs to avoid reading embedded resources on every CLI call.
-        if (areaFilter == null || string.Equals(areaFilter, s_serverAreaName, StringComparison.OrdinalIgnoreCase))
+        if (areaFilter == null || configuredServerArea)
         {
             services.AddRegistryRoot(thisAssembly, $"registry.json");
 
@@ -441,7 +442,7 @@ internal class Program
         // Only apply the optimization when the first token is a known registered area.
         // If the token doesn't match any area (e.g. a typo), fall through to full initialization
         // so System.CommandLine can produce helpful "Did you mean..." suggestions.
-        if (!Array.Exists(Areas, a => string.Equals(a.Name, firstToken, StringComparison.OrdinalIgnoreCase)))
+        if (!s_areas.Any(a => string.Equals(a.Name, firstToken, StringComparison.OrdinalIgnoreCase)))
         {
             return null;
         }

--- a/servers/Azure.Mcp.Server/src/Program.cs
+++ b/servers/Azure.Mcp.Server/src/Program.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Core.Services.Azure.ResourceGroup;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Core.Services.Azure.Tenant;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -37,8 +36,7 @@ internal class Program
 
     // Derived from the registered ServerSetup instance so the name stays in sync
     // with the actual area registration — no magic string duplication.
-    private static readonly string ServerAreaName =
-        Array.Find(Areas, static a => a is Microsoft.Mcp.Core.Areas.Server.ServerSetup)?.Name ?? "server";
+    private static readonly string s_serverAreaName = Array.Find(Areas, static a => a is ServerSetup)?.Name ?? "server";
 
     private static async Task<int> Main(string[] args)
     {
@@ -354,7 +352,7 @@ internal class Program
         // Optimization: server-mode providers (registry, instructions, plugin allowlists) are only
         // used when running as an MCP server. For CLI area invocations they are never resolved, so
         // register lightweight stubs to avoid reading embedded resources on every CLI call.
-        if (areaFilter == null || string.Equals(areaFilter, ServerAreaName, StringComparison.OrdinalIgnoreCase))
+        if (areaFilter == null || string.Equals(areaFilter, s_serverAreaName, StringComparison.OrdinalIgnoreCase))
         {
             services.AddRegistryRoot(thisAssembly, $"registry.json");
 

--- a/servers/Fabric.Mcp.Server/src/Program.cs
+++ b/servers/Fabric.Mcp.Server/src/Program.cs
@@ -24,12 +24,13 @@ using Microsoft.Mcp.Core.Services.Time;
 
 internal class Program
 {
-    private static IAreaSetup[] Areas = RegisterAreas();
+    private static readonly List<IAreaSetup> s_areas = RegisterAreas();
 
     private static async Task<int> Main(string[] args)
     {
         try
         {
+            ServiceStartCommand.Areas = s_areas;
             ServiceStartCommand.ConfigureServices = ConfigureServices;
             ServiceStartCommand.InitializeServicesAsync = InitializeServicesAsync;
 
@@ -103,7 +104,7 @@ internal class Program
             return 1;
         }
     }
-    private static IAreaSetup[] RegisterAreas()
+    private static List<IAreaSetup> RegisterAreas()
     {
 
         return [
@@ -191,7 +192,7 @@ internal class Program
         services.AddHttpClientServices();
         services.AddSingleUserCliCacheService(disabled: true);
 
-        foreach (var area in Areas)
+        foreach (var area in s_areas)
         {
             services.AddSingleton(area);
             area.ConfigureServices(services);

--- a/servers/Template.Mcp.Server/src/Program.cs
+++ b/servers/Template.Mcp.Server/src/Program.cs
@@ -24,12 +24,13 @@ using Microsoft.Mcp.Core.Services.Time;
 
 internal class Program
 {
-    private static IAreaSetup[] Areas = RegisterAreas();
+    private static readonly List<IAreaSetup> s_areas = RegisterAreas();
 
     private static async Task<int> Main(string[] args)
     {
         try
         {
+            ServiceStartCommand.Areas = s_areas;
             ServiceStartCommand.ConfigureServices = ConfigureServices;
             ServiceStartCommand.InitializeServicesAsync = InitializeServicesAsync;
 
@@ -104,7 +105,7 @@ internal class Program
         }
     }
 
-    private static IAreaSetup[] RegisterAreas()
+    private static List<IAreaSetup> RegisterAreas()
     {
         return [
             // Register core areas
@@ -115,9 +116,7 @@ internal class Program
     }
 
     private static void WriteResponse(CommandResponse response)
-    {
-        Console.WriteLine(JsonSerializer.Serialize(response, ModelsJsonContext.Default.CommandResponse));
-    }
+        => Console.WriteLine(JsonSerializer.Serialize(response, ModelsJsonContext.Default.CommandResponse));
 
     /// <summary>
     /// <para>
@@ -186,7 +185,7 @@ internal class Program
         // within ServiceStartCommand.ExecuteAsync().
         services.AddSingleUserCliCacheService(disabled: true);
 
-        foreach (var area in Areas)
+        foreach (var area in s_areas)
         {
             services.AddSingleton(area);
             area.ConfigureServices(services);

--- a/tools/Azure.Mcp.Tools.Acr/tests/Azure.Mcp.Tools.Acr.Tests/AcrCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Acr/tests/Azure.Mcp.Tools.Acr.Tests/AcrCommandTests.cs
@@ -15,6 +15,8 @@ namespace Azure.Mcp.Tools.Acr.Tests;
 public class AcrCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["acr_registry_list", "acr_registry_repository_list"];
+
     public override List<string> DisabledDefaultSanitizers =>
     [
         ..base.DisabledDefaultSanitizers,

--- a/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.Tests/AksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.Tests/AksCommandTests.cs
@@ -14,6 +14,7 @@ namespace Azure.Mcp.Tools.Aks.Tests;
 public sealed class AksCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["aks_cluster_get"];
 
     [Fact]
     public async Task Should_list_aks_clusters_by_subscription()

--- a/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.Tests/NodepoolCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.Tests/NodepoolCommandTests.cs
@@ -13,6 +13,8 @@ namespace Azure.Mcp.Tools.Aks.Tests;
 public sealed class NodepoolCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["aks_cluster_get", "aks_nodepool_get"];
+
     [Fact]
     public async Task Should_list_nodepools_for_cluster()
     {

--- a/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.Tests/NodepoolGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.Tests/NodepoolGetCommandTests.cs
@@ -14,6 +14,8 @@ namespace Azure.Mcp.Tools.Aks.Tests;
 public sealed class NodepoolGetCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["aks_cluster_get", "aks_nodepool_get"];
+
     [Fact]
     public async Task Should_get_nodepool_for_cluster()
     {

--- a/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/AppConfigCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/tests/Azure.Mcp.Tools.AppConfig.Tests/AppConfigCommandTests.cs
@@ -29,6 +29,13 @@ public class AppConfigCommandTests : RecordedCommandTestsBase
     private readonly ILogger<AppConfigService> _logger;
     private readonly ServiceProvider _httpClientProvider;
 
+    public override string[] Tools => [
+        "appconfig_account_list",
+        "appconfig_kv_get",
+        "appconfig_kv_lock_set",
+        "appconfig_kv_delete"
+    ];
+
     /// <summary>
     /// AZSDK3493 = $..name
     /// AZSDK3447 = $..key

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Database/DatabaseAddCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Database/DatabaseAddCommandLiveTests.cs
@@ -13,6 +13,8 @@ namespace Azure.Mcp.Tools.AppService.Tests.Database;
 public class DatabaseAddCommandLiveTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : BaseAppServiceCommandLiveTests(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["appservice_database_add"];
+
     [Fact]
     public async Task ExecuteAsync_WithValidParameters_ReturnsSuccessResult()
     {

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Webapp/Deployment/DeploymentGetCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Webapp/Deployment/DeploymentGetCommandLiveTests.cs
@@ -14,6 +14,8 @@ namespace Azure.Mcp.Tools.AppService.Tests.Webapp.Deployment;
 public class DeploymentGetCommandLiveTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : BaseAppServiceCommandLiveTests(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["appservice_webapp_deployment_get"];
+
     public override CustomDefaultMatcher? TestMatcher
     {
         get

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Webapp/Diagnostic/DetectorDiagnoseCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Webapp/Diagnostic/DetectorDiagnoseCommandLiveTests.cs
@@ -13,6 +13,8 @@ namespace Azure.Mcp.Tools.AppService.Tests.Webapp.Diagnostic;
 public class DetectorDiagnoseCommandLiveTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : BaseAppServiceCommandLiveTests(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["appservice_webapp_diagnostic_diagnose"];
+
     [Fact]
     public async Task ExecuteAsync_DetectorsDiagnose_ReturnsDiagnostics()
     {

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Webapp/Diagnostic/DetectorListCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Webapp/Diagnostic/DetectorListCommandLiveTests.cs
@@ -13,6 +13,8 @@ namespace Azure.Mcp.Tools.AppService.Tests.Webapp.Diagnostic;
 public class DetectorListCommandLiveTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : BaseAppServiceCommandLiveTests(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["appservice_webapp_diagnostic_list"];
+
     [Fact]
     public async Task ExecuteAsync_DetectorsList_ReturnsDetectors()
     {

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Webapp/Settings/AppSettingsGetCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Webapp/Settings/AppSettingsGetCommandLiveTests.cs
@@ -13,6 +13,8 @@ namespace Azure.Mcp.Tools.AppService.Tests.Webapp.Settings;
 public class AppSettingsGetCommandLiveTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : BaseAppServiceCommandLiveTests(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["appservice_webapp_settings_get-appsettings"];
+
     [Fact(Skip = "Test temporarily disabled - recording can't consent to secret elicitation")]
     public async Task ExecuteAsync_AppSettingsList_ReturnsAppSettings()
     {

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Webapp/Settings/AppSettingsUpdateCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Webapp/Settings/AppSettingsUpdateCommandLiveTests.cs
@@ -13,6 +13,8 @@ namespace Azure.Mcp.Tools.AppService.Tests.Webapp.Settings;
 public class AppSettingsUpdateCommandLiveTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : BaseAppServiceCommandLiveTests(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["appservice_webapp_settings_update-appsettings"];
+
     [Fact]
     public async Task ExecuteAsync_AddSetting_AddingNewSettingWorks()
     {

--- a/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Webapp/WebappGetCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.AppService/tests/Azure.Mcp.Tools.AppService.Tests/Webapp/WebappGetCommandLiveTests.cs
@@ -13,6 +13,8 @@ namespace Azure.Mcp.Tools.AppService.Tests.Webapp;
 public class WebappGetCommandLiveTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : BaseAppServiceCommandLiveTests(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["appservice_webapp_get"];
+
     [Fact]
     public async Task ExecuteAsync_SubscriptionList_ReturnsExpectedWebApp()
     {

--- a/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/AuthorizationCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/AuthorizationCommandTests.cs
@@ -13,6 +13,8 @@ namespace Azure.Mcp.Tools.Authorization.Tests;
 public class AuthorizationCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["role_assignment_list"];
+
     [Fact]
     public async Task Should_list_role_assignments()
     {

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/AzureBackupCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/AzureBackupCommandTests.cs
@@ -14,6 +14,28 @@ namespace Azure.Mcp.Tools.AzureBackup.Tests;
 public class AzureBackupCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => [
+        "azurebackup_vault_get",
+        "azurebackup_vault_create",
+        "azurebackup_vault_update",
+        "azurebackup_policy_get",
+        "azurebackup_policy_create",
+        "azurebackup_policy_update",
+        "azurebackup_protecteditem_get",
+        "azurebackup_protecteditem_protect",
+        "azurebackup_governance_find-unprotected",
+        "azurebackup_protectableitem_list",
+        "azurebackup_governance_soft-delete",
+        "azurebackup_governance_immutability",
+        "azurebackup_job_get",
+        "azurebackup_recoverypoint_get",
+        "azurebackup_backup_status",
+        "azurebackup_disasterrecovery_enable-crr",
+        "azurebackup_protecteditem_undelete",
+        "azurebackup_security_configure-mua",
+        "azurebackup_security_configure-encryption"
+    ];
+
     // Relax matching: ignore Authorization headers and don't compare request bodies
     // (ARM requests include timestamps, correlation IDs, etc. that vary between runs)
     public override CustomDefaultMatcher? TestMatcher => new()

--- a/tools/Azure.Mcp.Tools.AzureIsv/tests/Azure.Mcp.Tools.AzureIsv.Tests/AzureIsvCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureIsv/tests/Azure.Mcp.Tools.AzureIsv.Tests/AzureIsvCommandTests.cs
@@ -13,6 +13,8 @@ namespace Azure.Mcp.Tools.AzureIsv.Tests;
 public class AzureIsvCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["datadog_monitoredresources_list"];
+
     [Fact]
     public async Task Should_list_datadog_monitored_resources()
     {

--- a/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.Tests/AzureMigrateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.Tests/AzureMigrateCommandTests.cs
@@ -6,13 +6,14 @@ using Microsoft.Mcp.Tests;
 using Microsoft.Mcp.Tests.Client;
 using Microsoft.Mcp.Tests.Client.Helpers;
 using Microsoft.Mcp.Tests.Generated.Models;
-using Xunit;
 
 namespace Azure.Mcp.Tools.AzureMigrate.Tests;
 
 public class AzureMigrateCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["azuremigrate_platformlandingzone_request"];
+
     public override List<BodyKeySanitizer> BodyKeySanitizers =>
     [
         .. base.BodyKeySanitizers,

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/CommunicationCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/CommunicationCommandTests.cs
@@ -43,6 +43,8 @@ public class CommunicationCommandTests(ITestOutputHelper output, TestProxyFixtur
         await base.InitializeAsync();
     }
 
+    public override string[] Tools => ["communication_sms_send"];
+
     public override List<GeneralRegexSanitizer> GeneralRegexSanitizers =>
     [
         ..base.GeneralRegexSanitizers,

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/Email/EmailSendCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/Email/EmailSendCommandLiveTests.cs
@@ -41,6 +41,8 @@ public class EmailSendCommandLiveTests(ITestOutputHelper output, TestProxyFixtur
         await base.InitializeAsync();
     }
 
+    public override string[] Tools => ["communication_email_send"];
+
     public override List<GeneralRegexSanitizer> GeneralRegexSanitizers =>
     [
         ..base.GeneralRegexSanitizers,

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/ComputeCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/ComputeCommandTests.cs
@@ -19,6 +19,22 @@ public class ComputeCommandTests(ITestOutputHelper output, TestProxyFixture fixt
     private string VmssName => $"{Settings.ResourceBaseName}-vmss";
     private string DiskName => $"{Settings.ResourceBaseName}-disk";
 
+    public override string[] Tools => [
+        "compute_vm_get",
+        "compute_vmss_get",
+        "compute_vm_create",
+        "compute_vm_update",
+        "compute_vmss_create",
+        "compute_vmss_update",
+        "compute_vm_delete",
+        "compute_vmss_delete",
+        "compute_vm_power-state",
+        "compute_disk_get",
+        "compute_disk_create",
+        "compute_disk_update",
+        "compute_disk_delete"
+    ];
+
     // Disable default sanitizer additions to avoid conflicts (following SQL pattern)
     public override bool EnableDefaultSanitizerAdditions => false;
 

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosCommandTests.cs
@@ -14,6 +14,16 @@ namespace Azure.Mcp.Tools.Cosmos.Tests;
 public class CosmosCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => [
+        "cosmos_list",
+        "cosmos_database_container_item_query",
+        "cosmos_database_container_schema_infer",
+        "cosmos_database_container_item_list-recent",
+        "cosmos_database_container_item_get",
+        "cosmos_database_container_item_text-search",
+        "cosmos_database_container_item_vector-search"
+    ];
+
     protected override RecordingOptions? RecordingOptions => new()
     {
         HandleRedirects = false

--- a/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.Tests/DeployCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.Tests/DeployCommandTests.cs
@@ -20,6 +20,13 @@ public class DeployCommandTests(ITestOutputHelper output, TestProxyFixture fixtu
         _subscriptionId = Settings.SubscriptionId;
     }
 
+    public override string[] Tools => [
+        "deploy_plan_get",
+        "deploy_iac_rules_get",
+        "deploy_pipeline_guidance_get",
+        "deploy_app_logs_get"
+    ];
+
     [Fact]
     public async Task Should_get_plan()
     {

--- a/tools/Azure.Mcp.Tools.DeviceRegistry/tests/Azure.Mcp.Tools.DeviceRegistry.Tests/DeviceRegistryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.DeviceRegistry/tests/Azure.Mcp.Tools.DeviceRegistry.Tests/DeviceRegistryCommandTests.cs
@@ -12,6 +12,10 @@ namespace Azure.Mcp.Tools.DeviceRegistry.Tests;
 public class DeviceRegistryCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => [
+        "deviceregistry_namespace_list"
+    ];
+
     [Fact]
     public async Task Should_list_deviceregistry_namespaces_by_subscription()
     {

--- a/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.Tests/EventGridCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.Tests/EventGridCommandTests.cs
@@ -13,6 +13,12 @@ namespace Azure.Mcp.Tools.EventGrid.Tests;
 public class EventGridCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => [
+        "eventgrid_topic_list",
+        "eventgrid_subscription_list",
+        "eventgrid_events_publish"
+    ];
+
     public override List<UriRegexSanitizer> UriRegexSanitizers =>
     [
         .. base.UriRegexSanitizers,

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.Tests/EventHubsCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.Tests/EventHubsCommandTests.cs
@@ -14,6 +14,18 @@ namespace Azure.Mcp.Tools.EventHubs.Tests;
 public class EventHubsCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => [
+        "eventhubs_namespace_get",
+        "eventhubs_namespace_delete",
+        "eventhubs_namespace_update",
+        "eventhubs_eventhub_get",
+        "eventhubs_eventhub_delete",
+        "eventhubs_eventhub_update",
+        "eventhubs_eventhub_consumergroup_get",
+        "eventhubs_eventhub_consumergroup_delete",
+        "eventhubs_eventhub_consumergroup_update"
+    ];
+
     // Disable AZSDK2003 sanitizer to prevent it from over-sanitizing resource names in recordings.
     public override List<string> DisabledDefaultSanitizers =>
     [

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.Tests/FileSharesCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.Tests/FileSharesCommandTests.cs
@@ -21,8 +21,25 @@ public class FileSharesCommandTests(ITestOutputHelper output, TestProxyFixture f
     private const string Sanitized = "Sanitized";
     private const string Location = "eastus";
 
-    public override List<UriRegexSanitizer> UriRegexSanitizers => new[]
-    {
+    public override string[] Tools => [
+        "fileshares_fileshare_get",
+        "fileshares_fileshare_check-name-availability",
+        "fileshares_limits",
+        "fileshares_rec",
+        "fileshares_usage",
+        "fileshares_fileshare_create",
+        "fileshares_fileshare_update",
+        "fileshares_fileshare_delete",
+        "fileshares_fileshare_snapshot_create",
+        "fileshares_fileshare_snapshot_get",
+        "fileshares_fileshare_snapshot_update",
+        "fileshares_fileshare_snapshot_delete",
+        "fileshares_fileshare_peconnection_get",
+        "fileshares_fileshare_peconnection_update"
+    ];
+
+    public override List<UriRegexSanitizer> UriRegexSanitizers =>
+    [
         new UriRegexSanitizer(new UriRegexSanitizerBody
         {
             Regex = "resource[gG]roups\\/([^?\\/]+)",
@@ -36,10 +53,10 @@ public class FileSharesCommandTests(ITestOutputHelper output, TestProxyFixture f
             Value = Sanitized,
             GroupForReplace = "1"
         })
-    }.ToList();
+    ];
 
-    public override List<GeneralRegexSanitizer> GeneralRegexSanitizers => new[]
-    {
+    public override List<GeneralRegexSanitizer> GeneralRegexSanitizers =>
+    [
         // Sanitize private endpoint connection names BEFORE resource base name (format: {resourceBaseName}-fs-pe.{guid})
         new GeneralRegexSanitizer(new GeneralRegexSanitizerBody()
         {
@@ -71,7 +88,7 @@ public class FileSharesCommandTests(ITestOutputHelper output, TestProxyFixture f
             Regex = Settings.SubscriptionId,
             Value = "00000000-0000-0000-0000-000000000000",
         })
-    }.ToList();
+    ];
 
     public override List<BodyRegexSanitizer> BodyRegexSanitizers => [
         // Sanitizes all URLs to remove actual service names
@@ -85,8 +102,6 @@ public class FileSharesCommandTests(ITestOutputHelper output, TestProxyFixture f
           Value = "00000000-0000-0000-0000-000000000000",
         })
     ];
-
-
 
     [Fact]
     public async Task Should_get_file_share_details_by_subscription_and_name()

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.Tests/FoundryExtensionsCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.Tests/FoundryExtensionsCommandTests.cs
@@ -14,6 +14,16 @@ namespace Azure.Mcp.Tools.FoundryExtensions.Tests;
 public class FoundryExtensionsCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => [
+        "foundryextensions_knowledge_index_list",
+        "foundryextensions_knowledge_index_schema",
+        "foundryextensions_openai_create-completion",
+        "foundryextensions_openai_embeddings-create",
+        "foundryextensions_openai_models-list",
+        "foundryextensions_openai_chat-completions-create",
+        "foundryextensions_resource_get"
+    ];
+
     // Sanitize subscription IDs in URIs to allow playback to work
     public override List<UriRegexSanitizer> UriRegexSanitizers =>
     [

--- a/tools/Azure.Mcp.Tools.FunctionApp/tests/Azure.Mcp.Tools.FunctionApp.Tests/FunctionAppCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/tests/Azure.Mcp.Tools.FunctionApp.Tests/FunctionAppCommandTests.cs
@@ -15,6 +15,8 @@ namespace Azure.Mcp.Tools.FunctionApp.Tests;
 public sealed class FunctionAppCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["functionapp_get"];
+
     public override List<BodyKeySanitizer> BodyKeySanitizers =>
     [
         ..base.BodyKeySanitizers,

--- a/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.Tests/Language/LanguageListCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.Tests/Language/LanguageListCommandLiveTests.cs
@@ -28,11 +28,13 @@ public class LanguageListCommandLiveTests(
 {
     private static readonly string[] ExpectedLanguages = ["python", "typescript", "javascript", "csharp", "java", "powershell"];
 
+    public override string[] Tools => ["functions_language_list"];
+
     #region Helper Methods
 
     private async Task<LanguageListResult> GetLanguageListAsync()
     {
-        var result = await CallToolAsync("functions_language_list", new());
+        var result = await CallToolAsync("functions_language_list", []);
         Assert.NotNull(result);
         var languageResults = JsonSerializer.Deserialize(result.Value, FunctionsJsonContext.Default.ListLanguageListResult);
         Assert.NotNull(languageResults);

--- a/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.Tests/Template/TemplateGetCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.Tests/Template/TemplateGetCommandLiveTests.cs
@@ -26,6 +26,11 @@ public class TemplateGetCommandLiveTests(
     LiveServerFixture liveServerFixture)
     : BaseFunctionsCommandLiveTests(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => [
+        "functions_template_get",
+        "functions_language_list"
+    ];
+
     #region Helper Methods
 
     private async Task<TemplateListResult> GetTemplateListAsync(string language)
@@ -257,7 +262,7 @@ public class TemplateGetCommandLiveTests(
         // recorded, causing the test to fail. This implicitly asserts no CDN call is made.
 
         // Act - First call: language_list fetches and caches the manifest
-        var langResult = await CallToolAsync("functions_language_list", new());
+        var langResult = await CallToolAsync("functions_language_list", []);
 
         Assert.NotNull(langResult);
         var langList = JsonSerializer.Deserialize(langResult.Value, FunctionsJsonContext.Default.ListLanguageListResult);
@@ -284,7 +289,7 @@ public class TemplateGetCommandLiveTests(
     public async Task ExecuteAsync_WithRuntimeVersion_ReplacesPlaceholders()
     {
         // Get valid runtime version from language list
-        var langResult = await CallToolAsync("functions_language_list", new());
+        var langResult = await CallToolAsync("functions_language_list", []);
         Assert.NotNull(langResult);
         var langList = JsonSerializer.Deserialize(langResult.Value, FunctionsJsonContext.Default.ListLanguageListResult);
         Assert.NotNull(langList);

--- a/tools/Azure.Mcp.Tools.Grafana/tests/Azure.Mcp.Tools.Grafana.Tests/GrafanaCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/tests/Azure.Mcp.Tools.Grafana.Tests/GrafanaCommandTests.cs
@@ -12,6 +12,8 @@ namespace Azure.Mcp.Tools.Grafana.Tests;
 public class GrafanaCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["grafana_list"];
+
     [Fact]
     public async Task Should_list_grafana_workspaces_by_subscription_id()
     {

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/KeyVaultCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/KeyVaultCommandTests.cs
@@ -18,6 +18,16 @@ public class KeyVaultCommandTests(ITestOutputHelper output, TestProxyFixture fix
 {
     private readonly KeyVaultTestCertificateAssets _importCertificateAssets = KeyVaultTestCertificates.Load();
 
+    public override string[] Tools => [
+        "keyvault_key_get",
+        "keyvault_key_create",
+        "keyvault_secret_get",
+        "keyvault_certificate_get",
+        "keyvault_certificate_create",
+        "keyvault_certificate_import",
+        "keyvault_admin_settings_get"
+    ];
+
     public override CustomDefaultMatcher? TestMatcher => new()
     {
         ExcludedHeaders = "Authorization,Content-Type",

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/KustoCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/KustoCommandTests.cs
@@ -23,6 +23,14 @@ public class KustoCommandTests(ITestOutputHelper output, TestProxyFixture fixtur
     private const string Sanitized = "Sanitized";
     private readonly ServiceProvider _httpClientProvider = TestHttpClientFactoryProvider.Create(fixture);
 
+    public override string[] Tools => [
+        "kusto_cluster_get",
+        "kusto_database_list",
+        "kusto_table_list",
+        "kusto_table_schema",
+        "kusto_query"
+    ];
+
     public override List<BodyKeySanitizer> BodyKeySanitizers { get; } =
     [
         new(new BodyKeySanitizerBody("$..displayName")

--- a/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.Tests/LoadTestingCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/tests/Azure.Mcp.Tools.LoadTesting.Tests/LoadTestingCommandTests.cs
@@ -16,6 +16,8 @@ public class LoadTestingCommandTests(ITestOutputHelper output, TestProxyFixture 
     private const string TestResourceName = "TestResourceName";
     private const string TestRunId = "TestRunId";
 
+    public override string[] Tools => ["loadtesting_testresource_list"];
+
     public override List<UriRegexSanitizer> UriRegexSanitizers => [
         .. base.UriRegexSanitizers,
          new UriRegexSanitizer(new UriRegexSanitizerBody

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/ManagedLustreCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/ManagedLustreCommandTests.cs
@@ -14,6 +14,27 @@ namespace Azure.Mcp.Tools.ManagedLustre.Tests;
 public partial class ManagedLustreCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => [
+        "managedlustre_fs_list",
+        "managedlustre_fs_subnetsize_ask",
+        "managedlustre_fs_sku_get",
+        "managedlustre_fs_create",
+        "managedlustre_fs_blob_autoimport_create",
+        "managedlustre_fs_blob_autoimport_get",
+        "managedlustre_fs_blob_autoimport_cancel",
+        "managedlustre_fs_blob_autoimport_delete",
+        "managedlustre_fs_blob_autoexport_create",
+        "managedlustre_fs_blob_autoexport_get",
+        "managedlustre_fs_blob_autoexport_cancel",
+        "managedlustre_fs_blob_autoexport_delete",
+        "managedlustre_fs_blob_import_create",
+        "managedlustre_fs_blob_import_cancel",
+        "managedlustre_fs_blob_import_get",
+        "managedlustre_fs_blob_import_delete",
+        "managedlustre_fs_update",
+        "managedlustre_fs_subnetsize_validate"
+    ];
+
     private static readonly string[] _sanitizedHeaders =
     [
         "x-ms-correlation-request-id",

--- a/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.Tests/ProductGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.Tests/ProductGetCommandTests.cs
@@ -16,6 +16,8 @@ public sealed class ProductGetCommandTests(ITestOutputHelper output, TestProxyFi
     private const string ProductId = "test_test_pmc2pc1.vmsr_uat_beta";
     private const string Language = "en";
 
+    public override string[] Tools => ["marketplace_product_get"];
+
     [Fact]
     public async Task Should_get_marketplace_product()
     {

--- a/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.Tests/ProductListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.Tests/ProductListCommandTests.cs
@@ -15,6 +15,8 @@ public sealed class ProductListCommandTests(ITestOutputHelper output, TestProxyF
     private const string ProductsKey = "products";
     private const string Language = "en";
 
+    public override string[] Tools => ["marketplace_product_list"];
+
     [Fact]
     public async Task Should_list_marketplace_products()
     {

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/MonitorCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/MonitorCommandTests.cs
@@ -53,6 +53,20 @@ public sealed class MonitorCommandTests : RecordedCommandTestsBase
         _monitorService = new MonitorService(subscriptionService, _tenantService, resourceGroupService, resourceResolverService, _httpClientFactory, _logger);
     }
 
+    public override string[] Tools => [
+        // "monitor_table_list",
+        // "monitor_workspace_list",
+        // "monitor_workspace_log_query",
+        // "monitor_table_type_list",
+        // "monitor_resource_log_query",
+        // "monitor_metrics_definitions",
+        // "monitor_metrics_query",
+        // "storage_blob_container_list",
+        // "storage_blob_list",
+        "monitor_webtests_get",
+        "monitor_webtests_createorupdate"
+    ];
+
     public override List<UriRegexSanitizer> UriRegexSanitizers { get; } =
     [
         new(new UriRegexSanitizerBody

--- a/tools/Azure.Mcp.Tools.Pricing/tests/Azure.Mcp.Tools.Pricing.Tests/PricingGetCommandLiveTests.cs
+++ b/tools/Azure.Mcp.Tools.Pricing/tests/Azure.Mcp.Tools.Pricing.Tests/PricingGetCommandLiveTests.cs
@@ -20,6 +20,8 @@ public sealed class PricingGetCommandLiveTests(ITestOutputHelper output, TestPro
     private const string PricesKey = "prices";
     public override bool EnableDefaultSanitizerAdditions => false;
 
+    public override string[] Tools => ["pricing_get"];
+
     [Fact]
     public async Task Should_get_prices_by_sku()
     {

--- a/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.Tests/QuotaCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.Tests/QuotaCommandTests.cs
@@ -13,6 +13,8 @@ namespace Azure.Mcp.Tools.Quota.Tests;
 public sealed class QuotaCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["quota_usage_check", "quota_region_availability_list"];
+
     /// <summary>
     /// Disable the default sanitizer that redacts all JSON properties named "name". We need this
     /// to stick around so that we can verify that the expected resource names are present in the responses.

--- a/tools/Azure.Mcp.Tools.Redis/tests/Azure.Mcp.Tools.Redis.Tests/RedisCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Redis/tests/Azure.Mcp.Tools.Redis.Tests/RedisCommandTests.cs
@@ -13,6 +13,8 @@ namespace Azure.Mcp.Tools.Redis.Tests;
 public class RedisCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["redis_list"];
+
     public override List<BodyKeySanitizer> BodyKeySanitizers =>
     [
         new(new BodyKeySanitizerBody("$..displayName")

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/SearchCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/SearchCommandTests.cs
@@ -29,6 +29,12 @@ public class SearchCommandTests(ITestOutputHelper output, TestProxyFixture fixtu
         }
     }
 
+    public override string[] Tools => [
+        "search_service_list",
+        "search_index_get",
+        "search_index_query"
+    ];
+
     /// <summary>
     /// AZSDK3493 = $..name
     /// </summary>

--- a/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.Tests/ServiceBusCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.Tests/ServiceBusCommandTests.cs
@@ -22,6 +22,14 @@ public class ServiceBusCommandTests(ITestOutputHelper output, TestProxyFixture f
     private const string TopicName = "topic1";
     private const string SubscriptionName = "subscription1";
 
+    public override string[] Tools => [
+        "servicebus_queue_peek",
+        "servicebus_topic_subscription_peek",
+        "servicebus_queue_details",
+        "servicebus_topic_details",
+        "servicebus_topic_subscription_details"
+    ];
+
     [Fact(Skip = "The command for this test has been commented out until we know how to surface binary data.")]
     public async Task Queue_peek_messages()
     {

--- a/tools/Azure.Mcp.Tools.ServiceFabric/tests/Azure.Mcp.Tools.ServiceFabric.Tests/ServiceFabricCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ServiceFabric/tests/Azure.Mcp.Tools.ServiceFabric.Tests/ServiceFabricCommandTests.cs
@@ -12,6 +12,8 @@ namespace Azure.Mcp.Tools.ServiceFabric.Tests;
 public class ServiceFabricCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => ["servicefabric_managedcluster_node_get"];
+
     [Fact]
     public async Task Should_GetNodes_Successfully()
     {

--- a/tools/Azure.Mcp.Tools.SignalR/tests/Azure.Mcp.Tools.SignalR.Tests/SignalRCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SignalR/tests/Azure.Mcp.Tools.SignalR.Tests/SignalRCommandTests.cs
@@ -15,6 +15,8 @@ public sealed class SignalRCommandTests(ITestOutputHelper output, TestProxyFixtu
 {
     private const string SanitizedValue = "Sanitized";
 
+    public override string[] Tools => ["signalr_runtime_get"];
+
     public override List<UriRegexSanitizer> UriRegexSanitizers =>
      [
          new(new UriRegexSanitizerBody

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/SqlCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/SqlCommandTests.cs
@@ -15,6 +15,18 @@ namespace Azure.Mcp.Tools.Sql.Tests;
 public class SqlCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => [
+        "sql_db_get",
+        "sql_db_delete",
+        "sql_server_entra-admin_list",
+        "sql_server_firewall-rule_list",
+        "sql_elastic-pool_list",
+        "sql_server_firewall-rule_create",
+        "sql_server_firewall-rule_delete",
+        "sql_server_create",
+        "sql_server_delete"
+    ];
+
     /// <summary>
     /// AZSDK3493 = $..name
     /// </summary>

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/SreAgentCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/SreAgentCommandTests.cs
@@ -6,423 +6,449 @@ using Microsoft.Mcp.Tests.Client.Helpers;
 using Microsoft.Mcp.Tests.Generated.Models;
 using Xunit;
 
-namespace Azure.Mcp.Tools.SreAgent.Tests
+namespace Azure.Mcp.Tools.SreAgent.Tests;
+
+public class SreAgentCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
+    : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
-    public class SreAgentCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
-        : RecordedCommandTestsBase(output, fixture, liveServerFixture)
+    public override string[] Tools => [
+        "sreagent_agents_list",
+        "sreagent_agents_get",
+        "sreagent_threads_list",
+        "sreagent_connectors_list",
+        "sreagent_scheduledtasks_list",
+        "sreagent_incidents_active_list",
+        "sreagent_commonprompts_list",
+        "sreagent_agents_tools_list",
+        "sreagent_skills_list",
+        "sreagent_hooks_list",
+        "sreagent_incidents_plans_list",
+        "sreagent_docs_memories_list",
+        "sreagent_commonprompts_create",
+        "sreagent_commonprompts_get",
+        "sreagent_commonprompts_delete",
+        "sreagent_docs_memories_add",
+        "sreagent_docs_memories_search",
+        "sreagent_docs_memories_delete",
+        "sreagent_docs_memories_reindex",
+        "sreagent_connectors_create_mcp",
+        "sreagent_connectors_get",
+        "sreagent_connectors_delete",
+        "sreagent_skills_create",
+        "sreagent_skills_delete"
+    ];
+
+    // Disable body comparison: SRE Agent data-plane responses contain dynamic fields
+    // (timestamps, generated IDs, system state) that would cause spurious playback mismatches.
+    public override CustomDefaultMatcher? TestMatcher => new()
     {
-        // Disable body comparison: SRE Agent data-plane responses contain dynamic fields
-        // (timestamps, generated IDs, system state) that would cause spurious playback mismatches.
-        public override CustomDefaultMatcher? TestMatcher => new()
-        {
-            ExcludedHeaders = "Authorization,Content-Type",
-            CompareBodies = false
-        };
+        ExcludedHeaders = "Authorization,Content-Type",
+        CompareBodies = false
+    };
 
-        // Sanitize SRE Agent data-plane hostname in response bodies so recordings don't
-        // contain the real resource name (e.g. "mcpfb80ce3a--e5d0b29a.00632926.eastus2.azuresre.ai").
-        // Also sanitize tenant IDs and Owners fields (resource creator alias) from response bodies.
-        public override List<BodyRegexSanitizer> BodyRegexSanitizers =>
-        [
-            new BodyRegexSanitizer(new BodyRegexSanitizerBody
+    // Sanitize SRE Agent data-plane hostname in response bodies so recordings don't
+    // contain the real resource name (e.g. "mcpfb80ce3a--e5d0b29a.00632926.eastus2.azuresre.ai").
+    // Also sanitize tenant IDs and Owners fields (resource creator alias) from response bodies.
+    public override List<BodyRegexSanitizer> BodyRegexSanitizers =>
+    [
+        new BodyRegexSanitizer(new BodyRegexSanitizerBody
+        {
+            Regex = @"(?<=https://)(?<host>[^/""\s]+\.azuresre\.ai)",
+            GroupForReplace = "host",
+            Value = "sanitized.eastus2.azuresre.ai"
+        }),
+        new BodyRegexSanitizer(new BodyRegexSanitizerBody
+        {
+            Regex = @"(?<=/tenants/)(?<tenantId>[0-9a-fA-F-]{36})",
+            GroupForReplace = "tenantId",
+            Value = "00000000-0000-0000-0000-000000000000"
+        }),
+        new BodyRegexSanitizer(new BodyRegexSanitizerBody
+        {
+            Regex = @"(?<=""Owners""\s*:\s*"")(?<owner>[^""]+)",
+            GroupForReplace = "owner",
+            Value = "sanitized"
+        })
+    ];
+
+    // Sanitize SRE Agent data-plane hostname in request/response URIs.
+    public override List<UriRegexSanitizer> UriRegexSanitizers =>
+    [
+        new UriRegexSanitizer(new UriRegexSanitizerBody
+        {
+            Regex = @"(?<=https://)(?<host>[^/]+\.azuresre\.ai)",
+            GroupForReplace = "host",
+            Value = "sanitized.eastus2.azuresre.ai"
+        })
+    ];
+
+    // Sanitize x-ms-operation-identifier response header which contains real tenant ID and object ID.
+    public override List<HeaderRegexSanitizer> HeaderRegexSanitizers =>
+    [
+        new HeaderRegexSanitizer(new HeaderRegexSanitizerBody("x-ms-operation-identifier")
+        {
+            Value = "sanitized"
+        })
+    ];
+
+    [Fact]
+    public async Task Should_list_sre_agents_by_subscription_id()
+    {
+        var result = await CallToolAsync(
+            "sreagent_agents_list",
+            new()
             {
-                Regex = @"(?<=https://)(?<host>[^/""\s]+\.azuresre\.ai)",
-                GroupForReplace = "host",
-                Value = "sanitized.eastus2.azuresre.ai"
-            }),
-            new BodyRegexSanitizer(new BodyRegexSanitizerBody
-            {
-                Regex = @"(?<=/tenants/)(?<tenantId>[0-9a-fA-F-]{36})",
-                GroupForReplace = "tenantId",
-                Value = "00000000-0000-0000-0000-000000000000"
-            }),
-            new BodyRegexSanitizer(new BodyRegexSanitizerBody
-            {
-                Regex = @"(?<=""Owners""\s*:\s*"")(?<owner>[^""]+)",
-                GroupForReplace = "owner",
-                Value = "sanitized"
-            })
-        ];
+                { "subscription", Settings.SubscriptionId }
+            });
 
-        // Sanitize SRE Agent data-plane hostname in request/response URIs.
-        public override List<UriRegexSanitizer> UriRegexSanitizers =>
-        [
-            new UriRegexSanitizer(new UriRegexSanitizerBody
-            {
-                Regex = @"(?<=https://)(?<host>[^/]+\.azuresre\.ai)",
-                GroupForReplace = "host",
-                Value = "sanitized.eastus2.azuresre.ai"
-            })
-        ];
-
-        // Sanitize x-ms-operation-identifier response header which contains real tenant ID and object ID.
-        public override List<HeaderRegexSanitizer> HeaderRegexSanitizers =>
-        [
-            new HeaderRegexSanitizer(new HeaderRegexSanitizerBody("x-ms-operation-identifier")
-            {
-                Value = "sanitized"
-            })
-        ];
-
-        [Fact]
-        public async Task Should_list_sre_agents_by_subscription_id()
-        {
-            var result = await CallToolAsync(
-                "sreagent_agents_list",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId }
-                });
-
-            // Result may be an array directly or wrapped; just assert call succeeded.
-            Assert.NotNull(result);
-        }
-
-        [Fact]
-        public async Task Should_get_sre_agent_details()
-        {
-            var result = await CallToolAsync(
-                "sreagent_agents_get",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName }
-                });
-
-            Assert.NotNull(result);
-        }
-
-        [Fact]
-        public async Task Should_list_threads()
-        {
-            var result = await CallToolAsync(
-                "sreagent_threads_list",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName }
-                });
-
-            Assert.NotNull(result);
-        }
-
-        [Fact]
-        public async Task Should_list_connectors()
-        {
-            var result = await CallToolAsync(
-                "sreagent_connectors_list",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName }
-                });
-
-            Assert.NotNull(result);
-        }
-
-        [Fact]
-        public async Task Should_list_scheduled_tasks()
-        {
-            var result = await CallToolAsync(
-                "sreagent_scheduledtasks_list",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName }
-                });
-
-            Assert.NotNull(result);
-        }
-
-        [Fact]
-        public async Task Should_list_active_incidents()
-        {
-            var result = await CallToolAsync(
-                "sreagent_incidents_active_list",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName }
-                });
-
-            Assert.NotNull(result);
-        }
-
-        [Fact]
-        public async Task Should_list_common_prompts()
-        {
-            var result = await CallToolAsync(
-                "sreagent_commonprompts_list",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName }
-                });
-
-            Assert.NotNull(result);
-        }
-
-        [Fact]
-        public async Task Should_list_agent_tools()
-        {
-            var result = await CallToolAsync(
-                "sreagent_agents_tools_list",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName }
-                });
-
-            Assert.NotNull(result);
-        }
-
-        [Fact]
-        public async Task Should_list_skills()
-        {
-            var result = await CallToolAsync(
-                "sreagent_skills_list",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName }
-                });
-
-            Assert.NotNull(result);
-        }
-
-        [Fact]
-        public async Task Should_list_hooks()
-        {
-            var result = await CallToolAsync(
-                "sreagent_hooks_list",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName }
-                });
-
-            Assert.NotNull(result);
-        }
-
-        [Fact]
-        public async Task Should_list_incident_plans()
-        {
-            var result = await CallToolAsync(
-                "sreagent_incidents_plans_list",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName }
-                });
-
-            Assert.NotNull(result);
-        }
-
-        [Fact]
-        public async Task Should_list_memories()
-        {
-            var result = await CallToolAsync(
-                "sreagent_docs_memories_list",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName }
-                });
-
-            Assert.NotNull(result);
-        }
-
-        [Fact]
-        public async Task Should_create_get_and_delete_common_prompt()
-        {
-            const string promptName = "live-test-prompt";
-
-            // Create
-            var createResult = await CallToolAsync(
-                "sreagent_commonprompts_create",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName },
-                    { "name", promptName },
-                    { "content", "You are a helpful SRE assistant." }
-                });
-            Assert.NotNull(createResult);
-
-            // Get
-            var getResult = await CallToolAsync(
-                "sreagent_commonprompts_get",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName },
-                    { "name", promptName }
-                });
-            Assert.NotNull(getResult);
-
-            // Delete
-            var deleteResult = await CallToolAsync(
-                "sreagent_commonprompts_delete",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName },
-                    { "name", promptName },
-                    { "confirm", true }
-                });
-            Assert.NotNull(deleteResult);
-        }
-
-        [Fact]
-        public async Task Should_add_search_and_delete_memory()
-        {
-            const string memoryName = "live-test-memory.md";
-
-            // Add
-            var addResult = await CallToolAsync(
-                "sreagent_docs_memories_add",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName },
-                    { "name", memoryName },
-                    { "content", "# Live Test Memory\nThis document is used by automated live tests." }
-                });
-            Assert.NotNull(addResult);
-
-            // Search (best-effort; indexing may be asynchronous)
-            var searchResult = await CallToolAsync(
-                "sreagent_docs_memories_search",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName },
-                    { "query", "live test memory" }
-                });
-            Assert.NotNull(searchResult);
-
-            // Delete
-            var deleteResult = await CallToolAsync(
-                "sreagent_docs_memories_delete",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName },
-                    { "name", memoryName },
-                    { "confirm", true }
-                });
-            Assert.NotNull(deleteResult);
-        }
-
-        [Fact]
-        public async Task Should_reindex_memories()
-        {
-            var result = await CallToolAsync(
-                "sreagent_docs_memories_reindex",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName }
-                });
-
-            Assert.NotNull(result);
-        }
-
-        [Fact]
-        public async Task Should_create_get_and_delete_mcp_connector()
-        {
-            const string connectorName = "live-test-mcp-connector";
-
-            // Create (HTTP type with a placeholder endpoint)
-            var createResult = await CallToolAsync(
-                "sreagent_connectors_create_mcp",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName },
-                    { "name", connectorName },
-                    { "type", "http" },
-                    { "endpoint", "https://example.com/mcp" }
-                });
-            Assert.NotNull(createResult);
-
-            // Get
-            var getResult = await CallToolAsync(
-                "sreagent_connectors_get",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName },
-                    { "name", connectorName }
-                });
-            Assert.NotNull(getResult);
-
-            // Delete
-            var deleteResult = await CallToolAsync(
-                "sreagent_connectors_delete",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName },
-                    { "name", connectorName },
-                    { "confirm", true }
-                });
-            Assert.NotNull(deleteResult);
-        }
-
-        [Fact]
-        public async Task Should_create_and_delete_skill()
-        {
-            const string skillName = "live-test-skill";
-
-            // Create
-            var createResult = await CallToolAsync(
-                "sreagent_skills_create",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName },
-                    { "name", skillName },
-                    { "content", "## Restart Service\nRestart the given service using `systemctl restart <service>`." },
-                    { "description", "Runbook for restarting a service" }
-                });
-            Assert.NotNull(createResult);
-
-            // Delete
-            var deleteResult = await CallToolAsync(
-                "sreagent_skills_delete",
-                new()
-                {
-                    { "subscription", Settings.SubscriptionId },
-                    { "resource-group", Settings.ResourceGroupName },
-                    { "agent", Settings.ResourceBaseName },
-                    { "name", skillName },
-                    { "confirm", true }
-                });
-            Assert.NotNull(deleteResult);
-        }
-
+        // Result may be an array directly or wrapped; just assert call succeeded.
+        Assert.NotNull(result);
     }
+
+    [Fact]
+    public async Task Should_get_sre_agent_details()
+    {
+        var result = await CallToolAsync(
+            "sreagent_agents_get",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName }
+            });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Should_list_threads()
+    {
+        var result = await CallToolAsync(
+            "sreagent_threads_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName }
+            });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Should_list_connectors()
+    {
+        var result = await CallToolAsync(
+            "sreagent_connectors_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName }
+            });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Should_list_scheduled_tasks()
+    {
+        var result = await CallToolAsync(
+            "sreagent_scheduledtasks_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName }
+            });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Should_list_active_incidents()
+    {
+        var result = await CallToolAsync(
+            "sreagent_incidents_active_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName }
+            });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Should_list_common_prompts()
+    {
+        var result = await CallToolAsync(
+            "sreagent_commonprompts_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName }
+            });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Should_list_agent_tools()
+    {
+        var result = await CallToolAsync(
+            "sreagent_agents_tools_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName }
+            });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Should_list_skills()
+    {
+        var result = await CallToolAsync(
+            "sreagent_skills_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName }
+            });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Should_list_hooks()
+    {
+        var result = await CallToolAsync(
+            "sreagent_hooks_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName }
+            });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Should_list_incident_plans()
+    {
+        var result = await CallToolAsync(
+            "sreagent_incidents_plans_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName }
+            });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Should_list_memories()
+    {
+        var result = await CallToolAsync(
+            "sreagent_docs_memories_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName }
+            });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Should_create_get_and_delete_common_prompt()
+    {
+        const string promptName = "live-test-prompt";
+
+        // Create
+        var createResult = await CallToolAsync(
+            "sreagent_commonprompts_create",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName },
+                { "name", promptName },
+                { "content", "You are a helpful SRE assistant." }
+            });
+        Assert.NotNull(createResult);
+
+        // Get
+        var getResult = await CallToolAsync(
+            "sreagent_commonprompts_get",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName },
+                { "name", promptName }
+            });
+        Assert.NotNull(getResult);
+
+        // Delete
+        var deleteResult = await CallToolAsync(
+            "sreagent_commonprompts_delete",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName },
+                { "name", promptName },
+                { "confirm", true }
+            });
+        Assert.NotNull(deleteResult);
+    }
+
+    [Fact]
+    public async Task Should_add_search_and_delete_memory()
+    {
+        const string memoryName = "live-test-memory.md";
+
+        // Add
+        var addResult = await CallToolAsync(
+            "sreagent_docs_memories_add",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName },
+                { "name", memoryName },
+                { "content", "# Live Test Memory\nThis document is used by automated live tests." }
+            });
+        Assert.NotNull(addResult);
+
+        // Search (best-effort; indexing may be asynchronous)
+        var searchResult = await CallToolAsync(
+            "sreagent_docs_memories_search",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName },
+                { "query", "live test memory" }
+            });
+        Assert.NotNull(searchResult);
+
+        // Delete
+        var deleteResult = await CallToolAsync(
+            "sreagent_docs_memories_delete",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName },
+                { "name", memoryName },
+                { "confirm", true }
+            });
+        Assert.NotNull(deleteResult);
+    }
+
+    [Fact]
+    public async Task Should_reindex_memories()
+    {
+        var result = await CallToolAsync(
+            "sreagent_docs_memories_reindex",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName }
+            });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Should_create_get_and_delete_mcp_connector()
+    {
+        const string connectorName = "live-test-mcp-connector";
+
+        // Create (HTTP type with a placeholder endpoint)
+        var createResult = await CallToolAsync(
+            "sreagent_connectors_create_mcp",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName },
+                { "name", connectorName },
+                { "type", "http" },
+                { "endpoint", "https://example.com/mcp" }
+            });
+        Assert.NotNull(createResult);
+
+        // Get
+        var getResult = await CallToolAsync(
+            "sreagent_connectors_get",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName },
+                { "name", connectorName }
+            });
+        Assert.NotNull(getResult);
+
+        // Delete
+        var deleteResult = await CallToolAsync(
+            "sreagent_connectors_delete",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName },
+                { "name", connectorName },
+                { "confirm", true }
+            });
+        Assert.NotNull(deleteResult);
+    }
+
+    [Fact]
+    public async Task Should_create_and_delete_skill()
+    {
+        const string skillName = "live-test-skill";
+
+        // Create
+        var createResult = await CallToolAsync(
+            "sreagent_skills_create",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName },
+                { "name", skillName },
+                { "content", "## Restart Service\nRestart the given service using `systemctl restart <service>`." },
+                { "description", "Runbook for restarting a service" }
+            });
+        Assert.NotNull(createResult);
+
+        // Delete
+        var deleteResult = await CallToolAsync(
+            "sreagent_skills_delete",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "agent", Settings.ResourceBaseName },
+                { "name", skillName },
+                { "confirm", true }
+            });
+        Assert.NotNull(deleteResult);
+    }
+
 }

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/StorageCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/StorageCommandTests.cs
@@ -14,6 +14,16 @@ namespace Azure.Mcp.Tools.Storage.Tests;
 public class StorageCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => [
+        "storage_account_get",
+        "storage_blob_get",
+        "storage_blob_upload",
+        "storage_blob_container_get",
+        "storage_blob_container_create",
+        "storage_account_create",
+        "storage_table_list"
+    ];
+
     public override List<BodyKeySanitizer> BodyKeySanitizers =>
     [
         .. base.BodyKeySanitizers,

--- a/tools/Azure.Mcp.Tools.StorageSync/tests/Azure.Mcp.Tools.StorageSync.Tests/StorageSyncCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/tests/Azure.Mcp.Tools.StorageSync.Tests/StorageSyncCommandTests.cs
@@ -13,6 +13,26 @@ namespace Azure.Mcp.Tools.StorageSync.Tests;
 public class StorageSyncCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => [
+        "storagesync_service_get",
+        "storagesync_syncgroup_get",
+        "storagesync_cloudendpoint_get",
+        "storagesync_registeredserver_get",
+        "storagesync_serverendpoint_get",
+        "storagesync_service_create",
+        "storagesync_service_update",
+        "storagesync_service_delete",
+        "storagesync_syncgroup_create",
+        "storagesync_syncgroup_delete",
+        "storagesync_serverendpoint_delete",
+        "storagesync_cloudendpoint_create",
+        "storagesync_serverendpoint_create",
+        "storagesync_cloudendpoint_changedetection",
+        "storagesync_serverendpoint_update",
+        "storagesync_registeredserver_update",
+        "storagesync_registeredserver_unregister"
+    ];
+
     public override List<UriRegexSanitizer> UriRegexSanitizers => [
         .. base.UriRegexSanitizers,
         new(new()

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.Tests/VirtualDesktopCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.Tests/VirtualDesktopCommandTests.cs
@@ -13,6 +13,12 @@ namespace Azure.Mcp.Tools.VirtualDesktop.Tests;
 public class VirtualDesktopCommandTests(ITestOutputHelper output, TestProxyFixture fixture, LiveServerFixture liveServerFixture)
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
+    public override string[] Tools => [
+        "virtualdesktop_hostpool_list",
+        "virtualdesktop_hostpool_host_list",
+        "virtualdesktop_hostpool_host_user_list"
+    ];
+
     public override List<BodyRegexSanitizer> BodyRegexSanitizers =>
     [
         new BodyRegexSanitizer(new BodyRegexSanitizerBody()

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.Tests/WorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.Tests/WorkbooksCommandTests.cs
@@ -15,6 +15,15 @@ public class WorkbooksCommandTests(ITestOutputHelper output, TestProxyFixture fi
     : RecordedCommandTestsBase(output, fixture, liveServerFixture)
 {
     private const string EmptyGuid = "00000000-0000-0000-0000-000000000000";
+
+    public override string[] Tools => [
+        "workbooks_list",
+        "workbooks_show",
+        "workbooks_create",
+        "workbooks_update",
+        "workbooks_delete"
+    ];
+
     public override List<UriRegexSanitizer> UriRegexSanitizers =>
     [
         new UriRegexSanitizer(new UriRegexSanitizerBody


### PR DESCRIPTION
## What does this PR do?

Updates `ServiceStartCommand` to allow it to filter which `IAreaSetup`s it will register based on the `--namespace` or `--tool` arguments specified, instead of waiting to do this in `ToolLoader`s. This should improve MCP server start times by reducing what needs to be instantiated and dependency injected.

Additionally, updates live tests to specify which tools they'll be using to reduce the scope for the MCP servers started during testing.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
