### PR TITLE
docs: clarify Cosmos OpenAI endpoint constraint

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -2145,6 +2145,9 @@ azmcp cosmos database container item text-search --subscription <subscription> \
 # support custom dimensions like "text-embedding-3-small" or "text-embedding-3-large". Optionally pass
 # --properties-to-select to project specific fields; when omitted the full document is returned with the vector
 # property stripped so the embedding doesn't bloat the response. Requires a vector index on the vector property.
+# --openai-endpoint must be a trusted Azure first-party HTTPS endpoint on one of the following domains:
+#   *.openai.azure.com, *.cognitiveservices.azure.com, *.services.ai.azure.com
+# (and their US Government / China sovereign cloud equivalents). HTTP endpoints and non-Azure domains are rejected.
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp cosmos database container item vector-search --subscription <subscription> \
                                                    --account <account> \
@@ -2152,7 +2155,7 @@ azmcp cosmos database container item vector-search --subscription <subscription>
                                                    --container <container> \
                                                    --vector-property <vector-property> \
                                                    --search-text "free-form text" \
-                                                   --openai-endpoint <endpoint> \
+                                                   --openai-endpoint <azure-openai-endpoint> \
                                                    --embedding-deployment <deployment> \
                                                    [--properties-to-select <p1,p2,...>] \
                                                    [--count 10] \


### PR DESCRIPTION
## Summary

- Clarifies that `azmcp cosmos database container item vector-search --openai-endpoint` must use a trusted Azure first-party HTTPS endpoint.
- Updates the example placeholder from `<endpoint>` to `<azure-openai-endpoint>`.

Fixes microsoft/mcp#2902.

## Validation

- `git diff --check`
- `.\eng\common\spelling\Invoke-Cspell.ps1`

I also attempted the requested local builds:

- `dotnet build servers\Azure.Mcp.Server\`
- `dotnet build tools\Azure.Mcp.Tools.Cosmos\src\`

Both were blocked locally because this machine has .NET SDK `8.0.301`, while the repo `global.json` requires SDK `10.0.201`.

## AI assistance disclosure

This PR was prepared with assistance from OpenAI Codex. I reviewed the issue, repository contribution guidance, duplicate PR search results, and the final diff before submission.
