### PR TITLE
Fix Cosmos' `QueryItems` silently parsing non-success responses as data

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1780624204134.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1780624204134.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed an issue where the Cosmos DB QueryItems operation silently parsed non-success (e.g. throttled or auth-failure) responses as data. The response is now validated before parsing so failures surface as errors."

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
@@ -288,6 +288,8 @@ public sealed class CosmosService(ISubscriptionService subscriptionService, ITen
         while (queryIterator.HasMoreResults)
         {
             using ResponseMessage response = await queryIterator.ReadNextAsync(cancellationToken);
+            response.EnsureSuccessStatusCode();
+
             using var document = JsonDocument.Parse(response.Content);
             items.Add(document.RootElement.Clone());
         }

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosServiceTests.cs
@@ -195,6 +195,31 @@ public class CosmosServiceTests : IAsyncDisposable
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task QueryItems_NonSuccessResponse_Throws()
+    {
+        // Arrange: route the CosmosClient's transport through the mocked IHttpClientFactory it always returns 403.
+        var handler = new MockHttpHandler(HttpStatusCode.Forbidden);
+        _httpClientFactory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(handler));
+        var clientOptions = new CosmosClientOptions { HttpClientFactory = () => _httpClientFactory.CreateClient() };
+
+        var credential = Substitute.For<TokenCredential>();
+        var token = new AccessToken("fake-token", DateTimeOffset.UtcNow.AddHours(1));
+        credential.GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<AccessToken>(token));
+        credential.GetToken(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(token);
+
+        using var cosmosClient = new CosmosClient("https://myaccount.documents.azure.com", credential, clientOptions);
+
+        _cacheService.GetAsync<CosmosClient>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(cosmosClient);
+
+        // Act & Assert: a non-success response must throw rather than being returned as a data item
+        await Assert.ThrowsAnyAsync<CosmosException>(() =>
+            _service.QueryItems("myaccount", "mydb", "mycontainer", "SELECT * FROM c", "sub123", AuthMethod.Key, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
     private sealed class MockHttpHandler(HttpStatusCode statusCode) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosServiceTests.cs
@@ -198,7 +198,7 @@ public class CosmosServiceTests : IAsyncDisposable
     [Fact]
     public async Task QueryItems_NonSuccessResponse_Throws()
     {
-        // Arrange: route the CosmosClient's transport through the mocked IHttpClientFactory it always returns 403.
+        // Arrange: route the CosmosClient's transport through the mocked IHttpClientFactory so it always returns 403.
         var handler = new MockHttpHandler(HttpStatusCode.Forbidden);
         _httpClientFactory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(handler));
         var clientOptions = new CosmosClientOptions { HttpClientFactory = () => _httpClientFactory.CreateClient() };


### PR DESCRIPTION
## What does this PR do?

`CosmosService.QueryItems` read each page from the query stream iterator (`Container.GetItemQueryStreamIterator`, a `FeedIterator`) and parsed `ResponseMessage.Content` without first checking the HTTP status. The stream iterator surfaces non-success responses (throttled `429`, auth-failure `403`, unavailable `503`) as a non-success `ResponseMessage` rather than throwing, so the error JSON body was silently cloned into the result set and returned to the caller as if it were data.

The fix adds a `response.EnsureSuccessStatusCode();` guard immediately after `ReadNextAsync` and before `JsonDocument.Parse`, so a non-success page throws a `CosmosException` instead of being parsed as data. This matches the existing convention already used by `ListDatabases` and `ListContainers` in the same file, which guard their stream responses the same way.

## GitHub issue number?

Fixes [#432](https://github.com/microsoft/mcp-pr/issues/432)

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description

    > N/A - internal data-correctness bug fix. No tool was added, renamed, or had its description, name, or options changed, so the tool-surface, README, `consolidated-tools.json`, and `ToolDescriptionEvaluator` items do not apply.
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)

    > N/A - no command surface or metadata changed.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.