### PR TITLE
Add Azure Resilience Management to server README (#2988)

### DIFF
--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -1183,6 +1183,18 @@ Example prompts that generate Azure CLI commands:
 * "Turn off DDoS protection in my Platform Landing Zone"
 * "Turn off Bastion host in my Platform Landing Zone"
 
+### 🛡️ Azure Resilience Management
+
+* "List all resilience goal templates in service group 'my-service-group'"
+* "Get the details of goal template 'my-template' in service group 'my-service-group'"
+* "List all resilience goal assignments in service group 'my-service-group'"
+* "List the resources of goal assignment 'my-assignment' in service group 'my-service-group'"
+* "List my resilience usage plans in resource group 'my-rg'"
+* "List the enrollments of usage plan 'my-plan' in resource group 'my-rg'"
+* "List all resilience recovery plans in service group 'my-service-group'"
+* "Get the recovery plan 'my-recovery-plan' in service group 'my-service-group'"
+* "List the recovery jobs of recovery plan 'my-recovery-plan' in service group 'my-service-group'"
+
 ### Azure Resource Manager
 
 * Use Azure resource graph to query Azure resources
@@ -1212,7 +1224,7 @@ Example prompts that generate Azure CLI commands:
 
 ## Complete List of Supported Azure Services
 
-The Azure MCP Server provides tools for interacting with **43+ Azure service areas**:
+The Azure MCP Server provides tools for interacting with **44+ Azure service areas**:
 
 - 🧮 **Microsoft Foundry** - AI model management, AI model deployment, and knowledge index management
 - 📊 **Azure Advisor** - Advisor recommendations
@@ -1250,6 +1262,7 @@ The Azure MCP Server provides tools for interacting with **43+ Azure service are
 - 📊 **Azure Quota** - Resource quota and usage management
 - 🎭 **Azure RBAC** - Access control management
 - 🔴 **Azure Redis Cache** - In-memory data store
+- 🛡️ **Azure Resilience Management** - Resilience goal templates, goal assignments, goal resources, usage plans, usage plan enrollments, recovery plans, recovery plan resources, recovery jobs, and recovery job resources
 - 🏗️ **Azure Resource Groups** - Resource organization
 - 🚌 **Azure Service Bus** - Message queuing
 - 🧵 **Azure Service Fabric** - Managed cluster node operations


### PR DESCRIPTION
## Summary

Made README changes for the new Azure Resilience Management toolset.

Fixes #2988.

The `resilience` toolset was onboarded in #2948 but [`servers/Azure.Mcp.Server/README.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/README.md) was not updated. This PR closes that doc gap by:

- Adding an **Azure Resilience Management** subsection with example prompts under "What can you do with the Azure MCP Server?"
- Adding **Azure Resilience Management** to the "Complete List of Supported Azure Services".

Docs-only change; no code or tests affected.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
