### PR TITLE
Update create auth npmrc

### DIFF
--- a/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+++ b/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
@@ -1,34 +1,41 @@
 parameters:
   - name: npmrcPath
     type: string
+    # When empty, defaults to the agent user's .npmrc ($HOME/.npmrc on
+    # Linux/macOS, %USERPROFILE%\.npmrc on Windows) so every subsequent
+    # npm / pnpm / npx call in the job inherits the registry + auth.
+    default: ""
   - name: registryUrl
     type: string
-    default: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/'
+    default: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/"
   - name: CustomCondition
     type: string
     default: succeeded()
   - name: ServiceConnection
     type: string
-    default: ''
+    default: ""
 
 steps:
-- pwsh: |
-    Write-Host "Creating .npmrc file ${{ parameters.npmrcPath }} for registry ${{ parameters.registryUrl }}"
-    $parentFolder = Split-Path -Path '${{ parameters.npmrcPath }}' -Parent
-    
-    if (!(Test-Path $parentFolder)) {
-      Write-Host "Creating folder $parentFolder"
-      New-Item -Path $parentFolder -ItemType Directory | Out-Null
-    }
+  - pwsh: |
+      $npmrcPath = '${{ parameters.npmrcPath }}'
+      if (-not $npmrcPath) { $npmrcPath = Join-Path $HOME '.npmrc' }
 
-    $content = "registry=${{ parameters.registryUrl }}`n`nalways-auth=true"
-    $content | Out-File '${{ parameters.npmrcPath }}'
-  displayName: 'Create .npmrc'
-  condition: ${{ parameters.CustomCondition }}
+      Write-Host "Creating .npmrc file $npmrcPath for registry ${{ parameters.registryUrl }}"
+      $parentFolder = Split-Path -Path $npmrcPath -Parent
 
-- task: npmAuthenticate@0
-  displayName: Authenticate .npmrc
-  condition: ${{ parameters.CustomCondition }}
-  inputs:
-    workingFile: ${{ parameters.npmrcPath }}
-    azureDevOpsServiceConnection: ${{ parameters.ServiceConnection }}
+      if ($parentFolder -and -not (Test-Path $parentFolder)) {
+        Write-Host "Creating folder $parentFolder"
+        New-Item -Path $parentFolder -ItemType Directory | Out-Null
+      }
+
+      "registry=${{ parameters.registryUrl }}" | Out-File $npmrcPath
+      Write-Host "##vso[task.setvariable variable=resolvedNpmrcPath]$npmrcPath"
+    displayName: "Create .npmrc"
+    condition: ${{ parameters.CustomCondition }}
+
+  - task: npmAuthenticate@0
+    displayName: Authenticate .npmrc
+    condition: ${{ parameters.CustomCondition }}
+    inputs:
+      workingFile: $(resolvedNpmrcPath)
+      azureDevOpsServiceConnection: ${{ parameters.ServiceConnection }}


### PR DESCRIPTION
This pull request updates the `create-authenticated-npmrc.yml` pipeline template to improve how the `.npmrc` file path is handled and to enhance compatibility and robustness in pipeline jobs. The most important changes are grouped below:

**Improvements to `.npmrc` Path Handling:**

* The `npmrcPath` parameter now defaults to an empty string, which causes the script to use the agent user's default `.npmrc` location if not specified, ensuring all subsequent npm-related commands inherit the correct configuration.
* The script now dynamically sets and uses a resolved `.npmrc` path, storing it in a pipeline variable (`resolvedNpmrcPath`) for use in later steps, improving reliability and flexibility.

**Code Quality and Consistency:**

* Consistent use of double quotes for parameter defaults and improved formatting for readability.
* The script now checks for the existence of the parent folder before creating it, and only attempts to create it if necessary, reducing unnecessary operations.
* The `.npmrc` file is now created with only the registry line (removing `always-auth=true`), aligning with updated authentication practices.