### PR TITLE
back out CFSClean enforcement until nuget is fixed

### DIFF
--- a/eng/pipelines/templates/1es-redirect.yml
+++ b/eng/pipelines/templates/1es-redirect.yml
@@ -24,10 +24,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      ${{ if eq(variables['Build.Reason'], 'Manual') }}:
-        networkIsolationPolicy: Permissive
-      ${{ else }}:
-        networkIsolationPolicy: Permissive, CFSClean
+      networkIsolationPolicy: Permissive
       # only enable autoBaseline for the internal build of rust-core on main branch
       ${{ if parameters.AutoBaseline }}:
         featureFlags:


### PR DESCRIPTION
This pull request makes a small change to the `eng/pipelines/templates/1es-redirect.yml` file, simplifying the configuration for the `networkIsolationPolicy` setting. The conditional logic that set different values for manual and non-manual builds has been removed, and now `networkIsolationPolicy` is always set to `Permissive`.

- Simplified pipeline configuration by always setting `networkIsolationPolicy` to `Permissive`, removing conditional logic for manual and non-manual builds.