### PR TITLE
Fix tools functional issues

### DIFF
--- a/llms-install.md
+++ b/llms-install.md
@@ -28,7 +28,30 @@ The Azure MCP Server requires configuration based on the client type. Below are 
 ```json
 {
   "servers": {
-    "Azure MCP Server": {
+    "azure-mcp-server": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@azure/mcp@latest",
+        "server",
+        "start"
+      ]
+    }
+  }
+}
+```
+
+#### For GitHub Copilot CLI
+
+> **Requires Node.js (Latest LTS version)**
+
+1. Create or modify the configuration file at `~/.copilot/mcp-config.json`.
+2. Use a lowercase, hyphenated server key (spaces are invalid in Copilot CLI MCP server names).
+
+```json
+{
+  "mcpServers": {
+    "azure-mcp-server": {
       "command": "npx",
       "args": [
         "-y",
@@ -50,7 +73,7 @@ The Azure MCP Server requires configuration based on the client type. Below are 
 ```json
 {
   "mcpServers": {
-    "Azure MCP Server": {
+    "azure-mcp-server": {
       "command": "npx",
       "args": [
         "-y",

--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -169,7 +169,7 @@ To verify the .NET version, run the following command in the terminal: `dotnet -
     ```json
     {
         "mcpServers": {
-            "Azure MCP Server": {
+            "azure-mcp-server": {
                 "command": "dnx",
                 "args": [
                     "Azure.Mcp",
@@ -196,7 +196,7 @@ To verify the .NET version, run the following command in the terminal: `dotnet -
     ```json
     {
         "mcpServers": {
-            "Azure MCP Server": {
+            "azure-mcp-server": {
             "command": "npx",
             "args": [
                 "-y",
@@ -218,7 +218,7 @@ To verify the .NET version, run the following command in the terminal: `dotnet -
     ```json
     {
         "mcpServers": {
-            "Azure MCP Server": {
+            "azure-mcp-server": {
                 "command": "uvx",
                 "args": [
                     "--from",
@@ -386,7 +386,7 @@ AZURE_CLIENT_SECRET={YOUR_AZURE_CLIENT_SECRET}
 ```json
    {
       "mcpServers": {
-         "Azure MCP Server": {
+            "azure-mcp-server": {
             "command": "docker",
             "args": [
                "run",

--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -381,24 +381,24 @@ AZURE_CLIENT_SECRET={YOUR_AZURE_CLIENT_SECRET}
 
 #### Configure MCP client to use Docker
 
-2. Add or update existing `mcp.json`.  Replace `/full/path/to/.env` with the actual `.env` file path.
+2. Add or update existing `mcp.json`. Replace `/full/path/to/.env` with the actual `.env` file path.
 
 ```json
-   {
-      "mcpServers": {
-            "azure-mcp-server": {
+{
+    "mcpServers": {
+        "azure-mcp-server": {
             "command": "docker",
             "args": [
-               "run",
-               "-i",
-               "--rm",
-               "--env-file",
-               "/full/path/to/.env",
-               "mcr.microsoft.com/azure-sdk/azure-mcp:latest"
+                "run",
+                "-i",
+                "--rm",
+                "--env-file",
+                "/full/path/to/.env",
+                "mcr.microsoft.com/azure-sdk/azure-mcp:latest"
             ]
-         }
-      }
-   }
+        }
+    }
+}
 ```
 </details>
 

--- a/servers/Azure.Mcp.Server/changelog-entries/1782784032173.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1782784032173.yaml
@@ -1,0 +1,7 @@
+changes:
+  - section: "Bugs Fixed"
+    description: |
+      Fixed multiple user-facing issues:
+      - Event Hubs namespace-get now supports subscription-wide listing when resource-group is omitted, and treats whitespace resource-group as not provided for robust scope handling.
+      - FoundryExtensions resource-get routing and terminology were clarified to improve namespace tool selection confidence, and validation now fails fast when resource-name is provided without resource-group.
+      - Azure MCP Server README/Copilot CLI setup documentation was corrected for MCP server key usage.

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
@@ -32,7 +32,7 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
         var subscriptionResource = await ResolveSubscriptionResourceAsync(subscription, tenant, retryPolicy, cancellationToken);
         var namespaces = new List<Namespace>();
 
-        if (!string.IsNullOrEmpty(resourceGroup))
+        if (!string.IsNullOrWhiteSpace(resourceGroup))
         {
             // Get namespaces from specific resource group
             var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
@@ -26,7 +26,8 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(resourceGroup), resourceGroup), (nameof(subscription), subscription));
+        // Resource group is optional for subscription-wide listing.
+        ValidateRequiredParameters((nameof(subscription), subscription));
 
         var subscriptionResource = await ResolveSubscriptionResourceAsync(subscription, tenant, retryPolicy, cancellationToken);
         var namespaces = new List<Namespace>();

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.Tests/Namespace/NamespaceGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.Tests/Namespace/NamespaceGetCommandTests.cs
@@ -15,6 +15,31 @@ namespace Azure.Mcp.Tools.EventHubs.Tests.Namespace;
 
 public class NamespaceGetCommandTests : CommandUnitTestsBase<NamespaceGetCommand, IEventHubsService>
 {
+    [Fact]
+    public async Task ExecuteAsync_ListWithoutResourceGroup_CallsServiceWithNullResourceGroup()
+    {
+        // Arrange
+        Service.GetNamespacesAsync(
+            Arg.Any<string?>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        // Act
+        var response = await ExecuteCommandAsync("--subscription", "test-subscription");
+
+        // Assert
+        Assert.Equal(200, (int)response.Status);
+        await Service.Received(1).GetNamespacesAsync(
+            Arg.Is<string?>(rg => rg == null),
+            Arg.Is("test-subscription"),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
     [Theory]
     [InlineData("--subscription test-subscription", true)]
     [InlineData("--subscription test-subscription --resource-group test-rg", true)]

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/ResourceGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/ResourceGetCommand.cs
@@ -17,12 +17,12 @@ namespace Azure.Mcp.Tools.FoundryExtensions.Commands;
     Name = "get",
     Title = "Get Microsoft Foundry Resource Details",
     Description = """
-        Gets detailed information about Microsoft Foundry (Cognitive Services) resources, including endpoint URL,
-        location, SKU, and provisioning state. If a specific resource name is provided, returns details for that
-        resource only. If no resource name is provided, lists all Microsoft Foundry resources in the subscription
-        or resource group. Use this tool when users need endpoint information, want to discover available AI
-        resources, or need to check the configuration of a Foundry account. To list OpenAI model deployments
-        within a resource, use the openai models-list command instead.
+        Lists or gets Microsoft Foundry resources (accounts/services) and returns resource-level details such as
+        endpoint URL, location, SKU, kind, and provisioning state. Use this when users ask to list all Microsoft
+        Foundry resources in a subscription, show resources in a resource group, or get details for a specific
+        resource by name. If resource-name is provided with resource-group, returns that single resource; otherwise
+        returns the resource inventory in scope. This command is for Foundry resource metadata, not model
+        deployment inventory. For Azure OpenAI model deployments inside a Foundry resource, use openai models-list.
         """,
     Destructive = false,
     Idempotent = true,

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/ResourceGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/ResourceGetCommand.cs
@@ -22,7 +22,7 @@ namespace Azure.Mcp.Tools.FoundryExtensions.Commands;
         Foundry resources in a subscription, show resources in a resource group, or get details for a specific
         resource by name. If resource-name is provided with resource-group, returns that single resource; otherwise
         returns the resource inventory in scope. This command is for Foundry resource metadata, not model
-        deployment inventory. For Azure OpenAI model deployments inside a Foundry resource, use openai models-list.
+        deployment inventory. For Azure OpenAI model deployments inside a Foundry resource, use the 'openai models-list' tool.
         """,
     Destructive = false,
     Idempotent = true,
@@ -40,6 +40,12 @@ public sealed class ResourceGetCommand(ILogger<ResourceGetCommand> logger, IFoun
     {
         try
         {
+            // Validate that if resource name is provided, resource group must also be provided
+            if (!string.IsNullOrEmpty(options.ResourceName) && string.IsNullOrEmpty(options.ResourceGroup))
+            {
+                throw new ArgumentException("Resource group is required when resource name is specified.");
+            }
+
             // If resource name and resource group are provided, get specific resource
             if (!string.IsNullOrEmpty(options.ResourceName) && !string.IsNullOrEmpty(options.ResourceGroup))
             {

--- a/tools/Azure.Mcp.Tools.FoundryExtensions/src/Options/FoundryExtensionsOptionDescriptions.cs
+++ b/tools/Azure.Mcp.Tools.FoundryExtensions/src/Options/FoundryExtensionsOptionDescriptions.cs
@@ -7,7 +7,7 @@ internal static class FoundryExtensionsOptionDescriptions
 {
     internal const string Endpoint = "The endpoint URL for the Microsoft Foundry project/service. The endpoint follows this pattern https://<foundry-resource-name>.services.ai.azure.com/api/projects/<project-name>.";
     internal const string Deployment = "The name of the deployment.";
-    internal const string ResourceName = "The name of the Azure OpenAI resource.";
+    internal const string ResourceName = "The name of the Microsoft Foundry resource.";
     internal const string MaxTokens = "The maximum number of tokens to generate in the completion.";
     internal const string Temperature = "Controls randomness in the output. Lower values make it more deterministic.";
     internal const string User = "User identifier for tracking and abuse monitoring.";


### PR DESCRIPTION
## Issues Fixed
- Closes #2589
  - Corrected MCP server key documentation for Copilot CLI setup.
  - Updated:
    - llms-install.md
    - servers/Azure.Mcp.Server/README.md

- Closes #2818
  - Fixed Event Hubs namespace-get flow to work when resource-group is omitted for subscription-scope listing.
  - Added regression coverage for list-without-resource-group behavior.
  - Updated:
    - tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
    - tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.Tests/Namespace/NamespaceGetCommandTests.cs

- Closes #2792
  - Improved FoundryExtensions tool-selection clarity by refining resource-get description text and aligning option terminology with Microsoft Foundry wording.
  - Updated:
    - tools/Azure.Mcp.Tools.FoundryExtensions/src/Commands/ResourceGetCommand.cs
    - tools/Azure.Mcp.Tools.FoundryExtensions/src/Options/FoundryExtensionsOptionDescriptions.cs
    
      | Prompt | Before | After | Delta |
      |---|---:|---:|---:|
      | List all Microsoft Foundry resources in my subscription | 0.7254 | 0.7301 | +0.0047 |
      | Show me the Microsoft Foundry resources in resource group | 0.6515 | 0.7046 | +0.0531 |
      | Get details for Microsoft Foundry resource in resource group | 0.7248 | 0.7659 | +0.0411 |