### PR TITLE
Create authenticated npmrc in another job

### DIFF
--- a/eng/pipelines/templates/jobs/analyze.yml
+++ b/eng/pipelines/templates/jobs/analyze.yml
@@ -11,6 +11,8 @@ jobs:
 
   - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
 
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
   - task: UseNode@1
     displayName: 'Install Node.js 24'
     inputs:

--- a/eng/pipelines/templates/jobs/live-test.yml
+++ b/eng/pipelines/templates/jobs/live-test.yml
@@ -25,6 +25,10 @@ jobs:
     inputs:
       version: '24.x'
 
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: $(Agent.TempDirectory)/live_test/.npmrc
+
   - pwsh: |
       $serverName = $env:SERVERNAME
 
@@ -38,6 +42,8 @@ jobs:
       exit $LastExitCode
     displayName: "Build local package"
     workingDirectory: $(Build.SourcesDirectory)
+    env:
+      npm_config_userconfig: "$(Agent.TempDirectory)/live_test/.npmrc"
 
   - pwsh: >
       ./eng/scripts/Test-Code.ps1

--- a/eng/pipelines/templates/jobs/live-test.yml
+++ b/eng/pipelines/templates/jobs/live-test.yml
@@ -26,8 +26,6 @@ jobs:
       version: '24.x'
 
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-    parameters:
-      npmrcPath: $(Agent.TempDirectory)/live_test/.npmrc
 
   - pwsh: |
       $serverName = $env:SERVERNAME
@@ -42,8 +40,6 @@ jobs:
       exit $LastExitCode
     displayName: "Build local package"
     workingDirectory: $(Build.SourcesDirectory)
-    env:
-      npm_config_userconfig: "$(Agent.TempDirectory)/live_test/.npmrc"
 
   - pwsh: >
       ./eng/scripts/Test-Code.ps1

--- a/eng/pipelines/templates/jobs/verify-packages.yml
+++ b/eng/pipelines/templates/jobs/verify-packages.yml
@@ -42,8 +42,6 @@ jobs:
       version: '24.x'
 
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-    parameters:
-      npmrcPath: $(Agent.TempDirectory)/verify_packages/.npmrc
 
   - task: Powershell@2
     displayName: "Verify packages/images and run smoke tests"
@@ -55,6 +53,4 @@ jobs:
         -ArtifactsDirectory $(Pipeline.Workspace)
         -TargetOs ${{ parameters.OSName }}
         -TargetArch $(Architecture)
-        -TestDocker:$${{ parameters.PackageDocker }}
-    env:
-      npm_config_userconfig: "$(Agent.TempDirectory)/verify_packages/.npmrc"  
+        -TestDocker:$${{ parameters.PackageDocker }} 

--- a/eng/pipelines/templates/jobs/verify-packages.yml
+++ b/eng/pipelines/templates/jobs/verify-packages.yml
@@ -41,6 +41,10 @@ jobs:
     inputs:
       version: '24.x'
 
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: $(Agent.TempDirectory)/verify_packages/.npmrc
+
   - task: Powershell@2
     displayName: "Verify packages/images and run smoke tests"
     inputs:
@@ -52,3 +56,5 @@ jobs:
         -TargetOs ${{ parameters.OSName }}
         -TargetArch $(Architecture)
         -TestDocker:$${{ parameters.PackageDocker }}
+    env:
+      npm_config_userconfig: "$(Agent.TempDirectory)/verify_packages/.npmrc"  

--- a/eng/pipelines/templates/jobs/vscode-integration.yml
+++ b/eng/pipelines/templates/jobs/vscode-integration.yml
@@ -15,8 +15,6 @@ jobs:
       version: '24.x'
   
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-    parameters:
-      npmrcPath: $(Agent.TempDirectory)/vscode_integration/.npmrc
 
   - task: PowerShell@2
     displayName: "Run VS Code elicitation outerloop test"
@@ -24,8 +22,6 @@ jobs:
     inputs:
       pwsh: true
       filePath: $(Build.SourcesDirectory)/eng/scripts/Test-VSCodeIntegration.ps1
-    env:
-      npm_config_userconfig: "$(Agent.TempDirectory)/vscode_integration/.npmrc"
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:

--- a/eng/pipelines/templates/jobs/vscode-integration.yml
+++ b/eng/pipelines/templates/jobs/vscode-integration.yml
@@ -13,6 +13,10 @@ jobs:
     displayName: 'Install Node.js 24'
     inputs:
       version: '24.x'
+  
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: $(Agent.TempDirectory)/vscode_integration/.npmrc
 
   - task: PowerShell@2
     displayName: "Run VS Code elicitation outerloop test"
@@ -20,6 +24,8 @@ jobs:
     inputs:
       pwsh: true
       filePath: $(Build.SourcesDirectory)/eng/scripts/Test-VSCodeIntegration.ps1
+    env:
+      npm_config_userconfig: "$(Agent.TempDirectory)/vscode_integration/.npmrc"
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:

--- a/eng/pipelines/templates/jobs/vsix/pack-and-sign-vsix.yml
+++ b/eng/pipelines/templates/jobs/vsix/pack-and-sign-vsix.yml
@@ -24,6 +24,10 @@ jobs:
     inputs:
       version: '24.x'
 
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: $(Agent.TempDirectory)/pack_and_sign_vsix/.npmrc
+
   # --- VS Code Extension Packaging Steps ---
   - task: Powershell@2
     displayName: "Pack binaries for VSIX"
@@ -34,6 +38,8 @@ jobs:
         -BuildInfoPath '$(Pipeline.Workspace)/build_info/build_info.json'
         -ArtifactsPath '$(Pipeline.Workspace)/binaries_signed'
         -OutputPath '$(Build.ArtifactStagingDirectory)'
+    env:
+      npm_config_userconfig: "$(Agent.TempDirectory)/pack_and_sign_vsix/.npmrc"
 
   - template: pipelines/steps/azd-vscode-signing.yml@azure-sdk-build-tools
     parameters:
@@ -47,6 +53,8 @@ jobs:
       filePath: $(Build.SourcesDirectory)/eng/scripts/Verify-VsixSignatures.ps1
       arguments: >
         -ArtifactsPath '$(Build.ArtifactStagingDirectory)'
+    env:
+      npm_config_userconfig: "$(Agent.TempDirectory)/pack_and_sign_vsix/.npmrc"
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:

--- a/eng/pipelines/templates/jobs/vsix/pack-and-sign-vsix.yml
+++ b/eng/pipelines/templates/jobs/vsix/pack-and-sign-vsix.yml
@@ -25,8 +25,6 @@ jobs:
       version: '24.x'
 
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-    parameters:
-      npmrcPath: $(Agent.TempDirectory)/pack_and_sign_vsix/.npmrc
 
   # --- VS Code Extension Packaging Steps ---
   - task: Powershell@2
@@ -38,8 +36,6 @@ jobs:
         -BuildInfoPath '$(Pipeline.Workspace)/build_info/build_info.json'
         -ArtifactsPath '$(Pipeline.Workspace)/binaries_signed'
         -OutputPath '$(Build.ArtifactStagingDirectory)'
-    env:
-      npm_config_userconfig: "$(Agent.TempDirectory)/pack_and_sign_vsix/.npmrc"
 
   - template: pipelines/steps/azd-vscode-signing.yml@azure-sdk-build-tools
     parameters:
@@ -53,8 +49,6 @@ jobs:
       filePath: $(Build.SourcesDirectory)/eng/scripts/Verify-VsixSignatures.ps1
       arguments: >
         -ArtifactsPath '$(Build.ArtifactStagingDirectory)'
-    env:
-      npm_config_userconfig: "$(Agent.TempDirectory)/pack_and_sign_vsix/.npmrc"
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:

--- a/eng/pipelines/templates/jobs/vsix/release-vsix.yml
+++ b/eng/pipelines/templates/jobs/vsix/release-vsix.yml
@@ -58,7 +58,7 @@ jobs:
         targetPath: $(Pipeline.Workspace)/build_info
       - input: pipelineArtifact
         artifactName: vsix_npmrc
-        targetPath: $(Pipeline.Workspace)/npmrc
+        targetPath: $(Agent.TempDirectory)/vsix_npmrc
     environment: package-publish
     pool:
       name: azsdk-pool
@@ -99,7 +99,7 @@ jobs:
                 "@
 
                 Write-Host "`nInstalling vsce from authenticated feed..."
-                npm install -g @vscode/vsce --userconfig "$(Pipeline.Workspace)/npmrc/.npmrc"
+                npm install -g @vscode/vsce --userconfig "$(Agent.TempDirectory)/vsix_npmrc/.npmrc"
 
                 Write-Host "Executing: vsce publish $($publishArgs -join ' ')"
                 vsce publish @publishArgs

--- a/eng/pipelines/templates/jobs/vsix/release-vsix.yml
+++ b/eng/pipelines/templates/jobs/vsix/release-vsix.yml
@@ -13,13 +13,38 @@ parameters:
     - windows-x64
     - windows-arm64
 
-
 jobs:
+# Regular job: Create an authenticated .npmrc once and publish it so each
+# deployment job can install @vscode/vsce from the internal feed without
+# needing service-connection access from inside the production release job.
+- job: AuthenticateNpmrc
+  displayName: "Create authenticated .npmrc for vsce install"
+  dependsOn: ${{ parameters.DependsOn }}
+  condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
+  pool:
+    name: $(LINUXPOOL)
+    image: $(LINUXVMIMAGE)
+    os: linux
+  steps:
+  - checkout: self
+
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: $(Agent.TempDirectory)/vsix_npmrc/.npmrc
+
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: Publish authenticated .npmrc
+    inputs:
+      path: $(Agent.TempDirectory)
+      artifact: vsix_npmrc
+
 # Deployment Jobs: Publish VSIX artifacts to Marketplace for each vsix target
 - ${{ each VsixTarget in parameters.VsixTargets }}:
   - deployment: PublishVSIX_${{ replace(VsixTarget, '-', '_') }}
     displayName: "Publish VSIX Artifact to Marketplace - ${{ VsixTarget }}"
-    dependsOn: ${{ parameters.DependsOn }}
+    dependsOn:
+    - ${{ parameters.DependsOn }}
+    - AuthenticateNpmrc
     condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
     templateContext:
       type: releaseJob
@@ -31,6 +56,9 @@ jobs:
       - input: pipelineArtifact
         artifactName: build_info
         targetPath: $(Pipeline.Workspace)/build_info
+      - input: pipelineArtifact
+        artifactName: vsix_npmrc
+        targetPath: $(Pipeline.Workspace)/npmrc
     environment: package-publish
     pool:
       name: azsdk-pool
@@ -70,8 +98,8 @@ jobs:
                 Is Prerelease: $($server.vsixIsPrerelease)
                 "@
 
-                Write-Host "`nInstalling vsce..."
-                npm install -g @vscode/vsce
+                Write-Host "`nInstalling vsce from authenticated feed..."
+                npm install -g @vscode/vsce --userconfig "$(Pipeline.Workspace)/npmrc/.npmrc"
 
                 Write-Host "Executing: vsce publish $($publishArgs -join ' ')"
                 vsce publish @publishArgs

--- a/eng/pipelines/templates/steps/analyze-aot-compact.yml
+++ b/eng/pipelines/templates/steps/analyze-aot-compact.yml
@@ -6,6 +6,10 @@ parameters:
   default: $(Build.SourcesDirectory)
 
 steps:
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: $(Agent.TempDirectory)/analyze_aot_compact/.npmrc
+
   - task: PowerShell@2
     displayName: "Run AOT Compatibility Analysis"
     inputs:
@@ -16,6 +20,8 @@ steps:
         -OutputFormat Console
       workingDirectory: ${{ parameters.sourceDirectory }}
     continueOnError: true
+    env:
+      npm_config_userconfig: "$(Agent.TempDirectory)/analyze_aot_compact/.npmrc"  
 
   - task: PowerShell@2
     displayName: "Check if AOT report exists and publish artifact"

--- a/eng/pipelines/templates/steps/analyze-aot-compact.yml
+++ b/eng/pipelines/templates/steps/analyze-aot-compact.yml
@@ -6,10 +6,6 @@ parameters:
   default: $(Build.SourcesDirectory)
 
 steps:
-  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-    parameters:
-      npmrcPath: $(Agent.TempDirectory)/analyze_aot_compact/.npmrc
-
   - task: PowerShell@2
     displayName: "Run AOT Compatibility Analysis"
     inputs:
@@ -20,8 +16,6 @@ steps:
         -OutputFormat Console
       workingDirectory: ${{ parameters.sourceDirectory }}
     continueOnError: true
-    env:
-      npm_config_userconfig: "$(Agent.TempDirectory)/analyze_aot_compact/.npmrc"  
 
   - task: PowerShell@2
     displayName: "Check if AOT report exists and publish artifact"


### PR DESCRIPTION
This pull request updates the VSIX release pipeline to improve how the `@vscode/vsce` tool is installed during deployment. The main change is the introduction of a new job that creates and publishes an authenticated `.npmrc` file, allowing deployment jobs to install `@vscode/vsce` from an internal feed without needing direct service connection access. This enhances security and simplifies the deployment process.

**Pipeline authentication and artifact handling:**

* Added a new job, `AuthenticateNpmrc`, to create an authenticated `.npmrc` file and publish it as a pipeline artifact for use by deployment jobs.
* Updated deployment jobs to depend on the new `AuthenticateNpmrc` job and to download the `vsix_npmrc` artifact for authenticated npm installs. [[1]](diffhunk://#diff-313e6972a14356a61bb5832bfaf805dabfd0dda18827177e8cd4ba5940927ffaL16-R47) [[2]](diffhunk://#diff-313e6972a14356a61bb5832bfaf805dabfd0dda18827177e8cd4ba5940927ffaR59-R61)

**VSCE installation update:**

* Modified the VSIX deployment script to install `@vscode/vsce` using the authenticated `.npmrc`, ensuring installation from the internal feed.

[mcp - Template.Mcp.Server](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6467724&view=results)