### PR TITLE
Fix invalid dotnet dnx command in Azure MCP README

### DIFF
--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -472,7 +472,7 @@ Download the `.mcpb` file for your platform/architecture from **Assets** section
    | **Environment Variables** | *(leave blank - uses Azure CLI auth)* |
    | **Tools** | `*` |
 
-   > **Alternative Command (using .NET):** `dotnet dnx -p Azure.Mcp server start`
+   > **Alternative Command (using .NET):** `dotnet dnx Azure.Mcp server start`
 
 3. Press **Ctrl+S** (or **Cmd+S** on macOS) to save the server configuration.
 


### PR DESCRIPTION
## Summary
- Correct the .NET alternative command in servers/Azure.Mcp.Server/README.md for Copilot CLI MCP setup.
- Replace dotnet dnx -p Azure.Mcp server start with dotnet dnx Azure.Mcp server start.

## Context
This is the same change made in [Fix invalid dotnet dnx command in MCP quickstart by scottaddie · Pull Request #9526 · MicrosoftDocs/azure-dev-docs-pr](https://github.com/MicrosoftDocs/azure-dev-docs-pr/pull/9526).

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with write access to the repo need to validate the contents of this PR before leaving a comment with the text /azp run mcp - pullrequest - live. This will trigger the necessary livetest workflows to complete required validation.