### PR TITLE
Add outputSchema and structuredContent infrastructure with App Config pilot

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/OptionSchemaGeneratorTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/OptionSchemaGeneratorTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Microsoft.Mcp.Core.Areas.Server.Commands;
+using Xunit;
+
+namespace Azure.Mcp.Core.Tests.Areas.Server.Commands;
+
+public class OptionSchemaGeneratorTests
+{
+    [Fact]
+    public void CreateOutputSchema_ObjectResult_ReturnsObjectRootUnwrapped()
+    {
+        var schema = OptionSchemaGenerator.CreateOutputSchema(OutputSchemaTestJsonContext.Default.OutputSchemaSampleResult);
+
+        // An object-root result already satisfies MCP's "root must be an object" rule, so it is returned
+        // as-is: its own properties are exposed directly rather than nested under a synthetic wrapper.
+        Assert.Equal("object", (string?)schema["type"]);
+
+        var properties = Assert.IsType<JsonObject>(schema["properties"]);
+        Assert.True(properties.ContainsKey("name"), "Object-root result should expose its own 'name' property directly.");
+        Assert.False(properties.ContainsKey("value"), "Object-root result must not be wrapped under a 'value' property.");
+    }
+
+    [Fact]
+    public void CreateOutputSchema_ArrayResult_IsWrappedUnderValue()
+    {
+        var schema = OptionSchemaGenerator.CreateOutputSchema(OutputSchemaTestJsonContext.Default.StringArray);
+
+        AssertWrappedValue(schema, expectedInnerType: "array");
+    }
+
+    [Fact]
+    public void CreateOutputSchema_ScalarResult_IsWrappedUnderValue()
+    {
+        var schema = OptionSchemaGenerator.CreateOutputSchema(OutputSchemaTestJsonContext.Default.Int32);
+
+        AssertWrappedValue(schema, expectedInnerType: "integer");
+    }
+
+    // MCP requires the outputSchema root to be an object, so a non-object export (array or scalar) must be
+    // wrapped as { "type": "object", "properties": { "value": <inner> }, "required": ["value"] }.
+    private static void AssertWrappedValue(JsonObject schema, string expectedInnerType)
+    {
+        Assert.Equal("object", (string?)schema["type"]);
+
+        var properties = Assert.IsType<JsonObject>(schema["properties"]);
+        Assert.True(properties.ContainsKey("value"), "Non-object result must be wrapped under a single 'value' property.");
+
+        var inner = Assert.IsType<JsonObject>(properties["value"]);
+        Assert.Equal(expectedInnerType, (string?)inner["type"]);
+
+        var required = Assert.IsType<JsonArray>(schema["required"]);
+        Assert.Contains(required, node => (string?)node == "value");
+    }
+}
+
+// Shared sample result type + source-generated context used by the output-schema tests. Declaring them in
+// the parent test namespace keeps the schema-shaping contract decoupled from any shipping tool while
+// remaining visible to the nested ToolLoading tests.
+internal sealed record OutputSchemaSampleResult(string Name, int Count);
+
+[JsonSerializable(typeof(OutputSchemaSampleResult))]
+[JsonSerializable(typeof(string[]))]
+[JsonSerializable(typeof(int))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal sealed partial class OutputSchemaTestJsonContext : JsonSerializerContext;

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Helpers;
+using Microsoft.Mcp.Core.Models;
 using Microsoft.Mcp.Core.Models.Command;
 using Microsoft.Mcp.Core.Options;
 using ModelContextProtocol.Protocol;
@@ -758,6 +759,94 @@ public class CommandFactoryToolLoaderTests
         var tool = result.Tools.FirstOrDefault(t => t.Name == "fake-noschema-get");
         Assert.NotNull(tool);
         Assert.Null(tool.OutputSchema);
+    }
+
+    [Fact]
+    public void TryBuildStructuredContent_ObjectResult_IsMirroredUnwrapped()
+    {
+        // An object-root command result already satisfies MCP's "structuredContent must be an object" rule,
+        // so it is mirrored as-is: its own properties are surfaced directly rather than nested under a
+        // wrapper. This stays aligned with CreateOutputSchema, which leaves object roots unwrapped.
+        var json = SerializeResponse(ResponseResult.Create(
+            new OutputSchemaSampleResult("alpha", 3),
+            OutputSchemaTestJsonContext.Default.OutputSchemaSampleResult));
+
+        var structuredContent = CommandFactoryToolLoader.TryBuildStructuredContent(json);
+
+        Assert.NotNull(structuredContent);
+        var value = structuredContent!.Value;
+        Assert.Equal(JsonValueKind.Object, value.ValueKind);
+        Assert.Equal("alpha", value.GetProperty("name").GetString());
+        Assert.Equal(3, value.GetProperty("count").GetInt32());
+        Assert.False(value.TryGetProperty("value", out _), "Object results must not be wrapped under a 'value' property.");
+    }
+
+    [Fact]
+    public void TryBuildStructuredContent_ArrayResult_IsWrappedUnderValue()
+    {
+        // A non-object payload (array) cannot be the structuredContent root, so it is wrapped under a single
+        // 'value' property - mirroring the wrapping CreateOutputSchema applies to the advertised schema so the
+        // payload validates against it.
+        var json = SerializeResponse(ResponseResult.Create(
+            new[] { "one", "two" },
+            OutputSchemaTestJsonContext.Default.StringArray));
+
+        var structuredContent = CommandFactoryToolLoader.TryBuildStructuredContent(json);
+
+        Assert.NotNull(structuredContent);
+        var value = structuredContent!.Value;
+        Assert.Equal(JsonValueKind.Object, value.ValueKind);
+        Assert.True(value.TryGetProperty("value", out var wrapped), "Array results must be wrapped under a 'value' property.");
+        Assert.Equal(JsonValueKind.Array, wrapped.ValueKind);
+        Assert.Equal(2, wrapped.GetArrayLength());
+    }
+
+    [Fact]
+    public void TryBuildStructuredContent_ScalarResult_IsWrappedUnderValue()
+    {
+        // A scalar payload likewise cannot be the root object, so it is wrapped under 'value' to match the
+        // advertised schema.
+        var json = SerializeResponse(ResponseResult.Create(
+            42,
+            OutputSchemaTestJsonContext.Default.Int32));
+
+        var structuredContent = CommandFactoryToolLoader.TryBuildStructuredContent(json);
+
+        Assert.NotNull(structuredContent);
+        var value = structuredContent!.Value;
+        Assert.Equal(JsonValueKind.Object, value.ValueKind);
+        Assert.True(value.TryGetProperty("value", out var wrapped), "Scalar results must be wrapped under a 'value' property.");
+        Assert.Equal(42, wrapped.GetInt32());
+    }
+
+    [Fact]
+    public void TryBuildStructuredContent_NoResult_ReturnsNull()
+    {
+        // A command that sets no result serializes without a 'results' property (JsonIgnore-when-null), so
+        // there is nothing to mirror and structuredContent is left unset.
+        var json = SerializeResponse(results: null);
+
+        var structuredContent = CommandFactoryToolLoader.TryBuildStructuredContent(json);
+
+        Assert.Null(structuredContent);
+    }
+
+    [Fact]
+    public void TryBuildStructuredContent_NullResultsProperty_ReturnsNull()
+    {
+        // Defensive branch: even if a 'results' property is present but null, there is no payload to mirror.
+        // The realistic serializer path omits null results, so this uses a hand-built response to exercise it.
+        var structuredContent = CommandFactoryToolLoader.TryBuildStructuredContent("{\"results\":null}");
+
+        Assert.Null(structuredContent);
+    }
+
+    // Serializes a CommandResponse exactly as CallToolHandler does, so the structuredContent tests exercise
+    // the real 'results' property name and shape rather than a hand-rolled approximation.
+    private static string SerializeResponse(ResponseResult? results)
+    {
+        var response = new CommandResponse { Status = HttpStatusCode.OK, Results = results };
+        return JsonSerializer.Serialize(response, ModelsJsonContext.Default.CommandResponse);
     }
 
     // A self-contained enum + options POCO used only by ListToolsHandler_EnumOption_IsExportedAsStringType.

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
@@ -680,6 +680,86 @@ public class CommandFactoryToolLoaderTests
         }
     }
 
+    [Fact]
+    public async Task ListToolsHandler_CommandWithResultTypeInfo_EmitsObjectOutputSchema()
+    {
+        // Arrange
+        // A fake command that advertises a source-generated result type. GetTool should surface that type as
+        // the tool's outputSchema. Using a fake (rather than a shipping tool) keeps the wiring contract stable
+        // even as real commands are migrated over time.
+        var serviceProvider = CommandFactoryHelpers.CreateDefaultServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger<CommandFactoryToolLoader>();
+        var toolLoaderOptions = Microsoft.Extensions.Options.Options.Create(new ToolLoaderOptions());
+
+        var fakeCommand = Substitute.For<IBaseCommand>();
+        fakeCommand.GetCommand().Returns(new Command("fake-output-get", "A fake command that advertises a result type."));
+        fakeCommand.Title.Returns("Fake Output Get");
+        fakeCommand.Metadata.Returns(new ToolMetadata());
+        fakeCommand.ResultTypeInfo.Returns(OutputSchemaTestJsonContext.Default.OutputSchemaSampleResult);
+
+        var commandFactory = CommandFactoryHelpers.CreateCommandFactory(serviceProvider);
+        var commandMapField = typeof(CommandFactory).GetField("_commandMap", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var commandMap = (Dictionary<string, IBaseCommand>)commandMapField!.GetValue(commandFactory)!;
+        commandMap["fake-output-get"] = fakeCommand;
+
+        var toolLoader = new CommandFactoryToolLoader(serviceProvider, commandFactory, toolLoaderOptions, logger);
+        var request = CreateRequest();
+
+        // Act
+        var result = await toolLoader.ListToolsHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        // A migrated command (ResultTypeInfo != null) must surface an MCP outputSchema whose root is an
+        // object exposing the result record's own properties.
+        var tool = result.Tools.FirstOrDefault(t => t.Name == "fake-output-get");
+        Assert.NotNull(tool);
+        Assert.NotNull(tool.OutputSchema);
+
+        var outputSchema = tool.OutputSchema!.Value;
+        Assert.Equal(JsonValueKind.Object, outputSchema.ValueKind);
+
+        Assert.True(outputSchema.TryGetProperty("type", out var typeProperty), "outputSchema is missing 'type'.");
+        Assert.Equal("object", typeProperty.GetString());
+
+        Assert.True(outputSchema.TryGetProperty("properties", out var properties), "outputSchema is missing 'properties'.");
+        Assert.True(properties.TryGetProperty("name", out _), "outputSchema should expose the result record's 'name' property.");
+    }
+
+    [Fact]
+    public async Task ListToolsHandler_CommandWithoutResultTypeInfo_OmitsOutputSchema()
+    {
+        // Arrange
+        // A fake command that does not advertise a result type (ResultTypeInfo == null, the un-migrated
+        // default). GetTool should leave the tool's outputSchema unset so the command gracefully advertises
+        // no structured output.
+        var serviceProvider = CommandFactoryHelpers.CreateDefaultServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger<CommandFactoryToolLoader>();
+        var toolLoaderOptions = Microsoft.Extensions.Options.Options.Create(new ToolLoaderOptions());
+
+        var fakeCommand = Substitute.For<IBaseCommand>();
+        fakeCommand.GetCommand().Returns(new Command("fake-noschema-get", "A fake command with no result type."));
+        fakeCommand.Title.Returns("Fake No Schema Get");
+        fakeCommand.Metadata.Returns(new ToolMetadata());
+
+        var commandFactory = CommandFactoryHelpers.CreateCommandFactory(serviceProvider);
+        var commandMapField = typeof(CommandFactory).GetField("_commandMap", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var commandMap = (Dictionary<string, IBaseCommand>)commandMapField!.GetValue(commandFactory)!;
+        commandMap["fake-noschema-get"] = fakeCommand;
+
+        var toolLoader = new CommandFactoryToolLoader(serviceProvider, commandFactory, toolLoaderOptions, logger);
+        var request = CreateRequest();
+
+        // Act
+        var result = await toolLoader.ListToolsHandler(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var tool = result.Tools.FirstOrDefault(t => t.Name == "fake-noschema-get");
+        Assert.NotNull(tool);
+        Assert.Null(tool.OutputSchema);
+    }
+
     // A self-contained enum + options POCO used only by ListToolsHandler_EnumOption_IsExportedAsStringType.
     // Declaring them here keeps the enum-to-schema contract test independent of any shipping tool.
     private enum SchemaSampleLevel

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/OptionSchemaGenerator.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/OptionSchemaGenerator.cs
@@ -112,4 +112,35 @@ internal static class OptionSchemaGenerator
 
         return root;
     }
+
+    /// <summary>
+    /// Builds the <c>outputSchema</c> root <see cref="JsonObject"/> for the supplied result type.
+    /// MCP requires the root schema to be an <c>"object"</c>, so result types that export as a
+    /// non-object root (arrays or scalars) are wrapped under a single <c>value</c> property. Unlike the
+    /// input schema, <c>additionalProperties</c> is intentionally left unset for forward compatibility
+    /// with evolving result shapes.
+    /// </summary>
+    public static JsonObject CreateOutputSchema(JsonTypeInfo resultTypeInfo)
+    {
+        ArgumentNullException.ThrowIfNull(resultTypeInfo);
+
+        var schema = JsonSchemaExporter.GetJsonSchemaAsNode(resultTypeInfo, s_exporterOptions);
+
+        if (schema is JsonObject rootObject && IsObjectRoot(rootObject))
+        {
+            return rootObject;
+        }
+
+        return new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject { ["value"] = schema },
+            ["required"] = new JsonArray { (JsonNode)"value" },
+        };
+    }
+
+    private static bool IsObjectRoot(JsonObject schema)
+        => schema["type"] is JsonValue typeValue
+            && typeValue.TryGetValue<string>(out var typeName)
+            && typeName == "object";
 }

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -203,7 +203,7 @@ public sealed class CommandFactoryToolLoader(
             var jsonResponse = JsonSerializer.Serialize(commandResponse, ModelsJsonContext.Default.CommandResponse);
             var isError = commandResponse.Status < HttpStatusCode.OK || commandResponse.Status >= HttpStatusCode.Ambiguous;
 
-            return McpHelper.InjectToolIdMetadata(new CallToolResult
+            var callToolResult = new CallToolResult
             {
                 Content = [
                     new TextContentBlock {
@@ -211,7 +211,20 @@ public sealed class CommandFactoryToolLoader(
                     }
                 ],
                 IsError = isError
-            }, command.Id);
+            };
+
+            // When the command advertises an output schema, mirror its payload as structuredContent so
+            // clients can consume it against the schema. Wrapped identically to CreateOutputSchema.
+            if (!isError && command.ResultTypeInfo != null)
+            {
+                var structuredContent = TryBuildStructuredContent(jsonResponse);
+                if (structuredContent != null)
+                {
+                    callToolResult.StructuredContent = structuredContent;
+                }
+            }
+
+            return McpHelper.InjectToolIdMetadata(callToolResult, command.Id);
         }
         catch (Exception ex)
         {
@@ -263,6 +276,13 @@ public sealed class CommandFactoryToolLoader(
         }
         tool.Meta = meta;
 
+        var resultTypeInfo = command.ResultTypeInfo;
+        if (resultTypeInfo != null)
+        {
+            var outputSchema = OptionSchemaGenerator.CreateOutputSchema(resultTypeInfo);
+            tool.OutputSchema = JsonSerializer.SerializeToElement(outputSchema, ServerJsonContext.Default.JsonObject);
+        }
+
         var options = command.GetCommand().Options
             .Where(o => !CommandFactory.IsLearnOption(o))
             .ToList();
@@ -278,6 +298,35 @@ public sealed class CommandFactoryToolLoader(
         tool.InputSchema = JsonSerializer.SerializeToElement(schema, ServerJsonContext.Default.JsonObject);
 
         return tool;
+    }
+
+    /// <summary>
+    /// Extracts the command result payload from a serialized <see cref="CommandResponse"/> and shapes it
+    /// into the <c>structuredContent</c> value. Object payloads are used as-is; array or scalar payloads
+    /// are wrapped under a single <c>value</c> property to match the wrapping applied by
+    /// <see cref="OptionSchemaGenerator.CreateOutputSchema"/>. Returns <see langword="null"/> when there
+    /// is no result payload.
+    /// </summary>
+    private static JsonElement? TryBuildStructuredContent(string jsonResponse)
+    {
+        using var document = JsonDocument.Parse(jsonResponse);
+
+        if (!document.RootElement.TryGetProperty("results", out var results))
+        {
+            return null;
+        }
+
+        switch (results.ValueKind)
+        {
+            case JsonValueKind.Object:
+                return results.Clone();
+            case JsonValueKind.Null:
+            case JsonValueKind.Undefined:
+                return null;
+            default:
+                var wrapper = new JsonObject { ["value"] = JsonNode.Parse(results.GetRawText()) };
+                return JsonSerializer.SerializeToElement(wrapper, ServerJsonContext.Default.JsonObject);
+        }
     }
 
     /// <summary>

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -307,7 +307,9 @@ public sealed class CommandFactoryToolLoader(
     /// <see cref="OptionSchemaGenerator.CreateOutputSchema"/>. Returns <see langword="null"/> when there
     /// is no result payload.
     /// </summary>
-    private static JsonElement? TryBuildStructuredContent(string jsonResponse)
+    /// <remarks><see langword="internal"/> (rather than <see langword="private"/>) so the payload-shaping
+    /// contract can be unit tested directly without exercising the full call-tool pipeline.</remarks>
+    internal static JsonElement? TryBuildStructuredContent(string jsonResponse)
     {
         using var document = JsonDocument.Parse(jsonResponse);
 

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/RegistryToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/RegistryToolLoader.cs
@@ -70,7 +70,7 @@ public sealed class RegistryToolLoader(
             {
                 var exposedTool = string.IsNullOrEmpty(prefix)
                     ? tool
-                    : new Tool { Name = prefix + tool.Name, Description = tool.Description, InputSchema = tool.InputSchema, Annotations = tool.Annotations };
+                    : new Tool { Name = prefix + tool.Name, Description = tool.Description, InputSchema = tool.InputSchema, OutputSchema = tool.OutputSchema, Annotations = tool.Annotations };
                 allToolsResponse.Tools.Add(exposedTool);
             }
         }

--- a/core/Microsoft.Mcp.Core/src/Commands/BaseCommand`2.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/BaseCommand`2.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Reflection;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
 using Azure;
 using Azure.Mcp.Core.Areas.Server;
 using Microsoft.Identity.Client;
@@ -53,6 +54,16 @@ public abstract class BaseCommand<[DynamicallyAccessedMembers(TrimAnnotations.Co
     public string Description { get; }
     public string Title { get; }
     public ToolMetadata Metadata { get; }
+
+    /// <summary>
+    /// Gets the source-generated <see cref="JsonTypeInfo{TResult}"/> for this command's result type.
+    /// Migrated commands override this so the server can advertise an MCP <c>outputSchema</c> and emit
+    /// <c>structuredContent</c>. Commands that have not been migrated return <see langword="null"/> and
+    /// simply advertise no output schema.
+    /// </summary>
+    public virtual JsonTypeInfo<TResult>? ResultTypeInfo => null;
+
+    JsonTypeInfo? IBaseCommand.ResultTypeInfo => ResultTypeInfo;
 
     public Command GetCommand() => _command;
 
@@ -107,6 +118,22 @@ public abstract class BaseCommand<[DynamicallyAccessedMembers(TrimAnnotations.Co
 
         CommandResponse response = await ExecuteAsync(context, options, cancellationToken);
         return response;
+    }
+
+    /// <summary>
+    /// Stores the command result on the response using <see cref="ResultTypeInfo"/> so it is serialized
+    /// with the same source-generated <see cref="JsonTypeInfo{TResult}"/> used to advertise the
+    /// <c>outputSchema</c>. Only call this from commands that override <see cref="ResultTypeInfo"/>.
+    /// </summary>
+    protected void SetResult(CommandContext context, TResult result)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var typeInfo = ResultTypeInfo
+            ?? throw new InvalidOperationException(
+                $"Command type '{GetType().FullName}' called {nameof(SetResult)} without overriding {nameof(ResultTypeInfo)}.");
+
+        context.Response.Results = ResponseResult.Create(result, typeInfo);
     }
 
     protected virtual void HandleException(CommandContext context, Exception ex)

--- a/core/Microsoft.Mcp.Core/src/Commands/IBaseCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/IBaseCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine.Parsing;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.Mcp.Core.Models.Command;
 
 namespace Microsoft.Mcp.Core.Commands;
@@ -39,6 +40,13 @@ public interface IBaseCommand
     /// This metadata helps MCP clients understand how the tool operates and its potential effects.
     /// </summary>
     ToolMetadata Metadata { get; }
+
+    /// <summary>
+    /// Gets the JSON type information describing the command's result type, or <see langword="null"/>
+    /// when the command does not advertise a structured result. Used to generate the MCP
+    /// <c>outputSchema</c> and to serialize <c>structuredContent</c>.
+    /// </summary>
+    JsonTypeInfo? ResultTypeInfo => null;
 
     /// <summary>
     /// Gets the command definition

--- a/servers/Azure.Mcp.Server/changelog-entries/vcolin7-add-output-schema.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/vcolin7-add-output-schema.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Features Added"
+    description: "MCP tools can now advertise an `outputSchema` and return `structuredContent` describing the shape of their results. Output schemas are generated from each command's source-generated `JsonTypeInfo` via `System.Text.Json.Schema.JsonSchemaExporter`; result roots that are not JSON objects (arrays or scalars) are wrapped under a `value` property so the payload validates against the advertised schema. App Configuration commands are the first to opt in; other namespaces will follow."

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/Account/AccountListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/Account/AccountListCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.AppConfig.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Command;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Azure.Mcp.Tools.AppConfig.Commands.Account;
 
@@ -32,6 +33,8 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger, IAppC
     private readonly ILogger<AccountListCommand> _logger = logger;
     private readonly IAppConfigService _appConfigService = appConfigService;
 
+    public override JsonTypeInfo<AccountListCommandResult>? ResultTypeInfo => AppConfigJsonContext.Default.AccountListCommandResult;
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, AccountListOptions options, CancellationToken cancellationToken)
     {
         try
@@ -43,7 +46,7 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger, IAppC
                 options.RetryPolicy,
                 cancellationToken);
 
-            context.Response.Results = ResponseResult.Create(new(accounts?.Results ?? [], accounts?.AreResultsTruncated ?? false), AppConfigJsonContext.Default.AccountListCommandResult);
+            SetResult(context, new(accounts?.Results ?? [], accounts?.AreResultsTruncated ?? false));
         }
         catch (Exception ex)
         {

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueDeleteCommand.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Tools.AppConfig.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Command;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Azure.Mcp.Tools.AppConfig.Commands.KeyValue;
 
@@ -32,6 +33,8 @@ public sealed class KeyValueDeleteCommand(ILogger<KeyValueDeleteCommand> logger,
     private readonly ILogger<KeyValueDeleteCommand> _logger = logger;
     private readonly IAppConfigService _appConfigService = appConfigService;
 
+    public override JsonTypeInfo<KeyValueDeleteCommandResult>? ResultTypeInfo => AppConfigJsonContext.Default.KeyValueDeleteCommandResult;
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, KeyValueDeleteOptions options, CancellationToken cancellationToken)
     {
         try
@@ -49,7 +52,7 @@ public sealed class KeyValueDeleteCommand(ILogger<KeyValueDeleteCommand> logger,
             var message = existed
                 ? $"Key '{options.Key}'{labelSuffix} deleted successfully."
                 : $"Key '{options.Key}'{labelSuffix} did not exist in store '{options.Account}'.";
-            context.Response.Results = ResponseResult.Create(new(options.Key, options.Label, existed, message), AppConfigJsonContext.Default.KeyValueDeleteCommandResult);
+            SetResult(context, new(options.Key, options.Label, existed, message));
         }
         catch (Exception ex)
         {

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueGetCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.AppConfig.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Command;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Azure.Mcp.Tools.AppConfig.Commands.KeyValue;
 
@@ -33,6 +34,8 @@ public sealed class KeyValueGetCommand(ILogger<KeyValueGetCommand> logger, IAppC
 {
     private readonly ILogger<KeyValueGetCommand> _logger = logger;
     private readonly IAppConfigService _appConfigService = appConfigService;
+
+    public override JsonTypeInfo<KeyValueGetCommandResult>? ResultTypeInfo => AppConfigJsonContext.Default.KeyValueGetCommandResult;
 
     public override void ValidateOptions(KeyValueGetOptions options, ValidationResult validationResult)
     {
@@ -62,7 +65,7 @@ public sealed class KeyValueGetCommand(ILogger<KeyValueGetCommand> logger, IAppC
                 options.RetryPolicy,
                 cancellationToken);
 
-            context.Response.Results = ResponseResult.Create(new(settings ?? []), AppConfigJsonContext.Default.KeyValueGetCommandResult);
+            SetResult(context, new(settings ?? []));
         }
         catch (Exception ex)
         {

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueSetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/KeyValueSetCommand.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Tools.AppConfig.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Command;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Azure.Mcp.Tools.AppConfig.Commands.KeyValue;
 
@@ -33,6 +34,8 @@ public sealed class KeyValueSetCommand(ILogger<KeyValueSetCommand> logger, IAppC
     private readonly ILogger<KeyValueSetCommand> _logger = logger;
     private readonly IAppConfigService _appConfigService = appConfigService;
 
+    public override JsonTypeInfo<KeyValueSetCommandResult>? ResultTypeInfo => AppConfigJsonContext.Default.KeyValueSetCommandResult;
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, KeyValueSetOptions options, CancellationToken cancellationToken)
     {
         try
@@ -48,10 +51,7 @@ public sealed class KeyValueSetCommand(ILogger<KeyValueSetCommand> logger, IAppC
                 options.ContentType,
                 options.Tags,
                 cancellationToken);
-            context.Response.Results = ResponseResult.Create(
-                new(options.Key, options.Value, options.Label, options.ContentType, options.Tags),
-                AppConfigJsonContext.Default.KeyValueSetCommandResult
-            );
+            SetResult(context, new(options.Key, options.Value, options.Label, options.ContentType, options.Tags));
         }
         catch (Exception ex)
         {

--- a/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/Lock/KeyValueLockSetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AppConfig/src/Commands/KeyValue/Lock/KeyValueLockSetCommand.cs
@@ -8,6 +8,7 @@ using Azure.Mcp.Tools.AppConfig.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Command;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Azure.Mcp.Tools.AppConfig.Commands.KeyValue.Lock;
 
@@ -34,6 +35,8 @@ public sealed class KeyValueLockSetCommand(ILogger<KeyValueLockSetCommand> logge
     private readonly ILogger<KeyValueLockSetCommand> _logger = logger;
     private readonly IAppConfigService _appConfigService = appConfigService;
 
+    public override JsonTypeInfo<KeyValueLockSetCommandResult>? ResultTypeInfo => AppConfigJsonContext.Default.KeyValueLockSetCommandResult;
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, KeyValueLockSetOptions options, CancellationToken cancellationToken)
     {
         try
@@ -48,7 +51,7 @@ public sealed class KeyValueLockSetCommand(ILogger<KeyValueLockSetCommand> logge
                 options.Label,
                 cancellationToken);
 
-            context.Response.Results = ResponseResult.Create(new(options.Key, options.Label, options.Lock ?? false), AppConfigJsonContext.Default.KeyValueLockSetCommandResult);
+            SetResult(context, new(options.Key, options.Label, options.Lock ?? false));
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## What does this PR do?

> **Stacked on #2995** (base branch = `vcolin7/input-output-schema-v2`). This is PR 2 of the MCP schema modernization series, so it only shows its own 3 commits. Please review/merge after #2995; GitHub will retarget this PR to `main` automatically once #2995 merges.

Modernizes the Azure MCP Server to advertise **`outputSchema`** on `tools/list` and return **`structuredContent`** on `tools/call`, aligning with MCP spec [2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25). This PR lands the reusable core infrastructure plus **App Configuration** as the first opt-in pilot namespace. Every other namespace is untouched and keeps behaving exactly as before.

**Core infrastructure**
- `IBaseCommand.ResultTypeInfo` (default-interface member) and `BaseCommand<TOptions, TResult>` expose the command's result `JsonTypeInfo` plus a `SetResult` helper. `ResultTypeInfo` defaults to `null`, so this is strictly opt-in: un-migrated commands advertise no `outputSchema` and are completely unaffected.
- `OptionSchemaGenerator.CreateOutputSchema` derives a JSON Schema from the result type via `JsonSchemaExporter` (the same approach PR 1 used for inputs). The spec requires the schema root to be `{"type":"object"}`, so non-object results (arrays/scalars) are wrapped under a `value` property.
- `CommandFactoryToolLoader` emits `outputSchema` and builds a matching `structuredContent` payload; `RegistryToolLoader` passes both through for external/registry servers.

**App Configuration pilot**
- Migrated 5 commands (`account list`, `keyvalue get`/`set`/`delete`, `keyvalue lock set`) to declare `ResultTypeInfo` and call `SetResult`, so they now advertise `outputSchema` and return `structuredContent`.

**Reviewer notes**
- `structuredContent` shaping mirrors the schema wrapping: object results are mirrored as-is; arrays/scalars are wrapped under `value` so the payload validates against the advertised schema.
- `additionalProperties` is intentionally left unset on outputs (forward-compatible as servers add fields), unlike inputs where it is `false`.
- `ResultTypeInfo` is deliberately `virtual` with a `null` default rather than `abstract`; a later PR tightens this with a discovery test once every namespace is migrated.
- Tests are decoupled from any shipping tool: `CreateOutputSchema` and `TryBuildStructuredContent` are covered directly using a sample result record and a real serialized `CommandResponse`.

## GitHub issue number?

N/A

## Pre-merge Checklist
- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles _(N/A — shared schema infrastructure plus the App Configuration pilot namespace; no tools are added or renamed, only their advertised output schema)_
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation _(N/A — no tool names or descriptions change)_
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts _(N/A — descriptions unchanged)_
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json) _(N/A — no new/renamed tools)_
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label _(N/A)_
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description _(N/A)_
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
