### PR TITLE
Prepare for Fabric MCP Server 1.1.0 release

### DIFF
--- a/servers/Fabric.Mcp.Server/CHANGELOG.md
+++ b/servers/Fabric.Mcp.Server/CHANGELOG.md
@@ -5,19 +5,20 @@ All notable changes to the Microsoft Fabric MCP Server will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.0.0-beta.1 (Unreleased)
+## 1.1.0 (2026-06-15)
 
 ### Features Added
 
 - **Data Factory Tools**: Added 7 new commands for managing Microsoft Fabric Data Factory resources through MCP. Includes pipeline operations (list, create, get, run) and Dataflow Gen2 operations (list, create, execute query). Powered by the [Microsoft.DataFactory.MCP.Core](https://www.nuget.org/packages/Microsoft.DataFactory.MCP.Core) NuGet package.
-
-### Breaking Changes
 
 ### Bugs Fixed
 
 - Fixed console logging polluting stdout which caused smoke test failures on macOS. Console logs are now redirected to stderr via `LogToStandardErrorThreshold`.
 
 ### Other Changes
+
+- Add better handling for MsalClientException and MsalServiceException. [[#2587](https://github.com/microsoft/mcp/pull/2587)]
+- Updated Fabric REST API specifications and item definition documentation. [[#2797](https://github.com/microsoft/mcp/pull/2797)]
 
 ## 1.0.0 (2026-04-14)
 

--- a/servers/Fabric.Mcp.Server/changelog-entries/1778015734223.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1778015734223.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Other Changes"
-    description: "Update PluginTelemetryCommand to retrieve tool names from host it creates"

--- a/servers/Fabric.Mcp.Server/changelog-entries/1778015847682.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1778015847682.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Other Changes"
-    description: "Add better handling for MsalClientException and MsalServiceException"

--- a/servers/Fabric.Mcp.Server/changelog-entries/1780345683191.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1780345683191.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Breaking Changes"
-    description: "Changed appsetting.json property names to be scope to MicrosoftMcp instead of direct property names."

--- a/servers/Fabric.Mcp.Server/changelog-entries/1780418260113.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1780418260113.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Other Changes"
-    description: "Updated Fabric REST API specifications and item definition documentation"

--- a/servers/Fabric.Mcp.Server/src/Fabric.Mcp.Server.csproj
+++ b/servers/Fabric.Mcp.Server/src/Fabric.Mcp.Server.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta.1</Version>
+    <Version>1.1.0</Version>
     <CliName>fabmcp</CliName>
     <AssemblyTitle>Fabric MCP Server</AssemblyTitle>
     <Description>Microsoft Fabric MCP Server - Model Context Protocol implementation for Fabric</Description>

--- a/servers/Fabric.Mcp.Server/vscode/CHANGELOG.md
+++ b/servers/Fabric.Mcp.Server/vscode/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Release History
 
+## 1.1.0 (2026-06-15)
+
+### Added
+
+- **Data Factory Tools**: Added 7 new commands for managing Microsoft Fabric Data Factory resources through MCP. Includes pipeline operations (list, create, get, run) and Dataflow Gen2 operations (list, create, execute query). Powered by the [Microsoft.DataFactory.MCP.Core](https://www.nuget.org/packages/Microsoft.DataFactory.MCP.Core) NuGet package.
+
+### Changed
+
+- Add better handling for MsalClientException and MsalServiceException. [[#2587](https://github.com/microsoft/mcp/pull/2587)]
+- Updated Fabric REST API specifications and item definition documentation. [[#2797](https://github.com/microsoft/mcp/pull/2797)]
+
+### Fixed
+
+- Fixed console logging polluting stdout which caused smoke test failures on macOS. Console logs are now redirected to stderr via `LogToStandardErrorThreshold`.
+
 ## 1.0.0 (2026-04-14)
 
 **First Stable Release**


### PR DESCRIPTION
Bump version to 1.1.0, compile changelog entries into the 1.1.0 section, and sync the VS Code extension changelog.