### PR TITLE
Simplify and harden assets.json handling

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,4 +69,24 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <RepositoryUrl>https://github.com/microsoft/mcp</RepositoryUrl>
   </PropertyGroup>
+
+  <!-- Setup common output paths -->
+  <PropertyGroup>
+    <ArtifactsDir Condition="'$(ArtifactsDir)' == ''">$(RepoRoot)artifacts\</ArtifactsDir>
+    <ArtifactsObjDir>$(ArtifactsDir)obj\</ArtifactsObjDir>
+    <ArtifactsBinDir>$(ArtifactsDir)bin\</ArtifactsBinDir>
+    <ArtifactsPackagesDir>$(ArtifactsDir)packages\$(Configuration)\</ArtifactsPackagesDir>
+
+    <OutDirName Condition="'$(OutDirName)' == ''">$(MSBuildProjectName)</OutDirName>
+
+    <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)$(OutDirName)\'))</BaseOutputPath>
+    <OutputPath Condition="'$(PlatformName)' == 'AnyCPU'">$(BaseOutputPath)$(Configuration)\</OutputPath>
+    <OutputPath Condition="'$(PlatformName)' != 'AnyCPU'">$(BaseOutputPath)$(PlatformName)\$(Configuration)\</OutputPath>
+
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(ArtifactsObjDir)$(OutDirName)\'))</BaseIntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(PlatformName)' == 'AnyCPU'">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(PlatformName)' != 'AnyCPU'">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
+
+    <PackageOutputPath>$(ArtifactsPackagesDir)/$(MSBuildProjectName)</PackageOutputPath>
+  </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,24 +69,4 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <RepositoryUrl>https://github.com/microsoft/mcp</RepositoryUrl>
   </PropertyGroup>
-
-  <!-- Setup common output paths -->
-  <PropertyGroup>
-    <ArtifactsDir Condition="'$(ArtifactsDir)' == ''">$(RepoRoot)artifacts\</ArtifactsDir>
-    <ArtifactsObjDir>$(ArtifactsDir)obj\</ArtifactsObjDir>
-    <ArtifactsBinDir>$(ArtifactsDir)bin\</ArtifactsBinDir>
-    <ArtifactsPackagesDir>$(ArtifactsDir)packages\$(Configuration)\</ArtifactsPackagesDir>
-
-    <OutDirName Condition="'$(OutDirName)' == ''">$(MSBuildProjectName)</OutDirName>
-
-    <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)$(OutDirName)\'))</BaseOutputPath>
-    <OutputPath Condition="'$(PlatformName)' == 'AnyCPU'">$(BaseOutputPath)$(Configuration)\</OutputPath>
-    <OutputPath Condition="'$(PlatformName)' != 'AnyCPU'">$(BaseOutputPath)$(PlatformName)\$(Configuration)\</OutputPath>
-
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(ArtifactsObjDir)$(OutDirName)\'))</BaseIntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(PlatformName)' == 'AnyCPU'">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(PlatformName)' != 'AnyCPU'">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
-
-    <PackageOutputPath>$(ArtifactsPackagesDir)/$(MSBuildProjectName)</PackageOutputPath>
-  </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,8 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' or '$(IsPerfProject)' == 'true' or '$(IsStressProject)' == 'true'">
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>SourcePath</_Parameter1>
+      <_Parameter2>$(MSBuildProjectDirectory)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="'$(IsTestProject)' == 'true' or '$(IsPerfProject)' == 'true' or '$(IsStressProject)' == 'true'">
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
       <_Parameter1>SourcePath</_Parameter1>

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/Helpers/IRecordingPathResolver.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/Helpers/IRecordingPathResolver.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-
 namespace Microsoft.Mcp.Tests.Client.Helpers;
 
 /// <summary>

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/Helpers/RecordingPathResolver.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/Helpers/RecordingPathResolver.cs
@@ -63,7 +63,7 @@ public sealed class RecordingPathResolver : IRecordingPathResolver
     public string GetSessionDirectory(Type testType, string? variantSuffix = null)
     {
         // Locate the test project directory by ascending from the assembly location until a matching *.csproj exists.
-        var projectDir = GetProjectDirectory(testType);
+        var projectDir = testType.Assembly.GetCustomAttributes<AssemblyMetadataAttribute>().Single(a => a.Key == "SourcePath").Value!;
 
         // Compute relative path from repo root.
         var relativeProjectPath = Path.GetRelativePath(_repoRoot, projectDir)
@@ -75,35 +75,6 @@ public sealed class RecordingPathResolver : IRecordingPathResolver
 
         // TODO: Consider caching projectDir per assembly for performance if needed.
         return sessionDir;
-    }
-
-    private static string GetProjectDirectory(Type testType)
-    {
-        // Locate the test project directory by ascending from the assembly location until a matching *.csproj exists.
-        var assemblyDir = Path.GetDirectoryName(testType.Assembly.Location)!;
-        var projectDir = FindProjectDirectory(assemblyDir, testType);
-
-        return projectDir;
-    }
-
-    private static string FindProjectDirectory(string startDirectory, Type testType)
-    {
-        var current = new DirectoryInfo(startDirectory);
-        var expectedProjectName = testType.Assembly.GetName().Name; // Typically matches .csproj file name.
-
-        while (current != null)
-        {
-            // Look for any .csproj; prefer one matching assembly name.
-            var csprojFiles = current.GetFiles("*.csproj", SearchOption.TopDirectoryOnly);
-            if (csprojFiles.Length > 0)
-            {
-                var matching = csprojFiles.FirstOrDefault(f => Path.GetFileNameWithoutExtension(f.Name) == expectedProjectName);
-                return (matching ?? csprojFiles.First()).Directory!.FullName;
-            }
-            current = current.Parent;
-        }
-
-        throw new InvalidOperationException($"Unable to locate project directory for test type {testType.FullName} starting from {startDirectory}.");
     }
 
     /// <summary>
@@ -139,8 +110,8 @@ public sealed class RecordingPathResolver : IRecordingPathResolver
     /// </summary>
     public string GetAssetsJson(Type testType)
     {
-        var projectDir = GetProjectDirectory(testType);
-
+        var projectDir = testType.Assembly.GetCustomAttributes<AssemblyMetadataAttribute>().Single(a => a.Key == "SourcePath").Value!;
+        
         var current = new DirectoryInfo(projectDir);
 
         var assetsFile = Path.Combine(current.FullName, "assets.json");

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/Helpers/RecordingPathResolver.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/Helpers/RecordingPathResolver.cs
@@ -10,14 +10,9 @@ namespace Microsoft.Mcp.Tests.Client.Helpers;
 /// </summary>
 public sealed class RecordingPathResolver : IRecordingPathResolver
 {
-    private static readonly char[] _invalidChars = ['\\', '/', ':', '*', '?', '"', '<', '>', '|'];
+    private static readonly char[] s_invalidChars = ['\\', '/', ':', '*', '?', '"', '<', '>', '|'];
 
-    private readonly string _repoRoot;
-
-    public RecordingPathResolver()
-    {
-        _repoRoot = ResolveRepositoryRoot() ?? Directory.GetCurrentDirectory();
-    }
+    public string RepositoryRoot { get; } = ResolveRepositoryRoot() ?? Directory.GetCurrentDirectory();
 
     /// <summary>
     /// Attempt to locate the repository root by walking up until a .git directory/file or global.json is found.
@@ -38,8 +33,6 @@ public sealed class RecordingPathResolver : IRecordingPathResolver
         throw new InvalidOperationException("Unable to locate repository root. Ensure tests are running in a cloned repository.");
     }
 
-    public string RepositoryRoot => _repoRoot;
-
     /// <summary>
     /// Sanitizes a test display/name into a file-system friendly component.
     /// </summary>
@@ -51,7 +44,7 @@ public sealed class RecordingPathResolver : IRecordingPathResolver
         int i = 0;
         foreach (var c in name)
         {
-            buffer[i++] = _invalidChars.Contains(c) ? '_' : c;
+            buffer[i++] = s_invalidChars.Contains(c) ? '_' : c;
         }
         return new string(buffer);
     }
@@ -63,10 +56,10 @@ public sealed class RecordingPathResolver : IRecordingPathResolver
     public string GetSessionDirectory(Type testType, string? variantSuffix = null)
     {
         // Locate the test project directory by ascending from the assembly location until a matching *.csproj exists.
-        var projectDir = testType.Assembly.GetCustomAttributes<AssemblyMetadataAttribute>().Single(a => a.Key == "SourcePath").Value!;
+        var projectDir = GetSourcePath(testType.Assembly);
 
         // Compute relative path from repo root.
-        var relativeProjectPath = Path.GetRelativePath(_repoRoot, projectDir)
+        var relativeProjectPath = Path.GetRelativePath(RepositoryRoot, projectDir)
             .Replace('\\', '/'); // Normalize separators for consistency.
 
         // Append SessionRecords and suffix.
@@ -91,7 +84,7 @@ public sealed class RecordingPathResolver : IRecordingPathResolver
     /// <summary>
     /// Generates a clear message for missing assets.json file to assist users in creating one when they hit the error.
     /// </summary>
-    private string BuildMissingAssetsErrorMessage(string testClass, string projectDir)
+    private static string BuildMissingAssetsErrorMessage(string testClass, string projectDir)
     {
         string projectDirName = new DirectoryInfo(projectDir).Name;
 
@@ -106,11 +99,16 @@ public sealed class RecordingPathResolver : IRecordingPathResolver
     }
 
     /// <summary>
-    /// Attempts to find a nearest assets.json walking upwards.
+    /// Get the assets.json file for the test type using the assembly's SourcePath metadata.
+    /// <para>
+    /// This method uses the <see cref="AssemblyMetadataAttribute"/> with the key "SourcePath" to determine the
+    /// location of the test project and then looks for an "assets.json" file in that directory.
+    /// </para>
+    /// <param name="testType">The type of the test for which to find the assets.json file.</param>
     /// </summary>
     public string GetAssetsJson(Type testType)
     {
-        var projectDir = testType.Assembly.GetCustomAttributes<AssemblyMetadataAttribute>().Single(a => a.Key == "SourcePath").Value!;
+        var projectDir = GetSourcePath(testType.Assembly);
 
         var current = new DirectoryInfo(projectDir);
 
@@ -121,5 +119,17 @@ public sealed class RecordingPathResolver : IRecordingPathResolver
             return assetsFile;
         }
         throw new FileNotFoundException(BuildMissingAssetsErrorMessage(testType.FullName ?? "UnknownTestClass", projectDir));
+    }
+
+    private static string GetSourcePath(Assembly assembly)
+    {
+        var sourcePaths = assembly.GetCustomAttributes<AssemblyMetadataAttribute>().Where(a => a.Key == "SourcePath");
+        if (sourcePaths.Count() != 1)
+        {
+            throw new InvalidOperationException("No SourcePath metadata found. Ensure the test project is properly " +
+                "configured with '<IsTestProject>true</IsTestProject>' in the .csproj file, uses 'Directory.Build.targets', " +
+                "and has a single 'SourcePath' metadata.");
+        }
+        return sourcePaths.First().Value!;
     }
 }

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/Helpers/RecordingPathResolver.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/Helpers/RecordingPathResolver.cs
@@ -111,7 +111,7 @@ public sealed class RecordingPathResolver : IRecordingPathResolver
     public string GetAssetsJson(Type testType)
     {
         var projectDir = testType.Assembly.GetCustomAttributes<AssemblyMetadataAttribute>().Single(a => a.Key == "SourcePath").Value!;
-        
+
         var current = new DirectoryInfo(projectDir);
 
         var assetsFile = Path.Combine(current.FullName, "assets.json");

--- a/eng/tools/ToolMetadataExporter/src/ToolMetadataExporter.csproj
+++ b/eng/tools/ToolMetadataExporter/src/ToolMetadataExporter.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/servers/Azure.Mcp.Server/docs/new-command.md
+++ b/servers/Azure.Mcp.Server/docs/new-command.md
@@ -2321,7 +2321,6 @@ var subscriptionResource = armClient.GetSubscriptionResource(new ResourceIdentif
   ```xml
   <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-      <TargetFramework>net10.0</TargetFramework>
       <ImplicitUsings>enable</ImplicitUsings>
       <Nullable>enable</Nullable>
       <IsPackable>false</IsPackable>

--- a/tools/Azure.Mcp.Tools.AzureMigrate/src/Azure.Mcp.Tools.AzureMigrate.csproj
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/src/Azure.Mcp.Tools.AzureMigrate.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.Tests/Azure.Mcp.Tools.AzureMigrate.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/tests/Azure.Mcp.Tools.AzureMigrate.Tests/Azure.Mcp.Tools.AzureMigrate.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## What does this PR do?

Simplifies and hardens `assets.json` handling to copy what `azure-sdk-for-net` is doing. The new handling is agnostic of where `/bin` and `/obj` outputs for built assemblies are as the information for where `assets.json` can be found is now backed into the test assembly's metadata. This will make any future restructuring in the repository simpler, for example what was initially investigated in this PR using a shared artifacts folder.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
