### PR TITLE
Fix PostgreSQL server-config commands to honor tenant and retry policy

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1781226085485.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1781226085485.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed PostgreSQL server configuration commands (`server config get`, `server param get`, `server param set`) to honor the `--tenant` and retry policy options when making ARM calls, enabling sovereign cloud authentication and configurable retries."

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerConfigGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerConfigGetCommand.cs
@@ -36,7 +36,7 @@ public sealed class ServerConfigGetCommand(IPostgresService postgresService, ILo
         try
         {
 
-            var config = await _postgresService.GetServerConfigAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!, cancellationToken);
+            var config = await _postgresService.GetServerConfigAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!, options.Tenant, options.RetryPolicy, cancellationToken);
             context.Response.Results = config?.Length > 0 ?
                 ResponseResult.Create(new(config), PostgresJsonContext.Default.ServerConfigGetCommandResult) :
                 null;

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamGetCommand.cs
@@ -50,7 +50,7 @@ public sealed class ServerParamGetCommand(IPostgresService postgresService, ILog
 
         try
         {
-            var parameterValue = await _postgresService.GetServerParameterAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!, options.Param!, cancellationToken);
+            var parameterValue = await _postgresService.GetServerParameterAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!, options.Param!, options.Tenant, options.RetryPolicy, cancellationToken);
             context.Response.Results = parameterValue?.Length > 0 ?
                 ResponseResult.Create(new(parameterValue), PostgresJsonContext.Default.ServerParamGetCommandResult) :
                 null;

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamSetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamSetCommand.cs
@@ -55,7 +55,7 @@ public sealed class ServerParamSetCommand(IPostgresService postgresService, ILog
         {
             ServerParameterValidator.EnsureParameterAllowed(options.Param);
 
-            var result = await _postgresService.SetServerParameterAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!, options.Param!, options.Value!, cancellationToken);
+            var result = await _postgresService.SetServerParameterAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!, options.Param!, options.Value!, options.Tenant, options.RetryPolicy, cancellationToken);
             context.Response.Results = !string.IsNullOrEmpty(result) ?
                 ResponseResult.Create(new(result, options.Param!, options.Value!), PostgresJsonContext.Default.ServerParamSetCommandResult) :
                 null;

--- a/tools/Azure.Mcp.Tools.Postgres/src/Services/IPostgresService.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Services/IPostgresService.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Mcp.Core.Options;
+
 namespace Azure.Mcp.Tools.Postgres.Services;
 
 public interface IPostgresService
@@ -56,7 +58,9 @@ public interface IPostgresService
         string resourceGroup,
         string user,
         string server,
-        CancellationToken cancellationToken);
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<string> GetServerParameterAsync(
         string subscriptionId,
@@ -64,7 +68,9 @@ public interface IPostgresService
         string user,
         string server,
         string param,
-        CancellationToken cancellationToken);
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 
     Task<string> SetServerParameterAsync(
         string subscription,
@@ -73,5 +79,7 @@ public interface IPostgresService
         string server,
         string param,
         string value,
-        CancellationToken cancellationToken);
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
@@ -16,6 +16,7 @@ using Azure.ResourceManager.PostgreSql.FlexibleServers;
 using Azure.ResourceManager.Resources;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Helpers;
+using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Azure.Authentication;
 using Npgsql;
 
@@ -263,9 +264,11 @@ public class PostgresService(
         string resourceGroup,
         string user,
         string server,
-        CancellationToken cancellationToken)
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var rg = await _resourceGroupService.GetResourceGroupResource(subscriptionId, resourceGroup, cancellationToken: cancellationToken)
+        var rg = await _resourceGroupService.GetResourceGroupResource(subscriptionId, resourceGroup, tenant, retryPolicy, cancellationToken)
             ?? throw new Exception($"Resource group '{resourceGroup}' not found.");
 
         var pgServer = await rg.GetPostgreSqlFlexibleServerAsync(server, cancellationToken);
@@ -286,9 +289,11 @@ public class PostgresService(
         string user,
         string server,
         string param,
-        CancellationToken cancellationToken)
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var rg = await _resourceGroupService.GetResourceGroupResource(subscriptionId, resourceGroup, cancellationToken: cancellationToken)
+        var rg = await _resourceGroupService.GetResourceGroupResource(subscriptionId, resourceGroup, tenant, retryPolicy, cancellationToken)
             ?? throw new Exception($"Resource group '{resourceGroup}' not found.");
 
         var pgServer = await rg.GetPostgreSqlFlexibleServerAsync(server, cancellationToken);
@@ -308,9 +313,11 @@ public class PostgresService(
         string server,
         string param,
         string value,
-        CancellationToken cancellationToken)
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
     {
-        var rg = await _resourceGroupService.GetResourceGroupResource(subscriptionId, resourceGroup, cancellationToken: cancellationToken)
+        var rg = await _resourceGroupService.GetResourceGroupResource(subscriptionId, resourceGroup, tenant, retryPolicy, cancellationToken)
             ?? throw new Exception($"Resource group '{resourceGroup}' not found.");
 
         var pgServer = await rg.GetPostgreSqlFlexibleServerAsync(server, cancellationToken);

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Server/ServerConfigGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Server/ServerConfigGetCommandTests.cs
@@ -18,7 +18,7 @@ public class ServerConfigGetCommandTests : CommandUnitTestsBase<ServerConfigGetC
     public async Task ExecuteAsync_ReturnsConfig_WhenConfigExists()
     {
         var expectedConfig = "config123";
-        Service.GetServerConfigAsync("sub123", "rg1", "user1", "server123", Arg.Any<CancellationToken>()).Returns(expectedConfig);
+        Service.GetServerConfigAsync("sub123", "rg1", "user1", "server123", Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>()).Returns(expectedConfig);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -33,7 +33,7 @@ public class ServerConfigGetCommandTests : CommandUnitTestsBase<ServerConfigGetC
     [Fact]
     public async Task ExecuteAsync_ReturnsNull_WhenConfigDoesNotExist()
     {
-        Service.GetServerConfigAsync("sub123", "rg1", "user1", "server123", Arg.Any<CancellationToken>()).Returns("");
+        Service.GetServerConfigAsync("sub123", "rg1", "user1", "server123", Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>()).Returns("");
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -64,5 +64,21 @@ public class ServerConfigGetCommandTests : CommandUnitTestsBase<ServerConfigGetC
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Equal($"Missing Required options: {missingParameter}", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ForwardsTenantAndRetryPolicy()
+    {
+        Service.GetServerConfigAsync("sub123", "rg1", "user1", "server123", Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>()).Returns("config123");
+
+        await ExecuteCommandAsync(
+            "--subscription", "sub123",
+            "--resource-group", "rg1",
+            "--user", "user1",
+            "--server", "server123",
+            "--tenant", "tenant123",
+            "--retry-max-retries", "3");
+
+        await Service.Received(1).GetServerConfigAsync("sub123", "rg1", "user1", "server123", "tenant123", Arg.Is<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(p => p != null && p.MaxRetries == 3), Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Server/ServerParamGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Server/ServerParamGetCommandTests.cs
@@ -18,7 +18,7 @@ public class ServerParamGetCommandTests : CommandUnitTestsBase<ServerParamGetCom
     public async Task ExecuteAsync_ReturnsParamValue_WhenParamExists()
     {
         var expectedValue = "value123";
-        Service.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", Arg.Any<CancellationToken>()).Returns(expectedValue);
+        Service.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>()).Returns(expectedValue);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -34,7 +34,7 @@ public class ServerParamGetCommandTests : CommandUnitTestsBase<ServerParamGetCom
     [Fact]
     public async Task ExecuteAsync_ReturnsNull_WhenParamDoesNotExist()
     {
-        Service.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", Arg.Any<CancellationToken>()).Returns("");
+        Service.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>()).Returns("");
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
@@ -67,5 +67,22 @@ public class ServerParamGetCommandTests : CommandUnitTestsBase<ServerParamGetCom
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Equal($"Missing Required options: {missingParameter}", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ForwardsTenantAndRetryPolicy()
+    {
+        Service.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>()).Returns("value123");
+
+        await ExecuteCommandAsync(
+            "--subscription", "sub123",
+            "--resource-group", "rg1",
+            "--user", "user1",
+            "--server", "server123",
+            "--param", "param123",
+            "--tenant", "tenant123",
+            "--retry-max-retries", "3");
+
+        await Service.Received(1).GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", "tenant123", Arg.Is<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(p => p != null && p.MaxRetries == 3), Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Server/ServerParamSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Server/ServerParamSetCommandTests.cs
@@ -20,7 +20,7 @@ public class ServerParamSetCommandTests : CommandUnitTestsBase<ServerParamSetCom
     public async Task ExecuteAsync_ReturnsSuccessMessage_WhenParamIsSet()
     {
         var expectedMessage = "Parameter 'work_mem' updated successfully to '256MB'.";
-        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "work_mem", "256MB", Arg.Any<CancellationToken>()).Returns(expectedMessage);
+        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "work_mem", "256MB", Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>()).Returns(expectedMessage);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -40,7 +40,7 @@ public class ServerParamSetCommandTests : CommandUnitTestsBase<ServerParamSetCom
     [Fact]
     public async Task ExecuteAsync_ReturnsNull_WhenParamDoesNotExist()
     {
-        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "shared_buffers", "512MB", Arg.Any<CancellationToken>()).Returns("");
+        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "shared_buffers", "512MB", Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>()).Returns("");
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -83,7 +83,7 @@ public class ServerParamSetCommandTests : CommandUnitTestsBase<ServerParamSetCom
     public async Task ExecuteAsync_CallsServiceWithCorrectParameters()
     {
         var expectedMessage = "Parameter updated successfully.";
-        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200", Arg.Any<CancellationToken>()).Returns(expectedMessage);
+        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200", Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>()).Returns(expectedMessage);
 
         await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -93,7 +93,25 @@ public class ServerParamSetCommandTests : CommandUnitTestsBase<ServerParamSetCom
             "--param", "max_connections",
             "--value", "200");
 
-        await Service.Received(1).SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200", Arg.Any<CancellationToken>());
+        await Service.Received(1).SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200", Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ForwardsTenantAndRetryPolicy()
+    {
+        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200", Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>()).Returns("ok");
+
+        await ExecuteCommandAsync(
+            "--subscription", "sub123",
+            "--resource-group", "rg1",
+            "--user", "user1",
+            "--server", "server123",
+            "--param", "max_connections",
+            "--value", "200",
+            "--tenant", "tenant123",
+            "--retry-max-retries", "3");
+
+        await Service.Received(1).SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200", "tenant123", Arg.Is<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(p => p != null && p.MaxRetries == 3), Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -118,14 +136,14 @@ public class ServerParamSetCommandTests : CommandUnitTestsBase<ServerParamSetCom
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.Forbidden, response.Status);
         Assert.Contains("security-sensitive", response.Message);
-        await Service.DidNotReceiveWithAnyArgs().SetServerParameterAsync("", "", "", "", "", "", TestContext.Current.CancellationToken);
+        await Service.DidNotReceiveWithAnyArgs().SetServerParameterAsync("", "", "", "", "", "", null, null, TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task ExecuteAsync_AllowsNonBlockedParameters()
     {
         var expectedMessage = "Parameter 'custom_setting' updated successfully.";
-        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "custom_setting", "42", Arg.Any<CancellationToken>()).Returns(expectedMessage);
+        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "custom_setting", "42", Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>()).Returns(expectedMessage);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceTests.cs
@@ -202,6 +202,60 @@ namespace Azure.Mcp.Tools.Postgres.Tests.Services
                 () => sut.ListServersAsync(subscriptionId, resourceGroup, TestContext.Current.CancellationToken));
             Assert.Contains(resourceGroup, ex.Message);
         }
+
+        [Fact]
+        public async Task GetServerConfigAsync_ForwardsTenantAndRetryPolicy()
+        {
+            // Arrange
+            var tenant = "tenant123";
+            var retryPolicy = new Microsoft.Mcp.Core.Options.RetryPolicyOptions();
+            _resourceGroupService
+                .GetResourceGroupResource(subscriptionId, resourceGroup, tenant, retryPolicy, Arg.Any<CancellationToken>())
+                .Returns((ResourceGroupResource?)null);
+
+            // Act & Assert — resource group lookup happens first; null triggers the exception
+            await Assert.ThrowsAsync<Exception>(() =>
+                _postgresService.GetServerConfigAsync(subscriptionId, resourceGroup, user, server, tenant, retryPolicy, TestContext.Current.CancellationToken));
+
+            await _resourceGroupService.Received(1)
+                .GetResourceGroupResource(subscriptionId, resourceGroup, tenant, retryPolicy, Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task GetServerParameterAsync_ForwardsTenantAndRetryPolicy()
+        {
+            // Arrange
+            var tenant = "tenant123";
+            var retryPolicy = new Microsoft.Mcp.Core.Options.RetryPolicyOptions();
+            _resourceGroupService
+                .GetResourceGroupResource(subscriptionId, resourceGroup, tenant, retryPolicy, Arg.Any<CancellationToken>())
+                .Returns((ResourceGroupResource?)null);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<Exception>(() =>
+                _postgresService.GetServerParameterAsync(subscriptionId, resourceGroup, user, server, "param123", tenant, retryPolicy, TestContext.Current.CancellationToken));
+
+            await _resourceGroupService.Received(1)
+                .GetResourceGroupResource(subscriptionId, resourceGroup, tenant, retryPolicy, Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task SetServerParameterAsync_ForwardsTenantAndRetryPolicy()
+        {
+            // Arrange
+            var tenant = "tenant123";
+            var retryPolicy = new Microsoft.Mcp.Core.Options.RetryPolicyOptions();
+            _resourceGroupService
+                .GetResourceGroupResource(subscriptionId, resourceGroup, tenant, retryPolicy, Arg.Any<CancellationToken>())
+                .Returns((ResourceGroupResource?)null);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<Exception>(() =>
+                _postgresService.SetServerParameterAsync(subscriptionId, resourceGroup, user, server, "param123", "value123", tenant, retryPolicy, TestContext.Current.CancellationToken));
+
+            await _resourceGroupService.Received(1)
+                .GetResourceGroupResource(subscriptionId, resourceGroup, tenant, retryPolicy, Arg.Any<CancellationToken>());
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## What does this PR do?

The three ARM-level PostgreSQL server-config service methods (`GetServerConfigAsync`, `GetServerParameterAsync`, `SetServerParameterAsync`) did not accept or use `tenant` or `retryPolicy`, unlike the rest of the codebase. This had two consequences: users targeting sovereign clouds (Azure US Government / China) could not authenticate against the correct tenant, and transient ARM errors were not retried per the user's configured retry policy.

This change threads `tenant` and `retryPolicy` through those three service methods and into the underlying `IResourceGroupService.GetResourceGroupResource(...)` call, which already accepts both. The `--tenant` and `--retry-policy` options were already registered on the commands as global options; they were simply being dropped before reaching ARM.

## GitHub issue number?

Fixes [#470](https://github.com/microsoft/mcp-pr/issues/470)

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [x] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation (N/A - no surface/description change)
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme) (N/A)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts (N/A - descriptions unchanged)
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json) (N/A)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label (N/A)
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description (N/A)
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (N/A - CLI surface unchanged)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI) (N/A)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md) (N/A)

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.