### PR TITLE
Use csproj version for Fabric MCP VSIX instead of Major.0.X

### DIFF
--- a/eng/scripts/New-BuildInfo.ps1
+++ b/eng/scripts/New-BuildInfo.ps1
@@ -464,6 +464,15 @@ function Get-ServerDetails {
                 $vsixVersion = "$($version.Major).$($version.Minor).$($version.PrereleaseNumber)"
                 $vsixIsPrerelease = $true
             }
+            elseif ($serverName -eq 'Fabric.Mcp.Server') {
+                # Fabric MCP Server follows a GA-only, minor-increment versioning strategy and
+                # drives its own explicit version numbers. Use the .csproj version verbatim so the
+                # VSIX stays in sync with the other release targets (npm, NuGet, etc.) instead of the
+                # Major.0.X marketplace-derived patch scheme used by other servers.
+                $vsixVersion = "$($version.Major).$($version.Minor).$($version.Patch)"
+                $vsixIsPrerelease = $false
+                Write-Host "Fabric MCP Server: using .csproj version for VSIX: $vsixVersion" -ForegroundColor Green
+            }
             else {
                 # For all non-beta versions, calculate next patch version from marketplace
                 $vscodePath = "$RepoRoot/servers/$serverName/vscode"


### PR DESCRIPTION
## Description

The VS Code extension (VSIX) version is computed independently of the `.csproj` version in `New-BuildInfo.ps1` using a `Major.0.<next-marketplace-patch>` scheme. As a result, Fabric's `1.1.0` release published the extension as `1.0.1` while all other release targets (npm, NuGet, ADO feed, MCR) correctly showed `1.1.0`.

Fabric MCP Server follows a GA-only, minor-increment versioning strategy and drives its own explicit version numbers, so this change uses the `.csproj` version verbatim for the Fabric VSIX. All other servers keep the existing marketplace-derived `Major.0.X` patch behavior.

### Verified
- Fabric `1.2.0` -> VSIX `1.2.0`
- Fabric `1.1.0` -> VSIX `1.1.0`
- Azure (non-beta) -> VSIX `Major.0.<marketplace+1>` (unchanged)

Note: this does not retroactively change the already-published `1.0.1` VSIX; it applies from the next release (`1.2.0`).

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.