### PR TITLE
Fix CVE for glob 10.4.5 with adjustments to VS Code integration testing

### DIFF
--- a/eng/pipelines/templates/common.yml
+++ b/eng/pipelines/templates/common.yml
@@ -127,7 +127,7 @@ extends:
         displayName: 'VS Code integration test'
         dependsOn:
         - Initialize
-        - Build
+        # - Build # @vukelich 2026-07-17: This is not a necessary dependency. See https://github.com/microsoft/mcp/issues/3093
         pool:
           name: $(WINDOWSPOOL)
           image: $(WINDOWSVMIMAGE)

--- a/servers/Azure.Mcp.Server/vscode/package-lock.json
+++ b/servers/Azure.Mcp.Server/vscode/package-lock.json
@@ -19,6 +19,7 @@
             },
             "devDependencies": {
                 "@azure/core-auth": "^1.4",
+                "@playwright/test": "^1",
                 "@types/chai": "~4",
                 "@types/mocha": "~10",
                 "@types/node": "~16",
@@ -931,6 +932,22 @@
             "optional": true,
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+            "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.61.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@polka/url": {
@@ -3899,6 +3916,21 @@
                 "node": ">=14.14"
             }
         },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6097,6 +6129,38 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+            "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.61.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+            "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/pluralize": {

--- a/servers/Azure.Mcp.Server/vscode/package.json
+++ b/servers/Azure.Mcp.Server/vscode/package.json
@@ -222,8 +222,7 @@
         "lint": "eslint src --ext ts",
         "test": "npm run compile && node ./out/test/runAllTests.js",
         "unit-test": "npm run compile && node ./out/test/runUnitTests.js",
-        "outerloop-test:install": "npm install --no-save --no-package-lock @playwright/test@^1",
-        "outerloop-test": "npm run outerloop-test:install && node ./node_modules/@playwright/test/cli.js test src/test/outerloop/elicitation.outerloop.spec.js --reporter=line"
+        "outerloop-test": "node ./node_modules/@playwright/test/cli.js test src/test/outerloop/elicitation.outerloop.spec.js --reporter=line"
     },
     "devDependencies": {
         "@azure/core-auth": "^1.4",
@@ -237,6 +236,7 @@
         "@typescript-eslint/parser": "^8.47.0",
         "@vscode/test-electron": "~2",
         "@vscode/vsce": "~3.9.2",
+        "@playwright/test": "^1",
         "chai": "~4",
         "eslint": "~9",
         "glob": "^13.0.0",


### PR DESCRIPTION
## What does this PR do?

Fixes Component Governance detection of [CVE-2026-6734](https://dev.azure.com/azure-sdk/internal/_componentGovernance/231090/alert/16900925?typeId=55801490&pipelinesTrackingFilter=1). Moves the download of the `@playwright/test` NPM package into `package.json` and `package-lock.json` as a real `devDependency`. Script-based installation of this package caused non-deterministic package resolution which often caused Azure DevOps build machines to swap the safe `glob@10.5.0` with `glob@10.4.5`.

I also noticed the VS Code Integration job doesn't use any of the Build job artifacts. I removed that dependency in the build pipeline so that this job can be run quickly and without running the Build or Live Tests jobs. I created #3093 to track a longer-term change to how this job is run or what bits it tests.

## GitHub issue number?

Component Governance detection of [CVE-2026-6734](https://dev.azure.com/azure-sdk/internal/_componentGovernance/231090/alert/16900925?typeId=55801490&pipelinesTrackingFilter=1).

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
