### PR TITLE
Change how playback LRO is handled to reduce CI times

### DIFF
--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureResourceService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureResourceService.cs
@@ -244,8 +244,7 @@ public abstract class BaseAzureResourceService(
         GenericResourceData data = dataModel.Create(ref reader, new ModelReaderWriterOptions("W"))
             ?? throw new InvalidOperationException("Failed to create deployment data");
         // Create the resource
-        var result = await armClient.GetGenericResources().CreateOrUpdateAsync(WaitUntil.Started, resourceIdentifier, data, cancellationToken);
-        await WaitForLroCompletionAsync(result, cancellationToken);
+        var result = await armClient.GetGenericResources().CreateOrUpdateAsync(WaitUntil.Completed, resourceIdentifier, data, cancellationToken);
         return result.Value;
     }
 }

--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
@@ -7,7 +7,6 @@ using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Mcp.Core.Services.Azure.Tenant;
 using Azure.ResourceManager;
-using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Azure;
 
@@ -31,7 +30,6 @@ public abstract class BaseAzureService
     private static readonly string s_framework;
     private static readonly string s_platform;
     private static readonly string s_defaultUserAgent;
-    private static readonly TimeSpan? s_defaultPollInterval = null;
 
     static BaseAzureService()
     {
@@ -43,13 +41,6 @@ public abstract class BaseAzureService
         // Initialize the default user agent policy without transport type
         s_defaultUserAgent = $"azmcp/{s_version} ({s_framework}; {s_platform})";
         s_sharedUserAgentPolicy = new UserAgentPolicy(s_defaultUserAgent);
-
-#if DEBUG
-        if (EnvironmentHelpers.IsPlaybackTesting())
-        {
-            s_defaultPollInterval = TimeSpan.Zero;
-        }
-#endif
     }
 
     /// <summary>
@@ -163,15 +154,11 @@ public abstract class BaseAzureService
         return await TenantService.GetTenantId(tenant, cancellationToken);
     }
 
-    protected async Task<TokenCredential> GetCredential(CancellationToken cancellationToken)
-    {
-        // TODO @vukelich: separate PR for cancellationToken to be required, not optional default
-        return await GetCredential(null, cancellationToken);
-    }
+    protected async Task<TokenCredential> GetCredential(CancellationToken cancellationToken) =>
+        await GetCredential(null, cancellationToken);
 
     protected async Task<TokenCredential> GetCredential(string? tenant, CancellationToken cancellationToken)
     {
-        // TODO @vukelich: separate PR for cancellationToken to be required, not optional default
         var tenantId = string.IsNullOrEmpty(tenant) ? null : await ResolveTenantIdAsync(tenant, cancellationToken);
 
         try
@@ -294,61 +281,6 @@ public abstract class BaseAzureService
         {
             throw new ArgumentException(
                 $"Required parameter{(missingParams.Length > 1 ? "s are" : " is")} null or empty: {string.Join(", ", missingParams)}");
-        }
-    }
-
-    /// <summary>
-    /// Waits for the completion of a long-running operation, periodically polling the operation status until it completes.
-    /// </summary>
-    /// <typeparam name="T">The return type.</typeparam>
-    /// <param name="operation">The long-running operation.</param>
-    /// <param name="cancellationToken">The cancellation token that can cancel the request.</param>
-    /// <returns>The response once the long-running operation completes.</returns>
-    protected static async Task WaitForLroCompletionAsync<T>(Operation<T> operation, CancellationToken cancellationToken = default) where T : notnull
-    {
-        ArgumentNullException.ThrowIfNull(operation);
-
-        if (s_defaultPollInterval.HasValue)
-        {
-            await WaitForLroCompletionInternalAsync(operation, cancellationToken).ConfigureAwait(false);
-        }
-        else
-        {
-            await operation.WaitForCompletionAsync(cancellationToken);
-        }
-    }
-
-    /// <summary>
-    /// Waits for the completion of a long-running operation, periodically polling the operation status until it completes.
-    /// </summary>
-    /// <param name="operation">The long-running operation.</param>
-    /// <param name="cancellationToken">The cancellation token that can cancel the request.</param>
-    /// <returns>The response once the long-running operation completes.</returns>
-    protected static async Task WaitForLroCompletionAsync(Operation operation, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(operation);
-
-        if (s_defaultPollInterval.HasValue)
-        {
-            await WaitForLroCompletionInternalAsync(operation, cancellationToken).ConfigureAwait(false);
-        }
-        else
-        {
-            await operation.WaitForCompletionResponseAsync(cancellationToken);
-        }
-    }
-
-    private static async Task<Response> WaitForLroCompletionInternalAsync(Operation operation, CancellationToken cancellationToken)
-    {
-        while (true)
-        {
-            Response response = await operation.UpdateStatusAsync(cancellationToken);
-            if (operation.HasCompleted)
-            {
-                return operation.GetRawResponse();
-            }
-
-            await Task.Delay(s_defaultPollInterval!.Value, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/core/Microsoft.Mcp.Core/src/Services/Http/RecordingRedirectHandler.cs
+++ b/core/Microsoft.Mcp.Core/src/Services/Http/RecordingRedirectHandler.cs
@@ -65,10 +65,9 @@ internal sealed class RecordingRedirectHandler(Uri proxyUri) : DelegatingHandler
     {
         if (_playbackTesting)
         {
-            if (response.Headers.Remove("Retry-After"))
-            {
-                response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.Zero);
-            }
+            // Always set Retry-After to TimeSpan.Zero. This allows for centralized handling for LROs as they look at
+            // that to determine the polling interval. So, it effectively removes any polling interval delays.
+            response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.Zero);
             if (response.Headers.Remove("x-ms-retry-after-ms"))
             {
                 response.Headers.Add("x-ms-retry-after-ms", "0");

--- a/tools/Azure.Mcp.Tools.AppService/src/Services/AppServiceService.cs
+++ b/tools/Azure.Mcp.Tools.AppService/src/Services/AppServiceService.cs
@@ -132,8 +132,7 @@ public class AppServiceService(
         var configData = config.Value.Data;
         configData.ConnectionStrings = connectionStrings;
 
-        var updateOperation = await configResource.CreateOrUpdateAsync(WaitUntil.Started, configData, cancellationToken);
-        await WaitForLroCompletionAsync(updateOperation, cancellationToken);
+        var updateOperation = await configResource.CreateOrUpdateAsync(WaitUntil.Completed, configData, cancellationToken);
         if (updateOperation?.Value == null)
         {
             throw new InvalidOperationException($"Failed to update configuration for web app '{webApp.Data.Name}'.");

--- a/tools/Azure.Mcp.Tools.Communication/src/Services/CommunicationService.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Services/CommunicationService.cs
@@ -176,10 +176,9 @@ public class CommunicationService(ITenantService tenantService, ILogger<Communic
 
             // Send the email
             var sendOperation = await emailClient.SendAsync(
-                WaitUntil.Started,
+                WaitUntil.Completed,
                 emailMessage,
                 cancellationToken);
-            await WaitForLroCompletionAsync(sendOperation, cancellationToken);
 
             // Get the operation result
             var operationResult = sendOperation.Value;

--- a/tools/Azure.Mcp.Tools.Compute/src/Services/ComputeService.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Services/ComputeService.cs
@@ -215,11 +215,10 @@ public class ComputeService(
         // Create the VM
         var vmCollection = resourceGroupResource.GetVirtualMachines();
         var vmOperation = await vmCollection.CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             vmName,
             vmData,
             cancellationToken);
-        await WaitForLroCompletionAsync(vmOperation, cancellationToken);
 
         var createdVm = vmOperation.Value;
 
@@ -369,11 +368,10 @@ public class ComputeService(
             }
 
             var nsgOperation = await nsgCollection.CreateOrUpdateAsync(
-                WaitUntil.Started,
+                WaitUntil.Completed,
                 nsgName,
                 nsgData,
                 cancellationToken);
-            await WaitForLroCompletionAsync(nsgOperation, cancellationToken);
             nsgResource = nsgOperation.Value;
         }
 
@@ -401,11 +399,10 @@ public class ComputeService(
             });
 
             var vnetOperation = await vnetCollection.CreateOrUpdateAsync(
-                WaitUntil.Started,
+                WaitUntil.Completed,
                 vnetName,
                 vnetData,
                 cancellationToken);
-            await WaitForLroCompletionAsync(vnetOperation, cancellationToken);
             vnetResource = vnetOperation.Value;
         }
 
@@ -438,11 +435,10 @@ public class ComputeService(
                 };
 
                 var pipOperation = await pipCollection.CreateOrUpdateAsync(
-                    WaitUntil.Started,
+                    WaitUntil.Completed,
                     pipName,
                     pipData,
                     cancellationToken);
-                await WaitForLroCompletionAsync(pipOperation, cancellationToken);
                 publicIpResource = pipOperation.Value;
             }
         }
@@ -470,11 +466,10 @@ public class ComputeService(
         nicData.IPConfigurations.Add(ipConfig);
 
         var nicOperation = await nicCollection.CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             nicName,
             nicData,
             cancellationToken);
-        await WaitForLroCompletionAsync(nicOperation, cancellationToken);
 
         return nicOperation.Value.Id;
     }
@@ -872,11 +867,10 @@ public class ComputeService(
         // Create the VMSS
         var vmssCollection = resourceGroupResource.GetVirtualMachineScaleSets();
         var vmssOperation = await vmssCollection.CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             vmssName,
             vmssData,
             cancellationToken);
-        await WaitForLroCompletionAsync(vmssOperation, cancellationToken);
 
         var createdVmss = vmssOperation.Value;
 
@@ -992,10 +986,9 @@ public class ComputeService(
         if (needsUpdate)
         {
             var updateOperation = await vmssResource.UpdateAsync(
-                WaitUntil.Started,
+                WaitUntil.Completed,
                 patch,
                 cancellationToken: cancellationToken);
-            await WaitForLroCompletionAsync(updateOperation, cancellationToken);
             vmssResource = updateOperation.Value;
         }
 
@@ -1092,10 +1085,9 @@ public class ComputeService(
         if (needsUpdate)
         {
             var updateOperation = await vmResource.UpdateAsync(
-                WaitUntil.Started,
+                WaitUntil.Completed,
                 patch,
                 cancellationToken: cancellationToken);
-            await WaitForLroCompletionAsync(updateOperation, cancellationToken);
             vmResource = updateOperation.Value;
         }
 
@@ -1150,8 +1142,7 @@ public class ComputeService(
         {
             var vmResponse = await vmCollection.GetAsync(vmName, cancellationToken: cancellationToken);
             var vmResource = vmResponse.Value;
-            var deleteOperation = await vmResource.DeleteAsync(WaitUntil.Started, forceDeletion, cancellationToken);
-            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
+            var deleteOperation = await vmResource.DeleteAsync(WaitUntil.Completed, forceDeletion, cancellationToken);
             return true;
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
@@ -1194,7 +1185,7 @@ public class ComputeService(
 
         if (!noWait)
         {
-            await WaitForLroCompletionAsync(operation, cancellationToken);
+            await operation.WaitForCompletionResponseAsync(cancellationToken);
         }
 
         var completed = !noWait;
@@ -1244,8 +1235,7 @@ public class ComputeService(
         {
             var vmssResponse = await vmssCollection.GetAsync(vmssName, cancellationToken: cancellationToken);
             var vmssResource = vmssResponse.Value;
-            var deleteOperation = await vmssResource.DeleteAsync(WaitUntil.Started, forceDeletion, cancellationToken);
-            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
+            var deleteOperation = await vmssResource.DeleteAsync(WaitUntil.Completed, forceDeletion, cancellationToken);
             return true;
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
@@ -1318,11 +1308,10 @@ public class ComputeService(
             };
 
             var vnetOperation = await vnetCollection.CreateOrUpdateAsync(
-                WaitUntil.Started,
+                WaitUntil.Completed,
                 vnetName,
                 vnetData,
                 cancellationToken);
-            await WaitForLroCompletionAsync(vnetOperation, cancellationToken);
             vnetResource = vnetOperation.Value;
         }
 
@@ -1343,11 +1332,10 @@ public class ComputeService(
             };
 
             var subnetOperation = await subnetCollection.CreateOrUpdateAsync(
-                WaitUntil.Started,
+                WaitUntil.Completed,
                 subnetName,
                 subnetData,
                 cancellationToken);
-            await WaitForLroCompletionAsync(subnetOperation, cancellationToken);
             subnetResource = subnetOperation.Value;
         }
 
@@ -1696,8 +1684,7 @@ public class ComputeService(
         _logger.LogInformation("Creating disk {DiskName} in resource group {ResourceGroup}", diskName, resourceGroup);
 
         var createOperation = await rgResource.Value.GetManagedDisks()
-            .CreateOrUpdateAsync(WaitUntil.Started, diskName, diskData, cancellationToken);
-        await WaitForLroCompletionAsync(createOperation, cancellationToken);
+            .CreateOrUpdateAsync(WaitUntil.Completed, diskName, diskData, cancellationToken);
 
         return ConvertToDiskModel(createOperation.Value, resourceGroup);
     }
@@ -1807,8 +1794,7 @@ public class ComputeService(
 
         _logger.LogInformation("Updating disk {DiskName} in resource group {ResourceGroup}", diskName, resourceGroup);
 
-        var updateOperation = await diskResource.Value.UpdateAsync(WaitUntil.Started, diskPatch, cancellationToken);
-        await WaitForLroCompletionAsync(updateOperation, cancellationToken);
+        var updateOperation = await diskResource.Value.UpdateAsync(WaitUntil.Completed, diskPatch, cancellationToken);
 
         return ConvertToDiskModel(updateOperation.Value, resourceGroup);
     }
@@ -1884,8 +1870,7 @@ public class ComputeService(
             var resourceGroupResource = await subscriptionResource.GetResourceGroups().GetAsync(resourceGroup, cancellationToken);
             var diskResource = await resourceGroupResource.Value.GetManagedDisks().GetAsync(diskName, cancellationToken);
 
-            var deleteOperation = await diskResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
-            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
+            var deleteOperation = await diskResource.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
 
             _logger.LogInformation(
                 "Successfully deleted disk. Disk: {Disk}, ResourceGroup: {ResourceGroup}",

--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Services/ConfidentialLedgerService.cs
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/src/Services/ConfidentialLedgerService.cs
@@ -49,8 +49,7 @@ public class ConfidentialLedgerService(ITenantService tenantService)
 
         // Build RequestContent manually to avoid trimming issues from reflection-based serialization.
         using var content = CreateAppendEntryContent(entryData);
-        var operation = await client.PostLedgerEntryAsync(WaitUntil.Started, content, collectionId, new RequestContext() { CancellationToken = cancellationToken });
-        await WaitForLroCompletionAsync(operation, cancellationToken);
+        var operation = await client.PostLedgerEntryAsync(WaitUntil.Completed, content, collectionId, new() { CancellationToken = cancellationToken });
         var response = operation.GetRawResponse();
 
         return new()

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
@@ -198,8 +198,7 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
 
         // Create or update the namespace
         var operation = await resourceGroupResource.Value.GetEventHubsNamespaces()
-            .CreateOrUpdateAsync(WaitUntil.Started, namespaceName, namespaceData, cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
+            .CreateOrUpdateAsync(WaitUntil.Completed, namespaceName, namespaceData, cancellationToken);
 
         if (operation?.Value == null)
         {
@@ -236,8 +235,7 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
             var namespaceResource = await GetGenericResourceAsync(armClient, namespaceId, cancellationToken);
 
             // Delete the namespace
-            var deleteOperation = await namespaceResource.DeleteAsync(WaitUntil.Started, cancellationToken);
-            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
+            var deleteOperation = await namespaceResource.DeleteAsync(WaitUntil.Completed, cancellationToken);
 
             _logger.LogInformation(
                 "Successfully deleted Event Hubs namespace '{NamespaceName}' from resource group '{ResourceGroup}'",
@@ -407,8 +405,7 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
         }
 
         var operation = await namespaceResource.Value.GetEventHubs()
-            .CreateOrUpdateAsync(WaitUntil.Started, eventHubName, eventHubData, cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
+            .CreateOrUpdateAsync(WaitUntil.Completed, eventHubName, eventHubData, cancellationToken);
 
         if (operation?.Value == null)
         {
@@ -457,8 +454,7 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
                 return false;
             }
 
-            var deleteOperation = await eventHubResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
-            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
+            var deleteOperation = await eventHubResource.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
             return true;
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
@@ -515,11 +511,10 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
         }
 
         var operation = await eventHubResource.Value.GetEventHubsConsumerGroups().CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             consumerGroupName,
             consumerGroupData,
             cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
 
         var consumerGroupResource = operation.Value;
         if (string.IsNullOrEmpty(consumerGroupResource.Id))
@@ -588,8 +583,7 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
                 return false;
             }
 
-            var deleteOperation = await consumerGroupResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
-            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
+            var deleteOperation = await consumerGroupResource.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
             return true;
         }
         catch (RequestFailedException ex) when (ex.Status == 404)

--- a/tools/Azure.Mcp.Tools.FileShares/src/Services/FileSharesService.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Services/FileSharesService.cs
@@ -184,11 +184,10 @@ public sealed class FileSharesService(
         }
 
         var operation = await resourceGroupResource.Value.GetFileShares().CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             fileShareName,
             fileShareData,
             cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
 
         _logger.LogInformation(
             "Successfully created or updated file share. FileShare: {FileShare}, ResourceGroup: {ResourceGroup}, Location: {Location}",
@@ -281,8 +280,7 @@ public sealed class FileSharesService(
         var fileShareResource = await resourceGroupResource.Value.GetFileShares().GetAsync(fileShareName, cancellationToken);
 
         // Use UpdateAsync to patch the file share
-        var operation = await fileShareResource.Value.UpdateAsync(WaitUntil.Started, patch, cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
+        var operation = await fileShareResource.Value.UpdateAsync(WaitUntil.Completed, patch, cancellationToken);
 
         _logger.LogInformation(
             "Successfully patched file share. FileShare: {FileShare}, ResourceGroup: {ResourceGroup}",
@@ -311,8 +309,7 @@ public sealed class FileSharesService(
             var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
             var fileShareResource = await resourceGroupResource.Value.GetFileShares().GetAsync(fileShareName, cancellationToken);
 
-            var deleteOperation = await fileShareResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
-            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
+            await fileShareResource.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
 
             _logger.LogInformation(
                 "Successfully deleted file share. FileShare: {FileShare}, ResourceGroup: {ResourceGroup}",
@@ -398,11 +395,10 @@ public sealed class FileSharesService(
         }
 
         var operation = await snapshotCollection.CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             snapshotName,
             snapshotData,
             cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
 
         _logger.LogInformation(
             "Successfully created snapshot. Snapshot: {SnapshotName}, FileShare: {FileShare}, ResourceGroup: {ResourceGroup}",
@@ -523,10 +519,9 @@ public sealed class FileSharesService(
 
         // Use UpdateAsync to patch the snapshot
         var operation = await existingSnapshot.Value.UpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             patch,
             cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
 
         _logger.LogInformation(
             "Successfully updated snapshot. Snapshot: {SnapshotId}, FileShare: {FileShare}, ResourceGroup: {ResourceGroup}",
@@ -561,8 +556,7 @@ public sealed class FileSharesService(
 
             // Get the snapshot and delete it
             var snapshotResource = await snapshotCollection.GetAsync(snapshotId, cancellationToken);
-            var deleteOperation = await snapshotResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
-            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
+            await snapshotResource.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
 
             _logger.LogInformation(
                 "Successfully deleted snapshot. Snapshot: {SnapshotId}, FileShare: {FileShare}, ResourceGroup: {ResourceGroup}",
@@ -816,8 +810,7 @@ public sealed class FileSharesService(
             };
 
             var operation = await fileShareResource.Value.GetFileSharePrivateEndpointConnections()
-                .CreateOrUpdateAsync(WaitUntil.Started, connectionName, connectionData, cancellationToken);
-            await WaitForLroCompletionAsync(operation, cancellationToken);
+                .CreateOrUpdateAsync(WaitUntil.Completed, connectionName, connectionData, cancellationToken);
 
             _logger.LogInformation(
                 "Successfully updated private endpoint connection. Connection: {ConnectionName}, FileShare: {FileShareName}, Status: {Status}",

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Services/KeyVaultService.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Services/KeyVaultService.cs
@@ -183,7 +183,7 @@ public sealed class KeyVaultService(
         var client = CreateCertificateClient(vaultName, credential, retryPolicy);
 
         var certificateOperation = await client.StartCreateCertificateAsync(certificateName, CertificatePolicy.Default, cancellationToken: cancellationToken);
-        await WaitForLroCompletionAsync(certificateOperation, cancellationToken);
+        await certificateOperation.WaitForCompletionAsync(cancellationToken);
         return certificateOperation.Value;
     }
 

--- a/tools/Azure.Mcp.Tools.LoadTesting/src/Services/LoadTestingService.cs
+++ b/tools/Azure.Mcp.Tools.LoadTesting/src/Services/LoadTestingService.cs
@@ -99,11 +99,10 @@ public class LoadTestingService(
         }
         var location = (await rgResource.GetAsync(cancellationToken)).Value.Data.Location;
         var response = await rgResource.GetLoadTestingResources().CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             testResourceName,
             new(location),
             cancellationToken);
-        await WaitForLroCompletionAsync(response, cancellationToken);
         if (response == null || response.Value == null)
         {
             throw new Exception($"Failed to create or update Azure Load Testing resource: {response}");
@@ -234,14 +233,13 @@ public class LoadTestingService(
         using var requestContent = RequestContent.Create(JsonSerializer.Serialize(requestBody, LoadTestJsonContext.Default.TestRunRequest));
 
         var loadTestRunResponse = await loadTestClient.BeginTestRunAsync(
-            0,
+            WaitUntil.Completed,
             testRunId,
             requestContent,
             oldTestRunId: oldTestRunId,
             context: new() { CancellationToken = cancellationToken })
             ?? throw new Exception($"Failed to retrieve Azure Load Test Run.");
 
-        await WaitForLroCompletionAsync(loadTestRunResponse, cancellationToken);
         var loadTestRun = loadTestRunResponse.Value.ToString();
         return JsonSerializer.Deserialize(loadTestRun, LoadTestJsonContext.Default.TestRun) ?? new();
     }

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/ManagedLustreService.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/ManagedLustreService.cs
@@ -458,8 +458,7 @@ public sealed class ManagedLustreService(
         }
 
         var collection = rg.GetAmlFileSystems();
-        var createOperationResult = await collection.CreateOrUpdateAsync(WaitUntil.Started, name, data, cancellationToken);
-        await WaitForLroCompletionAsync(createOperationResult, cancellationToken);
+        var createOperationResult = await collection.CreateOrUpdateAsync(WaitUntil.Completed, name, data, cancellationToken);
         var fileSystemResource = createOperationResult.Value;
         return Map(fileSystemResource);
     }
@@ -505,8 +504,7 @@ public sealed class ManagedLustreService(
             patch.RootSquashSettings = GenerateRootSquashSettings(rootSquashMode ?? "None", noSquashNidLists, squashUid, squashGid);
         }
 
-        var updateOperation = await fs.Value.UpdateAsync(WaitUntil.Started, patch, cancellationToken);
-        await WaitForLroCompletionAsync(updateOperation, cancellationToken);
+        var updateOperation = await fs.Value.UpdateAsync(WaitUntil.Completed, patch, cancellationToken);
         return Map(updateOperation.Value);
     }
 
@@ -604,11 +602,10 @@ public sealed class ManagedLustreService(
 
         // Create the auto export job
         var createOperation = await fs.Value.GetAutoExportJobs().CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             jobName,
             autoExportJobData,
             cancellationToken);
-        await WaitForLroCompletionAsync(createOperation, cancellationToken);
 
         return createOperation.Value.Data.Name;
     }
@@ -646,11 +643,7 @@ public sealed class ManagedLustreService(
             var patchData = new AutoExportJobPatch();
             patchData.AdminStatus = AutoExportJobAdminStatus.Disable;
 
-            var updateOperation = await job.Value.UpdateAsync(
-                WaitUntil.Started,
-                patchData,
-                cancellationToken);
-            await WaitForLroCompletionAsync(updateOperation, cancellationToken);
+            await job.Value.UpdateAsync(WaitUntil.Completed, patchData, cancellationToken);
         }
         catch (RequestFailedException rfe) when (rfe.Status == 404)
         {
@@ -759,9 +752,8 @@ public sealed class ManagedLustreService(
 
             // Delete the auto export job
             var deleteOperation = await fs.Value.GetAutoExportJobs().Get(jobName, cancellationToken).Value.DeleteAsync(
-                WaitUntil.Started,
+                WaitUntil.Completed,
                 cancellationToken);
-            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
         }
         catch (RequestFailedException rfe) when (rfe.Status == 404)
         {
@@ -851,11 +843,10 @@ public sealed class ManagedLustreService(
 
         // Create the auto import job
         var createOperation = await fs.Value.GetAutoImportJobs().CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             actualJobName,
             autoImportJobData,
             cancellationToken);
-        await WaitForLroCompletionAsync(createOperation, cancellationToken);
 
         return createOperation.Value.Data.Name;
     }
@@ -895,11 +886,7 @@ public sealed class ManagedLustreService(
                 AdminStatus = AutoImportJobUpdatePropertiesAdminStatus.Disable
             };
 
-            var updateOperation = await job.Value.UpdateAsync(
-                WaitUntil.Started,
-                patchData,
-                cancellationToken);
-            await WaitForLroCompletionAsync(updateOperation, cancellationToken);
+            await job.Value.UpdateAsync(WaitUntil.Completed, patchData, cancellationToken);
         }
         catch (RequestFailedException rfe) when (rfe.Status == 404)
         {
@@ -1007,10 +994,9 @@ public sealed class ManagedLustreService(
             }
 
             // Delete the auto import job
-            var deleteOperation = await fs.Value.GetAutoImportJobs().Get(jobName, cancellationToken).Value.DeleteAsync(
-                WaitUntil.Started,
+            await fs.Value.GetAutoImportJobs().Get(jobName, cancellationToken).Value.DeleteAsync(
+                WaitUntil.Completed,
                 cancellationToken);
-            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
         }
         catch (RequestFailedException rfe) when (rfe.Status == 404)
         {
@@ -1079,11 +1065,10 @@ public sealed class ManagedLustreService(
         }
 
         var createOperation = await fs.Value.GetStorageCacheImportJobs().CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             actualJobName,
             importJobData,
             cancellationToken);
-        await WaitForLroCompletionAsync(createOperation, cancellationToken);
 
         return createOperation.Value.Data.Name;
     }
@@ -1115,10 +1100,9 @@ public sealed class ManagedLustreService(
             }
 
             // Delete the import job
-            var deleteOperation = await fs.Value.GetStorageCacheImportJobs().Get(jobName, cancellationToken).Value.DeleteAsync(
-                WaitUntil.Started,
+            await fs.Value.GetStorageCacheImportJobs().Get(jobName, cancellationToken).Value.DeleteAsync(
+                WaitUntil.Completed,
                 cancellationToken);
-            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
         }
         catch (RequestFailedException rfe) when (rfe.Status == 404)
         {
@@ -1230,10 +1214,9 @@ public sealed class ManagedLustreService(
             };
 
             var updateOperation = await job.Value.UpdateAsync(
-                WaitUntil.Started,
+                WaitUntil.Completed,
                 patchData,
                 cancellationToken);
-            await WaitForLroCompletionAsync(updateOperation, cancellationToken);
 
             // Get the updated job to return the actual status
             var updatedJob = await job.Value.GetAsync(cancellationToken: cancellationToken);

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorWebTestService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorWebTestService.cs
@@ -238,12 +238,11 @@ public class MonitorWebTestService(
 
         var webTestArmResource = await resourceGroupResource.GetApplicationInsightsWebTests()
             .CreateOrUpdateAsync(
-                WaitUntil.Started,
+                WaitUntil.Completed,
                 resourceName,
                 webTestData,
                 cancellationToken
             ).ConfigureAwait(false);
-        await WaitForLroCompletionAsync(webTestArmResource, cancellationToken);
 
         if (webTestArmResource == null || !webTestArmResource.HasCompleted || !webTestArmResource.HasValue)
         {
@@ -406,12 +405,11 @@ public class MonitorWebTestService(
 
         var webTestArmResource = await resourceGroupResource.GetApplicationInsightsWebTests()
             .CreateOrUpdateAsync(
-                WaitUntil.Started,
+                WaitUntil.Completed,
                 resourceName,
                 webTestData,
                 cancellationToken
             ).ConfigureAwait(false);
-        await WaitForLroCompletionAsync(webTestArmResource, cancellationToken);
 
         if (webTestArmResource == null || !webTestArmResource.HasCompleted || !webTestArmResource.HasValue)
         {

--- a/tools/Azure.Mcp.Tools.MySql/src/Services/MySqlService.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Services/MySqlService.cs
@@ -422,8 +422,7 @@ public sealed class MySqlService(IResourceGroupService resourceGroupService, ISu
         var configData = configuration.Value.Data;
         configData.Value = value;
 
-        var updateOperation = await mysqlServer.Value.GetMySqlFlexibleServerConfigurations().CreateOrUpdateAsync(WaitUntil.Started, param, configData, cancellationToken);
-        await WaitForLroCompletionAsync(updateOperation, cancellationToken);
+        var updateOperation = await mysqlServer.Value.GetMySqlFlexibleServerConfigurations().CreateOrUpdateAsync(WaitUntil.Completed, param, configData, cancellationToken);
         return updateOperation.Value.Data.Value;
     }
 

--- a/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
@@ -328,8 +328,7 @@ public class PostgresService(
             Source = "user-override"
         };
 
-        var updateOperation = await configResponse.Value.UpdateAsync(WaitUntil.Started, configData, cancellationToken);
-        await WaitForLroCompletionAsync(updateOperation, cancellationToken);
+        var updateOperation = await configResponse.Value.UpdateAsync(WaitUntil.Completed, configData, cancellationToken);
         if (updateOperation.HasCompleted && updateOperation.HasValue)
         {
             return $"Parameter '{param}' updated successfully to '{value}'.";

--- a/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
@@ -197,11 +197,10 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         }
 
         var operation = await sqlServerResource.GetSqlDatabases().CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             databaseName,
             databaseData,
             cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
 
         var database = operation.Value;
 
@@ -302,11 +301,10 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         }
 
         var operation = await sqlServerResource.GetSqlDatabases().CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             databaseName,
             databaseData,
             cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
 
         var updatedDatabase = operation.Value;
 
@@ -582,11 +580,10 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         };
 
         var operation = await sqlServerResource.GetSqlFirewallRules().CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             firewallRuleName,
             firewallRuleData,
             cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
 
         var firewallRule = operation.Value;
 
@@ -629,9 +626,7 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
 
             var firewallRuleResource = await sqlServerResource.GetSqlFirewallRules().GetAsync(firewallRuleName, cancellationToken);
 
-            var deleteOperation = await firewallRuleResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
-            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
-
+            await firewallRuleResource.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
             _logger.LogInformation(
                 "Successfully deleted SQL server firewall rule. Server: {Server}, ResourceGroup: {ResourceGroup}, Rule: {Rule}",
                 serverName, resourceGroup, firewallRuleName);
@@ -702,11 +697,10 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         };
 
         var operation = await resourceGroupResource.Value.GetSqlServers().CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             serverName,
             serverData,
             cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
 
         var server = operation.Value;
         var tags = server.Data.Tags?.ToDictionary() ?? [];
@@ -825,9 +819,7 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
         {
             var serverResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, retryPolicy, cancellationToken);
 
-            var operation = await serverResource.DeleteAsync(WaitUntil.Started, cancellationToken);
-            await WaitForLroCompletionAsync(operation, cancellationToken);
-
+            await serverResource.DeleteAsync(WaitUntil.Completed, cancellationToken);
             return true;
         }
         catch (RequestFailedException reqEx) when (reqEx.Status == (int)HttpStatusCode.NotFound)
@@ -870,9 +862,7 @@ public class SqlService(ISubscriptionService subscriptionService, ITenantService
 
             var databaseResource = await sqlServerResource.GetSqlDatabases().GetAsync(databaseName, cancellationToken);
 
-            var deleteOperation = await databaseResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
-            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
-
+            await databaseResource.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
             _logger.LogInformation(
                 "Successfully deleted SQL database. Server: {Server}, Database: {Database}, ResourceGroup: {ResourceGroup}",
                 serverName, databaseName, resourceGroup);

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Services/StorageSyncService.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Services/StorageSyncService.cs
@@ -133,11 +133,10 @@ public sealed class StorageSyncService(
         }
 
         var operation = await resourceGroupResource.Value.GetStorageSyncServices().CreateOrUpdateAsync(
-            WaitUntil.Started,
+            WaitUntil.Completed,
             storageSyncServiceName,
             content,
             cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
 
         _logger.LogInformation(
             "Successfully created Storage Sync service. Service: {Service}, ResourceGroup: {ResourceGroup}, Location: {Location}",
@@ -190,8 +189,7 @@ public sealed class StorageSyncService(
             patch.Identity = new(new(identityType));
         }
 
-        var operation = await serviceResource.Value.UpdateAsync(WaitUntil.Started, patch, cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
+        var operation = await serviceResource.Value.UpdateAsync(WaitUntil.Completed, patch, cancellationToken);
 
         _logger.LogInformation(
             "Successfully updated Storage Sync service. Service: {Service}, ResourceGroup: {ResourceGroup}",
@@ -218,9 +216,7 @@ public sealed class StorageSyncService(
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
 
-        var deleteOperation = await serviceResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
-        await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
-
+        await serviceResource.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
         _logger.LogInformation(
             "Successfully deleted Storage Sync service. Service: {Service}, ResourceGroup: {ResourceGroup}",
             storageSyncServiceName, resourceGroup);
@@ -306,8 +302,7 @@ public sealed class StorageSyncService(
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
 
-        var operation = await serviceResource.Value.GetStorageSyncGroups().CreateOrUpdateAsync(WaitUntil.Started, syncGroupName, new(), cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
+        var operation = await serviceResource.Value.GetStorageSyncGroups().CreateOrUpdateAsync(WaitUntil.Completed, syncGroupName, new(), cancellationToken);
 
         _logger.LogInformation("Successfully created Sync Group: {SyncGroup}", syncGroupName);
         return SyncGroupDataSchema.FromResource(operation.Value);
@@ -334,9 +329,7 @@ public sealed class StorageSyncService(
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
         var syncGroupResource = await serviceResource.Value.GetStorageSyncGroups().GetAsync(syncGroupName, cancellationToken);
 
-        var deleteOperation = await syncGroupResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
-        await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
-
+        await syncGroupResource.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
         _logger.LogInformation("Successfully deleted Sync Group: {SyncGroup}", syncGroupName);
     }
 
@@ -455,8 +448,7 @@ public sealed class StorageSyncService(
             StorageAccountTenantId = storageAccountTenantId
         };
         var operation = await syncGroupResource.Value.GetCloudEndpoints().CreateOrUpdateAsync(
-            WaitUntil.Started, cloudEndpointName, content, cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
+            WaitUntil.Completed, cloudEndpointName, content, cancellationToken);
 
         _logger.LogInformation("Successfully created Cloud Endpoint: {Endpoint}", cloudEndpointName);
         return CloudEndpointDataSchema.FromResource(operation.Value);
@@ -486,9 +478,7 @@ public sealed class StorageSyncService(
         var syncGroupResource = await serviceResource.Value.GetStorageSyncGroups().GetAsync(syncGroupName, cancellationToken);
         var endpointResource = await syncGroupResource.Value.GetCloudEndpoints().GetAsync(cloudEndpointName, cancellationToken);
 
-        var deleteOperation = await endpointResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
-        await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
-
+        await endpointResource.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
         _logger.LogInformation("Successfully deleted Cloud Endpoint: {Endpoint}", cloudEndpointName);
     }
 
@@ -540,9 +530,7 @@ public sealed class StorageSyncService(
             }
         }
 
-        var changeDetectionOperation = await endpointResource.Value.TriggerChangeDetectionAsync(WaitUntil.Started, content, cancellationToken);
-        await WaitForLroCompletionAsync(changeDetectionOperation, cancellationToken);
-
+        await endpointResource.Value.TriggerChangeDetectionAsync(WaitUntil.Completed, content, cancellationToken);
         _logger.LogInformation("Successfully triggered change detection for Cloud Endpoint: {Endpoint}", cloudEndpointName);
     }
 
@@ -667,8 +655,7 @@ public sealed class StorageSyncService(
         }
 
         var operation = await syncGroupResource.Value.GetStorageSyncServerEndpoints().CreateOrUpdateAsync(
-            WaitUntil.Started, serverEndpointName, content, cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
+            WaitUntil.Completed, serverEndpointName, content, cancellationToken);
 
         _logger.LogInformation("Successfully created Server Endpoint: {Endpoint}", serverEndpointName);
         return ServerEndpointDataSchema.FromResource(operation.Value);
@@ -720,8 +707,7 @@ public sealed class StorageSyncService(
             patch.LocalCacheMode = new(localCacheMode);
         }
 
-        var operation = await endpointResource.Value.UpdateAsync(WaitUntil.Started, patch, cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
+        var operation = await endpointResource.Value.UpdateAsync(WaitUntil.Completed, patch, cancellationToken);
 
         _logger.LogInformation("Successfully updated Server Endpoint: {Endpoint}", serverEndpointName);
         return ServerEndpointDataSchema.FromResource(operation.Value);
@@ -751,9 +737,7 @@ public sealed class StorageSyncService(
         var syncGroupResource = await serviceResource.Value.GetStorageSyncGroups().GetAsync(syncGroupName, cancellationToken);
         var endpointResource = await syncGroupResource.Value.GetStorageSyncServerEndpoints().GetAsync(serverEndpointName, cancellationToken);
 
-        var deleteOperation = await endpointResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
-        await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
-
+        await endpointResource.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
         _logger.LogInformation("Successfully deleted Server Endpoint: {Endpoint}", serverEndpointName);
     }
 
@@ -845,8 +829,7 @@ public sealed class StorageSyncService(
 
         var content = new StorageSyncRegisteredServerCreateOrUpdateContent();
         var operation = await serviceResource.Value.GetStorageSyncRegisteredServers().CreateOrUpdateAsync(
-            WaitUntil.Started, serverGuid, content, cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
+            WaitUntil.Completed, serverGuid, content, cancellationToken);
 
         _logger.LogInformation("Successfully registered Server: {Server}", registeredServerId);
         return RegisteredServerDataSchema.FromResource(operation.Value);
@@ -880,8 +863,7 @@ public sealed class StorageSyncService(
         var patch = new StorageSyncRegisteredServerPatch();
         // Add any patch-specific logic here if needed
 
-        var operation = await serverResource.Value.UpdateAsync(WaitUntil.Started, patch, cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
+        var operation = await serverResource.Value.UpdateAsync(WaitUntil.Completed, patch, cancellationToken);
 
         _logger.LogInformation("Successfully updated Registered Server: {Server}", registeredServerId);
         return RegisteredServerDataSchema.FromResource(operation.Value);
@@ -911,9 +893,7 @@ public sealed class StorageSyncService(
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
         var serverResource = await serviceResource.Value.GetStorageSyncRegisteredServers().GetAsync(serverGuid, cancellationToken);
 
-        var deleteOperation = await serverResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
-        await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
-
+        await serverResource.Value.DeleteAsync(WaitUntil.Completed, cancellationToken);
         _logger.LogInformation("Successfully unregistered Server: {Server}", registeredServerId);
     }
 

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Services/WorkbooksService.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Services/WorkbooksService.cs
@@ -182,8 +182,7 @@ public class WorkbooksService(
         var workbookName = Guid.NewGuid().ToString();
 
         var workbookCollection = resourceGroupResource.Value.GetApplicationInsightsWorkbooks();
-        var createOperation = await workbookCollection.CreateOrUpdateAsync(WaitUntil.Started, workbookName, workbookData, cancellationToken: cancellationToken);
-        await WaitForLroCompletionAsync(createOperation, cancellationToken);
+        var createOperation = await workbookCollection.CreateOrUpdateAsync(WaitUntil.Completed, workbookName, workbookData, cancellationToken: cancellationToken);
         var createdWorkbook = createOperation.Value;
 
         _logger.LogInformation("Successfully created workbook with name: {WorkbookName} in resource group: {ResourceGroup}", workbookName, resourceGroupName);
@@ -332,8 +331,7 @@ public class WorkbooksService(
         var workbookResource = armClient.GetApplicationInsightsWorkbookResource(workbookResourceId)
             ?? throw new InvalidOperationException($"Workbook with ID '{workbookId}' not found");
 
-        var deleteOperation = await workbookResource.DeleteAsync(WaitUntil.Started, cancellationToken);
-        await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
+        await workbookResource.DeleteAsync(WaitUntil.Completed, cancellationToken);
         _logger.LogInformation("Successfully deleted workbook with ID: {WorkbookId}", workbookId);
     }
 


### PR DESCRIPTION
## What does this PR do?

Changes how LROs are handling in playback testing to leverage the fact that default polling inspects `Retry-After` to override the polling interval. This is more effective than the previous design, where LROs had to have a special calling pattern and call into a shared method, where this is all handled centrally using the playback handler to inject a `TimeSpan.Zero` `Retry-After`.

Additionally, overriding the polling interval was bounded on a minimum value of `TimeSpan.FromSeconds(1)`, so the previous handling was also ignored.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
