### PR TITLE
Few updates to Option binding

### DIFF
--- a/core/Azure.Mcp.Core/src/Commands/Subscription/SubscriptionCommand`2.cs
+++ b/core/Azure.Mcp.Core/src/Commands/Subscription/SubscriptionCommand`2.cs
@@ -29,11 +29,9 @@ public abstract class SubscriptionCommand<
         }
     }
 
-    public override TOptions BindOptions(ParseResult parseResult)
+    public override void PostBindOptions(TOptions options)
     {
-        var options = base.BindOptions(parseResult);
         // Always post-process subscription via resolver (env var / CLI profile fallback)
         options.Subscription = _subscriptionResolver.ResolveSubscription(options.Subscription);
-        return options;
     }
 }

--- a/core/Microsoft.Mcp.Core/src/Commands/BaseCommand`2.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/BaseCommand`2.cs
@@ -56,9 +56,19 @@ public abstract class BaseCommand<[DynamicallyAccessedMembers(TrimAnnotations.Co
 
     public Command GetCommand() => _command;
 
-    public virtual TOptions BindOptions(ParseResult parseResult)
+    public TOptions BindOptions(ParseResult parseResult)
     {
-        return OptionBinder.BindOptions<TOptions>(parseResult);
+        var options = OptionBinder.BindOptions<TOptions>(parseResult);
+        PostBindOptions(options);
+        return options;
+    }
+
+    /// <summary>
+    /// Performs additional processing on the bound options after they have been bound.
+    /// </summary>
+    /// <param name="options">The bound options to process.</param>
+    public virtual void PostBindOptions(TOptions options)
+    {
     }
 
     public virtual void ValidateOptions(TOptions options, ValidationResult validationResult)

--- a/core/Microsoft.Mcp.Core/src/Options/OptionBinder.cs
+++ b/core/Microsoft.Mcp.Core/src/Options/OptionBinder.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections.Concurrent;
-using System.CommandLine.Parsing;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Reflection;

--- a/core/Microsoft.Mcp.Core/src/Options/OptionDescriptor.cs
+++ b/core/Microsoft.Mcp.Core/src/Options/OptionDescriptor.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.Mcp.Core.Commands;
 
 namespace Microsoft.Mcp.Core.Options;
@@ -27,7 +28,7 @@ public class OptionDescriptor
 
     [UnconditionalSuppressMessage("Trimming", "IL2070:UnrecognizedReflectionPattern",
         Justification = "Nested option types are rooted by the application.")]
-    private static void CollectDescriptors(Type type, string? prefix, List<OptionDescriptor> descriptors, NullabilityInfoContext nullabilityContext, bool parentOptional = false, PropertyInfo? parentProperty = null)
+    private static void CollectDescriptors(Type type, string? prefix, List<OptionDescriptor> descriptors, NullabilityInfoContext nullabilityContext, bool parentRequired = true, PropertyInfo? parentProperty = null)
     {
         PropertyInfo[] allProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
@@ -52,30 +53,32 @@ public class OptionDescriptor
             }
 
             OptionAttribute? optionAttribute = property.GetCustomAttribute<OptionAttribute>();
+            // Only include properties with [Option]
+            if (optionAttribute == null)
+            {
+                continue;
+            }
             string name = optionAttribute?.Name ?? OptionNameConvention.ToKebabCase(property.Name);
 
             if (!string.IsNullOrEmpty(prefix))
             {
                 name = $"{prefix}-{name}";
             }
-
+            
+            var required = Attribute.IsDefined(property, typeof(RequiredMemberAttribute));
             if (IsComplexType(property.PropertyType))
             {
-                bool isOptionalGroup = IsNullable(property, nullabilityContext);
-
                 // Flatten nested complex types with a prefix.
-                CollectDescriptors(property.PropertyType, name, descriptors, nullabilityContext, parentOptional: isOptionalGroup, parentProperty: property);
+                CollectDescriptors(property.PropertyType, name, descriptors, nullabilityContext, parentRequired: required, parentProperty: property);
             }
             else
             {
-                bool isNullable = IsNullable(property, nullabilityContext);
-
-                if (parentOptional && !isNullable)
+                if (!parentRequired && required)
                 {
                     throw new InvalidOperationException(
                         $"Optional group contains required member '{property.Name}'. " +
-                        "All properties within a nullable complex type must be nullable. " +
-                        "Either make the parent property required or make all child properties nullable.");
+                        "All properties within a non-required complex type must be non-required. " +
+                        "Either make the parent property required or make all child properties non-required.");
                 }
 
 
@@ -84,7 +87,7 @@ public class OptionDescriptor
                     Name = name,
                     Description = optionAttribute?.Description,
                     Type = property.PropertyType,
-                    Required = !isNullable,
+                    Required = required,
                     Hidden = optionAttribute?.Hidden ?? false,
                     TargetProperty = property,
                     ParentProperty = parentProperty

--- a/core/Microsoft.Mcp.Core/src/Options/OptionDescriptor.cs
+++ b/core/Microsoft.Mcp.Core/src/Options/OptionDescriptor.cs
@@ -64,7 +64,7 @@ public class OptionDescriptor
             {
                 name = $"{prefix}-{name}";
             }
-            
+
             var required = Attribute.IsDefined(property, typeof(RequiredMemberAttribute));
             if (IsComplexType(property.PropertyType))
             {

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Options/OptionBinderTests.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Options/OptionBinderTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.CommandLine;
-using System.CommandLine.Parsing;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Mcp.Core.Commands;
@@ -17,25 +16,33 @@ public sealed class OptionBinderTests
 
     private sealed class StringOptions
     {
+        [Option]
         public string? Name { get; set; }
+        [Option]
         public string? Description { get; set; }
     }
 
     private sealed class IntOptions
     {
+        [Option]
         public int Count { get; set; }
+        [Option]
         public int? Limit { get; set; }
     }
 
     private sealed class BoolOptions
     {
+        [Option]
         public bool Verbose { get; set; }
+        [Option]
         public bool? Debug { get; set; }
     }
 
     private sealed class ArrayOptions
     {
+        [Option]
         public string[]? Tags { get; set; }
+        [Option]
         public int[]? Ports { get; set; }
     }
 
@@ -48,55 +55,73 @@ public sealed class OptionBinderTests
 
     private sealed class EnumOptions
     {
+        [Option]
         public Color Color { get; set; }
+        [Option]
         public Color? Background { get; set; }
     }
 
     private sealed class GuidOptions
     {
+        [Option]
         public Guid Id { get; set; }
+        [Option]
         public Guid? CorrelationId { get; set; }
     }
 
     private sealed class DateTimeOptions
     {
+        [Option]
         public DateTime StartDate { get; set; }
+        [Option]
         public DateTimeOffset? Timestamp { get; set; }
     }
 
     private sealed class DecimalOptions
     {
+        [Option]
         public decimal Price { get; set; }
+        [Option]
         public double? Rate { get; set; }
     }
 
     private sealed class UnsupportedTypeOptions
     {
+        [Option]
         public object[]? Value { get; set; }
     }
 
     private sealed class NetworkSettings
     {
+        [Option]
         public string? Host { get; set; }
+        [Option]
         public int? Port { get; set; }
     }
 
     private sealed class RequiredNetworkSettings
     {
+        [Option]
         public required string Name { get; set; }
+        [Option]
         public int? Port { get; set; }
     }
 
     private sealed class NestedOptional
     {
+        [Option]
         public string? Name { get; set; }
+        [Option]
         public NetworkSettings? Optional { get; set; }
+        [Option]
         public required NetworkSettings Required { get; set; }
     }
 
     private sealed class NestedRequired
     {
+        [Option]
         public string? Name { get; set; }
+        [Option]
         public required RequiredNetworkSettings Required { get; set; }
     }
 

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/BaseClusterCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/BaseClusterCommand.cs
@@ -17,11 +17,9 @@ public abstract class BaseClusterCommand<
 {
     protected static bool UseClusterUri(TOptions options) => !string.IsNullOrEmpty(options.ClusterUri);
 
-    public override TOptions BindOptions(ParseResult parseResult)
+    public override void PostBindOptions(TOptions options)
     {
-        var options = base.BindOptions(parseResult);
         options.Subscription = subscriptionResolver.ResolveSubscription(options.Subscription);
-        return options;
     }
 
     public override void ValidateOptions(TOptions options, ValidationResult validationResult)


### PR DESCRIPTION
## What does this PR do?

- Make `required` determine parameter requiredness.
- Only bind parameters with `[Option]`, ignore those that don't have it.
- Add `PostBindOptions` so subtypes don't need to interact with `ParseResult`.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
