### PR TITLE
Route CLI parse-error help to stderr

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Commands/CustomHelpAction.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/CustomHelpAction.cs
@@ -37,20 +37,23 @@ internal class CustomHelpAction : SynchronousCommandLineAction
         _ => category.ToString()
     };
 
+    public override bool ClearsParseErrors => _defaultHelp.ClearsParseErrors;
+
     public override int Invoke(ParseResult parseResult)
     {
-        Console.WriteLine($"{_options.Value.Name} {_options.Value.Version}{Environment.NewLine}");
+        var output = parseResult.InvocationConfiguration.Output;
+        output.WriteLine($"{_options.Value.Name} {_options.Value.Version}{Environment.NewLine}");
 
         if (_serviceAreas != null && parseResult.CommandResult.Command is RootCommand rootCommand)
         {
-            RenderGroupAreasHelp(rootCommand);
+            RenderGroupAreasHelp(rootCommand, output);
             return 0;
         }
 
         return _defaultHelp.Invoke(parseResult);
     }
 
-    private void RenderGroupAreasHelp(RootCommand rootCommand)
+    private void RenderGroupAreasHelp(RootCommand rootCommand, TextWriter output)
     {
         const int descriptionColumnWidth = 72;
 
@@ -59,20 +62,20 @@ internal class CustomHelpAction : SynchronousCommandLineAction
 
         var indent = new string(' ', commandColumnWidth + 4);
 
-        Console.WriteLine($"Description:{Environment.NewLine}  {rootCommand.Description}{Environment.NewLine}");
-        Console.WriteLine($"Usage:{Environment.NewLine}  {_options.Value.RootCommandGroupName} [command] [options]{Environment.NewLine}");
-        Console.WriteLine("Options:");
-        Console.WriteLine("  -?, -h, --help  Show help and usage information");
-        Console.WriteLine("  --version       Show version information");
+        output.WriteLine($"Description:{Environment.NewLine}  {rootCommand.Description}{Environment.NewLine}");
+        output.WriteLine($"Usage:{Environment.NewLine}  {_options.Value.RootCommandGroupName} [command] [options]{Environment.NewLine}");
+        output.WriteLine("Options:");
+        output.WriteLine("  -?, -h, --help  Show help and usage information");
+        output.WriteLine("  --version       Show version information");
 
-        Console.WriteLine($"{Environment.NewLine}Examples:");
-        Console.WriteLine($"  {_options.Value.RootCommandGroupName} storage account get --subscription \"my-sub\"");
-        Console.WriteLine($"  {_options.Value.RootCommandGroupName} server start");
+        output.WriteLine($"{Environment.NewLine}Examples:");
+        output.WriteLine($"  {_options.Value.RootCommandGroupName} storage account get --subscription \"my-sub\"");
+        output.WriteLine($"  {_options.Value.RootCommandGroupName} server start");
 
         var groupedAreas = _serviceAreas!.GroupBy(area => area.Category).OrderBy(g => (int)g.Key);
         foreach (var group in groupedAreas)
         {
-            Console.WriteLine($"\n{GetCategoryName(group.Key)}:");
+            output.WriteLine($"\n{GetCategoryName(group.Key)}:");
             foreach (var commandArea in group.OrderBy(a => a.Name))
             {
                 var subCommand = rootCommand.Subcommands.FirstOrDefault(c => c.Name.Equals(commandArea.Name));
@@ -80,7 +83,7 @@ internal class CustomHelpAction : SynchronousCommandLineAction
                 {
                     var description = subCommand.Description ?? string.Empty;
                     var wrappedDescription = WrapDescription(description, descriptionColumnWidth, indent);
-                    Console.WriteLine($"  {commandArea.Name.PadRight(commandColumnWidth)}  {wrappedDescription}");
+                    output.WriteLine($"  {commandArea.Name.PadRight(commandColumnWidth)}  {wrappedDescription}");
                 }
             }
         }

--- a/servers/Azure.Mcp.Server/changelog-entries/pybsama-missing-command-stderr.yml
+++ b/servers/Azure.Mcp.Server/changelog-entries/pybsama-missing-command-stderr.yml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Write parse-error diagnostics and help to stderr so MCP stdio stdout remains reserved for JSON-RPC messages."

--- a/servers/Azure.Mcp.Server/src/Program.cs
+++ b/servers/Azure.Mcp.Server/src/Program.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.CommandLine;
 using System.Net;
 using System.Text.Json;
 using Azure.Mcp.Core.Services.Azure;
@@ -120,7 +121,7 @@ internal class Program
                 (extendedCommand.BaseCommand is ServerStartCommand || extendedCommand.BaseCommand is PluginTelemetryCommand))
             {
                 // One of the special commands that need to be handled differently.
-                status = await parseResult.InvokeAsync();
+                status = await InvokeCommandAsync(parseResult);
             }
             else
             {
@@ -144,7 +145,7 @@ internal class Program
                 rootCommand = commandFactory.RootCommand;
                 parseResult = rootCommand.Parse(args);
 
-                status = await parseResult.InvokeAsync();
+                status = await InvokeCommandAsync(parseResult);
 
                 await host.StopAsync();
                 await host.WaitForShutdownAsync();
@@ -167,6 +168,22 @@ internal class Program
             });
             return 1;
         }
+    }
+
+    private static Task<int> InvokeCommandAsync(ParseResult parseResult)
+    {
+        if (parseResult.Errors.Count == 0)
+        {
+            return parseResult.InvokeAsync();
+        }
+
+        var configuration = new InvocationConfiguration
+        {
+            Output = Console.Error,
+            Error = Console.Error
+        };
+
+        return parseResult.InvokeAsync(configuration);
     }
 
     private static IAreaSetup[] RegisterAreas()

--- a/servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.Tests/Infrastructure/CliOutputTests.cs
+++ b/servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.Tests/Infrastructure/CliOutputTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Xunit;
+
+namespace Azure.Mcp.Server.Tests.Infrastructure;
+
+public class CliOutputTests
+{
+    private static string AzmcpPath
+    {
+        get
+        {
+            var executableName = OperatingSystem.IsWindows() ? "azmcp.exe" : "azmcp";
+            return Path.Combine(AppContext.BaseDirectory, executableName);
+        }
+    }
+
+    [Fact]
+    public async Task BareInvocation_WritesDiagnosticsAndHelpToStandardError()
+    {
+        var result = await RunAzmcpAsync();
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Empty(result.StandardOutput);
+        Assert.Contains("azmcp [command] [options]", result.StandardError);
+
+        var helpStart = result.StandardError.IndexOf("Azure.Mcp.Server", StringComparison.Ordinal);
+        Assert.True(helpStart >= 0, "Expected the root help in standard error.");
+        Assert.False(
+            string.IsNullOrWhiteSpace(result.StandardError[..helpStart]),
+            "Expected a localized parse diagnostic before the root help.");
+    }
+
+    [Fact]
+    public async Task ExplicitHelp_WritesHelpToStandardOutput()
+    {
+        var result = await RunAzmcpAsync("--help");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Azure.Mcp.Server", result.StandardOutput);
+        Assert.Contains("azmcp [command] [options]", result.StandardOutput);
+        Assert.Empty(result.StandardError);
+    }
+
+    private static async Task<CliResult> RunAzmcpAsync(params string[] arguments)
+    {
+        Assert.True(File.Exists(AzmcpPath), $"Executable not found at {AzmcpPath}.");
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = AzmcpPath,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = new Process { StartInfo = startInfo };
+        Assert.True(process.Start());
+
+        try
+        {
+            var standardOutput = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+            var standardError = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+
+            await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+
+            return new CliResult(process.ExitCode, await standardOutput, await standardError);
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+    }
+
+    private sealed record CliResult(int ExitCode, string StandardOutput, string StandardError);
+}


### PR DESCRIPTION
## What does this PR do?

Routes Azure MCP command-line parse failures to stderr so stdout stays reserved for MCP JSON-RPC messages.

The root cause had two parts:

- `CustomHelpAction` wrote directly to `Console`, bypassing the output writer selected by System.CommandLine.
- Azure MCP invoked failed parse results with the default invocation configuration, which sent generated help to stdout.

This PR makes the shared custom help action honor `InvocationConfiguration.Output` and configures both the output and error writers as stderr only when parsing fails. Successful invocations keep the default stream routing, so explicit `--help` continues to exit successfully with help on stdout and valid `server start` JSON-RPC framing is unchanged.

Process-level tests cover both bare invocation and explicit help, and a bug-fix changelog entry records the user-visible correction.

## GitHub issue number?

Fixes #3098

## Validation

- TDD regression: the bare-invocation test failed before the implementation because stdout contained the root help, then passed after the fix.
- `dotnet build servers/Azure.Mcp.Server/src/Azure.Mcp.Server.csproj` — passed with zero errors.
- `dotnet test servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.Tests/Azure.Mcp.Server.Tests.csproj --filter "FullyQualifiedName~CliOutputTests"` — passed 2/2.
- `dotnet test servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.Tests/Azure.Mcp.Server.Tests.csproj --filter "FullyQualifiedName~ServerModeCoverageTests.SingleMode_Should_List_Tools_Without_Initialize"` — passed 1/1 and retained JSON-RPC output on stdout.
- Targeted `dotnet format --verify-no-changes` checks for all modified C# files — passed.
- `Compile-Changelog.ps1 -DryRun` — passed without changing the generated changelog.
- `Invoke-Cspell.ps1` and `git diff --check` — passed.
- Direct executable verification:
  - bare invocation: exit 1, stdout 0 lines, stderr 300 lines;
  - `--help`: exit 0, stdout 298 lines, stderr 0 lines.

Local restore note: the configured Azure Artifacts feed returned 401 for packages that were not already cached, and the repository's currently pinned dependency graph reports NU1903. The targeted local restore/build/test pass therefore used NuGet.org as a command-line package source with `NuGetAudit=false`. No dependencies or `nuget.config` files were changed.

## Pre-merge Checklist

- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Added the required bug-fix changelog entry
- [ ] For MCP tool changes — not applicable; this changes Core CLI stream routing and does not add or modify an MCP tool.
- [ ] Extra steps for Azure MCP Server tool changes — not applicable for the same reason.
