### PR TITLE
Change `GetResourceApiVersions.ResourceVisitor` in BicepSchema tools to throw `InvalidDataException` for unknown resource types

### DIFF
--- a/tools/Azure.Mcp.Tools.AzureTerraform/src/Services/AzApiDocsService.cs
+++ b/tools/Azure.Mcp.Tools.AzureTerraform/src/Services/AzApiDocsService.cs
@@ -21,19 +21,7 @@ public sealed class AzApiDocsService : IAzApiDocsService
     public AzApiDocsResult GetDocumentation(string resourceTypeName, string? apiVersion = null)
     {
         var serviceProvider = s_schemaServiceProvider.Value;
-        TypesDefinitionResult typesResult;
-        try
-        {
-            typesResult = SchemaGenerator.GetResourceTypeDefinitions(serviceProvider, resourceTypeName, apiVersion);
-        }
-        catch (InvalidDataException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidDataException(ex.Message, ex);
-        }
+        TypesDefinitionResult typesResult = SchemaGenerator.GetResourceTypeDefinitions(serviceProvider, resourceTypeName, apiVersion);
         List<ComplexType> complexTypes = SchemaGenerator.GetResponse(typesResult);
 
         string resolvedApiVersion = typesResult.ApiVersion;

--- a/tools/Azure.Mcp.Tools.BicepSchema/src/Services/ResourceProperties/ResourceVisitor.cs
+++ b/tools/Azure.Mcp.Tools.BicepSchema/src/Services/ResourceProperties/ResourceVisitor.cs
@@ -86,12 +86,13 @@ public class ResourceVisitor
     {
         (string providerName, _, _) = ResourceParser.ParseResourceType(resourceTypeName);
 
-        if (!GetAllResourceTypesAndVersionsByProvider().TryGetValue(providerName, out ProviderResourceTypes? provider))
+        if (!GetAllResourceTypesAndVersionsByProvider().TryGetValue(providerName, out ProviderResourceTypes? provider)
+            || !provider.ResourceTypes.TryGetValue(resourceTypeName.ToLowerInvariant(), out UniqueResourceType? uniqueResourceType))
         {
-            throw new Exception($"Resource type {resourceTypeName} not found.");
+            throw new InvalidDataException($"Resource type {resourceTypeName} not found.");
         }
 
-        return [.. provider.ResourceTypes[resourceTypeName.ToLowerInvariant()].ApiVersions];
+        return [.. uniqueResourceType.ApiVersions];
     }
 
     public TypesDefinitionResult LoadSingleResource(string resourceTypeName, string apiVersion)

--- a/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.Tests/GetSchemaTests.cs
+++ b/tools/Azure.Mcp.Tools.BicepSchema/tests/Azure.Mcp.Tools.BicepSchema.Tests/GetSchemaTests.cs
@@ -33,7 +33,7 @@ public class GetSchemaTests(ITestOutputHelper output)
         SchemaGenerator.ConfigureServices(serviceCollection);
         IServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
 
-        var exception = Assert.Throws<Exception>(() =>
+        var exception = Assert.Throws<InvalidDataException>(() =>
         {
             TypesDefinitionResult result = SchemaGenerator.GetResourceTypeDefinitions(serviceProvider, "Microsoft.Unknown/virtualRandom");
             _ = SchemaGenerator.GetResponse(result);


### PR DESCRIPTION
`ResourceVisitor.GetResourceApiVersions()` threw a bare `Exception` (and an unhandled `KeyNotFoundException` when the provider existed but the resource type did not), which `AzApiDocsService` normalized via a broad catch-all that also misclassified real server-side faults as `400 BadRequest`.

This PR throw `InvalidDataException()` at the source instead, consistent with `ResourceVisitor.LoadSingleResource`, and drop the catch-all so unexpected exceptions surface as `500`.