### PR TITLE
Document KQL query validation restrictions for Monitor and Kusto commands

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/copilot-kql-query-validation-docs.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/copilot-kql-query-validation-docs.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Other Changes"
+    description: "Added documentation for KQL query validation restrictions (max 10,000 characters, tautology pattern rejection, management/control command rejection) for azmcp kusto query, azmcp monitor resource log query, and azmcp monitor workspace log query."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -2193,7 +2193,11 @@ azmcp kusto table schema [--cluster-uri <cluster-uri> | --subscription <subscrip
                          --database <database> \
                          --table <table>
 
-# Query Azure Data Explorer database
+# Query Azure Data Explorer database.
+# KQL queries are validated for safety: max 10,000 characters; tautology patterns
+# (e.g., 'or 1==1', 'or true') and management commands (.drop, .alter, .create,
+# .delete, .set, .append, .set-or-append, .set-or-replace, .ingest, .purge, .execute)
+# are rejected.
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp kusto query [--cluster-uri <cluster-uri> | --subscription <subscription> --cluster <cluster>] \
                   --database <database> \
@@ -2986,7 +2990,11 @@ azmcp monitor table list --subscription <subscription> \
 azmcp monitor workspace list --subscription <subscription> \
                             [--resource-group <resource-group>]
 
-# Query logs from Azure Monitor using KQL
+# Query logs from Azure Monitor using KQL.
+# KQL queries are validated for safety: max 10,000 characters; tautology patterns
+# (e.g., 'or 1==1', 'or true') and management commands (.drop, .alter, .create,
+# .delete, .set, .append, .set-or-append, .set-or-replace, .ingest, .purge, .execute)
+# are rejected.
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp monitor resource log query --subscription <subscription> \
                                  --resource-id <resource-id> \
@@ -2995,6 +3003,11 @@ azmcp monitor resource log query --subscription <subscription> \
                                  [--hours <hours>] \
                                  [--limit <limit>]
 
+# Query logs from a Log Analytics workspace using KQL.
+# KQL queries are validated for safety: max 10,000 characters; tautology patterns
+# (e.g., 'or 1==1', 'or true') and management commands (.drop, .alter, .create,
+# .delete, .set, .append, .set-or-append, .set-or-replace, .ingest, .purge, .execute)
+# are rejected.
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp monitor workspace log query --subscription <subscription> \
                                   --workspace <workspace> \


### PR DESCRIPTION
﻿Fixes #2756

## Summary

PR #2747 introduced KQL query validation across the Monitor and Kusto tools, but the user-facing documentation in `servers/Azure.Mcp.Server/docs/azmcp-commands.md` did not mention the new restrictions. This PR adds inline documentation for the three affected commands, following the same pattern already used for `azmcp mysql database query`.

## Changes

Added a short description above each command that documents:
- Max query length: **10,000 characters**
- Tautology patterns (e.g., `or 1==1`, `or true`) are rejected
- Management/control commands (`.drop`, `.alter`, `.create`, `.delete`, `.set`, `.append`, `.set-or-append`, `.set-or-replace`, `.ingest`, `.purge`, `.execute`) are rejected

Commands updated:
- `azmcp kusto query`
- `azmcp monitor resource log query`
- `azmcp monitor workspace log query`

## Files Changed

- `servers/Azure.Mcp.Server/docs/azmcp-commands.md` — added validation notes (15 insertions, 2 deletions)

No code changes were required. `e2eTestPrompts.md` was reviewed; per the issue it does not require new prompts (no new tool names were added), and the file does not contain a descriptive-text section per service in which a validation note could naturally be placed.
