### PR TITLE
Add onboarding welcome action for [ONBOARD] issues

### DIFF
--- a/.github/workflows/onboarding-welcome.yml
+++ b/.github/workflows/onboarding-welcome.yml
@@ -11,8 +11,8 @@ on:
 
 permissions:
   issues: write
-
 jobs:
+  welcome:
     runs-on: ubuntu-latest
     concurrency:
       group: onboarding-welcome-${{ github.event.issue.number }}

--- a/.github/workflows/onboarding-welcome.yml
+++ b/.github/workflows/onboarding-welcome.yml
@@ -25,7 +25,7 @@ jobs:
       contains(github.event.issue.labels.*.name, 'Azure.Mcp.Server')
     steps:
       - name: Comment with onboarding guidance
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const marker = '<!-- onboarding-welcome-comment -->';

--- a/.github/workflows/onboarding-welcome.yml
+++ b/.github/workflows/onboarding-welcome.yml
@@ -17,7 +17,6 @@ jobs:
     concurrency:
       group: onboarding-welcome-${{ github.event.issue.number }}
       cancel-in-progress: true
-    runs-on: ubuntu-latest
     # Run only for Azure MCP onboarding requests. The Azure MCP onboarding
     # template applies the labels: onboarding, needs-triage, Azure.Mcp.Server.
     # Other onboarding templates (e.g. the generic "New Microsoft MCP Server

--- a/.github/workflows/onboarding-welcome.yml
+++ b/.github/workflows/onboarding-welcome.yml
@@ -1,0 +1,58 @@
+name: Onboarding Issue Welcome
+
+# Posts a welcome comment on Azure MCP onboarding requests, pointing new
+# contributors to the contribution guide and the @onboarding Copilot agent.
+# Onboarding issues are created from the "Azure MCP - Service Onboarding
+# Request" template, which applies the labels below.
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    # Run only for Azure MCP onboarding requests. The Azure MCP onboarding
+    # template applies the labels: onboarding, needs-triage, Azure.Mcp.Server.
+    # Other onboarding templates (e.g. the generic "New Microsoft MCP Server
+    # Onboarding Request") also use the "onboarding" label but NOT
+    # "Azure.Mcp.Server", so we require both to scope this to Azure MCP.
+    if: >-
+      contains(github.event.issue.labels.*.name, 'onboarding') &&
+      contains(github.event.issue.labels.*.name, 'Azure.Mcp.Server')
+    steps:
+      - name: Comment with onboarding guidance
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- onboarding-welcome-comment -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            // Avoid posting duplicate comments. The template applies multiple
+            // labels, so several "labeled" events can fire for one issue.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 }
+            );
+            if (comments.some(c => c.body && c.body.includes(marker))) {
+              core.info('Onboarding welcome comment already present. Skipping.');
+              return;
+            }
+
+            const body = [
+              marker,
+              '👋 Thanks for filing an onboarding request for the Azure MCP Server!',
+              '',
+              'While the team triages your issue, here are two things that will help you get started quickly:',
+              '',
+              '- 📖 **Read the contribution guide:** [CONTRIBUTING.md](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md) walks you through environment setup, adding a new command, testing, and the PR checklist.',
+              '- 🤖 **Try the `@onboarding` agent:** Open the [microsoft/mcp](https://github.com/microsoft/mcp) repo in VS Code with GitHub Copilot Chat and type `@onboarding` for interactive, step-by-step help with setup, finding your first issue, adding commands, and avoiding common pitfalls.',
+              '',
+              'A member of the team will follow up soon. 🚀',
+            ].join('\n');
+
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });

--- a/.github/workflows/onboarding-welcome.yml
+++ b/.github/workflows/onboarding-welcome.yml
@@ -25,7 +25,7 @@ jobs:
       contains(github.event.issue.labels.*.name, 'Azure.Mcp.Server')
     steps:
       - name: Comment with onboarding guidance
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const marker = '<!-- onboarding-welcome-comment -->';

--- a/.github/workflows/onboarding-welcome.yml
+++ b/.github/workflows/onboarding-welcome.yml
@@ -13,7 +13,10 @@ permissions:
   issues: write
 
 jobs:
-  welcome:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: onboarding-welcome-${{ github.event.issue.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     # Run only for Azure MCP onboarding requests. The Azure MCP onboarding
     # template applies the labels: onboarding, needs-triage, Azure.Mcp.Server.


### PR DESCRIPTION
Adds a GitHub Action that welcomes new contributors when an **Azure MCP** onboarding issue is filed.

**Trigger:** `issues` (`opened`, `labeled`), gated on **both** the `onboarding` and `Azure.Mcp.Server` labels applied by the *Azure MCP - Service Onboarding Request* template. Requiring both labels scopes this to Azure MCP only — the generic *New Microsoft MCP Server Onboarding Request* template also uses `onboarding` but pairs it with `Template.Mcp.Server`, so it will not trigger this action.

**Behavior:** Posts a comment pointing contributors to the [CONTRIBUTING.md](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md) guide and encouraging them to try the `@onboarding` Copilot agent. A hidden marker prevents duplicate comments across the multiple label events.

**Permissions:** `issues: write` only.