### PR TITLE
Fixed issue calling namespace_update related to PartitionCount updates

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/larryosterman-eventhubs-nullableresponse-fix.yml
+++ b/servers/Azure.Mcp.Server/changelog-entries/larryosterman-eventhubs-nullableresponse-fix.yml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bug Fixes"
+    description: "Fixed a bug in EventHubs where creating a new event hub or consumer group could throw an `InvalidOperationException` instead of succeeding, because the `NullableResponse<T>.Value` accessor was dereferenced without checking `HasValue` first."

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
@@ -372,11 +372,24 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
             throw new KeyNotFoundException($"Event Hubs namespace '{namespaceName}' not found in resource group '{resourceGroup}'.");
         }
 
+        // Fetch the existing event hub (if any) so an update preserves the fields the caller
+        // didn't ask to change. This is a create-or-update PUT, so any property left unset on
+        // the new EventHubData below is submitted as absent rather than "unchanged" - for
+        // PartitionCount in particular, Azure rejects a PUT to an existing event hub that
+        // omits it with "PartitionCount can only be changed on a Dedicated Event Hub cluster or
+        // Premium namespace", even when no partition-count change was requested.
+        var existingEventHub = await namespaceResource.Value.GetEventHubs().GetIfExistsAsync(eventHubName, cancellationToken);
+        var existingData = existingEventHub?.Value?.Data;
+
         var eventHubData = new EventHubData();
 
         if (partitionCount.HasValue)
         {
             eventHubData.PartitionCount = partitionCount.Value;
+        }
+        else if (existingData?.PartitionCount.HasValue == true)
+        {
+            eventHubData.PartitionCount = existingData.PartitionCount;
         }
 
         if (messageRetentionInHours.HasValue)
@@ -386,6 +399,10 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
                 RetentionTimeInHours = messageRetentionInHours.Value,
                 CleanupPolicy = CleanupPolicyRetentionDescription.Delete
             };
+        }
+        else if (existingData?.RetentionDescription is not null)
+        {
+            eventHubData.RetentionDescription = existingData.RetentionDescription;
         }
 
         if (status is not null)
@@ -405,6 +422,10 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
                     $"Invalid status '{status}'. Valid values: Active, Disabled, Restoring, SendDisabled, ReceiveDisabled, Creating, Deleting, Renaming, Unknown.",
                     nameof(status))
             };
+        }
+        else if (existingData?.Status is not null)
+        {
+            eventHubData.Status = existingData.Status;
         }
 
         var operation = await namespaceResource.Value.GetEventHubs()

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
@@ -372,14 +372,17 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
             throw new KeyNotFoundException($"Event Hubs namespace '{namespaceName}' not found in resource group '{resourceGroup}'.");
         }
 
-        // Fetch the existing event hub (if any) so an update preserves the fields the caller
-        // didn't ask to change. This is a create-or-update PUT, so any property left unset on
-        // the new EventHubData below is submitted as absent rather than "unchanged" - for
-        // PartitionCount in particular, Azure rejects a PUT to an existing event hub that
-        // omits it with "PartitionCount can only be changed on a Dedicated Event Hub cluster or
-        // Premium namespace", even when no partition-count change was requested.
-        var existingEventHub = await namespaceResource.Value.GetEventHubs().GetIfExistsAsync(eventHubName, cancellationToken);
-        var existingData = existingEventHub?.Value?.Data;
+        // Fetch the existing event hub only when at least one optional property is absent so
+        // that a create-or-update PUT preserves fields the caller didn't explicitly set.
+        // PartitionCount in particular: Azure rejects a PUT to an existing event hub that
+        // omits it with "PartitionCount can only be changed on a Dedicated Event Hub cluster or Premium namespace",
+        // even when no partition-count change was requested.
+        EventHubData? existingData = null;
+        if (!partitionCount.HasValue || !messageRetentionInHours.HasValue || status is null)
+        {
+            var existingEventHub = await namespaceResource.Value.GetEventHubs().GetIfExistsAsync(eventHubName, cancellationToken);
+            existingData = existingEventHub?.Value?.Data;
+        }
 
         var eventHubData = new EventHubData();
 

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
@@ -19,6 +19,47 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
     private readonly ISubscriptionService _subscriptionService = subscriptionService;
     private readonly ILogger<EventHubsService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
+    // Event Hub entity/consumer group creation exhibits read-after-write lag: the PUT can
+    // succeed while a near-immediate follow-up GET (performed internally when resolving the
+    // ARM operation's Value, or by an explicit GET right after create) still 404s until the
+    // new entity propagates. Retry briefly instead of failing the whole operation.
+    private static readonly TimeSpan s_eventualConsistencyRetryDelay = TimeSpan.FromSeconds(2);
+    private const int EventualConsistencyMaxAttempts = 5;
+
+    private static async Task<T> GetWithEventualConsistencyRetryAsync<T>(
+        Func<Task<T?>> getValue,
+        Func<Exception> notFoundExceptionFactory,
+        CancellationToken cancellationToken) where T : class
+    {
+        for (var attempt = 1; attempt <= EventualConsistencyMaxAttempts; attempt++)
+        {
+            try
+            {
+                var value = await getValue();
+                if (value != null)
+                {
+                    return value;
+                }
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404 && attempt < EventualConsistencyMaxAttempts)
+            {
+                // Fall through to retry below.
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("404") && attempt < EventualConsistencyMaxAttempts)
+            {
+                // Thrown by NoValueResponse<T>.Value when the service returns no content (e.g. a 404
+                // encountered while resolving an ArmOperation's final value). Retry below.
+            }
+
+            if (attempt < EventualConsistencyMaxAttempts)
+            {
+                await Task.Delay(s_eventualConsistencyRetryDelay, cancellationToken);
+            }
+        }
+
+        throw notFoundExceptionFactory();
+    }
+
     public async Task<List<Namespace>> GetNamespacesAsync(
         string? resourceGroup,
         string subscription,
@@ -380,8 +421,26 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
         EventHubData? existingData = null;
         if (!partitionCount.HasValue || !messageRetentionInHours.HasValue || status is null)
         {
-            var existingEventHub = await namespaceResource.Value.GetEventHubs().GetIfExistsAsync(eventHubName, cancellationToken);
-            existingData = existingEventHub?.Value?.Data;
+            // GetIfExistsAsync returns a NullableResponse whose Value getter throws
+            // InvalidOperationException when the entity doesn't exist (a 404 was returned) -
+            // the null-conditional operator on the response itself doesn't guard against this,
+            // since the response wrapper is never null. Check HasValue first.
+            try
+            {
+                var existingEventHub = await namespaceResource.Value.GetEventHubs().GetIfExistsAsync(eventHubName, cancellationToken);
+                if (existingEventHub.HasValue)
+                {
+                    existingData = existingEventHub.Value?.Data;
+                }
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                // Event hub doesn't exist yet; nothing to merge.
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("404"))
+            {
+                // Event hub doesn't exist yet; nothing to merge.
+            }
         }
 
         var eventHubData = new EventHubData();
@@ -435,12 +494,27 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
             .CreateOrUpdateAsync(WaitUntil.Started, eventHubName, eventHubData, cancellationToken);
         await WaitForLroCompletionAsync(operation, cancellationToken);
 
-        if (operation?.Value == null)
+        // The ARM operation's Value can throw immediately after creation (read-after-write lag);
+        // fall back to an explicit GET, retried with backoff, rather than failing outright.
+        EventHubData? eventHubResourceData;
+        try
         {
-            throw new InvalidOperationException($"Failed to create or update event hub '{eventHubName}'");
+            eventHubResourceData = operation.Value.Data;
+        }
+        catch (Exception ex) when (ex is RequestFailedException or InvalidOperationException)
+        {
+            var refreshed = await GetWithEventualConsistencyRetryAsync(
+                async () =>
+                {
+                    var response = await namespaceResource.Value.GetEventHubs().GetAsync(eventHubName, cancellationToken);
+                    return response?.Value;
+                },
+                () => new InvalidOperationException($"Failed to create or update event hub '{eventHubName}'"),
+                cancellationToken);
+            eventHubResourceData = refreshed.Data;
         }
 
-        return ConvertToEventHub(operation.Value.Data, resourceGroup);
+        return ConvertToEventHub(eventHubResourceData, resourceGroup);
     }
 
     public async Task<bool> DeleteEventHubAsync(
@@ -526,12 +600,16 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
             throw new KeyNotFoundException($"Event Hubs namespace '{namespaceName}' not found in resource group '{resourceGroup}'.");
         }
 
-        var eventHubResource = await namespaceResource.Value.GetEventHubs().GetAsync(eventHubName, cancellationToken);
-
-        if (eventHubResource?.Value == null)
-        {
-            throw new KeyNotFoundException($"Event Hub '{eventHubName}' not found in namespace '{namespaceName}'.");
-        }
+        // The event hub may have just been created; a near-immediate GET can 404 due to
+        // read-after-write lag, so retry briefly instead of failing outright.
+        var eventHub = await GetWithEventualConsistencyRetryAsync(
+            async () =>
+            {
+                var response = await namespaceResource.Value.GetEventHubs().GetAsync(eventHubName, cancellationToken);
+                return response?.Value;
+            },
+            () => new KeyNotFoundException($"Event Hub '{eventHubName}' not found in namespace '{namespaceName}'."),
+            cancellationToken);
 
         var consumerGroupData = new EventHubsConsumerGroupData();
         if (!string.IsNullOrEmpty(userMetadata))
@@ -539,14 +617,31 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
             consumerGroupData.UserMetadata = userMetadata;
         }
 
-        var operation = await eventHubResource.Value.GetEventHubsConsumerGroups().CreateOrUpdateAsync(
+        var operation = await eventHub.GetEventHubsConsumerGroups().CreateOrUpdateAsync(
             WaitUntil.Started,
             consumerGroupName,
             consumerGroupData,
             cancellationToken);
         await WaitForLroCompletionAsync(operation, cancellationToken);
 
-        var consumerGroupResource = operation.Value;
+        // Same read-after-write lag can occur when resolving the newly created consumer group.
+        EventHubsConsumerGroupResource consumerGroupResource;
+        try
+        {
+            consumerGroupResource = operation.Value;
+        }
+        catch (Exception ex) when (ex is RequestFailedException or InvalidOperationException)
+        {
+            consumerGroupResource = await GetWithEventualConsistencyRetryAsync(
+                async () =>
+                {
+                    var response = await eventHub.GetEventHubsConsumerGroups().GetAsync(consumerGroupName, cancellationToken);
+                    return response?.Value;
+                },
+                () => new InvalidOperationException($"Failed to create or update consumer group '{consumerGroupName}'"),
+                cancellationToken);
+        }
+
         if (string.IsNullOrEmpty(consumerGroupResource.Id))
         {
             throw new InvalidOperationException("Consumer group resource ID is missing");

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.Tests/assets.json
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.Tests/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "",
   "TagPrefix": "Azure.Mcp.Tools.EventHubs.Tests",
-  "Tag": "Azure.Mcp.Tools.EventHubs.Tests_4ff9688cf8"
+  "Tag": "Azure.Mcp.Tools.EventHubs.Tests_98137425e0"
 }


### PR DESCRIPTION
## What does this PR do?
The namespace_update tool fails with "PartitionCount cannot be updated" error when the tool is called to update a partition. This is because ARM treats the namespace update as a merge/patch update rather than a put.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
