### PR TITLE
Update Azure README table of contents

### DIFF
--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -271,188 +271,6 @@ To verify the .NET version, run the following command in the terminal: `dotnet -
 <!-- remove-section: start nuget;npm;pypi remove_package_manager_section -->
 </details>
 
-## Package Manager
-Package manager installation offers several advantages over IDE-specific setup, including centralized dependency management, CI/CD integration, support for headless/server environments, version control, and project portability.
-
-Install Azure MCP Server via a package manager:
-
-### NuGet
-
-Install the .NET Tool: [Azure.Mcp](https://www.nuget.org/packages/Azure.Mcp).
-
-```bash
-dotnet tool install Azure.Mcp
-```
-or
-```bash
-dotnet tool install Azure.Mcp --version <version>
-```
-
-### NPM
-
-Install the Node.js package: [@azure/mcp](https://www.npmjs.com/package/@azure/mcp).
-
-**Local installation (recommended):**
-
-```bash
-npm install @azure/mcp@latest
-```
-
-**Install a specific version:**
-
-```bash
-npm install @azure/mcp@<version>
-```
-
-**Run a command without installing (using npx):**
-
-```bash
-npx -y @azure/mcp@latest [command]
-```
-For example,
-
-Start a server
-```bash
-npx -y @azure/mcp@latest server start
-```
-
-List tools
-```bash
-npx -y @azure/mcp@latest tools list
-```
-
-<details>
-<summary>Additional instructions</summary>
-
-**When to use local vs global installation:**
-
--   **Local (recommended):** Install in the project directory for project-specific tooling, CI/CD pipelines, or when using mcp.json configuration.
--   **Global:** Install system-wide to run `azmcp` commands directly from any terminal.
-
-**Troubleshooting:**
-To troubleshoot [@azure/mcp](https://www.npmjs.com/package/@azure/mcp) package (or respective binaries) installation, review the [troubleshooting guide](https://github.com/microsoft/mcp/blob/main/eng/npm/TROUBLESHOOTING.md).
-
-**Architecture:**
-To understand how platform-specific binaries are installed with @azure/mcp, review the [wrapper binaries architecture](https://github.com/microsoft/mcp/blob/main/eng/npm/wrapperBinariesArchitecture.md).
-
-</details>
-
-### PyPI
-
-Install the Python package: [msmcp-azure](https://pypi.org/project/msmcp-azure/).
-
-**Run directly without installation (using uvx - recommended):**
-
-```bash
-uvx --from msmcp-azure azmcp server start
-```
-
-**Install as a global tool (using pipx):**
-
-```bash
-pipx install msmcp-azure
-```
-
-**Install using pip:**
-
-```bash
-pip install msmcp-azure
-```
-
-**Install a specific version:**
-
-```bash
-pip install msmcp-azure==<version>
-```
-
-<details>
-<summary>Additional instructions</summary>
-
-**When to use uvx vs pipx vs pip:**
-
--   **uvx (recommended):** Run directly without installation. Best for MCP server usage where you want the latest version without managing installations.
--   **pipx:** Install as an isolated global tool. Best when you want a persistent installation that doesn't interfere with other Python projects.
--   **pip:** Install in the current Python environment. Best for integration into existing Python projects or virtual environments.
-
-**Prerequisites:**
-
--   [uv](https://docs.astral.sh/uv/getting-started/installation/) for `uvx` commands
--   Python 3.10+ for `pip` or `pipx` installation
-
-</details>
-
-### Docker
-
-Run the Azure MCP server as a Docker container for easy deployment and isolation. The container image is available at [mcr.microsoft.com/azure-sdk/azure-mcp](https://mcr.microsoft.com/artifact/mar/azure-sdk/azure-mcp).
-
-<details>
-<summary>Docker instructions</summary>
-
-#### Create an env file with Azure credentials
-
-1. Create a `.env` file with Azure credentials ([see EnvironmentCredential options](https://learn.microsoft.com/dotnet/api/azure.identity.environmentcredential)):
-
-```bash
-AZURE_TENANT_ID={YOUR_AZURE_TENANT_ID}
-AZURE_CLIENT_ID={YOUR_AZURE_CLIENT_ID}
-AZURE_CLIENT_SECRET={YOUR_AZURE_CLIENT_SECRET}
-```
-
-#### Configure MCP client to use Docker
-
-2. Add or update existing `mcp.json`. Replace `/full/path/to/.env` with the actual `.env` file path.
-
-```json
-{
-    "mcpServers": {
-        "azure-mcp-server": {
-            "command": "docker",
-            "args": [
-                "run",
-                "-i",
-                "--rm",
-                "--env-file",
-                "/full/path/to/.env",
-                "mcr.microsoft.com/azure-sdk/azure-mcp:latest"
-            ]
-        }
-    }
-}
-```
-</details>
-
-To use Azure Entra ID, review the [troubleshooting guide](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/TROUBLESHOOTING.md#using-azure-entra-id-with-docker).
-
-### MCPB
-
-MCP Bundles (`.mcpb`) are portable versions of MCP servers that can be installed directly into clients like [Claude Desktop](https://claude.com/download). We produce an `.mcpb` file for each supported platform (Windows, macOS, Linux) and architecture (x64, ARM64). The `.mcpb` file contains the server binary and all dependencies, so it can be installed without Node.js or .NET.
-
-<details>
-<summary>MCPB installation instructions</summary>
-
-#### Download
-
-Download the `.mcpb` file for your platform/architecture from **Assets** section of the latest release in our [GitHub Releases](https://github.com/microsoft/mcp/releases?q=Azure.Mcp.Server-) page:
-
-|           | Windows | macOS | Linux |
-|-----------|---------|-------|-------|
-| **x64**   | `Azure.Mcp.Server-win-x64.mcpb` | `Azure.Mcp.Server-osx-x64.mcpb` | `Azure.Mcp.Server-linux-x64.mcpb` |
-| **ARM64** | `Azure.Mcp.Server-win-arm64.mcpb` | `Azure.Mcp.Server-osx-arm64.mcpb` | `Azure.Mcp.Server-linux-arm64.mcpb` |
-
-#### Install
-
-##### Claude Desktop
-
-- **Option 1 (Recommended):** Drag the downloaded `.mcpb` file into the Claude Desktop app window to install it. **This is the easiest method ✅.**
-- **Option 2:**
-    1. Open the hamburger menu on the top left of the Claude Desktop app.
-    2. Go to **File** > **Settings** > **Extensions** > **Advanced Settings** > **Install Extension**
-    3. Select the downloaded `.mcpb` file and click **Preview**.
-    4. Click **Install** in the preview window to add the Azure MCP Server to Claude Desktop.
-- **Option 3:** Set Claude Desktop to be the default application for `.mcpb` files on your computer. Then, double-click on the downloaded `.mcpb` file and Claude Desktop will automatically install the bundle.
-
-</details>
-
 ### GitHub Copilot CLI Configuration
 
 [GitHub Copilot CLI](https://github.blog/changelog/2026-01-14-github-copilot-cli-enhanced-agents-context-management-and-new-ways-to-install/) supports MCP servers via the `/mcp` command.
@@ -853,6 +671,188 @@ class Program
 ---
 
 > **Note:** If startup is slow, use a pinned version (`@azure/mcp@2.0.0-beta.13` instead of `@latest`) or install globally (`npm install -g @azure/mcp@latest`).
+
+</details>
+
+## Package Manager
+Package manager installation offers several advantages over IDE-specific setup, including centralized dependency management, CI/CD integration, support for headless/server environments, version control, and project portability.
+
+Install Azure MCP Server via a package manager:
+
+### NuGet
+
+Install the .NET Tool: [Azure.Mcp](https://www.nuget.org/packages/Azure.Mcp).
+
+```bash
+dotnet tool install Azure.Mcp
+```
+or
+```bash
+dotnet tool install Azure.Mcp --version <version>
+```
+
+### NPM
+
+Install the Node.js package: [@azure/mcp](https://www.npmjs.com/package/@azure/mcp).
+
+**Local installation (recommended):**
+
+```bash
+npm install @azure/mcp@latest
+```
+
+**Install a specific version:**
+
+```bash
+npm install @azure/mcp@<version>
+```
+
+**Run a command without installing (using npx):**
+
+```bash
+npx -y @azure/mcp@latest [command]
+```
+For example,
+
+Start a server
+```bash
+npx -y @azure/mcp@latest server start
+```
+
+List tools
+```bash
+npx -y @azure/mcp@latest tools list
+```
+
+<details>
+<summary>Additional instructions</summary>
+
+**When to use local vs global installation:**
+
+-   **Local (recommended):** Install in the project directory for project-specific tooling, CI/CD pipelines, or when using mcp.json configuration.
+-   **Global:** Install system-wide to run `azmcp` commands directly from any terminal.
+
+**Troubleshooting:**
+To troubleshoot [@azure/mcp](https://www.npmjs.com/package/@azure/mcp) package (or respective binaries) installation, review the [troubleshooting guide](https://github.com/microsoft/mcp/blob/main/eng/npm/TROUBLESHOOTING.md).
+
+**Architecture:**
+To understand how platform-specific binaries are installed with @azure/mcp, review the [wrapper binaries architecture](https://github.com/microsoft/mcp/blob/main/eng/npm/wrapperBinariesArchitecture.md).
+
+</details>
+
+### PyPI
+
+Install the Python package: [msmcp-azure](https://pypi.org/project/msmcp-azure/).
+
+**Run directly without installation (using uvx - recommended):**
+
+```bash
+uvx --from msmcp-azure azmcp server start
+```
+
+**Install as a global tool (using pipx):**
+
+```bash
+pipx install msmcp-azure
+```
+
+**Install using pip:**
+
+```bash
+pip install msmcp-azure
+```
+
+**Install a specific version:**
+
+```bash
+pip install msmcp-azure==<version>
+```
+
+<details>
+<summary>Additional instructions</summary>
+
+**When to use uvx vs pipx vs pip:**
+
+-   **uvx (recommended):** Run directly without installation. Best for MCP server usage where you want the latest version without managing installations.
+-   **pipx:** Install as an isolated global tool. Best when you want a persistent installation that doesn't interfere with other Python projects.
+-   **pip:** Install in the current Python environment. Best for integration into existing Python projects or virtual environments.
+
+**Prerequisites:**
+
+-   [uv](https://docs.astral.sh/uv/getting-started/installation/) for `uvx` commands
+-   Python 3.10+ for `pip` or `pipx` installation
+
+</details>
+
+### Docker
+
+Run the Azure MCP server as a Docker container for easy deployment and isolation. The container image is available at [mcr.microsoft.com/azure-sdk/azure-mcp](https://mcr.microsoft.com/artifact/mar/azure-sdk/azure-mcp).
+
+<details>
+<summary>Docker instructions</summary>
+
+#### Create an env file with Azure credentials
+
+1. Create a `.env` file with Azure credentials ([see EnvironmentCredential options](https://learn.microsoft.com/dotnet/api/azure.identity.environmentcredential)):
+
+```bash
+AZURE_TENANT_ID={YOUR_AZURE_TENANT_ID}
+AZURE_CLIENT_ID={YOUR_AZURE_CLIENT_ID}
+AZURE_CLIENT_SECRET={YOUR_AZURE_CLIENT_SECRET}
+```
+
+#### Configure MCP client to use Docker
+
+2. Add or update existing `mcp.json`. Replace `/full/path/to/.env` with the actual `.env` file path.
+
+```json
+{
+    "mcpServers": {
+        "azure-mcp-server": {
+            "command": "docker",
+            "args": [
+                "run",
+                "-i",
+                "--rm",
+                "--env-file",
+                "/full/path/to/.env",
+                "mcr.microsoft.com/azure-sdk/azure-mcp:latest"
+            ]
+        }
+    }
+}
+```
+</details>
+
+To use Azure Entra ID, review the [troubleshooting guide](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/TROUBLESHOOTING.md#using-azure-entra-id-with-docker).
+
+### MCPB
+
+MCP Bundles (`.mcpb`) are portable versions of MCP servers that can be installed directly into clients like [Claude Desktop](https://claude.com/download). We produce an `.mcpb` file for each supported platform (Windows, macOS, Linux) and architecture (x64, ARM64). The `.mcpb` file contains the server binary and all dependencies, so it can be installed without Node.js or .NET.
+
+<details>
+<summary>MCPB installation instructions</summary>
+
+#### Download
+
+Download the `.mcpb` file for your platform/architecture from **Assets** section of the latest release in our [GitHub Releases](https://github.com/microsoft/mcp/releases?q=Azure.Mcp.Server-) page:
+
+|           | Windows | macOS | Linux |
+|-----------|---------|-------|-------|
+| **x64**   | `Azure.Mcp.Server-win-x64.mcpb` | `Azure.Mcp.Server-osx-x64.mcpb` | `Azure.Mcp.Server-linux-x64.mcpb` |
+| **ARM64** | `Azure.Mcp.Server-win-arm64.mcpb` | `Azure.Mcp.Server-osx-arm64.mcpb` | `Azure.Mcp.Server-linux-arm64.mcpb` |
+
+#### Install
+
+##### Claude Desktop
+
+- **Option 1 (Recommended):** Drag the downloaded `.mcpb` file into the Claude Desktop app window to install it. **This is the easiest method ✅.**
+- **Option 2:**
+    1. Open the hamburger menu on the top left of the Claude Desktop app.
+    2. Go to **File** > **Settings** > **Extensions** > **Advanced Settings** > **Install Extension**
+    3. Select the downloaded `.mcpb` file and click **Preview**.
+    4. Click **Install** in the preview window to add the Azure MCP Server to Claude Desktop.
+- **Option 3:** Set Claude Desktop to be the default application for `.mcpb` files on your computer. Then, double-click on the downloaded `.mcpb` file and Claude Desktop will automatically install the bundle.
 
 </details>
 

--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -25,7 +25,7 @@ All Azure MCP tools in a single server. The Azure MCP Server implements the [MCP
 ## Table of Contents
 - [Overview](#overview)
 - [Local Setup](#local-setup)<!-- remove-section: start nuget;vsix;npm;pypi remove_installation_sub_sections -->
-    - [IDE](#ide)
+    - [Developer Tools](#developer-tools)
         - [VS Code (Recommended)](#vs-code-recommended)
         - [Visual Studio 2026](#visual-studio-2026)
         - [Visual Studio 2022](#visual-studio-2022)
@@ -33,6 +33,8 @@ All Azure MCP tools in a single server. The Azure MCP Server implements the [MCP
         - [Eclipse IDE](#eclipse-ide)
         - [Claude Code](#claude-code)
         - [Manual Setup](#manual-setup)
+        - [GitHub Copilot CLI Configuration](#github-copilot-cli-configuration)
+        - [GitHub Copilot SDK Configuration](#github-copilot-sdk-configuration)
     - [Package Manager](#package-manager)
         - [NuGet](#nuget)
         - [NPM](#npm)
@@ -115,7 +117,7 @@ Install Azure MCP Server using either an IDE extension or package manager. Choos
 > [!IMPORTANT]
 > Authenticate to Azure before running the Azure MCP server. See the [Authentication guide](https://github.com/microsoft/mcp/blob/main/docs/Authentication.md) for authentication methods and instructions.
 
-## IDE
+## Developer Tools
 
 Start using Azure MCP with your favorite IDE.  We recommend VS Code:
 


### PR DESCRIPTION
## Summary

- Rename the Azure MCP README's IDE section to Developer Tools.
- Add the GitHub Copilot CLI and SDK configuration links under Developer Tools in the table of contents.
- Keep Package Manager limited to package installation formats, incorporating feedback from #1586.

Fixes #1585

## Validation

- `./eng/common/spelling/Invoke-Cspell.ps1`

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.