### PR TITLE
Prepare for Fabric MCP Server 1.2.0 release

### DIFF
--- a/servers/Fabric.Mcp.Server/CHANGELOG.md
+++ b/servers/Fabric.Mcp.Server/CHANGELOG.md
@@ -5,15 +5,23 @@ All notable changes to the Microsoft Fabric MCP Server will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.2.0 (Unreleased)
+## 1.2.0 (2026-07-08)
 
 ### Features Added
 
-### Breaking Changes
+- Added 12 new OneLake tools: Data Access Security (list, get, create-or-update, delete roles), Shortcuts (list, get, create-or-update, delete, reset-cache), and Settings (get, modify-diagnostics, modify-immutability-policy) [[#2625](https://github.com/microsoft/mcp/pull/2625)]
+- Added 9 per-target shortcut creation tools (OneLake, ADLS Gen2, Amazon S3, Azure Blob, GCS, S3-compatible, Dataverse, OneDrive/SharePoint, External Data Share) with flat typed options for better LLM ergonomics. [[#2625](https://github.com/microsoft/mcp/pull/2625)]
+- Flattened JSON-string options into discrete typed parameters for diagnostics, immutability policy, and data access role commands. [[#2625](https://github.com/microsoft/mcp/pull/2625)]
+- Added the `core_search-catalog` tool to search the Microsoft Fabric OneLake catalog for items across workspaces by display name, description, or workspace name, with optional filtering by item type. Calls the Catalog Search API (POST /v1/catalog/search). [[#2963](https://github.com/microsoft/mcp/pull/2963)]
 
 ### Bugs Fixed
 
+- Refactored OneLake DFS ListPath methods to follow ADLS Gen2 Path List API specification (directory as query parameter) [[#2625](https://github.com/microsoft/mcp/pull/2625)]
+- Fixed OneLake diagnostics and immutability settings models to match the Fabric REST API contract. [[#2625](https://github.com/microsoft/mcp/pull/2625)]
+
 ### Other Changes
+
+- Updated Fabric REST API specifications and item definition documentation. [[#3006](https://github.com/microsoft/mcp/pull/3006)]
 
 ## 1.1.0 (2026-06-15)
 

--- a/servers/Fabric.Mcp.Server/changelog-entries/1778530260238.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1778530260238.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Features Added"
-    description: "Added 12 new OneLake tools: Data Access Security (list, get, create-or-update, delete roles), Shortcuts (list, get, create-or-update, delete, reset-cache), and Settings (get, modify-diagnostics, modify-immutability-policy)"

--- a/servers/Fabric.Mcp.Server/changelog-entries/1778530268679.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1778530268679.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Bugs Fixed"
-    description: "Refactored OneLake DFS ListPath methods to follow ADLS Gen2 Path List API specification (directory as query parameter)"

--- a/servers/Fabric.Mcp.Server/changelog-entries/1780766915548.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1780766915548.yaml
@@ -1,7 +1,0 @@
-changes:
-  - section: "Features Added"
-    description: "Added 9 per-target shortcut creation tools (OneLake, ADLS Gen2, Amazon S3, Azure Blob, GCS, S3-compatible, Dataverse, OneDrive/SharePoint, External Data Share) with flat typed options for better LLM ergonomics"
-  - section: "Features Added"
-    description: "Flattened JSON-string options into discrete typed parameters for diagnostics, immutability policy, and data access role commands"
-  - section: "Bugs Fixed"
-    description: "Fixed OneLake diagnostics and immutability settings models to match the Fabric REST API contract"

--- a/servers/Fabric.Mcp.Server/changelog-entries/1782300000000.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1782300000000.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Features Added"
-    description: "Added the `core_search-catalog` tool to search the Microsoft Fabric OneLake catalog for items across workspaces by display name, description, or workspace name, with optional filtering by item type. Calls the Catalog Search API (POST /v1/catalog/search)."

--- a/servers/Fabric.Mcp.Server/changelog-entries/1783507618310.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1783507618310.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Other Changes"
-    description: "Updated Fabric REST API specifications and item definition documentation."

--- a/servers/Fabric.Mcp.Server/vscode/CHANGELOG.md
+++ b/servers/Fabric.Mcp.Server/vscode/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0 (2026-07-08) (pre-release)
+## 1.2.0 (2026-07-08)
 
 ### Added
 

--- a/servers/Fabric.Mcp.Server/vscode/CHANGELOG.md
+++ b/servers/Fabric.Mcp.Server/vscode/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Release History
 
+## 1.2.0 (2026-07-08) (pre-release)
+
+### Added
+
+- Added 12 new OneLake tools: Data Access Security (list, get, create-or-update, delete roles), Shortcuts (list, get, create-or-update, delete, reset-cache), and Settings (get, modify-diagnostics, modify-immutability-policy) [[#2625](https://github.com/microsoft/mcp/pull/2625)]
+- Added 9 per-target shortcut creation tools (OneLake, ADLS Gen2, Amazon S3, Azure Blob, GCS, S3-compatible, Dataverse, OneDrive/SharePoint, External Data Share) with flat typed options for better LLM ergonomics. [[#2625](https://github.com/microsoft/mcp/pull/2625)]
+- Flattened JSON-string options into discrete typed parameters for diagnostics, immutability policy, and data access role commands. [[#2625](https://github.com/microsoft/mcp/pull/2625)]
+- Added the `core_search-catalog` tool to search the Microsoft Fabric OneLake catalog for items across workspaces by display name, description, or workspace name, with optional filtering by item type. Calls the Catalog Search API (POST /v1/catalog/search). [[#2963](https://github.com/microsoft/mcp/pull/2963)]
+
+### Changed
+
+- Updated Fabric REST API specifications and item definition documentation. [[#3006](https://github.com/microsoft/mcp/pull/3006)]
+
+### Fixed
+
+- Refactored OneLake DFS ListPath methods to follow ADLS Gen2 Path List API specification (directory as query parameter) [[#2625](https://github.com/microsoft/mcp/pull/2625)]
+- Fixed OneLake diagnostics and immutability settings models to match the Fabric REST API contract. [[#2625](https://github.com/microsoft/mcp/pull/2625)]
+
 ## 1.1.0 (2026-06-15)
 
 ### Added


### PR DESCRIPTION
## What does this PR do?

Prepares the Microsoft Fabric MCP Server **1.2.0** release.

- Compiles the pending changelog entries into the `## 1.2.0` section of [`servers/Fabric.Mcp.Server/CHANGELOG.md`](servers/Fabric.Mcp.Server/CHANGELOG.md) and sets the release date.
- Syncs the compiled notes into the VS Code extension changelog ([`servers/Fabric.Mcp.Server/vscode/CHANGELOG.md`](servers/Fabric.Mcp.Server/vscode/CHANGELOG.md)).
- Removes the compiled `changelog-entries/*.yaml` files.

The `<Version>` in `Fabric.Mcp.Server.csproj` is already `1.2.0` (set by the post-1.1.0 version increment), so no version bump is needed.

Release-prep-only change — no product code or tools were modified.

## GitHub issue number?

N/A

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages
    - [ ] Added comprehensive tests for new/modified functionality — N/A (release prep, changelog-only)
    - [x] Changelog entries compiled per the [changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
