### PR TITLE
fix: Change status code for CommandValidationException

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Commands/CommandValidationException.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/CommandValidationException.cs
@@ -11,13 +11,13 @@ namespace Microsoft.Mcp.Core.Commands;
 /// </summary>
 public class CommandValidationException(
     string message,
-    HttpStatusCode statusCode = HttpStatusCode.InternalServerError,
+    HttpStatusCode statusCode = HttpStatusCode.BadRequest,
     string? code = null,
     IReadOnlyList<string>? missingOptions = null) : Exception(message)
 {
 
     /// <summary>
-    /// HTTP status code to return in the response. Defaults to InternalServerError (500).
+    /// HTTP status code to return in the response. Defaults to BadRequest (400).
     /// </summary>
     public HttpStatusCode StatusCode { get; } = statusCode;
 

--- a/core/Microsoft.Mcp.Core/src/Validation/KqlQueryValidator.cs
+++ b/core/Microsoft.Mcp.Core/src/Validation/KqlQueryValidator.cs
@@ -52,14 +52,13 @@ public static class KqlQueryValidator
     {
         if (string.IsNullOrWhiteSpace(query))
         {
-            throw new CommandValidationException("Query cannot be empty.", HttpStatusCode.BadRequest);
+            throw new CommandValidationException("Query cannot be empty.");
         }
 
         if (query.Length > MaxQueryLength)
         {
             throw new CommandValidationException(
-                $"Query length exceeds the maximum allowed limit of {MaxQueryLength:N0} characters.",
-                HttpStatusCode.BadRequest);
+                $"Query length exceeds the maximum allowed limit of {MaxQueryLength:N0} characters.");
         }
 
         // Strip string literals before structural analysis to avoid false positives

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Commands/CommandValidationExceptionTests.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Commands/CommandValidationExceptionTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Models.Command;
+using Xunit;
+
+namespace Microsoft.Mcp.Core.Tests.Commands;
+
+/// <summary>
+/// Tests for <see cref="CommandValidationException"/> defaults and for the way
+/// <see cref="BaseCommand{TOptions}.HandleException"/> maps the exception's
+/// <see cref="CommandValidationException.StatusCode"/> into the command response.
+/// These lock in the BadRequest (400) default so it does not regress back to 500.
+/// </summary>
+public sealed class CommandValidationExceptionTests
+{
+    // ---------- Minimal concrete command fixture exposing HandleException ----------
+
+    [CommandMetadata(
+        Id = "00000000-0000-0000-0000-0000000000ce",
+        Name = "test-validation",
+        Title = "Test Validation Command",
+        Description = "A command used only to exercise HandleException in tests.")]
+    private sealed class ValidationTestCommand : BaseCommand<EmptyOptions>
+    {
+        protected override EmptyOptions BindOptions(ParseResult parseResult) => new();
+
+        public override Task<CommandResponse> ExecuteAsync(
+            CommandContext context, ParseResult parseResult, CancellationToken cancellationToken)
+            => Task.FromResult(context.Response);
+
+        public void InvokeHandleException(CommandContext context, Exception ex) => HandleException(context, ex);
+    }
+
+    private static CommandContext CreateContext()
+    {
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        return new CommandContext(serviceProvider);
+    }
+
+    // ---------- Exception default tests ----------
+
+    [Fact]
+    public void StatusCode_DefaultsToBadRequest()
+    {
+        var exception = new CommandValidationException("Validation failed.");
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+    }
+
+    [Fact]
+    public void Code_DefaultsToValidationError()
+    {
+        var exception = new CommandValidationException("Validation failed.");
+        Assert.Equal("ValidationError", exception.Code);
+    }
+
+    [Fact]
+    public void Constructor_PreservesExplicitValues()
+    {
+        var missingOptions = new[] { "--resource-group" };
+        var exception = new CommandValidationException(
+            "Validation failed.",
+            HttpStatusCode.Conflict,
+            "CustomCode",
+            missingOptions);
+
+        Assert.Equal(HttpStatusCode.Conflict, exception.StatusCode);
+        Assert.Equal("CustomCode", exception.Code);
+        Assert.Equal(missingOptions, exception.MissingOptions);
+    }
+
+    // ---------- HandleException mapping tests ----------
+
+    [Fact]
+    public void HandleException_MapsDefaultStatusCode_ToBadRequest()
+    {
+        var command = new ValidationTestCommand();
+        var context = CreateContext();
+
+        command.InvokeHandleException(context, new CommandValidationException("Validation failed."));
+
+        Assert.Equal(HttpStatusCode.BadRequest, context.Response.Status);
+        Assert.Equal("Validation failed.", context.Response.Message);
+        Assert.Null(context.Response.Results);
+    }
+
+    [Fact]
+    public void HandleException_HonorsExplicitStatusCode()
+    {
+        var command = new ValidationTestCommand();
+        var context = CreateContext();
+
+        command.InvokeHandleException(
+            context,
+            new CommandValidationException("Conflict occurred.", HttpStatusCode.Conflict));
+
+        Assert.Equal(HttpStatusCode.Conflict, context.Response.Status);
+        Assert.Equal("Conflict occurred.", context.Response.Message);
+        Assert.Null(context.Response.Results);
+    }
+
+    [Fact]
+    public void HandleException_FormatsMissingOptionsMessage()
+    {
+        var command = new ValidationTestCommand();
+        var context = CreateContext();
+
+        command.InvokeHandleException(
+            context,
+            new CommandValidationException(
+                "ignored",
+                missingOptions: new[] { "--resource-group", "--account" }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, context.Response.Status);
+        Assert.Equal("Missing Required options: --resource-group, --account", context.Response.Message);
+        Assert.Null(context.Response.Results);
+    }
+}

--- a/servers/Azure.Mcp.Server/changelog-entries/tmeschter-validation-status-code.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/tmeschter-validation-status-code.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Changed the default HTTP status code for command validation failures (`CommandValidationException`) from 500 (Internal Server Error) to 400 (Bad Request)."

--- a/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
@@ -366,11 +366,11 @@ public class PostgresService(
         {
             if (string.IsNullOrEmpty(password))
             {
-                throw new CommandValidationException($"Password must be provided for '{AuthTypes.PostgreSQL}' authentication.", HttpStatusCode.BadRequest);
+                throw new CommandValidationException($"Password must be provided for '{AuthTypes.PostgreSQL}' authentication.");
             }
             return password;
         }
 
-        throw new CommandValidationException($"Unsupported authentication type. Please use '{AuthTypes.MicrosoftEntra}' or '{AuthTypes.PostgreSQL}'", HttpStatusCode.BadRequest);
+        throw new CommandValidationException($"Unsupported authentication type. Please use '{AuthTypes.MicrosoftEntra}' or '{AuthTypes.PostgreSQL}'");
     }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/src/Validation/SqlQueryValidator.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Validation/SqlQueryValidator.cs
@@ -116,14 +116,14 @@ internal static class SqlQueryValidator
     {
         if (string.IsNullOrWhiteSpace(query))
         {
-            throw new CommandValidationException("Query cannot be empty.", HttpStatusCode.BadRequest);
+            throw new CommandValidationException("Query cannot be empty.");
         }
 
         var trimmed = query.Trim();
 
         if (trimmed.Length > MaxQueryLength)
         {
-            throw new CommandValidationException($"Query length exceeds limit of {MaxQueryLength} characters.", HttpStatusCode.BadRequest);
+            throw new CommandValidationException($"Query length exceeds limit of {MaxQueryLength} characters.");
         }
 
         // Allow an optional trailing semicolon; remove for further checks.
@@ -132,7 +132,7 @@ internal static class SqlQueryValidator
         // Must start with SELECT (ignoring leading whitespace already trimmed)
         if (!core.StartsWith("select", StringComparison.OrdinalIgnoreCase))
         {
-            throw new CommandValidationException("Only single read-only SELECT statements are allowed.", HttpStatusCode.BadRequest);
+            throw new CommandValidationException("Only single read-only SELECT statements are allowed.");
         }
 
         // Strip single-quoted string literals before checking for comment markers to avoid
@@ -147,13 +147,13 @@ internal static class SqlQueryValidator
         // Reject inline / block comments which can hide stacked statements or alter logic.
         if (withoutStrings.Contains("--", StringComparison.Ordinal) || withoutStrings.Contains("/*", StringComparison.Ordinal))
         {
-            throw new CommandValidationException("Comments are not allowed in the query.", HttpStatusCode.BadRequest);
+            throw new CommandValidationException("Comments are not allowed in the query.");
         }
 
         // Reject any additional semicolons (stacked statements) inside the core content.
         if (core.Contains(';'))
         {
-            throw new CommandValidationException("Multiple or stacked SQL statements are not allowed.", HttpStatusCode.BadRequest);
+            throw new CommandValidationException("Multiple or stacked SQL statements are not allowed.");
         }
 
         var lower = core.ToLowerInvariant();
@@ -161,20 +161,20 @@ internal static class SqlQueryValidator
         // Naive detection of tautology patterns still applied before token-level allow list.
         if (lower.Contains(" or 1=1") || lower.Contains(" or '1'='1"))
         {
-            throw new CommandValidationException("Suspicious boolean tautology pattern detected.", HttpStatusCode.BadRequest);
+            throw new CommandValidationException("Suspicious boolean tautology pattern detected.");
         }
 
         // Tokenize: capture word tokens (letters / underscore). Numerics & punctuation ignored.
         var matches = Regex.Matches(withoutStrings, "[A-Za-z_]+", RegexOptions.Compiled, RegexHelper.DefaultRegexTimeout);
         if (matches.Count == 0)
         {
-            throw new CommandValidationException("Query must contain a SELECT statement.", HttpStatusCode.BadRequest);
+            throw new CommandValidationException("Query must contain a SELECT statement.");
         }
 
         // First significant token must be SELECT.
         if (!matches[0].Value.Equals("select", StringComparison.OrdinalIgnoreCase))
         {
-            throw new CommandValidationException("Only single read-only SELECT statements are allowed.", HttpStatusCode.BadRequest);
+            throw new CommandValidationException("Only single read-only SELECT statements are allowed.");
         }
 
         // Check all tokens against blocklist of dangerous functions and system catalogs.


### PR DESCRIPTION
## What does this PR do?

Currently a `CommandValidationException` will default to an HTTP 500 status code ("internal server error"). When the command parameters fail validation it would make more sense to return HTTP 400 ("bad request").

Here we update the default, and fix up a few places that were explicitly setting HTTP 400 and no longer need to.

## GitHub issue number?

Fixes https://github.com/microsoft/mcp-pr/issues/392.

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
