### PR TITLE
Change Cloud Architect implementation to extend BaseCommand

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1780680250640.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1780680250640.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Breaking Changes"
+    description: "Removed resource group, tenant, auth method, and retry options from cloudarchitect_design tool as they aren't used."

--- a/tools/Azure.Mcp.Tools.CloudArchitect/src/Commands/Design/DesignCommand.cs
+++ b/tools/Azure.Mcp.Tools.CloudArchitect/src/Commands/Design/DesignCommand.cs
@@ -33,7 +33,7 @@ namespace Azure.Mcp.Tools.CloudArchitect.Commands.Design;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class DesignCommand(ILogger<DesignCommand> logger) : GlobalCommand<ArchitectureDesignToolOptions>
+public sealed class DesignCommand(ILogger<DesignCommand> logger) : BaseCommand<ArchitectureDesignToolOptions>
 {
     private readonly ILogger<DesignCommand> _logger = logger;
 
@@ -87,18 +87,16 @@ public sealed class DesignCommand(ILogger<DesignCommand> logger) : GlobalCommand
         });
     }
 
-    protected override ArchitectureDesignToolOptions BindOptions(ParseResult parseResult)
+    protected override ArchitectureDesignToolOptions BindOptions(ParseResult parseResult) => new()
     {
-        var options = base.BindOptions(parseResult);
-        options.Question = parseResult.GetValueOrDefault<string>(CloudArchitectOptionDefinitions.Question.Name) ?? string.Empty;
-        options.QuestionNumber = parseResult.GetValueOrDefault<int>(CloudArchitectOptionDefinitions.QuestionNumber.Name);
-        options.TotalQuestions = parseResult.GetValueOrDefault<int>(CloudArchitectOptionDefinitions.TotalQuestions.Name);
-        options.Answer = parseResult.GetValueOrDefault<string>(CloudArchitectOptionDefinitions.Answer.Name);
-        options.NextQuestionNeeded = parseResult.GetValueOrDefault<bool>(CloudArchitectOptionDefinitions.NextQuestionNeeded.Name);
-        options.ConfidenceScore = parseResult.GetValueOrDefault<double>(CloudArchitectOptionDefinitions.ConfidenceScore.Name);
-        options.State = DeserializeState(parseResult.GetValueOrDefault<string>(CloudArchitectOptionDefinitions.State.Name));
-        return options;
-    }
+        Question = parseResult.GetValueOrDefault<string>(CloudArchitectOptionDefinitions.Question.Name) ?? string.Empty;
+        QuestionNumber = parseResult.GetValueOrDefault<int>(CloudArchitectOptionDefinitions.QuestionNumber.Name);
+        TotalQuestions = parseResult.GetValueOrDefault<int>(CloudArchitectOptionDefinitions.TotalQuestions.Name);
+        Answer = parseResult.GetValueOrDefault<string>(CloudArchitectOptionDefinitions.Answer.Name);
+        NextQuestionNeeded = parseResult.GetValueOrDefault<bool>(CloudArchitectOptionDefinitions.NextQuestionNeeded.Name);
+        ConfidenceScore = parseResult.GetValueOrDefault<double>(CloudArchitectOptionDefinitions.ConfidenceScore.Name);
+        State = DeserializeState(parseResult.GetValueOrDefault<string>(CloudArchitectOptionDefinitions.State.Name));
+    };
 
     private static ArchitectureDesignToolState DeserializeState(string? stateJson)
     {

--- a/tools/Azure.Mcp.Tools.CloudArchitect/src/Commands/Design/DesignCommand.cs
+++ b/tools/Azure.Mcp.Tools.CloudArchitect/src/Commands/Design/DesignCommand.cs
@@ -89,13 +89,13 @@ public sealed class DesignCommand(ILogger<DesignCommand> logger) : BaseCommand<A
 
     protected override ArchitectureDesignToolOptions BindOptions(ParseResult parseResult) => new()
     {
-        Question = parseResult.GetValueOrDefault<string>(CloudArchitectOptionDefinitions.Question.Name) ?? string.Empty;
-        QuestionNumber = parseResult.GetValueOrDefault<int>(CloudArchitectOptionDefinitions.QuestionNumber.Name);
-        TotalQuestions = parseResult.GetValueOrDefault<int>(CloudArchitectOptionDefinitions.TotalQuestions.Name);
-        Answer = parseResult.GetValueOrDefault<string>(CloudArchitectOptionDefinitions.Answer.Name);
-        NextQuestionNeeded = parseResult.GetValueOrDefault<bool>(CloudArchitectOptionDefinitions.NextQuestionNeeded.Name);
-        ConfidenceScore = parseResult.GetValueOrDefault<double>(CloudArchitectOptionDefinitions.ConfidenceScore.Name);
-        State = DeserializeState(parseResult.GetValueOrDefault<string>(CloudArchitectOptionDefinitions.State.Name));
+        Question = parseResult.GetValueOrDefault<string>(CloudArchitectOptionDefinitions.Question.Name) ?? string.Empty,
+        QuestionNumber = parseResult.GetValueOrDefault<int>(CloudArchitectOptionDefinitions.QuestionNumber.Name),
+        TotalQuestions = parseResult.GetValueOrDefault<int>(CloudArchitectOptionDefinitions.TotalQuestions.Name),
+        Answer = parseResult.GetValueOrDefault<string>(CloudArchitectOptionDefinitions.Answer.Name),
+        NextQuestionNeeded = parseResult.GetValueOrDefault<bool>(CloudArchitectOptionDefinitions.NextQuestionNeeded.Name),
+        ConfidenceScore = parseResult.GetValueOrDefault<double>(CloudArchitectOptionDefinitions.ConfidenceScore.Name),
+        State = DeserializeState(parseResult.GetValueOrDefault<string>(CloudArchitectOptionDefinitions.State.Name))
     };
 
     private static ArchitectureDesignToolState DeserializeState(string? stateJson)

--- a/tools/Azure.Mcp.Tools.CloudArchitect/src/Options/ArchitectureDesignToolOptions.cs
+++ b/tools/Azure.Mcp.Tools.CloudArchitect/src/Options/ArchitectureDesignToolOptions.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Mcp.Core.Options;
-
 namespace Azure.Mcp.Tools.CloudArchitect.Options;
 
 /// <summary>
 /// The set of parameters that the architecture design tool takes as input.
 /// </summary>
-public class ArchitectureDesignToolOptions : GlobalOptions
+public class ArchitectureDesignToolOptions
 {
     public string Question { get; set; } = string.Empty;
 


### PR DESCRIPTION
## What does this PR do?

Changed Cloud Architect's `DesignCommand` to extend from `BaseCommand` instead of `GlobalCommand` as it doesn't use any of the parameters defined in `GlobalCommand`. This will eliminate parameters from the tool definition it doesn't use and reduce token usage and simplify tool consumption by an agent.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
