### PR TITLE
Clarify async provisioning in Redis create tool description

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/vcolin7-redis-create-async-description.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/vcolin7-redis-create-async-description.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Other Changes"
+    description: "Clarified the `azmcp redis create` tool description to convey that provisioning is asynchronous and callers should poll `provisioningState` until it shows 'Succeeded' before connecting."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3554,7 +3554,7 @@ azmcp role assignment list --subscription <subscription> \
 ### Azure Redis Operations
 
 ```bash
-# Creates a new Azure Managed Redis resource
+# Creates a new Azure Managed Redis resource (asynchronous; poll provisioningState until 'Succeeded')
 # ✅ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp redis create --subscription <subscription> \
                    --resource-group <resource-group> \

--- a/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceCreateCommand.cs
@@ -14,13 +14,14 @@ using Microsoft.Mcp.Core.Models.Option;
 namespace Azure.Mcp.Tools.Redis.Commands;
 
 /// <summary>
-/// Creates a new Azure Managed Redis resource.
+/// Creates a new Azure Managed Redis resource. Provisioning is asynchronous and the
+/// command returns immediately while the resource is still being created.
 /// </summary>
 [CommandMetadata(
     Id = "750133dd-d57f-4ed4-9488-c1d406ad4a83",
     Name = "create",
     Title = "Create Redis Resource",
-    Description = "Create a new Azure Managed Redis resource in Azure. Use this command to provision a new Redis resource in your subscription.",
+    Description = "Create a new Azure Managed Redis resource in Azure. Use this command to provision a new Redis resource in your subscription. Provisioning is asynchronous and typically takes several minutes; the command returns immediately while the resource is still being created. Poll the resource's provisioningState field until it shows 'Succeeded' before attempting connections.",
     Destructive = true,
     Idempotent = false,
     OpenWorld = false,

--- a/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Redis/src/Commands/ResourceCreateCommand.cs
@@ -21,7 +21,7 @@ namespace Azure.Mcp.Tools.Redis.Commands;
     Id = "750133dd-d57f-4ed4-9488-c1d406ad4a83",
     Name = "create",
     Title = "Create Redis Resource",
-    Description = "Create a new Azure Managed Redis resource in Azure. Use this command to provision a new Redis resource in your subscription. Provisioning is asynchronous and typically takes several minutes; the command returns immediately while the resource is still being created. Poll the resource's provisioningState field until it shows 'Succeeded' before attempting connections.",
+    Description = "Create a new Azure Managed Redis resource in Azure. Use this command to provision a new Redis resource in your subscription. Provisioning is asynchronous and typically takes several minutes; the command returns immediately with status \"Creating\" while the resource is still being created.",
     Destructive = true,
     Idempotent = false,
     OpenWorld = false,


### PR DESCRIPTION
## What does this PR do?
This PR updates the `azmcp redis create` tool description to correctly say that Azure Cache for Redis provisioning is asynchronous. Without this change, callers and AI agents that immediately `GET` or test connectivity see a provisioning state and may misread it as an error.

## GitHub issue number?
Fixes [#459](https://github.com/microsoft/mcp-pr/issues/459)

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages
    - [ ] Added comprehensive tests for new/modified functionality (N/A - description-only change; no behavior change)
    - [x] Created a changelog entry
- [x] For MCP tool changes:
    - [x] **One tool per PR**: This PR modifies only the `azmcp redis create` tool
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation (N/A - no README command list change required)
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1` (N/A)
    - [ ] For new or modified tool descriptions, ran `ToolDescriptionEvaluator` and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names: update `consolidated-tools.json` (N/A - no name change)
    - [ ] For **renamed** tools: Tool Rename Checklist (N/A)
    - [ ] For new tools: add URL to documentation (N/A)
- [x] Extra steps for **Azure MCP Server** tool changes:
    - [x] Updated command list in `servers/Azure.Mcp.Server/docs/azmcp-commands.md`
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata
    - [ ] Updated test prompts in `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md` (N/A - no new prompts)

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.