### PR TITLE
Omit pre-release suffix for Fabric in VS Code changelog sync

### DIFF
--- a/eng/scripts/Sync-VsCodeChangelog.ps1
+++ b/eng/scripts/Sync-VsCodeChangelog.ps1
@@ -67,6 +67,10 @@ $MainChangelogPath = $ChangelogPath
 $mainChangelogFile = Join-Path $RepoRoot $MainChangelogPath
 $vscodeChangelogFile = Join-Path $RepoRoot $VsCodeChangelogPath
 
+# VS Code changelog entries are marked "(pre-release)" by default. The Fabric
+# extension omits this suffix, so detect it from the changelog path.
+$preReleaseSuffix = if ($ChangelogPath -like '*Fabric.Mcp.Server*') { '' } else { ' (pre-release)' }
+
 # Validate files exist
 if (-not (Test-Path $mainChangelogFile)) {
     LogError "Main CHANGELOG not found: $mainChangelogFile"
@@ -155,7 +159,7 @@ if ($currentSection -and $currentEntries.Count -gt 0) {
 
 # Build VS Code changelog entry
 $vscodeEntry = @()
-$vscodeEntry += "## $Version ($(Get-Date -Format 'yyyy-MM-dd')) (pre-release)"
+$vscodeEntry += "## $Version ($(Get-Date -Format 'yyyy-MM-dd'))$preReleaseSuffix"
 $vscodeEntry += ""
 
 # Helper function to add section if it has content


### PR DESCRIPTION
## What does this PR do?

Updates the VS Code changelog sync script so the **Fabric** MCP Server does not get a `(pre-release)` suffix on its generated changelog entries.

- [`eng/scripts/Sync-VsCodeChangelog.ps1`](eng/scripts/Sync-VsCodeChangelog.ps1) now selects the heading suffix based on the changelog path: Fabric gets no suffix, while other servers (Azure, Template, etc.) keep ` (pre-release)` as before.

This matches how the Fabric VS Code extension changelog entries are formatted (e.g., `## 1.1.0 (2026-06-15)`) and removes the need to manually strip the suffix during each Fabric release.

Engineering tooling change — no product code or tools were modified.

## GitHub issue number?

N/A

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages
    - [ ] Added comprehensive tests for new/modified functionality — N/A (build/release script change)

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
