### PR TITLE
Fix misleading error log in Cosmos list command

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1780624333026.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1780624333026.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed misleading error log in the Cosmos DB list command that referenced an unbound ResourceGroup value."

--- a/servers/Azure.Mcp.Server/changelog-entries/1780624333026.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1780624333026.yaml
@@ -1,3 +1,3 @@
 changes:
   - section: "Bugs Fixed"
-    description: "Fixed misleading error log in the Cosmos DB list command that referenced an unbound ResourceGroup value."
+    description: "Replaced misleading error logging in CosmosListCommand, removing the always-null ResourceGroup field and adding non-sensitive diagnostic context (Subscription, Account, Database) consistent with MySqlListCommand and PostgresListCommand."

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CosmosListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CosmosListCommand.cs
@@ -112,7 +112,7 @@ public sealed class CosmosListCommand(ILogger<CosmosListCommand> logger, ICosmos
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error in {Operation}. Account: {Account}, ResourceGroup: {ResourceGroup}.", Name, options.Account, options.ResourceGroup);
+            _logger.LogError(ex, "Error in {Operation}. Account: {Account}.", Name, options.Account);
             HandleException(context, ex);
         }
 

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CosmosListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CosmosListCommand.cs
@@ -112,7 +112,7 @@ public sealed class CosmosListCommand(ILogger<CosmosListCommand> logger, ICosmos
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error in {Operation}. Account: {Account}.", Name, options.Account);
+            _logger.LogError(ex, "Error in {Operation}. Subscription: {Subscription}, Account: {Account}, Database: {Database}.", Name, options.Subscription, options.Account, options.Database);
             HandleException(context, ex);
         }
 


### PR DESCRIPTION
## What does this PR do?

The `CosmosListCommand` error log included a `ResourceGroup` token, but `cosmos list` never binds a resource group, so that value was always null and misleading when diagnosing failures.

This aligns the error log with the non-sensitive diagnostic logging convention established in #2393 (mysql/postgres). Rather than trimming the log to a single field, it drops the always-null `ResourceGroup` token and retains the rich, non-sensitive diagnostic context that is actually bound by `cosmos list`:

```diff
- _logger.LogError(ex, "Error in {Operation}. Account: {Account}, ResourceGroup: {ResourceGroup}.", Name, options.Account, options.ResourceGroup);
+ _logger.LogError(ex, "Error in {Operation}. Subscription: {Subscription}, Account: {Account}, Database: {Database}.", Name, options.Subscription, options.Account, options.Database);
```

## GitHub issue number?

Fixes #439

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages
    - [x] Added comprehensive tests for new/modified functionality (N/A - log-string fix, no behavior change)
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies
- [ ] For MCP tool changes: N/A - no tool added, removed, or renamed; no tool description or behavior change

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.