### PR TITLE
Docs: add Catalog Discovery example prompts for core_search-catalog

### DIFF
--- a/servers/Fabric.Mcp.Server/README.md
+++ b/servers/Fabric.Mcp.Server/README.md
@@ -23,6 +23,7 @@ A local-first Model Context Protocol (MCP) server that provides AI agents with c
 - [Usage](#usage)
   - [Getting Started](#getting-started)
   - [What can you do with the Fabric MCP Server?](#what-can-you-do-with-the-fabric-mcp-server)
+    - [Catalog Discovery](#catalog-discovery)
     - [Fabric Workloads & APIs](#fabric-workloads--apis)
     - [Resource Definitions & Schemas](#resource-definitions--schemas)
     - [Best Practices & Examples](#best-practices--examples)
@@ -189,6 +190,13 @@ Use one of the following options to configure your `mcp.json`:
 ## What can you do with the Fabric MCP Server?
 
 The Fabric MCP Server supercharges your agents with Microsoft Fabric context. Here are some prompts you can try:
+
+### Catalog Discovery
+
+* "Search the OneLake catalog for items related to 'sales revenue'"
+* "Find a Lakehouse with 'customer' in the name across my workspaces"
+* "Discover all Report items in the catalog and show which workspace they live in"
+* "Filter the catalog to Warehouse and Notebook items"
 
 ### Fabric Workloads & APIs
 


### PR DESCRIPTION
## What
Adds a **Catalog Discovery** subsection (and its TOC entry) under "What can you do with the Fabric MCP Server?" in the Fabric MCP Server README, placed first in the list. It gives example prompts for the `core_search-catalog` tool added in #2963.

## Why
#2963 added the `core_search-catalog` tool and listed it under "Available Tools", but the "What can you do?" prompt section had no catalog-discovery examples. This is a small docs-only follow-up.

## Notes
- Docs-only change; no code, tests, or tool behavior affected.
- Kept distinct from the existing `workloads`-backed "List all supported Fabric item types" prompt, which is a different capability (lists workload/type names from API specs rather than searching catalog items).