### PR TITLE
Docs: list Advisor apply resource values

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -331,7 +331,8 @@ azmcp server info
 <!-- cspell:ignore applicationgatewaywebapplicationfirewallpolicies expressrouteports frontdoorwebapplicationfirewallpolicies -->
 <!-- cspell:ignore managedinstances staticsites -->
 
-The `--resource` parameter for `azmcp advisor recommendation apply` accepts the following values:
+The `--resource` parameter for `azmcp advisor recommendation apply` accepts the following values.
+This list is derived from the Advisor recommendation rule resource files in [`tools/Azure.Mcp.Tools.Advisor/src/Resources`](../../../tools/Azure.Mcp.Tools.Advisor/src/Resources); update that source directory and refresh this section when supported resources change:
 
 - `aad_domainservices`
 - `apimanagement_service`
@@ -4674,3 +4675,5 @@ The CLI returns structured JSON responses for errors, including:
 
 - Service availability issues
 - Authentication errors
+
+

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -4675,4 +4675,3 @@ The CLI returns structured JSON responses for errors, including:
 
 - Service availability issues
 - Authentication errors
-

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -326,6 +326,34 @@ azmcp server info
 
 ### Azure Advisor Operations
 
+<!-- cspell:ignore domainservices virtualmachinescalesets containerregistry containerservice managedclusters -->
+<!-- cspell:ignore flexibleservers databaseaccounts connectedclusters kubernetesconfiguration -->
+<!-- cspell:ignore applicationgatewaywebapplicationfirewallpolicies expressrouteports frontdoorwebapplicationfirewallpolicies -->
+<!-- cspell:ignore managedinstances staticsites -->
+
+The `--resource` parameter for `azmcp advisor recommendation apply` accepts the following values:
+
+- `aad_domainservices`
+- `apimanagement_service`
+- `cognitiveservices_accounts`
+- `compute_virtualmachines`
+- `compute_virtualmachinescalesets`
+- `containerregistry_registries`
+- `containerservice_managedclusters`
+- `dbforpostgresql_flexibleservers`
+- `documentdb_databaseaccounts`
+- `keyvault_vaults`
+- `kubernetes_connectedclusters`
+- `kubernetesconfiguration_extensions`
+- `netapp_volumes`
+- `network_applicationgatewaywebapplicationfirewallpolicies`
+- `network_expressrouteports`
+- `network_frontdoorwebapplicationfirewallpolicies`
+- `sql_managedinstances`
+- `storage_storageaccounts`
+- `web_serverfarms`
+- `web_staticsites`
+
 ```bash
 # List Advisor recommendations in a subscription
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -332,7 +332,7 @@ azmcp server info
 <!-- cspell:ignore managedinstances staticsites -->
 
 The `--resource` parameter for `azmcp advisor recommendation apply` accepts the following values.
-This list is derived from the Advisor recommendation rule resource files in [`tools/Azure.Mcp.Tools.Advisor/src/Resources`](../../../tools/Azure.Mcp.Tools.Advisor/src/Resources); update that source directory and refresh this section when supported resources change:
+This list is derived from the Advisor recommendation rule resource files in [`tools/Azure.Mcp.Tools.Advisor/src/Resources`](https://github.com/microsoft/mcp/tree/main/tools/Azure.Mcp.Tools.Advisor/src/Resources); update that source directory and refresh this section when supported resources change:
 
 - `aad_domainservices`
 - `apimanagement_service`
@@ -4675,5 +4675,4 @@ The CLI returns structured JSON responses for errors, including:
 
 - Service availability issues
 - Authentication errors
-
 


### PR DESCRIPTION
## What does this PR do?
Adds the supported `--resource` values for `azmcp advisor recommendation apply` to the Azure MCP command reference.

The list matches the Advisor recommendation rule resources embedded under `tools/Azure.Mcp.Tools.Advisor/src/Resources`.

## GitHub issue number?
Fixes #2762

## Validation
- `git diff --check`
- Compared the documented values with `tools/Azure.Mcp.Tools.Advisor/src/Resources/*.json` (20 documented values, 20 resource files)
- `git diff --name-only | .\eng\common\spelling\Invoke-Cspell.ps1` (new Advisor resource terms are ignored; this file still has existing unrelated cspell warnings)

Not run: `dotnet build servers\Azure.Mcp.Server\src` because the local machine only has .NET SDK 8.0.422 installed and this repository requires SDK 10.0.201.

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] Read contribution guidelines
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages
    - [x] Tests are not added because this is a documentation-only change
    - [x] Changelog entry is not added because this is a documentation-only change
- [x] For MCP tool changes
    - [x] This updates documentation for one existing Azure MCP command and does not change tool behavior
    - [x] Updated `servers/Azure.Mcp.Server/docs/azmcp-commands.md`