### PR TITLE
fix: align azurebackup option descriptions with parameter settings

### DIFF
--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Options/AzureBackupOptionDefinitions.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Options/AzureBackupOptionDefinitions.cs
@@ -111,7 +111,7 @@ public static class AzureBackupOptionDefinitions
 
     public static readonly Option<string> VaultType = new($"--{VaultTypeName}")
     {
-        Description = "The type of backup vault: 'rsv' (Recovery Services vault) or 'dpp' (Backup vault / Data Protection). Required for vault create; optional elsewhere (auto-detected if omitted).",
+        Description = "The type of backup vault: 'rsv' (Recovery Services vault) or 'dpp' (Backup vault / Data Protection). Auto-detected if omitted for existing vaults.",
         Required = false
     };
 
@@ -183,7 +183,7 @@ public static class AzureBackupOptionDefinitions
 
     public static readonly Option<string> IdentityType = new($"--{IdentityTypeName}")
     {
-        Description = "Managed identity type: 'SystemAssigned', 'UserAssigned', or 'None'.",
+        Description = "Managed identity type: 'SystemAssigned', 'UserAssigned', 'SystemAssigned,UserAssigned', or 'None'.",
         Required = false
     };
 


### PR DESCRIPTION
## Summary

Fix 2 description/setting mismatches in \AzureBackupOptionDefinitions.cs\ where the option \Description\ text did not match the actual \Required\ field or supported values.

## Changes

### 1. \--vault-type\ description
- **Before:** \Required for vault create; optional elsewhere (auto-detected if omitted).\
- **After:** \Auto-detected if omitted for existing vaults.\
- **Why:** The \Required\ field is \alse\. Vault create enforces this via a custom validator in \VaultCreateCommand.cs\, not via the structured \equired\ metadata. The description was misleading — tools.json consumers (including doc generation) use the \equired\ field, not description text, to determine required/optional status.

### 2. \--identity-type\ description
- **Before:** \'SystemAssigned', 'UserAssigned', or 'None'.\
- **After:** \'SystemAssigned', 'UserAssigned', 'SystemAssigned,UserAssigned', or 'None'.\
- **Why:** \VaultUpdateCommand\ validator and both \RsvBackupOperations\/\DppBackupOperations\ backends support the combined \SystemAssigned,UserAssigned\ value. The description was missing this valid option.

## Context

Identified during review of [MicrosoftDocs/azure-dev-docs-pr#9015](https://github.com/MicrosoftDocs/azure-dev-docs-pr/pull/9015) (Azure Backup MCP tool documentation). These fixes ensure the next \	ools.json\ regeneration produces accurate metadata for doc generation.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with \write\ access to the repo need to validate the contents of this PR before leaving a comment with the text \/azp run mcp - pullrequest - live\. This will trigger the necessary livetest workflows to complete required validation.