### PR TITLE
Document valid --sku-tier values for eventhubs namespace update

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -2492,7 +2492,7 @@ azmcp eventhubs namespace update --subscription <subscription> \
                                  --namespace <namespace> \
                                  [--location <location>] \
                                  [--sku-name <sku-name>] \
-                                 [--sku-tier <sku-tier>] \
+                                 [--sku-tier <Basic|Standard|Premium>] \
                                  [--sku-capacity <sku-capacity>] \
                                  [--is-auto-inflate-enabled <true/false>] \
                                  [--maximum-throughput-units <units>] \


### PR DESCRIPTION
## Summary

Closes the documentation gap reported in #2846.

PR #2678 introduced a **breaking change** in the EventHubs toolset: `azmcp eventhubs namespace update` (and create) now rejects invalid `--sku-tier` values with an `ArgumentException` instead of silently defaulting to `Standard`. Valid values are `Basic`, `Standard`, and `Premium` (case-insensitive).

This PR updates `servers/Azure.Mcp.Server/docs/azmcp-commands.md` so the `--sku-tier` placeholder lists the accepted values, using the established inline-enum notation already used elsewhere in the file (e.g. `[--policy-sub-type <Standard|Enhanced>]`).

```diff
-                                 [--sku-tier <sku-tier>] \
+                                 [--sku-tier <Basic|Standard|Premium>] \
```

## Scope

- Documentation-only change; no code changed.
- The two other `--sku-tier` occurrences belong to `azmcp sql db create`/`update` (a different service with different validation) and are intentionally left unchanged.

## Validation

- Ran `.\eng\common\spelling\Invoke-Cspell.ps1` on the file; the edit produces no new warnings (remaining warnings are pre-existing and unrelated).

Fixes #2846

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
