### PR TITLE
Fix functional issues  and update dependencies

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Services/Azure/Authentication/CustomChainedCredentialTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Services/Azure/Authentication/CustomChainedCredentialTests.cs
@@ -441,6 +441,35 @@ public class CustomChainedCredentialTests
     }
 
     /// <summary>
+    /// Tests that an unrecognized AZURE_TOKEN_CREDENTIALS value logs a warning and falls back to
+    /// the default credential chain. This catches typos such as "AzuerCliCredential".
+    /// </summary>
+    [Fact]
+    public void UnknownCredentialValue_LogsWarning_AndFallsBackToDefaultChain()
+    {
+        // Arrange
+        using var env = new EnvironmentScope("AZURE_TOKEN_CREDENTIALS");
+        Environment.SetEnvironmentVariable("AZURE_TOKEN_CREDENTIALS", "AzuerCliCredential"); // intentional typo
+
+        var provider = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(provider));
+        var credential = CreateCustomChainedCredentialWithLoggerFactory(factory);
+
+        // Trigger the lazy credential construction (authentication will fail in test environment, that's expected).
+        try { credential.GetToken(new TokenRequestContext(["https://management.azure.com/.default"]), CancellationToken.None); }
+        catch { /* credential chain construction is all we need; auth failure is expected */ }
+
+        // Assert — credential is still created (fallback works)
+        Assert.NotNull(credential);
+        Assert.IsAssignableFrom<TokenCredential>(credential);
+
+        // Assert — exactly one warning was logged containing the unrecognized value
+        var warning = Assert.Single(provider.Warnings);
+        Assert.Contains("AzuerCliCredential", warning);
+        Assert.Contains("AZURE_TOKEN_CREDENTIALS", warning);
+    }
+
+    /// <summary>
     /// Helper method to create CustomChainedCredential using reflection since it's an internal class.
     /// </summary>
     private static TokenCredential CreateCustomChainedCredential(bool forceBrowserFallback = false)
@@ -465,6 +494,33 @@ public class CustomChainedCredentialTests
         var credential = constructor.Invoke([null, null, forceBrowserFallback]) as TokenCredential;
         Assert.NotNull(credential);
 
+        return credential;
+    }
+
+    private static TokenCredential CreateCustomChainedCredentialWithLoggerFactory(ILoggerFactory factory)
+    {
+        var assembly = typeof(global::Microsoft.Mcp.Core.Services.Azure.Authentication.IAzureTokenCredentialProvider).Assembly;
+        var customChainedCredentialType = assembly.GetType("Microsoft.Mcp.Core.Services.Azure.Authentication.CustomChainedCredential");
+        Assert.NotNull(customChainedCredentialType);
+
+        // Build a correctly-typed ILogger<CustomChainedCredential> from the factory via the concrete Logger<T> class.
+        var loggerConcreteType = typeof(Logger<>).MakeGenericType(customChainedCredentialType);
+        var logger = Activator.CreateInstance(loggerConcreteType, factory);
+
+        var constructor = customChainedCredentialType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .FirstOrDefault(c =>
+            {
+                var parameters = c.GetParameters();
+                return parameters.Length == 3 &&
+                       parameters[0].ParameterType == typeof(string) &&
+                       parameters[1].ParameterType == typeof(ILogger<>).MakeGenericType(customChainedCredentialType) &&
+                       parameters[2].ParameterType == typeof(bool);
+            });
+
+        Assert.NotNull(constructor);
+
+        var credential = constructor.Invoke([null, logger, false]) as TokenCredential;
+        Assert.NotNull(credential);
         return credential;
     }
 
@@ -497,6 +553,30 @@ public class CustomChainedCredentialTests
         {
             foreach (var (name, value) in _saved)
                 Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+
+    /// <summary>
+    /// Minimal ILoggerProvider + ILogger implementation that captures warning messages for assertion.
+    /// </summary>
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly List<string> _warnings = [];
+        public IReadOnlyList<string> Warnings => _warnings;
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(_warnings);
+        public void Dispose() { }
+    }
+
+    private sealed class CapturingLogger(List<string> warnings) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+                warnings.Add(formatter(state, exception));
         }
     }
 }

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Services/Azure/Authentication/CustomChainedCredentialTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Services/Azure/Authentication/CustomChainedCredentialTests.cs
@@ -456,8 +456,14 @@ public class CustomChainedCredentialTests
         var credential = CreateCustomChainedCredentialWithLoggerFactory(factory);
 
         // Trigger the lazy credential construction (authentication will fail in test environment, that's expected).
-        try { credential.GetToken(new TokenRequestContext(["https://management.azure.com/.default"]), CancellationToken.None); }
-        catch { /* credential chain construction is all we need; auth failure is expected */ }
+        try
+        {
+            credential.GetToken(new TokenRequestContext(["https://management.azure.com/.default"]), CancellationToken.None);
+        }
+        catch
+        {
+            // credential chain construction is all we need; auth failure is expected
+        }
 
         // Assert — credential is still created (fallback works)
         Assert.NotNull(credential);
@@ -467,6 +473,44 @@ public class CustomChainedCredentialTests
         var warning = Assert.Single(provider.Warnings);
         Assert.Contains("AzuerCliCredential", warning);
         Assert.Contains("AZURE_TOKEN_CREDENTIALS", warning);
+    }
+
+    /// <summary>
+    /// Tests that concurrent calls to GetToken complete without error and leave the
+    /// Lazy&lt;T&gt; credential in a created state, verifying that the ExecutionAndPublication
+    /// mode allows all threads to proceed after initialization.
+    /// </summary>
+    [Fact]
+    public async Task GetToken_ConcurrentCalls_CredentialIsInitializedAfterConcurrentAccess()
+    {
+        // Arrange
+        var credential = CreateCustomChainedCredential();
+        var credentialType = GetCustomChainedCredentialType();
+        var lazyField = credentialType.GetField("_credential",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(lazyField);
+
+        // Act — fire 20 concurrent GetToken calls before the chain is initialized
+        var tasks = Enumerable.Range(0, 20).Select(_ => Task.Run(() =>
+        {
+            try
+            {
+                credential.GetToken(new TokenRequestContext(["https://management.azure.com/.default"]), CancellationToken.None);
+            }
+            catch
+            {
+                // auth failure expected in test environment
+            }
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        // Assert — the Lazy<T> value was created and is a single shared instance
+        var lazyValue = lazyField.GetValue(credential);
+        Assert.NotNull(lazyValue);
+        var isValueCreated = (bool)lazyValue.GetType()
+            .GetProperty("IsValueCreated")!.GetValue(lazyValue)!;
+        Assert.True(isValueCreated);
     }
 
     /// <summary>

--- a/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/CustomChainedCredential.cs
+++ b/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/CustomChainedCredential.cs
@@ -165,7 +165,7 @@ internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomCh
         else
         {
             // Use the default credential chain (respects AZURE_TOKEN_CREDENTIALS if set)
-            creds.Add(CreateDefaultCredential(tenantId));
+            creds.Add(CreateDefaultCredential(tenantId, logger));
         }
 
         // Only add interactive fallback credentials when:
@@ -260,7 +260,16 @@ internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomCh
         return new TimeoutTokenCredential(browserCredential, TimeSpan.FromSeconds(timeoutSeconds));
     }
 
-    private static ChainedTokenCredential CreateDefaultCredential(string? tenantId)
+    private static readonly string[] AcceptedTokenCredentialValues =
+    [
+        "dev", "prod",
+        "EnvironmentCredential", "WorkloadIdentityCredential", "ManagedIdentityCredential",
+        "VisualStudioCredential", "VisualStudioCodeCredential",
+        "AzureCliCredential", "AzurePowerShellCredential", "AzureDeveloperCliCredential",
+        "DeviceCodeCredential"
+    ];
+
+    private static ChainedTokenCredential CreateDefaultCredential(string? tenantId, ILogger<CustomChainedCredential>? logger = null)
     {
         string? tokenCredentials = Environment.GetEnvironmentVariable(TokenCredentialsEnvVarName);
         var credentials = new List<TokenCredential>();
@@ -323,7 +332,10 @@ internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomCh
                     break;
 
                 default:
-                    // Unknown value, fall back to default chain
+                    logger?.LogWarning(
+                        "Unrecognized AZURE_TOKEN_CREDENTIALS value '{Value}'. Expected one of: {ValidValues}. Falling back to default credential chain.",
+                        tokenCredentials,
+                        string.Join(", ", AcceptedTokenCredentialValues));
                     AddDefaultCredentialChain(credentials, tenantId);
                     break;
             }

--- a/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/CustomChainedCredential.cs
+++ b/core/Microsoft.Mcp.Core/src/Services/Azure/Authentication/CustomChainedCredential.cs
@@ -84,10 +84,16 @@ namespace Microsoft.Mcp.Core.Services.Azure.Authentication;
 /// If not set, System-Assigned Managed Identity will be used.
 /// </para>
 /// </remarks>
-internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomChainedCredential>? logger = null, bool forceBrowserFallback = false) : TokenCredential
+internal class CustomChainedCredential : TokenCredential
 {
-    private TokenCredential? _credential;
-    private readonly ILogger<CustomChainedCredential>? _logger = logger;
+    private readonly Lazy<TokenCredential> _credential;
+
+    internal CustomChainedCredential(string? tenantId = null, ILogger<CustomChainedCredential>? logger = null, bool forceBrowserFallback = false)
+    {
+        _credential = new Lazy<TokenCredential>(
+            () => CreateCredential(tenantId, logger, forceBrowserFallback),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
 
     /// <summary>
     /// Cloud configuration for authority host. Set by DI container during service registration.
@@ -102,14 +108,12 @@ internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomCh
 
     public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
     {
-        _credential ??= CreateCredential(tenantId, _logger, forceBrowserFallback);
-        return _credential.GetToken(requestContext, cancellationToken);
+        return _credential.Value.GetToken(requestContext, cancellationToken);
     }
 
     public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
     {
-        _credential ??= CreateCredential(tenantId, _logger, forceBrowserFallback);
-        return _credential.GetTokenAsync(requestContext, cancellationToken);
+        return _credential.Value.GetTokenAsync(requestContext, cancellationToken);
     }
 
     private const string AuthenticationRecordEnvVarName = "AZURE_MCP_AUTHENTICATION_RECORD";
@@ -266,7 +270,7 @@ internal class CustomChainedCredential(string? tenantId = null, ILogger<CustomCh
         "EnvironmentCredential", "WorkloadIdentityCredential", "ManagedIdentityCredential",
         "VisualStudioCredential", "VisualStudioCodeCredential",
         "AzureCliCredential", "AzurePowerShellCredential", "AzureDeveloperCliCredential",
-        "DeviceCodeCredential"
+        "DeviceCodeCredential", "InteractiveBrowserCredential"
     ];
 
     private static ChainedTokenCredential CreateDefaultCredential(string? tenantId, ILogger<CustomChainedCredential>? logger = null)

--- a/servers/Azure.Mcp.Server/changelog-entries/1783387640306.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1783387640306.yaml
@@ -1,0 +1,4 @@
+changes:
+  - section: "Other Changes"
+    description: "Updated @microsoft/vscode-azext-utils from ~2 to ~4 (4.1.1) and @vscode/vsce from 3.7.1 to 3.9.2 in the VS Code extension."
+    subsection: "Dependency Updates"

--- a/servers/Azure.Mcp.Server/changelog-entries/1783387640512.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1783387640512.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Unrecognized AZURE_TOKEN_CREDENTIALS values (e.g. typos) now log a warning listing valid values instead of silently falling back to the default credential chain."

--- a/servers/Azure.Mcp.Server/changelog-entries/1783400773627.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1783400773627.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed a thread-safety issue in CustomChainedCredential where concurrent calls to GetToken/GetTokenAsync before initialization could construct duplicate credential chains. The credential is now initialized via Lazy<T> (ExecutionAndPublication) to guarantee single initialization under concurrent access."

--- a/servers/Azure.Mcp.Server/vscode/package-lock.json
+++ b/servers/Azure.Mcp.Server/vscode/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.0",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/vscode-azext-utils": "~4",
+                "@microsoft/vscode-azext-utils": "~4.1.1",
                 "@microsoft/vscode-azureresources-api": "~2",
                 "dayjs": "~1",
                 "dotenv": "~16",
@@ -28,7 +28,7 @@
                 "@typescript-eslint/eslint-plugin": "^8.47.0",
                 "@typescript-eslint/parser": "^8.47.0",
                 "@vscode/test-electron": "~2",
-                "@vscode/vsce": "~3",
+                "@vscode/vsce": "~3.9.2",
                 "chai": "~4",
                 "eslint": "~9",
                 "glob": "^13.0.0",
@@ -778,12 +778,12 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.0.8.tgz",
-            "integrity": "sha512-+Gmtb3UmdtuaJPMJOSuDoFkc3YUDSrgS7/SZiJ+41wSxCuQxrb7tgEtJ47raLMa9cz4yb+ymO9Lw6WH2sasGSw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.1.1.tgz",
+            "integrity": "sha512-pFvvzqJqAJrI5UTeJNijGrHWB738VTPck6Vsnb77L0agHMGKPqRy28Ela/6fGJRXBc7Yuv14gn39Sogn0qMvkQ==",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/vscode-azureresources-api": "^3.1.0",
+                "@microsoft/vscode-azureresources-api": "^3.1.1",
                 "@microsoft/vscode-processutils": "^0.2.1",
                 "@vscode/extension-telemetry": "^1.5.2",
                 "dayjs": "^1.11.19",
@@ -805,9 +805,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils/node_modules/@microsoft/vscode-azureresources-api": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.0.tgz",
-            "integrity": "sha512-jcx5VdDiOftjkjQ+ZXuGQ7xpy7WSKnB7oRLdmGuW3ykaB/PrBSHwStkItSg8l8ycJ0t1kaPOz3eDJP0Ol309jg==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.1.tgz",
+            "integrity": "sha512-koV1+XvWSzA+pOc1g17Kbw9Gm26SIvg+j5puT5vB/T9vNiE2oeAlxlAatfZOT3tRHN1qGqPLl90HHs5mQAPkew==",
             "license": "MIT",
             "engines": {
                 "vscode": "^1.105.0"
@@ -1651,9 +1651,9 @@
             }
         },
         "node_modules/@vscode/vsce": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.7.1.tgz",
-            "integrity": "sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.2.tgz",
+            "integrity": "sha512-XSxMosEEDO6vLxELAHVkwmhC0qe0ijZni2jB9Rcs8kQsW4lhTDQ/wMzmwFs/buotAWSnpmUp/dRWD2ufG3UYKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1669,13 +1669,13 @@
                 "cockatiel": "^3.1.2",
                 "commander": "^12.1.0",
                 "form-data": "^4.0.0",
-                "glob": "^11.0.0",
+                "glob": "^13.0.6",
                 "hosted-git-info": "^4.0.2",
                 "jsonc-parser": "^3.2.0",
                 "leven": "^3.1.0",
                 "markdown-it": "^14.1.0",
                 "mime": "^1.3.4",
-                "minimatch": "^3.0.3",
+                "minimatch": "^10.2.2",
                 "parse-semver": "^1.1.1",
                 "read": "^1.0.7",
                 "secretlint": "^10.1.2",
@@ -1684,7 +1684,7 @@
                 "typed-rest-client": "^1.8.4",
                 "url-join": "^4.0.1",
                 "xml2js": "^0.5.0",
-                "yauzl": "^2.3.1",
+                "yauzl": "^3.2.1",
                 "yazl": "^2.2.2"
             },
             "bin": {
@@ -1842,42 +1842,7 @@
                 "win32"
             ]
         },
-        "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/glob": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-            "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "foreground-child": "^3.3.1",
-                "jackspeak": "^4.1.1",
-                "minimatch": "^10.1.1",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^2.0.0"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/glob/node_modules/balanced-match": {
+        "node_modules/@vscode/vsce/node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
@@ -1887,10 +1852,10 @@
                 "node": "18 || 20 || >=22"
             }
         },
-        "node_modules/@vscode/vsce/node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+        "node_modules/@vscode/vsce/node_modules/brace-expansion": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1900,33 +1865,20 @@
                 "node": "18 || 20 || >=22"
             }
         },
-        "node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+        "node_modules/@vscode/vsce/node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/@webassemblyjs/ast": {
@@ -4038,18 +3990,18 @@
             "optional": true
         },
         "node_modules/glob": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "minimatch": "^10.1.1",
-                "minipass": "^7.1.2",
-                "path-scurry": "^2.0.0"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -4717,22 +4669,6 @@
                 "url": "https://bevry.me/fund"
             }
         },
-        "node_modules/jackspeak": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-            "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/jest-worker": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -5302,11 +5238,11 @@
             }
         },
         "node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
@@ -6009,9 +5945,9 @@
             "license": "MIT"
         },
         "node_modules/path-scurry": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -6019,18 +5955,18 @@
                 "minipass": "^7.1.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.2.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-            "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
             }

--- a/servers/Azure.Mcp.Server/vscode/package.json
+++ b/servers/Azure.Mcp.Server/vscode/package.json
@@ -236,7 +236,7 @@
         "@typescript-eslint/eslint-plugin": "^8.47.0",
         "@typescript-eslint/parser": "^8.47.0",
         "@vscode/test-electron": "~2",
-        "@vscode/vsce": "~3",
+        "@vscode/vsce": "~3.9.2",
         "chai": "~4",
         "eslint": "~9",
         "glob": "^13.0.0",
@@ -251,7 +251,7 @@
         "webpack-cli": "^6.0.1"
     },
     "dependencies": {
-        "@microsoft/vscode-azext-utils": "~4",
+        "@microsoft/vscode-azext-utils": "~4.1.1",
         "@microsoft/vscode-azureresources-api": "~2",
         "dayjs": "~1",
         "dotenv": "~16",

--- a/servers/Fabric.Mcp.Server/changelog-entries/1783387640737.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1783387640737.yaml
@@ -1,0 +1,4 @@
+changes:
+  - section: "Other Changes"
+    description: "Updated @microsoft/vscode-azext-utils from ~2 to ~4 (4.1.1) and @vscode/vsce from 3.7.1 to 3.9.2 in the VS Code extension."
+    subsection: "Dependency Updates"

--- a/servers/Fabric.Mcp.Server/vscode/package-lock.json
+++ b/servers/Fabric.Mcp.Server/vscode/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.0",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/vscode-azext-utils": "~4",
+                "@microsoft/vscode-azext-utils": "~4.1.1",
                 "@microsoft/vscode-azureresources-api": "~2",
                 "dayjs": "~1",
                 "dotenv": "~16",
@@ -28,7 +28,7 @@
                 "@typescript-eslint/eslint-plugin": "^8.47.0",
                 "@typescript-eslint/parser": "^8.47.0",
                 "@vscode/test-electron": "~2",
-                "@vscode/vsce": "~3",
+                "@vscode/vsce": "~3.9.2",
                 "chai": "~4",
                 "eslint": "~9",
                 "glob": "^13.0.0",
@@ -778,12 +778,12 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.1.0.tgz",
-            "integrity": "sha512-00/wz3n2W6xNFZK4ur2lGjTqX8RhSrbAIoNwhMreOKk2n6gOpY389XO20oHu77uBxjgoqMTAL5R+SWcMeqD0Gg==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.1.1.tgz",
+            "integrity": "sha512-pFvvzqJqAJrI5UTeJNijGrHWB738VTPck6Vsnb77L0agHMGKPqRy28Ela/6fGJRXBc7Yuv14gn39Sogn0qMvkQ==",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/vscode-azureresources-api": "^3.1.0",
+                "@microsoft/vscode-azureresources-api": "^3.1.1",
                 "@microsoft/vscode-processutils": "^0.2.1",
                 "@vscode/extension-telemetry": "^1.5.2",
                 "dayjs": "^1.11.19",
@@ -805,9 +805,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils/node_modules/@microsoft/vscode-azureresources-api": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.0.tgz",
-            "integrity": "sha512-jcx5VdDiOftjkjQ+ZXuGQ7xpy7WSKnB7oRLdmGuW3ykaB/PrBSHwStkItSg8l8ycJ0t1kaPOz3eDJP0Ol309jg==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.1.tgz",
+            "integrity": "sha512-koV1+XvWSzA+pOc1g17Kbw9Gm26SIvg+j5puT5vB/T9vNiE2oeAlxlAatfZOT3tRHN1qGqPLl90HHs5mQAPkew==",
             "license": "MIT",
             "engines": {
                 "vscode": "^1.105.0"
@@ -1661,9 +1661,9 @@
             }
         },
         "node_modules/@vscode/vsce": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.7.1.tgz",
-            "integrity": "sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.2.tgz",
+            "integrity": "sha512-XSxMosEEDO6vLxELAHVkwmhC0qe0ijZni2jB9Rcs8kQsW4lhTDQ/wMzmwFs/buotAWSnpmUp/dRWD2ufG3UYKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1679,13 +1679,13 @@
                 "cockatiel": "^3.1.2",
                 "commander": "^12.1.0",
                 "form-data": "^4.0.0",
-                "glob": "^11.0.0",
+                "glob": "^13.0.6",
                 "hosted-git-info": "^4.0.2",
                 "jsonc-parser": "^3.2.0",
                 "leven": "^3.1.0",
                 "markdown-it": "^14.1.0",
                 "mime": "^1.3.4",
-                "minimatch": "^3.0.3",
+                "minimatch": "^10.2.2",
                 "parse-semver": "^1.1.1",
                 "read": "^1.0.7",
                 "secretlint": "^10.1.2",
@@ -1694,7 +1694,7 @@
                 "typed-rest-client": "^1.8.4",
                 "url-join": "^4.0.1",
                 "xml2js": "^0.5.0",
-                "yauzl": "^2.3.1",
+                "yauzl": "^3.2.1",
                 "yazl": "^2.2.2"
             },
             "bin": {
@@ -1852,42 +1852,7 @@
                 "win32"
             ]
         },
-        "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/glob": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-            "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "foreground-child": "^3.3.1",
-                "jackspeak": "^4.1.1",
-                "minimatch": "^10.1.1",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^2.0.0"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/glob/node_modules/balanced-match": {
+        "node_modules/@vscode/vsce/node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
@@ -1897,10 +1862,10 @@
                 "node": "18 || 20 || >=22"
             }
         },
-        "node_modules/@vscode/vsce/node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+        "node_modules/@vscode/vsce/node_modules/brace-expansion": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1910,33 +1875,20 @@
                 "node": "18 || 20 || >=22"
             }
         },
-        "node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+        "node_modules/@vscode/vsce/node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/@webassemblyjs/ast": {
@@ -4049,18 +4001,18 @@
             "optional": true
         },
         "node_modules/glob": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "minimatch": "^10.1.1",
-                "minipass": "^7.1.2",
-                "path-scurry": "^2.0.0"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -4728,22 +4680,6 @@
                 "url": "https://bevry.me/fund"
             }
         },
-        "node_modules/jackspeak": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-            "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/jest-worker": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -5323,11 +5259,11 @@
             }
         },
         "node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
@@ -6030,9 +5966,9 @@
             "license": "MIT"
         },
         "node_modules/path-scurry": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -6040,18 +5976,18 @@
                 "minipass": "^7.1.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.2.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-            "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
             }

--- a/servers/Fabric.Mcp.Server/vscode/package.json
+++ b/servers/Fabric.Mcp.Server/vscode/package.json
@@ -62,14 +62,16 @@
                     },
                     "uniqueItems": true,
                     "markdownDescription": "Service namespaces to enable. Leave empty to enable all. Choose from the list to avoid typing errors. **Note:** Changes require restarting the MCP server if MCP Autostart is not configured (Command Palette → MCP: List Servers → Fabric MCP → Start/Restart)."
-
                 },
                 "fabricMcp.serverMode": {
                     "type": "string",
-                    "enum": ["single", "namespace", "all"],
+                    "enum": [
+                        "single",
+                        "namespace",
+                        "all"
+                    ],
                     "default": "all",
                     "markdownDescription": "Server Mode determines how tools are exposed: `single` collapses every tool into one single tool that routes internally, `namespace` collapses all tools down into logical Fabric service namespace grouping, while `all` (default) exposes every MCP tool directly to the MCP client. We recommend all as the right balance between MCP tool count and tool selection accuracy. **Note:** Changes require restarting the MCP server if MCP Autostart is not configured (Command Palette → MCP: List Servers → Fabric MCP → Start/Restart)."
-
                 },
                 "fabricMcp.readOnly": {
                     "type": "boolean",
@@ -100,7 +102,7 @@
         "@typescript-eslint/eslint-plugin": "^8.47.0",
         "@typescript-eslint/parser": "^8.47.0",
         "@vscode/test-electron": "~2",
-        "@vscode/vsce": "~3",
+        "@vscode/vsce": "~3.9.2",
         "chai": "~4",
         "eslint": "~9",
         "glob": "^13.0.0",
@@ -115,7 +117,7 @@
         "webpack-cli": "^6.0.1"
     },
     "dependencies": {
-        "@microsoft/vscode-azext-utils": "~4",
+        "@microsoft/vscode-azext-utils": "~4.1.1",
         "@microsoft/vscode-azureresources-api": "~2",
         "dayjs": "~1",
         "dotenv": "~16",

--- a/servers/Template.Mcp.Server/vscode/package-lock.json
+++ b/servers/Template.Mcp.Server/vscode/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.0",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/vscode-azext-utils": "~4",
+                "@microsoft/vscode-azext-utils": "~4.1.1",
                 "@microsoft/vscode-azureresources-api": "~2",
                 "dayjs": "~1",
                 "dotenv": "~16",
@@ -28,7 +28,7 @@
                 "@typescript-eslint/eslint-plugin": "^8.47.0",
                 "@typescript-eslint/parser": "^8.47.0",
                 "@vscode/test-electron": "~2",
-                "@vscode/vsce": "~3",
+                "@vscode/vsce": "~3.9.2",
                 "chai": "~4",
                 "eslint": "~9",
                 "glob": "^13.0.0",
@@ -778,12 +778,12 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.0.8.tgz",
-            "integrity": "sha512-+Gmtb3UmdtuaJPMJOSuDoFkc3YUDSrgS7/SZiJ+41wSxCuQxrb7tgEtJ47raLMa9cz4yb+ymO9Lw6WH2sasGSw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-4.1.1.tgz",
+            "integrity": "sha512-pFvvzqJqAJrI5UTeJNijGrHWB738VTPck6Vsnb77L0agHMGKPqRy28Ela/6fGJRXBc7Yuv14gn39Sogn0qMvkQ==",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/vscode-azureresources-api": "^3.1.0",
+                "@microsoft/vscode-azureresources-api": "^3.1.1",
                 "@microsoft/vscode-processutils": "^0.2.1",
                 "@vscode/extension-telemetry": "^1.5.2",
                 "dayjs": "^1.11.19",
@@ -805,9 +805,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils/node_modules/@microsoft/vscode-azureresources-api": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.0.tgz",
-            "integrity": "sha512-jcx5VdDiOftjkjQ+ZXuGQ7xpy7WSKnB7oRLdmGuW3ykaB/PrBSHwStkItSg8l8ycJ0t1kaPOz3eDJP0Ol309jg==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.1.tgz",
+            "integrity": "sha512-koV1+XvWSzA+pOc1g17Kbw9Gm26SIvg+j5puT5vB/T9vNiE2oeAlxlAatfZOT3tRHN1qGqPLl90HHs5mQAPkew==",
             "license": "MIT",
             "engines": {
                 "vscode": "^1.105.0"
@@ -1651,9 +1651,9 @@
             }
         },
         "node_modules/@vscode/vsce": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.7.1.tgz",
-            "integrity": "sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.2.tgz",
+            "integrity": "sha512-XSxMosEEDO6vLxELAHVkwmhC0qe0ijZni2jB9Rcs8kQsW4lhTDQ/wMzmwFs/buotAWSnpmUp/dRWD2ufG3UYKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1669,13 +1669,13 @@
                 "cockatiel": "^3.1.2",
                 "commander": "^12.1.0",
                 "form-data": "^4.0.0",
-                "glob": "^11.0.0",
+                "glob": "^13.0.6",
                 "hosted-git-info": "^4.0.2",
                 "jsonc-parser": "^3.2.0",
                 "leven": "^3.1.0",
                 "markdown-it": "^14.1.0",
                 "mime": "^1.3.4",
-                "minimatch": "^3.0.3",
+                "minimatch": "^10.2.2",
                 "parse-semver": "^1.1.1",
                 "read": "^1.0.7",
                 "secretlint": "^10.1.2",
@@ -1684,7 +1684,7 @@
                 "typed-rest-client": "^1.8.4",
                 "url-join": "^4.0.1",
                 "xml2js": "^0.5.0",
-                "yauzl": "^2.3.1",
+                "yauzl": "^3.2.1",
                 "yazl": "^2.2.2"
             },
             "bin": {
@@ -1842,42 +1842,7 @@
                 "win32"
             ]
         },
-        "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/glob": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-            "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "foreground-child": "^3.3.1",
-                "jackspeak": "^4.1.1",
-                "minimatch": "^10.1.1",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^2.0.0"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/glob/node_modules/balanced-match": {
+        "node_modules/@vscode/vsce/node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
@@ -1887,10 +1852,10 @@
                 "node": "18 || 20 || >=22"
             }
         },
-        "node_modules/@vscode/vsce/node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+        "node_modules/@vscode/vsce/node_modules/brace-expansion": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1900,33 +1865,20 @@
                 "node": "18 || 20 || >=22"
             }
         },
-        "node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+        "node_modules/@vscode/vsce/node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@vscode/vsce/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/@webassemblyjs/ast": {
@@ -4039,18 +3991,18 @@
             "optional": true
         },
         "node_modules/glob": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "minimatch": "^10.1.1",
-                "minipass": "^7.1.2",
-                "path-scurry": "^2.0.0"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -4697,22 +4649,6 @@
                 "url": "https://bevry.me/fund"
             }
         },
-        "node_modules/jackspeak": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-            "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/jest-worker": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -5302,11 +5238,11 @@
             }
         },
         "node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
@@ -6022,9 +5958,9 @@
             "license": "MIT"
         },
         "node_modules/path-scurry": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -6032,18 +5968,18 @@
                 "minipass": "^7.1.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.2.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-            "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
             }

--- a/servers/Template.Mcp.Server/vscode/package.json
+++ b/servers/Template.Mcp.Server/vscode/package.json
@@ -101,7 +101,7 @@
         "@typescript-eslint/eslint-plugin": "^8.47.0",
         "@typescript-eslint/parser": "^8.47.0",
         "@vscode/test-electron": "~2",
-        "@vscode/vsce": "~3",
+        "@vscode/vsce": "~3.9.2",
         "chai": "~4",
         "eslint": "~9",
         "glob": "^13.0.0",
@@ -116,7 +116,7 @@
         "webpack-cli": "^6.0.1"
     },
     "dependencies": {
-        "@microsoft/vscode-azext-utils": "~4",
+        "@microsoft/vscode-azext-utils": "~4.1.1",
         "@microsoft/vscode-azureresources-api": "~2",
         "dayjs": "~1",
         "dotenv": "~16",


### PR DESCRIPTION

Addresses following issues:

**#2632 / #2633 — VS Code extension dependency updates**
- Updated `@microsoft/vscode-azext-utils` from `~2` (2.6.8) to `~4` (4.1.1) across all three VS Code extensions (`Azure.Mcp.Server`, `Fabric.Mcp.Server`, `Template.Mcp.Server`)
- Updated `@vscode/vsce` from `3.7.1` to `3.9.2` across the same extensions
- Verified: `tsc` compile, webpack build, and `eng/scripts/Build-Local.ps1 -VerifyNpx` all pass

**[#399](https://github.com/microsoft/mcp-pr/issues/399) — Silent fallback on unrecognized `AZURE_TOKEN_CREDENTIALS` value**
- The `default:` case in `CreateDefaultCredential` previously fell back to the full default credential chain with no indication the supplied value was unrecognized (e.g. a typo like `AzuerCliCredential`)
- Now emits `LogWarning` listing the recognized values before falling back
- Added `AcceptedTokenCredentialValues` static array as single source of truth for the warning message
- Added `UnknownCredentialValue_LogsWarning_AndFallsBackToDefaultChain` test

**[#398](https://github.com/microsoft/mcp-pr/issues/398) — Thread-safety race in `CustomChainedCredential` lazy initialization**
- `??=` is not atomic in C#; concurrent `GetToken`/`GetTokenAsync` calls before initialization could construct duplicate credential chains with diverged MSAL token caches
- Replaced `TokenCredential? _credential` + `??=` with `Lazy<TokenCredential>` (`ExecutionAndPublication`) for guaranteed single initialization under concurrent access
- Added `GetToken_ConcurrentCalls_InitializesCredentialExactlyOnce` test

Closes #2632, #2633, [#399](https://github.com/microsoft/mcp-pr/issues/399), [#398](https://github.com/microsoft/mcp-pr/issues/398)