### PR TITLE
docs: clarify Foundry resource group constraint

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -2684,12 +2684,12 @@ azmcp foundryextensions openai models-list \
     --resource-group <resource-group> \
     --resource-name <resource-name>
 
-# Get details of Microsoft Foundry (AI) resources in a subscription or resource group
+# List or get Microsoft Foundry resource details (endpoint, SKU, location). --resource-group is required when --resource-name is specified.
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp foundryextensions resource get \
     --subscription <subscription> \
     [--resource-group <resource-group>] \
-    [--resource-name <resource-name>]
+    [--resource-name <resource-name>]   # --resource-group required when --resource-name is provided
 ```
 
 ### Azure Function App Operations


### PR DESCRIPTION
## What does this PR do?
Clarifies that `--resource-group` is required when `--resource-name` is passed to `azmcp foundryextensions resource get`. It also updates the command summary to describe the returned resource metadata.

Closes #2978

## GitHub issue number?
https://github.com/microsoft/mcp/issues/2978

## Validation
- `dotnet build servers/Azure.Mcp.Server/`
- `dotnet build tools/Azure.Mcp.Tools.FoundryExtensions/src/`
- `dotnet test tools/Azure.Mcp.Tools.FoundryExtensions/tests/Azure.Mcp.Tools.FoundryExtensions.Tests/ --filter "TestType!=Live"` (80 passed)
- `git diff --check`

The PowerShell spelling wrapper could not run because `pwsh` is unavailable locally; the direct Node fallback is also blocked by a broken local Homebrew `simdjson` linkage.

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages
    - [x] Tests are not required for this documentation-only correction
    - [x] Changelog entry is not required for this documentation-only correction
- [x] Extra steps for **Azure MCP Server** documentation changes:
    - [x] Updated command list in `servers/Azure.Mcp.Server/docs/azmcp-commands.md`
    - [x] Reviewed the change for security vulnerabilities or suspicious content
