### PR TITLE
Backport fixes to Fabric MCP server

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -88,14 +88,15 @@
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="System.ClientModel" Version="1.8.0" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.1" />
-    <PackageVersion Include="System.Formats.Asn1" Version="10.0.2" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
-    <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.2" />
-    <PackageVersion Include="System.Numerics.Tensors" Version="10.0.2" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.6" />
+    <PackageVersion Include="System.Formats.Asn1" Version="10.0.6" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+    <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.6" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageVersion Include="System.Numerics.Tensors" Version="10.0.6" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.6" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.11.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,6 +60,7 @@
     <PackageVersion Include="Azure.ResourceManager.StorageSync" Version="1.3.1" />
     <PackageVersion Include="Azure.ResourceManager.FileShares" Version="1.0.0-beta.2" />
     <PackageVersion Include="Azure.ResourceManager.ResourceGraph" Version="1.1.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Azure.Kusto.Data" Version="14.0.3" />
     <PackageVersion Include="Microsoft.Azure.Kusto.Ingest" Version="14.0.3" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.46.0" />

--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ This repository contains core libraries, test frameworks, engineering systems, p
 - **INSTALL**: [![Install Microsoft Sentinel Data Exploration MCP in VS Code](https://img.shields.io/badge/VS_Code-0098FF?style=flat-square&logo=visualstudiocode&logoColor=ffffff)](https://vscode.dev/redirect?url=vscode:mcp/install?%7B%22name%22%3A%22microsoft-sentinel-data-exploration%22%2C%22url%22%3A%22https%3A%2F%2Fsentinel.microsoft.com%2Fmcp%2Fdata-exploration%22%7D) [![Install Microsoft Sentinel Data Exploration MCP in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=ffffff)](https://vscode.dev/redirect?url=vscode-insiders:mcp/install?%7B%22name%22%3A%22microsoft-sentinel-data-exploration%22%2C%22url%22%3A%22https%3A%2F%2Fsentinel.microsoft.com%2Fmcp%2Fdata-exploration%22%7D)
 
 ### 🛢️ Microsoft SQL
-- **REPOSITORY**: [MSSQL MCP Server](https://aka.ms/MssqlMcp)
+- **REPOSITORY**: [MSSQL MCP Server](https://aka.ms/sql/mcp)
 - **DESCRIPTION**: Chat with your business data the new agentic way using natural language and AI. Connect to any SQL database—from ground (on-premises) to Azure cloud to Microsoft Fabric via a simple connection string. Discover and define table schemas, manage tables, and perform CRUD operations through conversational prompts.
 - **CATEGORY**: `DEVELOPER TOOLS`
 - **TYPE**: `Local`
-- **INSTALL**: [MSSQL MCP Server](https://aka.ms/MssqlMcp)
+- **INSTALL**: [MSSQL MCP Server](https://aka.ms/sql/mcp)
 
 ### 💬 Microsoft Teams
 - **REPOSITORY**: [bap-microsoft/MCP-Platform](https://github.com/bap-microsoft/MCP-Platform/tree/main/src/Services/WebApi/MCPServers/FirstParty/CodeBased/mcp_TeamsServer)

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.LiveTests/Azure.Mcp.Core.LiveTests.csproj
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.LiveTests/Azure.Mcp.Core.LiveTests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
+  <ProjectReference Include="..\..\src\Azure.Mcp.Core.csproj" />
     <ProjectReference Include="..\Azure.Mcp.Tests\Azure.Mcp.Tests.csproj" />
     <ProjectReference Include="..\..\..\..\servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />
   </ItemGroup>

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ServiceInfoCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ServiceInfoCommandTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Mcp.Core.Areas.Server.Commands;
+using Microsoft.Mcp.Core.Configuration;
+using Microsoft.Mcp.Tests.Client;
+using Xunit;
+
+namespace Azure.Mcp.Core.Tests.Areas.Server.Commands;
+
+public class ServiceInfoCommandTests : CommandUnitTestsBase<ServiceInfoCommand, object>
+{
+    private readonly McpServerConfiguration _mcpServerConfiguration;
+
+    public ServiceInfoCommandTests()
+    {
+        _mcpServerConfiguration = new McpServerConfiguration
+        {
+            Name = "Test-Name?",
+            ShortName = "test",
+            Version = "Test-Version?",
+            DisplayName = "Test Display",
+            Description = "Test Description",
+            RootCommandGroupName = "azmcp"
+        };
+        Services.AddSingleton(Microsoft.Extensions.Options.Options.Create(_mcpServerConfiguration));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsCorrectProperties()
+    {
+        var response = await ExecuteCommandAsync([]);
+
+        // Assert
+        var result = ValidateAndDeserializeResponse(response, ServiceInfoJsonContext.Default.ServiceInfoCommandResult);
+
+        Assert.Equal(_mcpServerConfiguration.Name, result.Name);
+        Assert.Equal(_mcpServerConfiguration.Version, result.Version);
+    }
+}

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/CommandFactoryHelpers.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/CommandFactoryHelpers.cs
@@ -111,8 +111,10 @@ internal class CommandFactoryHelpers
         var configurationOptions = Microsoft.Extensions.Options.Options.Create(new McpServerConfiguration
         {
             Name = "Test Server",
+            ShortName = "test",
             Version = "Test Version",
             DisplayName = "Test Display",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         });
         var telemetryService = services.GetService<ITelemetryService>() ?? new NoOpTelemetryService();

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategyTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/Discovery/ConsolidatedToolDiscoveryStrategyTests.cs
@@ -24,8 +24,10 @@ public class ConsolidatedToolDiscoveryStrategyTests
         var configurationOptions = Microsoft.Extensions.Options.Options.Create(new McpServerConfiguration
         {
             Name = "Test Server",
+            ShortName = "test",
             Version = "Test Version",
             DisplayName = "Test Display",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         });
 

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ServiceCollectionExtensionsTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ServiceCollectionExtensionsTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Mcp.Core.Areas.Server.Commands.Runtime;
 using Microsoft.Mcp.Core.Areas.Server.Commands.ServerInstructions;
 using Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
 using Microsoft.Mcp.Core.Areas.Server.Options;
+using Microsoft.Mcp.Core.Configuration;
 using Microsoft.Mcp.Core.Services.Azure.Authentication;
 using ModelContextProtocol.Server;
 using NSubstitute;
@@ -25,6 +26,19 @@ public class ServiceCollectionExtensionsTests
         services.AddSingleton(sp => CommandFactoryHelpers.CreateCommandFactory(sp));
         services.AddSingleIdentityTokenCredentialProvider();
         services.AddRegistryRoot(typeof(Azure.Mcp.Server.Program).Assembly, "Azure.Mcp.Server.Resources.registry.json");
+
+        var serverConfiguration = new McpServerConfiguration
+        {
+            Name = "Azure.Mcp.Server",
+            ShortName = "azure",
+            DisplayName = "Azure MCP Server",
+            Version = "1.0.0",
+            RootCommandGroupName = "azmcp",
+            Description = "Test description"
+        };
+        services.AddSingleton(serverConfiguration);
+        services.AddSingleton(Microsoft.Extensions.Options.Options.Create(serverConfiguration));
+
         return services;
     }
 

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ServiceInfoCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ServiceInfoCommandTests.cs
@@ -32,8 +32,10 @@ public class ServiceInfoCommandTests
         _mcpServerConfiguration = new McpServerConfiguration
         {
             Name = "Test-Name?",
+            ShortName = "test",
             Version = "Test-Version?",
             DisplayName = "Test Display",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         };
         _command = new(Microsoft.Extensions.Options.Options.Create(_mcpServerConfiguration), _logger);

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/PluginTelemetryCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/PluginTelemetryCommandTests.cs
@@ -46,7 +46,9 @@ public class PluginTelemetryCommandTests
         {
             RootCommandGroupName = "azmcp",
             Name = "Azure.Mcp.Server.Test",
+            ShortName = "azure",
             DisplayName = "Azure MCP Server (Test)",
+            Description = "Azure MCP Server (Test) description",
             Version = "1.0.0-test"
         }));
         services.AddSingleton<ITelemetryService>(Substitute.For<ITelemetryService>());

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/SingleProxyToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/SingleProxyToolLoaderTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Areas.Server.Commands.Discovery;
 using Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
 using Microsoft.Mcp.Core.Areas.Server.Options;
+using Microsoft.Mcp.Core.Configuration;
 using Microsoft.Mcp.Core.Helpers;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
@@ -19,6 +20,19 @@ namespace Azure.Mcp.Core.UnitTests.Areas.Server.Commands.ToolLoading;
 
 public class SingleProxyToolLoaderTests
 {
+    private static Microsoft.Extensions.Options.IOptions<McpServerConfiguration> CreateServerConfigurationOptions()
+    {
+        return Microsoft.Extensions.Options.Options.Create(new McpServerConfiguration
+        {
+            Name = "Azure.Mcp.Server",
+            ShortName = "azure",
+            DisplayName = "Azure MCP Server",
+            Version = "1.0.0",
+            RootCommandGroupName = "azmcp",
+            Description = "This server/tool provides real-time, programmatic access to all Azure products, services, and resources."
+        });
+    }
+
     private static RegistryDiscoveryStrategy CreateStrategy(ServiceStartOptions options, ILogger<RegistryDiscoveryStrategy> logger)
     {
         var serviceOptions = Microsoft.Extensions.Options.Options.Create(options ?? new ServiceStartOptions());
@@ -49,13 +63,13 @@ public class SingleProxyToolLoaderTests
                 commandGroupDiscoveryStrategy,
                 registryDiscoveryStrategy
             ], compositeLogger);
-            var toolLoader = new SingleProxyToolLoader(compositeDiscoveryStrategy, logger, Microsoft.Extensions.Options.Options.Create(toolLoaderOptions ?? new ToolLoaderOptions()));
+            var toolLoader = new SingleProxyToolLoader(compositeDiscoveryStrategy, logger, Microsoft.Extensions.Options.Options.Create(toolLoaderOptions ?? new ToolLoaderOptions()), CreateServerConfigurationOptions());
             return (toolLoader, compositeDiscoveryStrategy);
         }
         else
         {
             var mockDiscoveryStrategy = Substitute.For<IMcpDiscoveryStrategy>();
-            var toolLoader = new SingleProxyToolLoader(mockDiscoveryStrategy, logger, Microsoft.Extensions.Options.Options.Create(toolLoaderOptions ?? new ToolLoaderOptions()));
+            var toolLoader = new SingleProxyToolLoader(mockDiscoveryStrategy, logger, Microsoft.Extensions.Options.Options.Create(toolLoaderOptions ?? new ToolLoaderOptions()), CreateServerConfigurationOptions());
             return (toolLoader, mockDiscoveryStrategy);
         }
     }
@@ -285,7 +299,7 @@ public class SingleProxyToolLoaderTests
         var toolLoaderOptions = Microsoft.Extensions.Options.Options.Create(new ToolLoaderOptions() { ReadOnly = true });
         var logger = Substitute.For<ILogger<SingleProxyToolLoader>>();
 
-        var toolLoader = new SingleProxyToolLoader(discoveryStrategy, logger, toolLoaderOptions);
+        var toolLoader = new SingleProxyToolLoader(discoveryStrategy, logger, toolLoaderOptions, CreateServerConfigurationOptions());
         var request = CreateCallToolRequest("storage");
 
         // Act
@@ -339,7 +353,7 @@ public class SingleProxyToolLoaderTests
         var toolLoaderOptions = Microsoft.Extensions.Options.Options.Create(new ToolLoaderOptions() { IsHttpMode = true });
         var logger = Substitute.For<ILogger<SingleProxyToolLoader>>();
 
-        var toolLoader = new SingleProxyToolLoader(discoveryStrategy, logger, toolLoaderOptions);
+        var toolLoader = new SingleProxyToolLoader(discoveryStrategy, logger, toolLoaderOptions, CreateServerConfigurationOptions());
         var request = CreateCallToolRequest("storage");
 
         // Act
@@ -394,11 +408,13 @@ public class SingleProxyToolLoaderTests
         var logger = Substitute.For<ILogger<SingleProxyToolLoader>>();
         var discoveryStrategy = Substitute.For<IMcpDiscoveryStrategy>();
         var toolLoaderOptions = Microsoft.Extensions.Options.Options.Create(new ToolLoaderOptions());
+        var serverConfigurationOptions = CreateServerConfigurationOptions();
 
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new SingleProxyToolLoader(null!, logger, toolLoaderOptions));
-        Assert.Throws<ArgumentNullException>(() => new SingleProxyToolLoader(discoveryStrategy, null!, toolLoaderOptions));
-        Assert.Throws<ArgumentNullException>(() => new SingleProxyToolLoader(discoveryStrategy, logger, null!));
+        Assert.Throws<ArgumentNullException>(() => new SingleProxyToolLoader(null!, logger, toolLoaderOptions, serverConfigurationOptions));
+        Assert.Throws<ArgumentNullException>(() => new SingleProxyToolLoader(discoveryStrategy, null!, toolLoaderOptions, serverConfigurationOptions));
+        Assert.Throws<ArgumentNullException>(() => new SingleProxyToolLoader(discoveryStrategy, logger, null!, serverConfigurationOptions));
+        Assert.Throws<ArgumentNullException>(() => new SingleProxyToolLoader(discoveryStrategy, logger, toolLoaderOptions, null!));
     }
 
     #region Execution-Time Mode Enforcement Tests
@@ -413,7 +429,7 @@ public class SingleProxyToolLoaderTests
         var logger = Substitute.For<ILogger<SingleProxyToolLoader>>();
         var options = Microsoft.Extensions.Options.Options.Create(toolLoaderOptions);
 
-        return new SingleProxyToolLoader(discoveryStrategy, logger, options);
+        return new SingleProxyToolLoader(discoveryStrategy, logger, options, CreateServerConfigurationOptions());
     }
 
     private static ModelContextProtocol.Server.RequestContext<CallToolRequestParams> CreateCallToolRequestWithToolAndCommand(

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Tools/UnitTests/ToolsListCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Areas/Tools/UnitTests/ToolsListCommandTests.cs
@@ -399,8 +399,10 @@ public class ToolsListCommandTests
         var configurationOptions = Microsoft.Extensions.Options.Options.Create(new McpServerConfiguration
         {
             Name = "Test Server",
+            ShortName = "test",
             Version = "Test Version",
             DisplayName = "Test Display",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         });
 

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Commands/CommandFactoryTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.UnitTests/Commands/CommandFactoryTests.cs
@@ -35,8 +35,10 @@ public class CommandFactoryTests
         _serverConfiguration = new McpServerConfiguration
         {
             Name = "Test Server",
+            ShortName = "test",
             Version = "Test Version",
             DisplayName = "Test Display",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         };
 

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
@@ -270,14 +270,15 @@ public static partial class ServiceCollectionExtensions
             .Configure<IConfiguration, IOptions<ServiceStartOptions>>((options, rootConfiguration, serviceStartOptions) =>
             {
                 // Manually bind configuration values to avoid reflection-based binding for AOT compatibility
-                options.RootCommandGroupName = rootConfiguration[nameof(McpServerConfiguration.RootCommandGroupName)]
+                var mcpConfiguration = rootConfiguration.GetRequiredSection("MicrosoftMcp");
+                options.RootCommandGroupName = mcpConfiguration[nameof(McpServerConfiguration.RootCommandGroupName)]
                     ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.RootCommandGroupName)}' is required.");
-                options.Name = rootConfiguration[nameof(McpServerConfiguration.Name)]
+                options.Name = mcpConfiguration[nameof(McpServerConfiguration.Name)]
                     ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.Name)}' is required.");
-                options.DisplayName = rootConfiguration[nameof(McpServerConfiguration.DisplayName)]
+                options.DisplayName = mcpConfiguration[nameof(McpServerConfiguration.DisplayName)]
                     ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.DisplayName)}' is required.");
 
-                options.ShortName = rootConfiguration[nameof(McpServerConfiguration.ShortName)]
+                options.ShortName = mcpConfiguration[nameof(McpServerConfiguration.ShortName)]
                     ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.ShortName)}' is required.");
                 options.ShortName = options.ShortName.Trim();
                 if (!ShortNamePattern().IsMatch(options.ShortName))
@@ -286,7 +287,7 @@ public static partial class ServiceCollectionExtensions
                         $"Configuration value '{nameof(McpServerConfiguration.ShortName)}' must contain only letters, digits, '_', or '-'.");
                 }
 
-                options.Description = rootConfiguration[nameof(McpServerConfiguration.Description)]
+                options.Description = mcpConfiguration[nameof(McpServerConfiguration.Description)]
                     ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.Description)}' is required.");
                 if (string.IsNullOrWhiteSpace(options.Description))
                 {

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -26,8 +27,11 @@ using Options = Microsoft.Extensions.Options.Options;
 /// <summary>
 /// Extension methods for configuring Azure MCP server services.
 /// </summary>
-public static class ServiceCollectionExtensions
+public static partial class ServiceCollectionExtensions
 {
+    [GeneratedRegex("^[A-Za-z0-9_-]+$")]
+    private static partial Regex ShortNamePattern();
+
     /// <summary>
     /// Adds the Azure MCP server services to the specified <see cref="IServiceCollection"/>.
     /// </summary>
@@ -272,6 +276,23 @@ public static class ServiceCollectionExtensions
                     ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.Name)}' is required.");
                 options.DisplayName = rootConfiguration[nameof(McpServerConfiguration.DisplayName)]
                     ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.DisplayName)}' is required.");
+
+                options.ShortName = rootConfiguration[nameof(McpServerConfiguration.ShortName)]
+                    ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.ShortName)}' is required.");
+                options.ShortName = options.ShortName.Trim();
+                if (!ShortNamePattern().IsMatch(options.ShortName))
+                {
+                    throw new InvalidOperationException(
+                        $"Configuration value '{nameof(McpServerConfiguration.ShortName)}' must contain only letters, digits, '_', or '-'.");
+                }
+
+                options.Description = rootConfiguration[nameof(McpServerConfiguration.Description)]
+                    ?? throw new InvalidOperationException($"Configuration value '{nameof(McpServerConfiguration.Description)}' is required.");
+                if (string.IsNullOrWhiteSpace(options.Description))
+                {
+                    throw new InvalidOperationException(
+                        $"Configuration value '{nameof(McpServerConfiguration.Description)}' must not be empty or whitespace.");
+                }
 
                 // Assembly.GetEntryAssembly is used to retrieve the version of the server application as that is
                 // the assembly that will run the tool calls.

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/SingleProxyToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/SingleProxyToolLoader.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Mcp.Core.Areas.Server.Commands.Discovery;
 using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Configuration;
 using ModelContextProtocol;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
@@ -16,13 +17,19 @@ namespace Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
 public sealed class SingleProxyToolLoader(
     IMcpDiscoveryStrategy discoveryStrategy,
     ILogger<SingleProxyToolLoader> logger,
-    IOptions<ToolLoaderOptions> options) : BaseToolLoader(logger)
+    IOptions<ToolLoaderOptions> options,
+    IOptions<McpServerConfiguration> serverConfiguration) : BaseToolLoader(logger)
 {
     private readonly IMcpDiscoveryStrategy _discoveryStrategy = discoveryStrategy ?? throw new ArgumentNullException(nameof(discoveryStrategy));
+    private readonly IOptions<ToolLoaderOptions> _options = options ?? throw new ArgumentNullException(nameof(options));
+    private readonly string _toolName = serverConfiguration?.Value.ShortName ?? throw new ArgumentNullException(nameof(serverConfiguration));
+    private readonly string _toolDescription = serverConfiguration!.Value.Description;
+    private readonly string _displayName = serverConfiguration!.Value.DisplayName;
+    private readonly JsonElement _toolSchema = BuildToolSchema(serverConfiguration!.Value.ShortName);
+
     private string? _cachedRootToolsJson;
     private readonly ConcurrentDictionary<string, string> _cachedToolListsJson = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, IList<McpClientTool>> _cachedAllToolLists = new(StringComparer.OrdinalIgnoreCase);
-    private readonly IOptions<ToolLoaderOptions> _options = options ?? throw new ArgumentNullException(nameof(options));
 
     private const string ToolCallProxySchema = """
         {
@@ -41,36 +48,41 @@ public sealed class SingleProxyToolLoader(
         }
         """;
 
-    private static readonly JsonElement ToolSchema = JsonSerializer.Deserialize("""
-        {
-          "type": "object",
-          "properties": {
-            "intent": {
-              "type": "string",
-              "description": "The intent of the azure operation to perform."
-            },
-            "tool": {
-              "type": "string",
-              "description": "The azure tool to use to execute the operation."
-            },
-            "command": {
-              "type": "string",
-              "description": "The command to execute against the specified tool."
-            },
-            "parameters": {
+    private static JsonElement BuildToolSchema(string toolName)
+    {
+        var schemaJson = $$"""
+            {
               "type": "object",
-              "description": "The parameters to pass to the tool command."
-            },
-            "learn": {
-              "type": "boolean",
-              "description": "To learn about the tool and its supported child tools and parameters.",
-              "default": false
+              "properties": {
+                "intent": {
+                  "type": "string",
+                  "description": "The intent of the {{toolName}} operation to perform."
+                },
+                "tool": {
+                  "type": "string",
+                  "description": "The {{toolName}} tool to use to execute the operation."
+                },
+                "command": {
+                  "type": "string",
+                  "description": "The command to execute against the specified tool."
+                },
+                "parameters": {
+                  "type": "object",
+                  "description": "The parameters to pass to the tool command."
+                },
+                "learn": {
+                  "type": "boolean",
+                  "description": "To learn about the tool and its supported child tools and parameters.",
+                  "default": false
+                }
+              },
+              "required": ["intent"],
+              "additionalProperties": false
             }
-          },
-          "required": ["intent"],
-          "additionalProperties": false
-        }
-        """, ServerJsonContext.Default.JsonElement);
+            """;
+
+        return JsonSerializer.Deserialize(schemaJson, ServerJsonContext.Default.JsonElement);
+    }
 
     public override ValueTask<ListToolsResult> ListToolsHandler(RequestContext<ListToolsRequestParams> request, CancellationToken cancellationToken)
     {
@@ -80,19 +92,10 @@ public sealed class SingleProxyToolLoader(
             [
                 new()
                 {
-                    Name = "azure",
-                    Description = """
-                        This server/tool provides real-time, programmatic access to all Azure products, services, and resources,
-                        as well as all interactions with the Azure Developer CLI (azd).
-                        Use this tool for any Azure control plane or data plane operation, including resource management and automation.
-                        To discover available capabilities, call the tool with the "learn" parameter to get a list of top-level tools.
-                        To explore further, set "learn" and specify a tool name to retrieve supported commands and their parameters.
-                        To execute an action, set the "tool", "command", and convert the users intent into the "parameters" based on the discovered schema.
-                        Always use this tool for any Azure or "azd" related operation requiring up-to-date, dynamic, and interactive capabilities.
-                        Always include the "intent" parameter to specify the operation you want to perform.
-                        """,
+                    Name = _toolName,
+                    Description = _toolDescription,
                     Annotations = new ToolAnnotations(),
-                    InputSchema = ToolSchema,
+                    InputSchema = _toolSchema,
                 }
             ],
         };
@@ -101,7 +104,7 @@ public sealed class SingleProxyToolLoader(
     }
 
     /// <summary>
-    /// Handles invocation of the Azure proxy tool, routing requests to the correct Azure tool or command.
+    /// Handles invocation of the proxy tool, routing requests to the correct tool or command.
     /// </summary>
     /// <param name="request">The request context containing parameters and metadata.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
@@ -436,7 +439,7 @@ public sealed class SingleProxyToolLoader(
 
     private async Task<string?> GetToolNameFromIntentAsync(RequestContext<CallToolRequestParams> request, string intent, string toolsJson, CancellationToken cancellationToken)
     {
-        await NotifyProgressAsync(request, "Learning about Azure capabilities...", cancellationToken);
+        await NotifyProgressAsync(request, $"Learning about {_displayName} capabilities...", cancellationToken);
 
         var samplingRequest = new CreateMessageRequestParams
         {
@@ -447,7 +450,7 @@ public sealed class SingleProxyToolLoader(
                     Role = Role.Assistant,
                     Content = [new TextContentBlock{
                         Text = $"""
-                            The following is a list of available tools for the Azure server.
+                            The following is a list of available tools for the {_displayName}.
 
                             Your task:
                             - Select a single tool that best matches the user's intent and return the name of the tool.

--- a/core/Microsoft.Mcp.Core/src/Configuration/McpServerConfiguration.cs
+++ b/core/Microsoft.Mcp.Core/src/Configuration/McpServerConfiguration.cs
@@ -19,6 +19,12 @@ public class McpServerConfiguration
     public required string Name { get; set; }
 
     /// <summary>
+    /// A short identifier for the MCP server (i.e. "azure", "fabric").
+    /// Used, for example, as the tool name when the server runs in single tool proxy mode.
+    /// </summary>
+    public required string ShortName { get; set; }
+
+    /// <summary>
     /// The display name of the MCP server.
     /// </summary>
     public required string DisplayName { get; set; }
@@ -27,6 +33,11 @@ public class McpServerConfiguration
     /// The version of the MCP server.
     /// </summary>
     public required string Version { get; set; }
+
+    /// <summary>
+    /// A description of the MCP server. Used, for example, as the tool description when the server runs in single tool proxy mode.
+    /// </summary>
+    public required string Description { get; set; }
 
     /// <summary>
     /// Indicates whether telemetry is enabled for the MCP server.  By default, it is set to true.

--- a/core/Microsoft.Mcp.Core/src/Microsoft.Mcp.Core.csproj
+++ b/core/Microsoft.Mcp.Core/src/Microsoft.Mcp.Core.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="Azure.ResourceManager" />
     <PackageReference Include="Azure.ResourceManager.ResourceGraph" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
@@ -29,6 +30,7 @@
     <PackageReference Include="ModelContextProtocol.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.UnitTests/Services/Telemetry/TelemetryServiceTests.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.UnitTests/Services/Telemetry/TelemetryServiceTests.cs
@@ -24,9 +24,11 @@ public class TelemetryServiceTests
     private readonly McpServerConfiguration _testConfiguration = new()
     {
         Name = "TestService",
+        ShortName = "test",
         Version = "1.0.0",
         IsTelemetryEnabled = true,
         DisplayName = "Test Display",
+        Description = "Test Description",
         RootCommandGroupName = "azmcp"
     };
     private readonly IOptions<McpServerConfiguration> _mockOptions;
@@ -159,9 +161,11 @@ public class TelemetryServiceTests
         var configuration = new McpServerConfiguration
         {
             Name = "TestService",
+            ShortName = "test",
             Version = "1.0.0",
             IsTelemetryEnabled = true,
             DisplayName = "Test Display",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         };
 
@@ -191,9 +195,11 @@ public class TelemetryServiceTests
         var configuration = new McpServerConfiguration
         {
             Name = "TestService",
+            ShortName = "test",
             Version = "1.0.0",
             IsTelemetryEnabled = true,
             DisplayName = "Test Display",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         };
 
@@ -224,9 +230,11 @@ public class TelemetryServiceTests
         var configuration = new McpServerConfiguration
         {
             Name = "TestService",
+            ShortName = "test",
             Version = "1.0.0",
             IsTelemetryEnabled = true,
             DisplayName = "Test Display",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         };
 
@@ -263,9 +271,11 @@ public class TelemetryServiceTests
         var configuration = new McpServerConfiguration
         {
             Name = "TestService",
+            ShortName = "test",
             Version = "1.0.0",
             IsTelemetryEnabled = true,
             DisplayName = "Test Display",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         };
         var operationName = "an-activity-id";
@@ -297,9 +307,11 @@ public class TelemetryServiceTests
         var configuration = new McpServerConfiguration
         {
             Name = "TestService",
+            ShortName = "test",
             Version = "1.0.0",
             IsTelemetryEnabled = true,
             DisplayName = "Test Display",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         };
 
@@ -342,9 +354,11 @@ public class TelemetryServiceTests
         var configuration = new McpServerConfiguration
         {
             Name = "TestService",
+            ShortName = "test",
             Version = "1.0.0",
             IsTelemetryEnabled = true,
             DisplayName = "Test Display",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         };
         var operationName = "an-activity-id";
@@ -385,9 +399,11 @@ public class TelemetryServiceTests
         var configuration = new McpServerConfiguration
         {
             Name = "TestService",
+            ShortName = "test",
             Version = "1.0.0",
             IsTelemetryEnabled = true,
             DisplayName = "Test Display",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         };
         var operationName = "an-activity-id";
@@ -449,9 +465,11 @@ public class TelemetryServiceTests
         var configuration = new McpServerConfiguration
         {
             Name = "TestService",
+            ShortName = "test",
             Version = "1.0.0",
             IsTelemetryEnabled = true,
             DisplayName = "Test Display",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         };
         var operationName = "an-activity-id";

--- a/servers/Azure.Mcp.Server/changelog-entries/1780345675706.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1780345675706.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Breaking Changes"
+    description: "Changed appsetting.json property names to be scope to MicrosoftMcp instead of direct property names."

--- a/servers/Azure.Mcp.Server/src/appsettings.json
+++ b/servers/Azure.Mcp.Server/src/appsettings.json
@@ -1,5 +1,7 @@
 ﻿{
     "RootCommandGroupName": "azmcp",
     "Name": "Azure.Mcp.Server",
-    "DisplayName": "Azure MCP Server"
+    "ShortName": "azure",
+    "DisplayName": "Azure MCP Server",
+    "Description": "This server/tool provides real-time, programmatic access to all Azure products, services, and resources, as well as all interactions with the Azure Developer CLI (azd). Use this tool for any Azure control plane or data plane operation, including resource management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Azure or \"azd\" related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
 }

--- a/servers/Azure.Mcp.Server/src/appsettings.json
+++ b/servers/Azure.Mcp.Server/src/appsettings.json
@@ -1,7 +1,9 @@
 ﻿{
-    "RootCommandGroupName": "azmcp",
-    "Name": "Azure.Mcp.Server",
-    "ShortName": "azure",
-    "DisplayName": "Azure MCP Server",
-    "Description": "This server/tool provides real-time, programmatic access to all Azure products, services, and resources, as well as all interactions with the Azure Developer CLI (azd). Use this tool for any Azure control plane or data plane operation, including resource management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Azure or \"azd\" related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
+    "MicrosoftMcp": {
+        "RootCommandGroupName": "azmcp",
+        "Name": "Azure.Mcp.Server",
+        "ShortName": "azure",
+        "DisplayName": "Azure MCP Server",
+        "Description": "This server/tool provides real-time, programmatic access to all Azure products, services, and resources, as well as all interactions with the Azure Developer CLI (azd). Use this tool for any Azure control plane or data plane operation, including resource management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Azure or \"azd\" related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
+    }
 }

--- a/servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.UnitTests/Infrastructure/VisualStudioToolNameTests.cs
+++ b/servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.UnitTests/Infrastructure/VisualStudioToolNameTests.cs
@@ -60,8 +60,10 @@ public sealed class VisualStudioToolNameTests
         var configurationOptions = Options.Create(new McpServerConfiguration
         {
             Name = "Test Server",
+            ShortName = "test",
             Version = "1.0",
             DisplayName = "Test",
+            Description = "Test Description",
             RootCommandGroupName = "azmcp"
         });
 

--- a/servers/Fabric.Mcp.Server/changelog-entries/1780345683191.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1780345683191.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Breaking Changes"
+    description: "Changed appsetting.json property names to be scope to MicrosoftMcp instead of direct property names."

--- a/servers/Fabric.Mcp.Server/src/appsettings.json
+++ b/servers/Fabric.Mcp.Server/src/appsettings.json
@@ -1,5 +1,7 @@
 ﻿{
     "RootCommandGroupName": "fabmcp",
     "Name": "Fabric.Mcp.Server",
-    "DisplayName": "Fabric MCP Server"
+    "ShortName": "fabric",
+    "DisplayName": "Fabric MCP Server",
+    "Description": "This server/tool provides real-time, programmatic access to all Microsoft Fabric workspaces, items, and data platform capabilities. Use this tool for any Microsoft Fabric operation, including workspace, item, and data platform management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Microsoft Fabric related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
 }

--- a/servers/Fabric.Mcp.Server/src/appsettings.json
+++ b/servers/Fabric.Mcp.Server/src/appsettings.json
@@ -1,7 +1,9 @@
 ﻿{
-    "RootCommandGroupName": "fabmcp",
-    "Name": "Fabric.Mcp.Server",
-    "ShortName": "fabric",
-    "DisplayName": "Fabric MCP Server",
-    "Description": "This server/tool provides real-time, programmatic access to all Microsoft Fabric workspaces, items, and data platform capabilities. Use this tool for any Microsoft Fabric operation, including workspace, item, and data platform management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Microsoft Fabric related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
+    "MicrosoftMcp": {
+        "RootCommandGroupName": "fabmcp",
+        "Name": "Fabric.Mcp.Server",
+        "ShortName": "fabric",
+        "DisplayName": "Fabric MCP Server",
+        "Description": "This server/tool provides real-time, programmatic access to all Microsoft Fabric workspaces, items, and data platform capabilities. Use this tool for any Microsoft Fabric operation, including workspace, item, and data platform management and automation. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always use this tool for any Microsoft Fabric related operation requiring up-to-date, dynamic, and interactive capabilities. Always include the \"intent\" parameter to specify the operation you want to perform."
+    }
 }

--- a/servers/Template.Mcp.Server/src/appsettings.json
+++ b/servers/Template.Mcp.Server/src/appsettings.json
@@ -1,7 +1,9 @@
 ﻿{
-    "RootCommandGroupName": "mcptmp",
-    "Name": "Template.Mcp.Server",
-    "ShortName": "template",
-    "DisplayName": "Template MCP Server",
-    "Description": "This server/tool provides real-time, programmatic access to the Template MCP Server capabilities. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always include the \"intent\" parameter to specify the operation you want to perform."
+    "MicrosoftMcp": {
+        "RootCommandGroupName": "mcptmp",
+        "Name": "Template.Mcp.Server",
+        "ShortName": "template",
+        "DisplayName": "Template MCP Server",
+        "Description": "This server/tool provides real-time, programmatic access to the Template MCP Server capabilities. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always include the \"intent\" parameter to specify the operation you want to perform."
+    }
 }

--- a/servers/Template.Mcp.Server/src/appsettings.json
+++ b/servers/Template.Mcp.Server/src/appsettings.json
@@ -1,5 +1,7 @@
 ﻿{
     "RootCommandGroupName": "mcptmp",
     "Name": "Template.Mcp.Server",
-    "DisplayName": "Template MCP Server"
+    "ShortName": "template",
+    "DisplayName": "Template MCP Server",
+    "Description": "This server/tool provides real-time, programmatic access to the Template MCP Server capabilities. To discover available capabilities, call the tool with the \"learn\" parameter to get a list of top-level tools. To explore further, set \"learn\" and specify a tool name to retrieve supported commands and their parameters. To execute an action, set the \"tool\", \"command\", and convert the user's intent into the \"parameters\" based on the discovered schema. Always include the \"intent\" parameter to specify the operation you want to perform."
 }

--- a/tools/Azure.Mcp.Tools.Monitor/src/Instrumentation/Resources/concepts/dotnet/azure-monitor-distro.md
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Instrumentation/Resources/concepts/dotnet/azure-monitor-distro.md
@@ -83,7 +83,7 @@ builder.Services.AddOpenTelemetry().UseAzureMonitor(options =>
 ## Package Reference
 
 ```xml
-<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
+<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
 ```
 
 ## When to Use

--- a/tools/Azure.Mcp.Tools.Monitor/src/Instrumentation/Resources/examples/dotnet/aspnetcore-distro-setup.md
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Instrumentation/Resources/examples/dotnet/aspnetcore-distro-setup.md
@@ -23,7 +23,7 @@ dotnet add package Azure.Monitor.OpenTelemetry.AspNetCore
 Or in `.csproj`:
 
 ```xml
-<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
+<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
 ```
 
 ## Step 2: Configure in Program.cs


### PR DESCRIPTION
## What does this PR do?

Backports a few fixes to Fabric MCP server

- Fix server configuration settings to use `MicrosoftMcp` prefix to differentiate them from generic property name usage such as `Name`, `DisplayName`, etc.
- Fix tool description when running in `--mode single` to allow each server to supply their description using `appsettings.json`.
- Update dependency versions to resolve CVEs.
- Fix broken AKA links.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
