### PR TITLE
fix: Update placeholder values

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Helpers/CommandHelperTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Helpers/CommandHelperTests.cs
@@ -59,7 +59,7 @@ public class CommandHelperTests
     }
 
     [Fact]
-    public void GetSubscription_ParameterValueContainingSubscription_ReturnsEnvironmentValue()
+    public void GetSubscription_ParameterValueContainingSubscription_ReturnsParameterValue()
     {
         // Arrange
         TestEnvironment.SetAzureSubscriptionId("env-subs");
@@ -70,16 +70,16 @@ public class CommandHelperTests
         var actual = CommandHelper.GetSubscription(parseResult);
 
         // Assert
-        Assert.Equal(subscription, actual);
+        Assert.Equal("Azure subscription 1", actual);
     }
 
     [Fact]
-    public void GetSubscription_ParameterValueContainingDefault_ReturnsEnvironmentValue()
+    public void GetSubscription_ParameterValueMatchingKnownPlaceholder_ReturnsEnvironmentValue()
     {
         // Arrange
         TestEnvironment.SetAzureSubscriptionId("env-subs");
         var subscription = CommandHelper.GetDefaultSubscription();
-        var parseResult = GetParseResult(["--subscription", "Some default name"]);
+        var parseResult = GetParseResult(["--subscription", "<subscription_id>"]);
 
         // Act
         var actual = CommandHelper.GetSubscription(parseResult);
@@ -89,12 +89,12 @@ public class CommandHelperTests
     }
 
     [Fact]
-    public void GetSubscription_NoEnvironmentVariableParameterValueContainingDefault_ReturnsParameterValue()
+    public void GetSubscription_NoEnvironmentVariableParameterValueMatchingKnownPlaceholder_ReturnsParameterValue()
     {
         // Arrange
         TestEnvironment.ClearAzureSubscriptionId();
         var subscription = CommandHelper.GetProfileSubscription();
-        var parseResult = GetParseResult(["--subscription", "Some default name"]);
+        var parseResult = GetParseResult(["--subscription", "<subscription_id>"]);
 
         // Act
         var actual = CommandHelper.GetSubscription(parseResult);
@@ -108,31 +108,7 @@ public class CommandHelperTests
         }
         else
         {
-            Assert.Equal("Some default name", actual);
-        }
-    }
-
-    [Fact]
-    public void GetSubscription_NoEnvironmentVariableParameterValueContainingSubscription_ReturnsParameterValue()
-    {
-        // Arrange
-        TestEnvironment.ClearAzureSubscriptionId();
-        var subscription = CommandHelper.GetProfileSubscription();
-        var parseResult = GetParseResult(["--subscription", "Azure subscription 1"]);
-
-        // Act
-        var actual = CommandHelper.GetSubscription(parseResult);
-
-        // Assert
-        // If-else this test as being logged in with Azure CLI cannot be mocked out at this time.
-        // So, if the running environment is logged in the subscription will be defaulted to the Azure CLI subscription.
-        if (subscription != null)
-        {
-            Assert.Equal(subscription, actual);
-        }
-        else
-        {
-            Assert.Equal("Azure subscription 1", actual);
+            Assert.Equal("<subscription_id>", actual);
         }
     }
 

--- a/core/Microsoft.Mcp.Core/src/Helpers/CommandHelper.cs
+++ b/core/Microsoft.Mcp.Core/src/Helpers/CommandHelper.cs
@@ -36,7 +36,15 @@ public static class CommandHelper
         "{subscription-name}",
         "{subscription-name-or-id}",
         "YOUR SUBSCRIPTION",
-        "YOUR SUBSCRIPTION ID"
+        "YOUR SUBSCRIPTION ID",
+        "default",
+        "<default>",
+        "{default}",
+        "default-sub",
+        "<default-sub>",
+        "{default-sub}",
+        "default_sub",
+        "default_subscription",
     };
 
     /// <summary>

--- a/core/Microsoft.Mcp.Core/src/Helpers/CommandHelper.cs
+++ b/core/Microsoft.Mcp.Core/src/Helpers/CommandHelper.cs
@@ -14,6 +14,32 @@ public static class CommandHelper
     private static readonly Lazy<string?> s_profileDefault = new(AzureCliProfileHelper.GetDefaultSubscriptionId);
 
     /// <summary>
+    /// A set of common placeholder values for subscription ID/name options.
+    /// </summary>
+    private static readonly HashSet<string> s_subscriptionPlaceholders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "<subscription>",
+        "<subscription-id>",
+        "<subscription-name>",
+        "<subscription-id-or-name>",
+        "<subscriptionId>",
+        "<subscription_id>",
+        "<subscription_name>",
+        "<sub-id>",
+        "<your-subscription-id>",
+        "your-subscription-id",
+        "SUBSCRIPTION_ID",
+        "{subscription}",
+        "{subscriptionId}",
+        "{subscription-id}",
+        "{subscription_id}",
+        "{subscription-name}",
+        "{subscription-name-or-id}",
+        "YOUR SUBSCRIPTION",
+        "YOUR SUBSCRIPTION ID"
+    };
+
+    /// <summary>
     /// Checks if a subscription is available from the command option, Azure CLI profile, or AZURE_SUBSCRIPTION_ID environment variable.
     /// </summary>
     /// <param name="commandResult">The command result to check for the subscription option.</param>
@@ -71,5 +97,8 @@ public static class CommandHelper
 
     internal static string? GetProfileSubscription() => s_profileDefault.Value;
 
-    private static bool IsPlaceholder(string value) => value.Contains("subscription") || value.Contains("default");
+    /// <summary>
+    /// Checks if the given <paramref name="value"/> is a common placeholder for subscription ID or name.
+    /// </summary>
+    private static bool IsPlaceholder(string value) => s_subscriptionPlaceholders.Contains(value);
 }

--- a/servers/Azure.Mcp.Server/changelog-entries/1781034841883.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1781034841883.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed an issue where a valid subscription name or ID containing the words `subscription` or `default` could be incorrectly treated as a placeholder value and replaced with the default subscription."


### PR DESCRIPTION
## What does this PR do?

`CommandHelper` has methods for translating the raw input for a subscription ID or name option into the name or ID that should actually be used. This largely amounts to replacing any empty inputs or "placeholder" inputs with either a value from `az account` or the AZURE_SUBSCRIPTION_ID environment variable.

The issue here is that the check for placeholder values is overly broad--any string containing "subscription" or "default" is treated as a placeholder. However, many valid subscription names will includes these words, and you can end up in a situation where the provided subscription name is replaced with whatever `az` is currently using as a default.

Here we replace the substring check with an exact (though case-insensitive) check against a pre-determined set of subscription placeholder values. This set was determined by examining this repo as well as the skills from github.com/microsoft/azure-skills for examples of placeholder values.

## GitHub issue number?

Fixes https://github.com/microsoft/mcp-pr/issues/406.

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
