### PR TITLE
Enforce network Isolation only for non release runs

### DIFF
--- a/eng/pipelines/templates/1es-redirect.yml
+++ b/eng/pipelines/templates/1es-redirect.yml
@@ -24,7 +24,10 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive, CFSClean
+      ${{ if eq(variables['Build.Reason'], 'Manual') }}:
+        networkIsolationPolicy: Permissive
+      ${{ else }}:
+        networkIsolationPolicy: Permissive, CFSClean
       # only enable autoBaseline for the internal build of rust-core on main branch
       ${{ if parameters.AutoBaseline }}:
         featureFlags:


### PR DESCRIPTION
This pull request updates the network isolation policy configuration in the pipeline template to better handle manual builds. The main change is to apply a more permissive network isolation policy when the build is triggered manually, while keeping stricter policies for other cases.

Pipeline configuration changes:

* Updated the `eng/pipelines/templates/1es-redirect.yml` file so that when the build is triggered manually (`Build.Reason` equals `Manual`), the `networkIsolationPolicy` is set to `Permissive`. For all other build reasons, the policy remains `Permissive, CFSClean`.