### PR TITLE
Remove ServiceProvider from CommandContext

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
@@ -1,5 +1,4 @@
 #pragma warning disable MCP9003 // Obsolete RequestContext constructor - migrating during Phase 1
-#pragma warning disable MCP9005 // Deprecated Sampling/Logging APIs - backward compat during Phase 1
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
@@ -29,7 +28,7 @@ public class CommandFactoryToolLoaderTests
         var logger = loggerFactory.CreateLogger<CommandFactoryToolLoader>();
         var toolLoaderOptions = Microsoft.Extensions.Options.Options.Create(options ?? new ToolLoaderOptions());
 
-        var toolLoader = new CommandFactoryToolLoader(serviceProvider, commandFactory, toolLoaderOptions, logger);
+        var toolLoader = new CommandFactoryToolLoader(commandFactory, toolLoaderOptions, logger);
         return (toolLoader, commandFactory);
     }
 
@@ -625,7 +624,7 @@ public class CommandFactoryToolLoaderTests
         var commandMap = (Dictionary<string, IBaseCommand>)commandMapField!.GetValue(commandFactory)!;
         commandMap["fake-enum-get"] = fakeCommand;
 
-        var toolLoader = new CommandFactoryToolLoader(serviceProvider, commandFactory, toolLoaderOptions, logger);
+        var toolLoader = new CommandFactoryToolLoader(commandFactory, toolLoaderOptions, logger);
         var request = CreateRequest();
 
         // Act
@@ -725,7 +724,7 @@ public class CommandFactoryToolLoaderTests
         var commandMap = (Dictionary<string, IBaseCommand>)commandMapField!.GetValue(commandFactory)!;
         commandMap["fake-secret-get"] = fakeCommand;
 
-        var toolLoader = new CommandFactoryToolLoader(serviceProvider, commandFactory, toolLoaderOptions, logger);
+        var toolLoader = new CommandFactoryToolLoader(commandFactory, toolLoaderOptions, logger);
         var request = CreateRequest();
 
         // Act

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
@@ -1,5 +1,3 @@
-#pragma warning disable MCP9003 // Obsolete RequestContext constructor - migrating during Phase 1
-#pragma warning disable MCP9005 // Deprecated Sampling/Logging APIs - backward compat during Phase 1
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
@@ -38,42 +36,28 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     [Fact]
     public void Constructor_InitializesSuccessfully()
     {
-        // Arrange & Act
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
-
-        // Assert
-        Assert.NotNull(loader);
+        Assert.NotNull(new NamespaceToolLoader(_commandFactory, _options, _logger));
     }
 
     [Fact]
     public void Constructor_ThrowsOnNullCommandFactory()
     {
         // Arrange & Act & Assert
-        Assert.Throws<ArgumentNullException>(() =>
-            new NamespaceToolLoader(null!, _options, _serviceProvider, _logger));
+        Assert.Throws<ArgumentNullException>(() => new NamespaceToolLoader(null!, _options, _logger));
     }
 
     [Fact]
     public void Constructor_ThrowsOnNullOptions()
     {
         // Arrange & Act & Assert
-        Assert.Throws<ArgumentNullException>(() =>
-            new NamespaceToolLoader(_commandFactory, null!, _serviceProvider, _logger));
-    }
-
-    [Fact]
-    public void Constructor_ThrowsOnNullServiceProvider()
-    {
-        // Arrange & Act & Assert
-        Assert.Throws<ArgumentNullException>(() =>
-            new NamespaceToolLoader(_commandFactory, _options, null!, _logger));
+        Assert.Throws<ArgumentNullException>(() => new NamespaceToolLoader(_commandFactory, null!, _logger));
     }
 
     [Fact]
     public async Task ListToolsHandler_ReturnsNamespaceTools()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var request = CreateListToolsRequest();
 
         // Act
@@ -105,7 +89,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task ListToolsHandler_CachesResults()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var request = CreateListToolsRequest();
 
         // Act - Call twice
@@ -120,16 +104,12 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task ListToolsHandler_FiltersNamespacesWhenConfigured()
     {
         // Arrange
-        await using var serviceProvider = CommandFactoryHelpers.CreateDefaultServiceProvider() as ServiceProvider
-            ?? throw new InvalidOperationException("Failed to create service provider");
-        var commandFactory = CommandFactoryHelpers.CreateCommandFactory(serviceProvider);
         var options = Microsoft.Extensions.Options.Options.Create(new ServerStartOptions
         {
             Namespace = ["storage", "keyvault"]
         });
-        var logger = serviceProvider.GetRequiredService<ILogger<NamespaceToolLoader>>();
 
-        var loader = new NamespaceToolLoader(commandFactory, options, serviceProvider, logger);
+        var loader = new NamespaceToolLoader(_commandFactory, options, _logger);
         var request = CreateListToolsRequest();
 
         // Act
@@ -158,14 +138,12 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
         rootGroup.SubGroup.AddRange([storageGroup, keyvaultGroup]);
         commandFactory.RootGroup.Returns(rootGroup);
 
-        var serviceProvider = Substitute.For<IServiceProvider>();
         var options = Microsoft.Extensions.Options.Options.Create(new ServerStartOptions
         {
             ReadOnly = true
         });
-        var logger = Substitute.For<ILogger<NamespaceToolLoader>>();
 
-        var loader = new NamespaceToolLoader(commandFactory, options, serviceProvider, logger);
+        var loader = new NamespaceToolLoader(commandFactory, options, _logger);
         var request = CreateListToolsRequest();
 
         // Act
@@ -193,14 +171,12 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
         rootGroup.SubGroup.AddRange([stroageGroup, keyvaultGroup]);
         commandFactory.RootGroup.Returns(rootGroup);
 
-        var serviceProvider = Substitute.For<IServiceProvider>();
         var options = Microsoft.Extensions.Options.Options.Create(new ServerStartOptions
         {
             Transport = TransportTypes.Http
         });
-        var logger = Substitute.For<ILogger<NamespaceToolLoader>>();
 
-        var loader = new NamespaceToolLoader(commandFactory, options, serviceProvider, logger);
+        var loader = new NamespaceToolLoader(commandFactory, options, _logger);
         var request = CreateListToolsRequest();
 
         // Act
@@ -215,7 +191,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CallToolHandler_WithLearnTrue_ReturnsAvailableCommands()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var toolName = GetFirstAvailableNamespace();
         var request = CreateCallToolRequest(toolName, new Dictionary<string, object?>
         {
@@ -241,7 +217,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CallToolHandler_WithLearnTrue_CachesCommandList()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var toolName = GetFirstAvailableNamespace();
         var request = CreateCallToolRequest(toolName, new Dictionary<string, object?>
         {
@@ -266,7 +242,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CallToolHandler_WithIntentButNoCommand_AutoEnablesLearn()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var toolName = GetFirstAvailableNamespace();
         var request = CreateCallToolRequest(toolName, new Dictionary<string, object?>
         {
@@ -290,7 +266,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CallToolHandler_WithInvalidNamespace_ReturnsError()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var request = CreateCallToolRequest("nonexistent-namespace", new Dictionary<string, object?>
         {
             ["learn"] = true
@@ -312,7 +288,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CallToolHandler_WithNullToolName_ThrowsArgumentException()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var request = CreateCallToolRequest(null!, []);
 
         // Act & Assert
@@ -324,7 +300,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CallToolHandler_WithoutCommandOrLearn_ReturnsHelpMessage()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var toolName = GetFirstAvailableNamespace();
         var request = CreateCallToolRequest(toolName, []);
 
@@ -345,7 +321,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CallToolHandler_ParsesHierarchicalStructure()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var toolName = GetFirstAvailableNamespace();
 
         var arguments = new Dictionary<string, JsonElement>
@@ -370,7 +346,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CallToolHandler_ConvertsObjectDictionaryToJsonElements()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var toolName = GetFirstAvailableNamespace();
 
         var arguments = new Dictionary<string, object?>
@@ -395,7 +371,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CallToolHandler_HandlesCommandNotFoundGracefully()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var toolName = GetFirstAvailableNamespace();
 
         var request = CreateCallToolRequest(toolName, new Dictionary<string, object?>
@@ -419,7 +395,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CallToolHandler_LazyLoadsCommandsPerNamespace()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
 
         // Get two different namespaces
         var listRequest = CreateListToolsRequest();
@@ -461,7 +437,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CallToolHandler_ThreadSafeLazyLoading()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var toolName = GetFirstAvailableNamespace();
 
         // Act - Simulate concurrent access
@@ -498,7 +474,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task DisposeAsync_ClearsCaches()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var toolName = GetFirstAvailableNamespace();
 
         // Populate cache
@@ -521,7 +497,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CallToolHandler_WithInvalidCommand_ReturnsErrorWithGuidance()
     {
         // Arrange - Test error handling and guidance message structure
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var toolName = GetFirstAvailableNamespace();
 
         // Create request with invalid command that doesn't exist
@@ -553,7 +529,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public void CreateClientOptions_WithElicitationCapability_ReturnsOptionsWithElicitationHandler()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var mockServer = Substitute.For<ModelContextProtocol.Server.McpServer>();
         var capabilities = new ClientCapabilities
         {
@@ -574,7 +550,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public void CreateClientOptions_WithNoElicitationCapability_ReturnsOptionsWithoutElicitationHandler()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var mockServer = Substitute.For<ModelContextProtocol.Server.McpServer>();
         mockServer.ClientCapabilities.Returns(new ClientCapabilities());
 
@@ -591,7 +567,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CreateClientOptions_ElicitationHandler_DelegatesToServerSendRequestAsync()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var mockServer = Substitute.For<ModelContextProtocol.Server.McpServer>();
         var capabilities = new ClientCapabilities
         {
@@ -644,7 +620,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task CreateClientOptions_ElicitationHandler_ValidatesRequestAndThrowsOnNull()
     {
         // Arrange
-        var loader = new NamespaceToolLoader(_commandFactory, _options, _serviceProvider, _logger);
+        var loader = new NamespaceToolLoader(_commandFactory, _options, _logger);
         var mockServer = Substitute.For<ModelContextProtocol.Server.McpServer>();
         var capabilities = new ClientCapabilities
         {
@@ -658,7 +634,7 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
 
         // Assert - verify handler validates null request
         await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            await options.Handlers.ElicitationHandler.Invoke(null!, TestContext.Current.CancellationToken));
+            await options.Handlers.ElicitationHandler.Invoke(null, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -685,11 +661,9 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
         commandFactory.GroupCommands(Arg.Any<string[]>())
             .Returns(new Dictionary<string, IBaseCommand> { ["write-cmd"] = writeCmd });
 
-        var serviceProvider = Substitute.For<IServiceProvider>();
         var options = Microsoft.Extensions.Options.Options.Create(new ServerStartOptions { ReadOnly = true });
-        var logger = Substitute.For<ILogger<NamespaceToolLoader>>();
 
-        var loader = new NamespaceToolLoader(commandFactory, options, serviceProvider, logger);
+        var loader = new NamespaceToolLoader(commandFactory, options, _logger);
         var request = CreateCallToolRequest("storage", new Dictionary<string, object?>
         {
             ["command"] = "write-cmd",
@@ -727,11 +701,9 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
         commandFactory.GroupCommands(Arg.Any<string[]>())
             .Returns(new Dictionary<string, IBaseCommand> { ["read-cmd"] = readCmd });
 
-        var serviceProvider = Substitute.For<IServiceProvider>();
         var options = Microsoft.Extensions.Options.Options.Create(new ServerStartOptions { ReadOnly = true });
-        var logger = Substitute.For<ILogger<NamespaceToolLoader>>();
 
-        var loader = new NamespaceToolLoader(commandFactory, options, serviceProvider, logger);
+        var loader = new NamespaceToolLoader(commandFactory, options, _logger);
         var request = CreateCallToolRequest("storage", new Dictionary<string, object?>
         {
             ["command"] = "read-cmd",
@@ -769,11 +741,9 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
         commandFactory.GroupCommands(Arg.Any<string[]>())
             .Returns(new Dictionary<string, IBaseCommand> { ["local-cmd"] = localCmd });
 
-        var serviceProvider = Substitute.For<IServiceProvider>();
         var options = Microsoft.Extensions.Options.Options.Create(new ServerStartOptions { Transport = TransportTypes.Http });
-        var logger = Substitute.For<ILogger<NamespaceToolLoader>>();
 
-        var loader = new NamespaceToolLoader(commandFactory, options, serviceProvider, logger);
+        var loader = new NamespaceToolLoader(commandFactory, options, _logger);
         var request = CreateCallToolRequest("storage", new Dictionary<string, object?>
         {
             ["command"] = "local-cmd",
@@ -811,11 +781,9 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
         commandFactory.GroupCommands(Arg.Any<string[]>())
             .Returns(new Dictionary<string, IBaseCommand> { ["remote-cmd"] = remoteCmd });
 
-        var serviceProvider = Substitute.For<IServiceProvider>();
         var options = Microsoft.Extensions.Options.Options.Create(new ServerStartOptions { Transport = TransportTypes.Http });
-        var logger = Substitute.For<ILogger<NamespaceToolLoader>>();
 
-        var loader = new NamespaceToolLoader(commandFactory, options, serviceProvider, logger);
+        var loader = new NamespaceToolLoader(commandFactory, options, _logger);
         var request = CreateCallToolRequest("storage", new Dictionary<string, object?>
         {
             ["command"] = "remote-cmd",
@@ -833,16 +801,12 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     public async Task GetChildToolList_WithReadOnlyOption_ReturnsOnlyReadOnlyTools()
     {
         // Arrange
-        await using var serviceProvider = CommandFactoryHelpers.CreateDefaultServiceProvider() as ServiceProvider
-            ?? throw new InvalidOperationException("Failed to create service provider");
-        var commandFactory = CommandFactoryHelpers.CreateCommandFactory(serviceProvider);
         var options = Microsoft.Extensions.Options.Options.Create(new ServerStartOptions
         {
             ReadOnly = true
         });
-        var logger = serviceProvider.GetRequiredService<ILogger<NamespaceToolLoader>>();
 
-        var loader = new NamespaceToolLoader(commandFactory, options, serviceProvider, logger);
+        var loader = new NamespaceToolLoader(_commandFactory, options, _logger);
         var request = CreateCallToolRequest("storage", []);
 
         // Act
@@ -861,9 +825,8 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
         {
             Transport = TransportTypes.Http
         });
-        var logger = NullLogger<NamespaceToolLoader>.Instance;
 
-        var loader = new NamespaceToolLoader(_commandFactory, options, _serviceProvider, logger);
+        var loader = new NamespaceToolLoader(_commandFactory, options, _logger);
         var request = CreateCallToolRequest("storage", []);
 
         // Act

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/ServiceStartCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/ServiceStartCommandTests.cs
@@ -742,9 +742,8 @@ public class ServiceStartCommandTests
 
     private async Task<CommandResponse> ExecuteAsync(List<string> args)
     {
-        var context = new CommandContext(new ServiceCollection().BuildServiceProvider());
         // Need to use IBaseCommand here for ExecuteAsync as it handles binding and validating the args.
-        return await ((IBaseCommand)_command).ExecuteAsync(context, _command.GetCommand().Parse(args), TestContext.Current.CancellationToken);
+        return await ((IBaseCommand)_command).ExecuteAsync(new(), _command.GetCommand().Parse(args), TestContext.Current.CancellationToken);
     }
 
     private string GetErrorMessage(Exception exception)

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Tools/ToolsListCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Tools/ToolsListCommandTests.cs
@@ -25,22 +25,16 @@ public class ToolsListCommandTests
 
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<ToolsListCommand> _logger;
-    private readonly CommandContext _context;
     private readonly ToolsListCommand _command;
     private readonly Command _commandDefinition;
 
     public ToolsListCommandTests()
     {
-        var collection = new ServiceCollection();
-        collection.AddLogging();
+        _serviceProvider = Substitute.For<IServiceProvider>();
+        _serviceProvider.GetService(typeof(ICommandFactory)).Returns(CommandFactoryHelpers.CreateCommandFactory());
 
-        var commandFactory = CommandFactoryHelpers.CreateCommandFactory();
-        collection.AddSingleton(commandFactory);
-
-        _serviceProvider = collection.BuildServiceProvider();
-        _context = new(_serviceProvider);
         _logger = Substitute.For<ILogger<ToolsListCommand>>();
-        _command = new(_logger);
+        _command = new(_serviceProvider, _logger);
         _commandDefinition = _command.GetCommand();
     }
 
@@ -171,15 +165,18 @@ public class ToolsListCommandTests
     /// and returns appropriate error response.
     /// </summary>
     [Fact]
-    public async Task ExecuteAsync_WithNullServiceProvider_HandlesGracefully()
+    public async Task ExecuteAsync_WithNullCommandFactory_HandlesGracefully()
     {
-        // Arrange & Act
-        var response = await ExecuteAsync(new CommandContext(null!));
+        // Arrange
+        _serviceProvider.GetService(typeof(ICommandFactory)).Returns(null);
+
+        // Act
+        var response = await ExecuteAsync();
 
         // Assert
         Assert.NotNull(response);
-        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
-        Assert.Contains("cannot be null", response.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(HttpStatusCode.UnprocessableContent, response.Status);
+        Assert.Contains("No service for type", response.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -190,12 +187,11 @@ public class ToolsListCommandTests
     public async Task ExecuteAsync_WithCorruptedCommandFactory_HandlesGracefully()
     {
         // Arrange
-        var faultyServiceProvider = Substitute.For<IServiceProvider>();
-        faultyServiceProvider.GetService(typeof(ICommandFactory))
+        _serviceProvider.GetService(typeof(ICommandFactory))
             .Returns(x => throw new InvalidOperationException("Corrupted command factory"));
 
         // Act
-        var response = await ExecuteAsync(new CommandContext(faultyServiceProvider));
+        var response = await ExecuteAsync();
 
         // Assert
         Assert.NotNull(response);
@@ -351,17 +347,11 @@ public class ToolsListCommandTests
             RootCommandGroupName = "azmcp"
         });
 
-        // Create a NEW service collection just for the empty command factory
-        var finalCollection = new ServiceCollection();
-        finalCollection.AddLogging();
-
         var emptyCommandFactory = new CommandFactory(tempServiceProvider, emptyAreaSetups, telemetryService, configurationOptions, logger);
-        finalCollection.AddSingleton<ICommandFactory>(emptyCommandFactory);
-
-        var emptyServiceProvider = finalCollection.BuildServiceProvider();
+        _serviceProvider.GetService(typeof(ICommandFactory)).Returns(emptyCommandFactory);
 
         // Act
-        var response = await ExecuteAsync(new CommandContext(emptyServiceProvider));
+        var response = await ExecuteAsync();
 
         // Assert
         var result = DeserializeCommandsResults(response);
@@ -713,11 +703,6 @@ public class ToolsListCommandTests
         Assert.Contains(result.Commands, cmd => cmd.Name.Equals("keyvault", StringComparison.OrdinalIgnoreCase));
     }
 
-    private async Task<CommandResponse> ExecuteAsync(params string[] args) => await ExecuteAsync(_context, args);
-
-    private async Task<CommandResponse> ExecuteAsync(CommandContext context, params string[] args)
-    {
-        var parseResult = _commandDefinition.Parse(args);
-        return await _command.ExecuteAsync(context, _command.BindOptions(parseResult), TestContext.Current.CancellationToken);
-    }
+    private async Task<CommandResponse> ExecuteAsync(params string[] args) =>
+        await _command.ExecuteAsync(new(), _command.BindOptions(_commandDefinition.Parse(args)), TestContext.Current.CancellationToken);
 }

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
@@ -154,7 +154,6 @@ public static partial class ServiceCollectionExtensions
                 );
 
                 toolLoaders.Add(new CommandFactoryToolLoader(
-                    sp,
                     sp.GetRequiredService<ICommandFactory>(),
                     Options.Create(utilityToolLoaderOptions),
                     loggerFactory.CreateLogger<CommandFactoryToolLoader>()
@@ -191,7 +190,6 @@ public static partial class ServiceCollectionExtensions
                     new NamespaceToolLoader(
                         consolidatedCommandFactory,
                         sp.GetRequiredService<IOptions<ServerStartOptions>>(),
-                        sp,
                         loggerFactory.CreateLogger<NamespaceToolLoader>(),
                         false
                     ),

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -22,12 +22,10 @@ namespace Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
 /// Exposes AzureMcp commands as MCP tools that can be invoked through the MCP protocol.
 /// </summary>
 public sealed class CommandFactoryToolLoader(
-    IServiceProvider serviceProvider,
     ICommandFactory commandFactory,
     IOptions<ToolLoaderOptions> options,
     ILogger<CommandFactoryToolLoader> logger) : BaseToolLoader(logger)
 {
-    private readonly IServiceProvider _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
     private readonly ICommandFactory _commandFactory = commandFactory;
     private readonly IOptions<ToolLoaderOptions> _options = options;
     private IReadOnlyDictionary<string, IBaseCommand> _toolCommands =
@@ -159,7 +157,7 @@ public sealed class CommandFactoryToolLoader(
             }, command.Id);
         }
 
-        var commandContext = new CommandContext(_serviceProvider, activity)
+        var commandContext = new CommandContext(activity)
         {
             McpServer = request.Server,
             ProgressToken = request.Params.ProgressToken

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
@@ -28,13 +28,11 @@ namespace Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
 public sealed class NamespaceToolLoader(
     ICommandFactory commandFactory,
     IOptions<ServerStartOptions> options,
-    IServiceProvider serviceProvider,
     ILogger<NamespaceToolLoader> logger,
     bool applyFilter = true) : BaseToolLoader(logger)
 {
     private readonly ICommandFactory _commandFactory = commandFactory ?? throw new ArgumentNullException(nameof(commandFactory));
     private readonly IOptions<ServerStartOptions> _options = options ?? throw new ArgumentNullException(nameof(options));
-    private readonly IServiceProvider _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
 
     private readonly Lazy<IReadOnlyList<string>> _availableNamespaces = new(() =>
     {
@@ -415,7 +413,7 @@ public sealed class NamespaceToolLoader(
             }
 
             var currentActivity = Activity.Current;
-            var commandContext = new CommandContext(_serviceProvider, currentActivity)
+            var commandContext = new CommandContext(currentActivity)
             {
                 McpServer = request.Server,
                 ProgressToken = request.Params?.ProgressToken

--- a/core/Microsoft.Mcp.Core/src/Areas/Tools/Commands/ToolsListCommand.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Tools/Commands/ToolsListCommand.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Areas.Tools.Options;
 using Microsoft.Mcp.Core.Commands;
@@ -28,7 +29,7 @@ namespace Microsoft.Mcp.Core.Areas.Tools.Commands;
     ReadOnly = true,
     LocalRequired = false,
     Secret = false)]
-public sealed class ToolsListCommand(ILogger<ToolsListCommand> logger)
+public sealed class ToolsListCommand(IServiceProvider serviceProvider, ILogger<ToolsListCommand> logger)
     : BaseCommand<ToolsListOptions, ToolsListCommand.ToolsListResult>
 {
     private static readonly HashSet<string> s_ignored = new(StringComparer.OrdinalIgnoreCase) { "server", "tools" };
@@ -38,7 +39,7 @@ public sealed class ToolsListCommand(ILogger<ToolsListCommand> logger)
     {
         try
         {
-            var factory = context.GetService<ICommandFactory>();
+            var factory = serviceProvider.GetRequiredService<ICommandFactory>();
 
             // If the --namespace-mode flag is set, return distinct top‑level namespaces (e.g. child groups beneath root 'azmcp').
             if (options.NamespaceMode)

--- a/core/Microsoft.Mcp.Core/src/Commands/CommandFactory.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/CommandFactory.cs
@@ -322,7 +322,7 @@ public class CommandFactory : ICommandFactory
             activity?.SetTag(TagName.ToolId, implementation.Id)
                 .SetTag(TagName.ServerMode, "cli");
             InjectToolAreaAndName(activity, parseResult);
-            var cmdContext = new CommandContext(_serviceProvider, activity);
+            var cmdContext = new CommandContext(activity);
             var startTime = DateTime.UtcNow;
             try
             {

--- a/core/Microsoft.Mcp.Core/src/Models/Command/CommandContext.cs
+++ b/core/Microsoft.Mcp.Core/src/Models/Command/CommandContext.cs
@@ -9,7 +9,7 @@ using ModelContextProtocol.Server;
 namespace Microsoft.Mcp.Core.Models.Command;
 
 /// <summary>
-/// Provides context for command execution including service access and response management
+/// Provides context for command execution including response management
 /// </summary>
 public class CommandContext
 {

--- a/core/Microsoft.Mcp.Core/src/Models/Command/CommandContext.cs
+++ b/core/Microsoft.Mcp.Core/src/Models/Command/CommandContext.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Net;
-using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -14,11 +13,6 @@ namespace Microsoft.Mcp.Core.Models.Command;
 /// </summary>
 public class CommandContext
 {
-    /// <summary>
-    /// The service provider for dependency injection
-    /// </summary>
-    private readonly IServiceProvider _serviceProvider;
-
     /// <summary>
     /// The response object that will be returned to the client
     /// </summary>
@@ -37,7 +31,7 @@ public class CommandContext
     /// so <see cref="McpServer.ClientInfo"/> will be <see langword="null"/> on every request.
     /// Per-request client identity is instead available via
     /// <c>_meta["io.modelcontextprotocol/clientInfo"]</c> — see
-    /// <see cref="Microsoft.Mcp.Core.Helpers.McpHelper.ClientInfoMetaKey"/>. The <c>McpServer</c>
+    /// <see cref="Helpers.McpHelper.ClientInfoMetaKey"/>. The <c>McpServer</c>
     /// reference itself is still populated by the tool loaders on every request.
     /// </para>
     /// </summary>
@@ -53,26 +47,13 @@ public class CommandContext
     /// <summary>
     /// Creates a new command context
     /// </summary>
-    /// <param name="serviceProvider">The service provider for dependency injection</param>
-    public CommandContext(IServiceProvider serviceProvider, Activity? activity = default)
+    public CommandContext(Activity? activity = default)
     {
-        _serviceProvider = serviceProvider;
         Activity = activity;
         Response = new CommandResponse
         {
             Status = HttpStatusCode.OK,
             Message = "Success"
         };
-    }
-
-    /// <summary>
-    /// Gets a required service from the service provider
-    /// </summary>
-    /// <typeparam name="T">The type of service to retrieve</typeparam>
-    /// <returns>The requested service instance</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the service is not registered</exception>
-    internal T GetService<T>() where T : class
-    {
-        return _serviceProvider.GetRequiredService<T>();
     }
 }

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/ToolLoaderTelemetryTests.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/ToolLoaderTelemetryTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Mcp.Core.Tests.Areas.Server.Commands.ToolLoading;
 /// </summary>
 public class ToolLoaderTelemetryTests : IDisposable
 {
-    private Activity _activity;
+    private readonly Activity _activity;
 
     public ToolLoaderTelemetryTests()
     {
@@ -43,12 +43,11 @@ public class ToolLoaderTelemetryTests : IDisposable
     {
         var toolName = "tool";
         var mcpServer = Substitute.For<McpServer>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
         var commandFactory = Substitute.For<ICommandFactory>();
         var options = Microsoft.Extensions.Options.Options.Create(new ToolLoaderOptions(Tool: ["nevercalled"]));
         var logger = Substitute.For<ILogger<CommandFactoryToolLoader>>();
 
-        var mcpRuntime = CreateRuntime(new CommandFactoryToolLoader(serviceProvider, commandFactory, options, logger));
+        var mcpRuntime = CreateRuntime(new CommandFactoryToolLoader(commandFactory, options, logger));
         var request = CreateToolCallRequest(mcpServer, toolName);
 
         await mcpRuntime.CallToolHandler(request, TestContext.Current.CancellationToken);
@@ -65,7 +64,6 @@ public class ToolLoaderTelemetryTests : IDisposable
     {
         var toolName = "tool";
         var mcpServer = Substitute.For<McpServer>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
         var commandFactory = Substitute.For<ICommandFactory>();
         commandFactory.AllCommands.Returns(new Dictionary<string, IBaseCommand>
         {
@@ -74,7 +72,7 @@ public class ToolLoaderTelemetryTests : IDisposable
         var options = Microsoft.Extensions.Options.Options.Create(new ToolLoaderOptions());
         var logger = Substitute.For<ILogger<CommandFactoryToolLoader>>();
 
-        var mcpRuntime = CreateRuntime(new CommandFactoryToolLoader(serviceProvider, commandFactory, options, logger));
+        var mcpRuntime = CreateRuntime(new CommandFactoryToolLoader( commandFactory, options, logger));
         var request = CreateToolCallRequest(mcpServer, toolName);
 
         await mcpRuntime.CallToolHandler(request, TestContext.Current.CancellationToken);
@@ -94,7 +92,6 @@ public class ToolLoaderTelemetryTests : IDisposable
         var mcpServer = Substitute.For<McpServer>();
         var clientCapabilities = new ClientCapabilities();
         mcpServer.ClientCapabilities.Returns(clientCapabilities);
-        var serviceProvider = Substitute.For<IServiceProvider>();
         var commandFactory = Substitute.For<ICommandFactory>();
         var toolCommand = Substitute.For<IBaseCommand>();
         toolCommand.Id.Returns(toolId);
@@ -106,7 +103,7 @@ public class ToolLoaderTelemetryTests : IDisposable
         var options = Microsoft.Extensions.Options.Options.Create(new ToolLoaderOptions());
         var logger = Substitute.For<ILogger<CommandFactoryToolLoader>>();
 
-        var mcpRuntime = CreateRuntime(new CommandFactoryToolLoader(serviceProvider, commandFactory, options, logger));
+        var mcpRuntime = CreateRuntime(new CommandFactoryToolLoader(commandFactory, options, logger));
         var request = CreateToolCallRequest(mcpServer, toolName);
 
         await mcpRuntime.CallToolHandler(request, TestContext.Current.CancellationToken);
@@ -125,7 +122,6 @@ public class ToolLoaderTelemetryTests : IDisposable
         var toolArea = "area";
         var toolId = Guid.NewGuid().ToString();
         var mcpServer = Substitute.For<McpServer>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
         var commandFactory = Substitute.For<ICommandFactory>();
         commandFactory.GetServiceArea(Arg.Is(toolName)).Returns(toolArea);
         var toolCommand = Substitute.For<IBaseCommand>();
@@ -141,7 +137,7 @@ public class ToolLoaderTelemetryTests : IDisposable
         var options = Microsoft.Extensions.Options.Options.Create(new ToolLoaderOptions());
         var logger = Substitute.For<ILogger<CommandFactoryToolLoader>>();
 
-        var mcpRuntime = CreateRuntime(new CommandFactoryToolLoader(serviceProvider, commandFactory, options, logger));
+        var mcpRuntime = CreateRuntime(new CommandFactoryToolLoader(commandFactory, options, logger));
         var request = CreateToolCallRequest(mcpServer, toolName);
 
         await Assert.ThrowsAsync<Exception>(() => mcpRuntime.CallToolHandler(request, TestContext.Current.CancellationToken).AsTask());
@@ -160,7 +156,6 @@ public class ToolLoaderTelemetryTests : IDisposable
         var toolArea = "area";
         var toolId = Guid.NewGuid().ToString();
         var mcpServer = Substitute.For<McpServer>();
-        var serviceProvider = Substitute.For<IServiceProvider>();
         var commandFactory = Substitute.For<ICommandFactory>();
         commandFactory.GetServiceArea(Arg.Is(toolName)).Returns(toolArea);
 
@@ -177,7 +172,7 @@ public class ToolLoaderTelemetryTests : IDisposable
         var options = Microsoft.Extensions.Options.Options.Create(new ToolLoaderOptions());
         var logger = Substitute.For<ILogger<CommandFactoryToolLoader>>();
 
-        var mcpRuntime = CreateRuntime(new CommandFactoryToolLoader(serviceProvider, commandFactory, options, logger));
+        var mcpRuntime = CreateRuntime(new CommandFactoryToolLoader(commandFactory, options, logger));
         var request = CreateToolCallRequest(mcpServer, toolName);
 
         await mcpRuntime.CallToolHandler(request, TestContext.Current.CancellationToken);

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/ToolLoaderTelemetryTests.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/ToolLoaderTelemetryTests.cs
@@ -72,7 +72,7 @@ public class ToolLoaderTelemetryTests : IDisposable
         var options = Microsoft.Extensions.Options.Options.Create(new ToolLoaderOptions());
         var logger = Substitute.For<ILogger<CommandFactoryToolLoader>>();
 
-        var mcpRuntime = CreateRuntime(new CommandFactoryToolLoader( commandFactory, options, logger));
+        var mcpRuntime = CreateRuntime(new CommandFactoryToolLoader(commandFactory, options, logger));
         var request = CreateToolCallRequest(mcpServer, toolName);
 
         await mcpRuntime.CallToolHandler(request, TestContext.Current.CancellationToken);

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Commands/CommandValidationExceptionTests.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Commands/CommandValidationExceptionTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Command;
 using Xunit;
@@ -31,12 +30,6 @@ public sealed class CommandValidationExceptionTests
             => Task.FromResult(context.Response);
 
         public void InvokeHandleException(CommandContext context, Exception ex) => HandleException(context, ex);
-    }
-
-    private static CommandContext CreateContext()
-    {
-        var serviceProvider = new ServiceCollection().BuildServiceProvider();
-        return new CommandContext(serviceProvider);
     }
 
     // ---------- Exception default tests ----------
@@ -76,7 +69,7 @@ public sealed class CommandValidationExceptionTests
     public void HandleException_MapsDefaultStatusCode_ToBadRequest()
     {
         var command = new ValidationTestCommand();
-        var context = CreateContext();
+        var context = new CommandContext();
 
         command.InvokeHandleException(context, new CommandValidationException("Validation failed."));
 
@@ -89,7 +82,7 @@ public sealed class CommandValidationExceptionTests
     public void HandleException_HonorsExplicitStatusCode()
     {
         var command = new ValidationTestCommand();
-        var context = CreateContext();
+        var context = new CommandContext();
 
         command.InvokeHandleException(
             context,
@@ -104,7 +97,7 @@ public sealed class CommandValidationExceptionTests
     public void HandleException_FormatsMissingOptionsMessage()
     {
         var command = new ValidationTestCommand();
-        var context = CreateContext();
+        var context = new CommandContext();
 
         command.InvokeHandleException(
             context,

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/CommandUnitTestsBase.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Tests/Client/CommandUnitTestsBase.cs
@@ -29,7 +29,7 @@ public abstract class CommandUnitTestsBase<TCommand, TService> : IDisposable
     protected IServiceCollection Services { get; init; }
 
     protected ServiceProvider ServiceProvider { get => field ??= Services.BuildServiceProvider(); }
-    protected CommandContext Context { get => field ??= new CommandContext(ServiceProvider); }
+    protected CommandContext Context { get => field ??= new(); }
     protected TCommand Command { get => field ??= ServiceProvider.GetRequiredService<TCommand>(); }
     protected Command CommandDefinition { get => field ??= Command.GetCommand(); }
 

--- a/servers/Azure.Mcp.Server/changelog-entries/1785438711215.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1785438711215.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Other Changes"
+    description: "Removed IServiceProvider from CommandContext and downstream locations where no longer used."

--- a/servers/Fabric.Mcp.Server/changelog-entries/1785438721114.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1785438721114.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Other Changes"
+    description: "Removed IServiceProvider from CommandContext and downstream locations where no longer used."

--- a/tools/Azure.Mcp.Tools.Insights/tests/Azure.Mcp.Tools.Insights.UnitTests/InsightsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Insights/tests/Azure.Mcp.Tools.Insights.UnitTests/InsightsGetCommandTests.cs
@@ -355,7 +355,7 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
     {
         var server = Substitute.For<McpServer>();
         server.ClientCapabilities.Returns(new ClientCapabilities { Sampling = new SamplingCapability() });
-        var context = new CommandContext(ServiceProvider) { McpServer = server };
+        var context = new CommandContext() { McpServer = server };
         return ((IBaseCommand)Command).ExecuteAsync(context, CommandDefinition.Parse(args), TestContext.Current.CancellationToken);
     }
 

--- a/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.Tests/Stt/SttRecognizeCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.Tests/Stt/SttRecognizeCommandTests.cs
@@ -12,7 +12,6 @@ using Azure.Mcp.Tools.Speech.Models.Realtime;
 using Azure.Mcp.Tools.Speech.Services;
 using Azure.Mcp.Tools.Speech.Services.Recognizers;
 using Azure.Mcp.Tools.Speech.Services.Synthesizers;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Command;
@@ -25,7 +24,6 @@ namespace Azure.Mcp.Tools.Speech.Tests.Stt;
 
 public class SttRecognizeCommandTests : IDisposable
 {
-    private readonly IServiceProvider _serviceProvider;
     private readonly ISpeechService _speechService;
     private readonly IFastTranscriptionRecognizer _fastTranscriptionRecognizer;
     private readonly IRealtimeTranscriptionRecognizer _realtimeTranscriptionRecognizer;
@@ -34,7 +32,6 @@ public class SttRecognizeCommandTests : IDisposable
     private readonly ILogger<SttRecognizeCommand> _logger;
     private readonly ILogger<SpeechService> _speechServiceLogger;
     private readonly SttRecognizeCommand _command;
-    private readonly CommandContext _context;
     private readonly Command _commandDefinition;
     private readonly string _knownEndpoint = "https://eastus.cognitiveservices.azure.com/";
     private readonly List<string> _testFilesToCleanup = [];
@@ -52,11 +49,7 @@ public class SttRecognizeCommandTests : IDisposable
         // Create real SpeechService with mocked dependencies
         _speechService = new SpeechService(_tenantService, _speechServiceLogger, _fastTranscriptionRecognizer, _realtimeTranscriptionRecognizer, _realtimeTtsSynthesizer);
 
-        var collection = new ServiceCollection();
-
-        _serviceProvider = collection.BuildServiceProvider();
         _command = new(_logger, _speechService);
-        _context = new(_serviceProvider);
         _commandDefinition = _command.GetCommand();
     }
 
@@ -158,7 +151,7 @@ public class SttRecognizeCommandTests : IDisposable
         await ExecuteCommandAsync(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
 
     private async Task<CommandResponse> ExecuteCommandAsync(params string[] args) =>
-        await ((IBaseCommand)_command).ExecuteAsync(_context, _commandDefinition.Parse(args), TestContext.Current.CancellationToken);
+        await ((IBaseCommand)_command).ExecuteAsync(new(), _commandDefinition.Parse(args), TestContext.Current.CancellationToken);
 
     private static SttRecognizeCommand.SttRecognizeCommandResult DeserializeResult(CommandResponse response) =>
         JsonSerializer.Deserialize(JsonSerializer.Serialize(response.Results), SpeechJsonContext.Default.SttRecognizeCommandResult)!;

--- a/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.Tests/Commands/CombinedWorkflowTests.cs
+++ b/tools/Fabric.Mcp.Tools.Docs/tests/Fabric.Mcp.Tools.Docs.Tests/Commands/CombinedWorkflowTests.cs
@@ -268,8 +268,8 @@ public class CombinedWorkflowTests : IDisposable
         Assert.Equal(workloads1.OrderBy(w => w), workloads2.OrderBy(w => w));
     }
 
-    private Task<CommandResponse> ExecuteCommandAsync(IBaseCommand command, params string[] args)
-        => command.ExecuteAsync(new(_serviceProvider), command.GetCommand().Parse(args), TestContext.Current.CancellationToken);
+    private static Task<CommandResponse> ExecuteCommandAsync(IBaseCommand command, params string[] args)
+        => command.ExecuteAsync(new(), command.GetCommand().Parse(args), TestContext.Current.CancellationToken);
 
     private static IEnumerable<string> ValidateAndDeserializeWorkloadsResponse(CommandResponse response)
     {

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Shortcut/ShortcutCreateCommandVariantsTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Shortcut/ShortcutCreateCommandVariantsTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Fabric.Mcp.Tools.OneLake.Commands.Shortcut;
 using Fabric.Mcp.Tools.OneLake.Models;
 using Fabric.Mcp.Tools.OneLake.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Models.Command;
 using NSubstitute;
@@ -262,10 +261,6 @@ public class ShortcutCreateCommandVariantsTests
         return service;
     }
 
-    private static async Task<CommandResponse> ExecuteAsync(IBaseCommand command, params string[] args)
-    {
-        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
-        var context = new CommandContext(serviceProvider);
-        return await command.ExecuteAsync(context, command.GetCommand().Parse(args), CancellationToken.None);
-    }
+    private static async Task<CommandResponse> ExecuteAsync(IBaseCommand command, params string[] args) =>
+        await command.ExecuteAsync(new(), command.GetCommand().Parse(args), CancellationToken.None);
 }


### PR DESCRIPTION
## What does this PR do?

Work to migrate `IBaseCommand` implementations to using dependency injection via the class constructor has completed. `ServiceProvider` can now be removed from `CommandContext` as it should no longer be used to handle dependency injection scenarios. Caveat is `ToolsListCommand` which requires `ServiceProvider` to prevent issues with `CommandFactory` as `CommandFactory` uses `ToolsListCommand` and `ToolsListCommand` uses `CommandFactory`.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
