### PR TITLE
Add git worktree safety guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@
 - Access HttpContext directly from commands
 - Make transport-specific decisions in command logic
 - Assume single-user scenarios when implementing services
+- Use `git stash` in linked worktrees; the stash stack is shared across worktrees and can collide during concurrent work
 
 ## Commands
 
@@ -722,6 +723,9 @@ When adding new commands:
 # Remove git hooks
 ./eng/scripts/Remove-GitHooks.ps1
 ```
+
+### Git Worktree Safety
+When working in a linked git worktree (multiple worktrees sharing one repository common git directory), do **not** use `git stash`. Git stores stash entries in the shared `refs/stash`, so stash operations from concurrent worktrees share the same stack and can apply or drop the wrong changes. To compare against a baseline, use `git diff <ref>` (e.g., `git diff main -- <files>`) or create a throwaway worktree of the base branch with `git worktree add`. When committing, stage intended changes explicitly (`git add -p` or specific paths) rather than `git add -A`.
 
 ### Pull Request Guidelines
 - **Run all tests**: `./eng/scripts/Test-Code.ps1`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -725,7 +725,7 @@ When adding new commands:
 ```
 
 ### Git Worktree Safety
-When working in a linked git worktree (multiple worktrees sharing one repository common git directory), do **not** use `git stash`. Git stores stash entries in the shared `refs/stash`, so stash operations from concurrent worktrees share the same stack and can apply or drop the wrong changes. To compare against a baseline, use `git diff <ref>` (e.g., `git diff main -- <files>`) or create a throwaway worktree of the base branch with `git worktree add`. When committing, stage intended changes explicitly (`git add -p` or specific paths) rather than `git add -A`.
+When working in a linked git worktree (multiple worktrees sharing one repository common git directory), do **not** use `git stash`. Git stores stash entries in the shared `refs/stash`, so stash operations from concurrent worktrees share the same stack and can apply or drop the wrong changes. To compare against a baseline, use `git diff <ref>` (e.g., `git diff main -- <files>`) or create a throwaway worktree of the base branch with `git worktree add <path> <base-ref>` (e.g., `git worktree add ../mcp-main main`). When committing, stage intended changes explicitly (`git add -p` or specific paths) rather than `git add -A`.
 
 ### Pull Request Guidelines
 - **Run all tests**: `./eng/scripts/Test-Code.ps1`


### PR DESCRIPTION
## What does this PR do?
Documents a `git stash` hazard for contributors who work in linked git worktrees. When multiple worktrees share one repository common git directory, Git stores stash entries in the shared `refs/stash`, so stash operations from concurrent worktrees share a single stack. A stash created, popped, or dropped in one worktree can therefore apply or restore the wrong changes in another. This caused a real near-miss during parallel work, so this PR adds explicit guidance to steer contributors away from it.

The change is documentation-only and edits a single file, `AGENTS.md`:

- Adds a new **Git Worktree Safety** subsection under "Git Workflow and Automation" explaining the problem and recommending safer alternatives (`git diff <ref>`, a throwaway `git worktree add` of the base branch, and explicit staging with `git add -p` / specific paths instead of `git add -A`).
- Adds one concise bullet to the top-level "Don't" list.

Spelling was verified with `.\eng\common\spelling\Invoke-Cspell.ps1` (passes). No build or tests are needed for a docs-only change.

## GitHub issue number?
N/A

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality (N/A - docs-only change)
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies (N/A - internal contributor documentation only)
- [ ] For MCP tool changes: N/A - no tool changes in this PR

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.