### PR TITLE
Update AppLens SignalR endpoint to diagnosticschatnext

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/adwait-applens-signalr-endpoint.yml
+++ b/servers/Azure.Mcp.Server/changelog-entries/adwait-applens-signalr-endpoint.yml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Updated AppLens conversational diagnostics to use the new SignalR endpoint."

--- a/tools/Azure.Mcp.Tools.AppLens/src/Services/AppLensService.cs
+++ b/tools/Azure.Mcp.Tools.AppLens/src/Services/AppLensService.cs
@@ -531,10 +531,10 @@ public class AppLensService(
     {
         return _tenantService.CloudConfiguration.CloudType switch
         {
-            AzureCloudConfiguration.AzureCloud.AzurePublicCloud => "https://diagnosticschat.azure.com/chatHub",
+            AzureCloudConfiguration.AzureCloud.AzurePublicCloud => "https://diagnosticschatnext.azure.com/chathub",
             AzureCloudConfiguration.AzureCloud.AzureChinaCloud => "https://diagnosticschat.azure.cn/chatHub",
             AzureCloudConfiguration.AzureCloud.AzureUSGovernmentCloud => "https://diagnosticschat.azure.us/chatHub",
-            _ => "https://diagnosticschat.azure.com/chatHub",
+            _ => "https://diagnosticschatnext.azure.com/chathub",
         };
     }
 


### PR DESCRIPTION
## Summary
- Update AppLens public-cloud conversational diagnostics SignalR URL from `https://diagnosticschat.azure.com/chatHub` to `https://diagnosticschatnext.azure.com/chathub` (#3164).
- Leave China and US Government cloud endpoints unchanged.
- Add changelog entry under Bugs Fixed.

## Test plan
- [x] `dotnet build tools/Azure.Mcp.Tools.AppLens/src`
- [x] `dotnet test` AppLens unit tests (27 passed)
- [ ] Manual/live smoke: `azmcp applens resource diagnose` against a diagnosable Azure resource to confirm SignalR connects via the new hub

Fixes #3164


Made with [Cursor](https://cursor.com)