### PR TITLE
Seal SqlService class per repo convention (#456)

### DIFF
--- a/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
@@ -16,7 +16,7 @@ using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Sql.Services;
 
-public class SqlService(ISubscriptionService subscriptionService, ITenantService tenantService, ILogger<SqlService> logger) : BaseAzureResourceService(subscriptionService, tenantService), ISqlService
+public sealed class SqlService(ISubscriptionService subscriptionService, ITenantService tenantService, ILogger<SqlService> logger) : BaseAzureResourceService(subscriptionService, tenantService), ISqlService
 {
     private readonly ILogger<SqlService> _logger = logger;
 


### PR DESCRIPTION
## What does this PR do?
`SqlService` was declared `public class` but the project convention (AGENTS.md) requires service classes to be `sealed` unless they are explicitly designed for inheritance. This PR seals the class.

## GitHub issue number?
[#456](https://github.com/microsoft/mcp-pr/issues/456)

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages
    - [x] Added comprehensive tests for new/modified functionality (N/A - no behavioral change; existing tests cover SqlService consumers via ISqlService)
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies (N/A - internal code-quality change)

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.