### PR TITLE
Fix Cosmos DB cache keys to include subscription, tenant, and auth method

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1780623890060.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1780623890060.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed Cosmos DB cache keys to include subscription, tenant, and authentication method."

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
@@ -127,7 +127,7 @@ public sealed class CosmosService(ISubscriptionService subscriptionService, ITen
     {
         ValidateRequiredParameters((nameof(accountName), accountName), (nameof(subscription), subscription));
 
-        var key = CacheKeyBuilder.Build(CosmosClientsCacheKeyPrefix, accountName, authMethod.ToString());
+        var key = CacheKeyBuilder.Build(CosmosClientsCacheKeyPrefix, accountName, subscription, tenant ?? string.Empty, authMethod.ToString());
         var cosmosClient = await _cacheService.GetAsync<CosmosClient>(CacheGroup, key, s_cacheDurationClients, cancellationToken);
         if (cosmosClient != null)
             return cosmosClient;
@@ -171,7 +171,7 @@ public sealed class CosmosService(ISubscriptionService subscriptionService, ITen
     {
         ValidateRequiredParameters((nameof(accountName), accountName), (nameof(subscription), subscription));
 
-        var cacheKey = CacheKeyBuilder.Build(CosmosDatabasesCacheKeyPrefix, accountName);
+        var cacheKey = CacheKeyBuilder.Build(CosmosDatabasesCacheKeyPrefix, accountName, subscription, tenant ?? string.Empty, authMethod.ToString());
 
         var cachedDatabases = await _cacheService.GetAsync<List<string>>(CacheGroup, cacheKey, s_cacheDurationResources, cancellationToken);
         if (cachedDatabases != null)
@@ -217,7 +217,7 @@ public sealed class CosmosService(ISubscriptionService subscriptionService, ITen
     {
         ValidateRequiredParameters((nameof(accountName), accountName), (nameof(databaseName), databaseName), (nameof(subscription), subscription));
 
-        var cacheKey = CacheKeyBuilder.Build(CosmosContainersCacheKeyPrefix, accountName, databaseName);
+        var cacheKey = CacheKeyBuilder.Build(CosmosContainersCacheKeyPrefix, accountName, databaseName, subscription, tenant ?? string.Empty, authMethod.ToString());
 
         var cachedContainers = await _cacheService.GetAsync<List<string>>(CacheGroup, cacheKey, s_cacheDurationResources, cancellationToken);
         if (cachedContainers != null)

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosServiceTests.cs
@@ -119,14 +119,14 @@ public class CosmosServiceTests : IAsyncDisposable
         // Assert: cache was queried with the credential-specific key
         await _cacheService.Received().GetAsync<CosmosClient>(
             "cosmos",
-            CacheKeyBuilder.Build("clients", "myaccount", "Credential"),
+            CacheKeyBuilder.Build("clients", "myaccount", "sub123", string.Empty, "Credential"),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
 
         // Assert: the key-auth cache key was NOT queried (no cross-contamination)
         await _cacheService.DidNotReceive().GetAsync<CosmosClient>(
             "cosmos",
-            CacheKeyBuilder.Build("clients", "myaccount", "Key"),
+            CacheKeyBuilder.Build("clients", "myaccount", "sub123", string.Empty, "Key"),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
     }
@@ -147,14 +147,14 @@ public class CosmosServiceTests : IAsyncDisposable
         // Assert: cache was queried with the key-auth-specific key
         await _cacheService.Received().GetAsync<CosmosClient>(
             "cosmos",
-            CacheKeyBuilder.Build("clients", "myaccount", "Key"),
+            CacheKeyBuilder.Build("clients", "myaccount", "sub123", string.Empty, "Key"),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
 
         // Assert: the credential cache key was NOT queried (no cross-contamination)
         await _cacheService.DidNotReceive().GetAsync<CosmosClient>(
             "cosmos",
-            CacheKeyBuilder.Build("clients", "myaccount", "Credential"),
+            CacheKeyBuilder.Build("clients", "myaccount", "sub123", string.Empty, "Credential"),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
     }
@@ -180,17 +180,173 @@ public class CosmosServiceTests : IAsyncDisposable
         await Assert.ThrowsAnyAsync<Exception>(() =>
             _service.ListDatabases("myaccount", "sub123", AuthMethod.Key, cancellationToken: TestContext.Current.CancellationToken));
 
-        // Assert: the Key request queries "clients_myaccount_Key", NOT "clients_myaccount_Credential"
+        // Assert: the Key request queries the key-auth client key, NOT the credential client key
         // This proves a Key-cached client can never be served to a Credential request and vice versa.
         await _cacheService.Received().GetAsync<CosmosClient>(
             "cosmos",
-            CacheKeyBuilder.Build("clients", "myaccount", "Key"),
+            CacheKeyBuilder.Build("clients", "myaccount", "sub123", string.Empty, "Key"),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
 
         await _cacheService.DidNotReceive().GetAsync<CosmosClient>(
             "cosmos",
-            CacheKeyBuilder.Build("clients", "myaccount", "Credential"),
+            CacheKeyBuilder.Build("clients", "myaccount", "sub123", string.Empty, "Credential"),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetCosmosClientAsync_SameAccountAndAuth_DifferentSubscriptions_UseSeparateCacheKeys()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.Unauthorized);
+        _httpClientFactory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(handler));
+
+        _cacheService.GetAsync<CosmosClient>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(default(CosmosClient));
+        _cacheService.GetAsync<List<string>>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(default(List<string>));
+
+        // Act: same account and auth method, but two different subscriptions
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            _service.ListDatabases("myaccount", "sub-A", AuthMethod.Credential, cancellationToken: TestContext.Current.CancellationToken));
+
+        _cacheService.ClearReceivedCalls();
+
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            _service.ListDatabases("myaccount", "sub-B", AuthMethod.Credential, cancellationToken: TestContext.Current.CancellationToken));
+
+        // Assert: the second subscription queries its own client key, never sub-A's cached client
+        await _cacheService.Received().GetAsync<CosmosClient>(
+            "cosmos",
+            CacheKeyBuilder.Build("clients", "myaccount", "sub-B", string.Empty, "Credential"),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await _cacheService.DidNotReceive().GetAsync<CosmosClient>(
+            "cosmos",
+            CacheKeyBuilder.Build("clients", "myaccount", "sub-A", string.Empty, "Credential"),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetCosmosClientAsync_SameAccountAndAuth_DifferentTenants_UseSeparateCacheKeys()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.Unauthorized);
+        _httpClientFactory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(handler));
+
+        _cacheService.GetAsync<CosmosClient>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(default(CosmosClient));
+        _cacheService.GetAsync<List<string>>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(default(List<string>));
+
+        // Act: same account, subscription, and auth method, but two different tenants
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            _service.ListDatabases("myaccount", "sub123", AuthMethod.Credential, "tenant-A", cancellationToken: TestContext.Current.CancellationToken));
+
+        _cacheService.ClearReceivedCalls();
+
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            _service.ListDatabases("myaccount", "sub123", AuthMethod.Credential, "tenant-B", cancellationToken: TestContext.Current.CancellationToken));
+
+        // Assert: tenant-B queries its own client key, never tenant-A's cached client
+        await _cacheService.Received().GetAsync<CosmosClient>(
+            "cosmos",
+            CacheKeyBuilder.Build("clients", "myaccount", "sub123", "tenant-B", "Credential"),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await _cacheService.DidNotReceive().GetAsync<CosmosClient>(
+            "cosmos",
+            CacheKeyBuilder.Build("clients", "myaccount", "sub123", "tenant-A", "Credential"),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListDatabases_DifferentSubscriptionTenantOrAuth_UseSeparateCacheKeys()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.Unauthorized);
+        _httpClientFactory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(handler));
+
+        _cacheService.GetAsync<CosmosClient>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(default(CosmosClient));
+        _cacheService.GetAsync<List<string>>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(default(List<string>));
+
+        // Act: first caller for account "myaccount" on sub-A / tenant-A via Credential
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            _service.ListDatabases("myaccount", "sub-A", AuthMethod.Credential, "tenant-A", cancellationToken: TestContext.Current.CancellationToken));
+
+        // Assert: the database-list cache key is scoped to subscription, tenant, and auth method
+        await _cacheService.Received().GetAsync<List<string>>(
+            "cosmos",
+            CacheKeyBuilder.Build("databases", "myaccount", "sub-A", "tenant-A", "Credential"),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        _cacheService.ClearReceivedCalls();
+
+        // Act: a different caller for the SAME account but different sub/tenant/auth
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            _service.ListDatabases("myaccount", "sub-B", AuthMethod.Key, "tenant-B", cancellationToken: TestContext.Current.CancellationToken));
+
+        // Assert: it queries its own scoped key and never the first caller's cached database list
+        await _cacheService.Received().GetAsync<List<string>>(
+            "cosmos",
+            CacheKeyBuilder.Build("databases", "myaccount", "sub-B", "tenant-B", "Key"),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await _cacheService.DidNotReceive().GetAsync<List<string>>(
+            "cosmos",
+            CacheKeyBuilder.Build("databases", "myaccount", "sub-A", "tenant-A", "Credential"),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListContainers_DifferentSubscriptionTenantOrAuth_UseSeparateCacheKeys()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.Unauthorized);
+        _httpClientFactory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(handler));
+
+        _cacheService.GetAsync<CosmosClient>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(default(CosmosClient));
+        _cacheService.GetAsync<List<string>>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(default(List<string>));
+
+        // Act: first caller for account/database on sub-A / tenant-A via Credential
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            _service.ListContainers("myaccount", "mydb", "sub-A", AuthMethod.Credential, "tenant-A", cancellationToken: TestContext.Current.CancellationToken));
+
+        // Assert: the container-list cache key is scoped to subscription, tenant, and auth method
+        await _cacheService.Received().GetAsync<List<string>>(
+            "cosmos",
+            CacheKeyBuilder.Build("containers", "myaccount", "mydb", "sub-A", "tenant-A", "Credential"),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        _cacheService.ClearReceivedCalls();
+
+        // Act: a different caller for the SAME account/database but different sub/tenant/auth
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            _service.ListContainers("myaccount", "mydb", "sub-B", AuthMethod.Key, "tenant-B", cancellationToken: TestContext.Current.CancellationToken));
+
+        // Assert: it queries its own scoped key and never the first caller's cached container list
+        await _cacheService.Received().GetAsync<List<string>>(
+            "cosmos",
+            CacheKeyBuilder.Build("containers", "myaccount", "mydb", "sub-B", "tenant-B", "Key"),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+
+        await _cacheService.DidNotReceive().GetAsync<List<string>>(
+            "cosmos",
+            CacheKeyBuilder.Build("containers", "myaccount", "mydb", "sub-A", "tenant-A", "Credential"),
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
## What does this PR do?

The Cosmos DB service cached several resources using keys that did not fully capture the request context. The `CosmosClient` cache key was built only from account name and auth method, and the `ListDatabases` / `ListContainers` keys were built only from account (and database) name.

This PR scopes all three cache keys to the full request context so cached entries are only reused for matching requests:

- `GetCosmosClientAsync` now includes `subscription` and `tenant` in the client cache key.
- `ListDatabases` now includes `subscription`, `tenant`, and `authMethod` in its cache key.
- `ListContainers` now includes `subscription`, `tenant`, and `authMethod` (alongside account and database) in its cache key.

## GitHub issue number?

Fixes [#433](https://github.com/microsoft/mcp-pr/issues/433) & [#435](https://github.com/microsoft/mcp-pr/issues/435)

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry

This change fixes internal caching behavior in an existing service; it does not add or rename an MCP tool, so the tool-specific and command-metadata checklist items are N/A.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.