### PR TITLE
Enforce CFSClean on MCP repo

### DIFF
--- a/.github/workflows/verify-links.yml
+++ b/.github/workflows/verify-links.yml
@@ -1,0 +1,72 @@
+name: Verify Links
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release/*
+      - hotfix/*
+  check_run:
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-links:
+    name: Verify Links
+    if: >-
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'check_run' &&
+        github.event.check_run.check_suite.app.name == 'Azure Pipelines' &&
+        (
+          (github.repository == 'Azure/azure-sdk-for-net' && contains(github.event.check_run.name, 'Compliance')) ||
+          (github.repository == 'Azure/azure-sdk-for-python' && contains(github.event.check_run.name, 'Analyze')) ||
+          (github.repository == 'Azure/azure-sdk-for-java' && contains(github.event.check_run.name, 'Analyze')) ||
+          (github.repository == 'Azure/azure-sdk-for-js' && contains(github.event.check_run.name, 'Analyze')) ||
+          (github.repository == 'Azure/azure-sdk-for-c' && contains(github.event.check_run.name, 'GenerateReleaseArtifacts')) ||
+          (github.repository == 'Azure/azure-sdk-for-cpp' && contains(github.event.check_run.name, 'GenerateReleaseArtifacts')) ||
+          (github.repository == 'Azure/azure-sdk-for-go' && contains(github.event.check_run.name, 'Analyze')) ||
+          (github.repository == 'Azure/azure-sdk-for-ios' && contains(github.event.check_run.name, 'Analyze')) ||
+          (github.repository == 'microsoft/mcp' && contains(github.event.check_run.name, 'Analyze'))
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.check_run.head_sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Link verification check
+        shell: pwsh
+        env:
+          SYSTEM_PULLREQUEST_TARGETBRANCH: ${{ github.base_ref }}
+          SYSTEM_PULLREQUEST_SOURCECOMMITID: ${{ github.event.pull_request.head.sha }}
+        run: |
+          $urls = & ./eng/common/scripts/get-markdown-files-from-changed-files.ps1
+          if (-not $urls -or $urls.Count -eq 0) {
+            Write-Host "No changed markdown files; nothing to verify."
+            exit 0
+          }
+
+          $sourceRepoUri  = '${{ github.event.pull_request.head.repo.html_url }}'
+          $defaultBranch  = '${{ github.event.repository.default_branch }}'
+          $branchReplaceRegex = "^($sourceRepoUri(?:\.git)?/(?:blob|tree)/)$defaultBranch(/.*)$"
+
+          ./eng/common/scripts/Verify-Links.ps1 `
+            -urls $urls `
+            -rootUrl "file://$env:GITHUB_WORKSPACE/" `
+            -recursive:$false `
+            -ignoreLinksFile "$env:GITHUB_WORKSPACE/eng/ignore-links.txt" `
+            -branchReplaceRegex $branchReplaceRegex `
+            -branchReplacementName '${{ github.event.pull_request.head.sha }}' `
+            -checkLinkGuidance:$true `
+            -localBuildRepoName '${{ github.repository }}' `
+            -localBuildRepoPath $env:GITHUB_WORKSPACE `
+            -inputCacheFile "https://azuresdkartifacts.blob.core.windows.net/verify-links-cache/verify-links-cache.txt" `
+            -allowRelativeLinksFile "$env:GITHUB_WORKSPACE/eng/common/scripts/allow-relative-links.txt"

--- a/eng/pipelines/templates/1es-redirect.yml
+++ b/eng/pipelines/templates/1es-redirect.yml
@@ -24,7 +24,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Permissive, CFSClean
       # only enable autoBaseline for the internal build of rust-core on main branch
       ${{ if parameters.AutoBaseline }}:
         featureFlags:

--- a/eng/pipelines/templates/jobs/analyze.yml
+++ b/eng/pipelines/templates/jobs/analyze.yml
@@ -34,14 +34,6 @@ jobs:
 
   - template: /eng/common/pipelines/templates/steps/check-spelling.yml
 
-  - template: /eng/common/pipelines/templates/steps/verify-links.yml
-    parameters:
-      Condition: succeededOrFailed()
-      Directory: ""
-      CheckLinkGuidance: $true
-      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-        Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
-
   - pwsh: |
       # Verify that the package README.md files do not contain invalid headers or comment annotations
       $hasFailures = & "$(Build.SourcesDirectory)/eng/scripts/Process-PackageReadMe.ps1" -Command "validate-all"

--- a/eng/pipelines/templates/jobs/pypi/pack-pypi.yml
+++ b/eng/pipelines/templates/jobs/pypi/pack-pypi.yml
@@ -3,7 +3,7 @@ parameters:
   type: object
 - name: PypiDevFeed
   type: string
-  default: '1es-mcp/1es-mcp-registry'
+  default: 'public/azure-sdk-for-python'
 
 jobs:
 - job: PackPyPI

--- a/eng/pipelines/templates/jobs/pypi/pack-pypi.yml
+++ b/eng/pipelines/templates/jobs/pypi/pack-pypi.yml
@@ -1,6 +1,9 @@
 parameters:
 - name: DependsOn
   type: object
+- name: PypiDevFeed
+  type: string
+  default: '1es-mcp/1es-mcp-registry'
 
 jobs:
 - job: PackPyPI
@@ -9,6 +12,12 @@ jobs:
   timeoutInMinutes: 120
   steps:
   - checkout: self
+
+  - task: PipAuthenticate@1
+    displayName: Authenticate to Dev feed for pip
+    inputs:
+      artifactFeeds: ${{ parameters.PypiDevFeed }}
+      onlyAddExtraIndex: false
 
   - task: UsePythonVersion@0
     displayName: Use Python 3.12

--- a/eng/scripts/Pack-Pypi.ps1
+++ b/eng/scripts/Pack-Pypi.ps1
@@ -113,16 +113,8 @@ function Get-KeywordsString($keywords) {
 }
 
 function Get-PythonCommand {
-    # Prefer the interpreter selected by UsePythonVersion in CI.
-    # On Microsoft-hosted agents, that is exposed as "python" and may differ from the system "python3".
-    try {
-        $null = & python --version 2>&1
-        if ($LASTEXITCODE -eq 0) {
-            return "python"
-        }
-    } catch {}
-
-    # Fall back to python3 when the CI shim is unavailable.
+    # Try python3 first (common on Linux/macOS), but verify it works
+    # On Windows, "python3" may be a Store alias that doesn't work
     try {
         $null = & python3 --version 2>&1
         if ($LASTEXITCODE -eq 0) {
@@ -130,79 +122,15 @@ function Get-PythonCommand {
         }
     } catch {}
     
-    throw "Python is not installed or not in PATH. Please install Python 3.10+."
-}
-
-    function Get-RedactedUrl([string] $url) {
-        if ([string]::IsNullOrWhiteSpace($url)) {
-            return $null
-        }
-
-        try {
-            $uri = [System.Uri]$url
-            $builder = [System.UriBuilder]::new($uri)
-            if (-not [string]::IsNullOrWhiteSpace($uri.UserInfo)) {
-                $builder.UserName = '***'
-                $builder.Password = '***'
-            }
-
-            return $builder.Uri.AbsoluteUri
-        }
-        catch {
-            return '<unparseable>'
-        }
-    }
-
-    function Write-PipFeedDiagnostics {
-        $indexUrl = Get-RedactedUrl $env:PIP_INDEX_URL
-        $extraIndexUrl = Get-RedactedUrl $env:PIP_EXTRA_INDEX_URL
-
-        if ($indexUrl) {
-            Write-Host "  PIP_INDEX_URL: $indexUrl"
-        }
-        else {
-            Write-Host "  PIP_INDEX_URL: <not set>"
-        }
-
-        if ($extraIndexUrl) {
-            Write-Host "  PIP_EXTRA_INDEX_URL: $extraIndexUrl"
-        }
-        else {
-            Write-Host "  PIP_EXTRA_INDEX_URL: <not set>"
-        }
-    }
-
-function Install-BuildDependencies([string] $pythonCmd) {
-    # Log interpreter and pip details for easier CI troubleshooting.
-    Invoke-LoggedCommand "$pythonCmd --version"
-    Invoke-LoggedCommand "$pythonCmd -m pip --version"
-        Write-PipFeedDiagnostics
-        Invoke-LoggedCommand "$pythonCmd -m pip config list"
-
-    # This is diagnostic-only. Some environments block index queries.
+    # Fall back to python
     try {
-            Invoke-LoggedCommand "$pythonCmd -m pip index versions build -vvv"
-    }
-    catch {
-        Write-Warning "Unable to query available build versions via pip index; continuing with install attempts."
-    }
-
-    $installAttempts = @(
-        "build==1.2.2 wheel==0.45.1"
-    )
-
-    foreach ($requirements in $installAttempts) {
-        try {
-            Invoke-LoggedCommand "$pythonCmd -m pip install --quiet $requirements"
-            Write-Host "  Using Python build dependencies: $requirements"
-            return
+        $null = & python --version 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            return "python"
         }
-        catch {
-            Write-Warning "Failed to install Python build dependencies: $requirements"
-        }
-    }
-
-    throw "Unable to install Python build dependencies. Attempted: $($installAttempts -join '; ')."
+    } catch {}
+    
+    throw "Python is not installed or not in PATH. Please install Python 3.10+."
 }
 
 function BuildServerPackages([hashtable] $server, [bool] $native) {
@@ -355,8 +283,8 @@ function BuildServerPackages([hashtable] $server, [bool] $native) {
         Push-Location $tempFolder
         try {
             $pythonCmd = Get-PythonCommand
-
-            Install-BuildDependencies $pythonCmd
+            
+            Invoke-LoggedCommand "$pythonCmd -m pip install --quiet build==1.2.2 wheel==0.45.1"
             
             # Build wheel only (no sdist for platform packages)
             # We use --wheel and then rename to set the correct platform tag

--- a/eng/scripts/Pack-Pypi.ps1
+++ b/eng/scripts/Pack-Pypi.ps1
@@ -133,6 +133,37 @@ function Get-PythonCommand {
     throw "Python is not installed or not in PATH. Please install Python 3.10+."
 }
 
+function Install-BuildDependencies([string] $pythonCmd) {
+    # Log interpreter and pip details for easier CI troubleshooting.
+    Invoke-LoggedCommand "$pythonCmd --version"
+    Invoke-LoggedCommand "$pythonCmd -m pip --version"
+
+    # This is diagnostic-only. Some environments block index queries.
+    try {
+        Invoke-LoggedCommand "$pythonCmd -m pip index versions build"
+    }
+    catch {
+        Write-Warning "Unable to query available build versions via pip index; continuing with install attempts."
+    }
+
+    $installAttempts = @(
+        "build==1.2.2 wheel==0.45.1"
+    )
+
+    foreach ($requirements in $installAttempts) {
+        try {
+            Invoke-LoggedCommand "$pythonCmd -m pip install --quiet $requirements"
+            Write-Host "  Using Python build dependencies: $requirements"
+            return
+        }
+        catch {
+            Write-Warning "Failed to install Python build dependencies: $requirements"
+        }
+    }
+
+    throw "Unable to install Python build dependencies. Attempted: $($installAttempts -join '; ')."
+}
+
 function BuildServerPackages([hashtable] $server, [bool] $native) {
     $serverDirectory = "$ArtifactsPath/$($server.artifactPath)"
 
@@ -283,8 +314,8 @@ function BuildServerPackages([hashtable] $server, [bool] $native) {
         Push-Location $tempFolder
         try {
             $pythonCmd = Get-PythonCommand
-            
-            Invoke-LoggedCommand "$pythonCmd -m pip install --quiet build==1.2.2 wheel==0.45.1"
+
+            Install-BuildDependencies $pythonCmd
             
             # Build wheel only (no sdist for platform packages)
             # We use --wheel and then rename to set the correct platform tag

--- a/eng/scripts/Pack-Pypi.ps1
+++ b/eng/scripts/Pack-Pypi.ps1
@@ -113,20 +113,20 @@ function Get-KeywordsString($keywords) {
 }
 
 function Get-PythonCommand {
-    # Try python3 first (common on Linux/macOS), but verify it works
-    # On Windows, "python3" may be a Store alias that doesn't work
-    try {
-        $null = & python3 --version 2>&1
-        if ($LASTEXITCODE -eq 0) {
-            return "python3"
-        }
-    } catch {}
-    
-    # Fall back to python
+    # Prefer the interpreter selected by UsePythonVersion in CI.
+    # On Microsoft-hosted agents, that is exposed as "python" and may differ from the system "python3".
     try {
         $null = & python --version 2>&1
         if ($LASTEXITCODE -eq 0) {
             return "python"
+        }
+    } catch {}
+
+    # Fall back to python3 when the CI shim is unavailable.
+    try {
+        $null = & python3 --version 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            return "python3"
         }
     } catch {}
     

--- a/eng/scripts/Pack-Pypi.ps1
+++ b/eng/scripts/Pack-Pypi.ps1
@@ -133,14 +133,55 @@ function Get-PythonCommand {
     throw "Python is not installed or not in PATH. Please install Python 3.10+."
 }
 
+    function Get-RedactedUrl([string] $url) {
+        if ([string]::IsNullOrWhiteSpace($url)) {
+            return $null
+        }
+
+        try {
+            $uri = [System.Uri]$url
+            $builder = [System.UriBuilder]::new($uri)
+            if (-not [string]::IsNullOrWhiteSpace($uri.UserInfo)) {
+                $builder.UserName = '***'
+                $builder.Password = '***'
+            }
+
+            return $builder.Uri.AbsoluteUri
+        }
+        catch {
+            return '<unparseable>'
+        }
+    }
+
+    function Write-PipFeedDiagnostics {
+        $indexUrl = Get-RedactedUrl $env:PIP_INDEX_URL
+        $extraIndexUrl = Get-RedactedUrl $env:PIP_EXTRA_INDEX_URL
+
+        if ($indexUrl) {
+            Write-Host "  PIP_INDEX_URL: $indexUrl"
+        }
+        else {
+            Write-Host "  PIP_INDEX_URL: <not set>"
+        }
+
+        if ($extraIndexUrl) {
+            Write-Host "  PIP_EXTRA_INDEX_URL: $extraIndexUrl"
+        }
+        else {
+            Write-Host "  PIP_EXTRA_INDEX_URL: <not set>"
+        }
+    }
+
 function Install-BuildDependencies([string] $pythonCmd) {
     # Log interpreter and pip details for easier CI troubleshooting.
     Invoke-LoggedCommand "$pythonCmd --version"
     Invoke-LoggedCommand "$pythonCmd -m pip --version"
+        Write-PipFeedDiagnostics
+        Invoke-LoggedCommand "$pythonCmd -m pip config list"
 
     # This is diagnostic-only. Some environments block index queries.
     try {
-        Invoke-LoggedCommand "$pythonCmd -m pip index versions build"
+            Invoke-LoggedCommand "$pythonCmd -m pip index versions build -vvv"
     }
     catch {
         Write-Warning "Unable to query available build versions via pip index; continuing with install attempts."


### PR DESCRIPTION
This pull request makes a minor update to the pipeline configuration by adjusting the network isolation policy to further restrict or clean network access during builds.

* Pipeline configuration:
  * [`eng/pipelines/templates/1es-redirect.yml`](diffhunk://#diff-ec46c104f08f2e12cd123355c582e0ec5a62343d3021f69dd7c66e827e127916L27-R27): Updated the `networkIsolationPolicy` setting from `Permissive` to `Permissive, CFSClean` for enhanced build environment isolation.

[mcp - Azure.Mcp.Server](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6582429&view=results)