### PR TITLE
Add progress notifications during EventHubs namespace update LRO wait

### DIFF
--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
@@ -409,13 +409,13 @@ public abstract class BaseAzureService
             Response response = await operation.UpdateStatusAsync(cancellationToken).ConfigureAwait(false);
             if (operation.HasCompleted)
             {
-                return operation.GetRawResponse();
+                return response;
             }
 
-            elapsed += pollInterval;
             progress.Report($"Still waiting for the operation to complete ({elapsed:mm\\:ss} elapsed)...");
 
             await Task.Delay(pollInterval, cancellationToken).ConfigureAwait(false);
+            elapsed += pollInterval;
         }
     }
 }

--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
@@ -397,54 +397,48 @@ public abstract class BaseAzureService
     /// </remarks>
     private static async Task<Response> WaitForLroCompletionInternalAsync(Operation operation, IProgress<string>? progress, CancellationToken cancellationToken)
     {
-        // Base case: No progress, no default poll interval. Just wait for the operation to complete.
-        if (progress == null && !s_defaultPollInterval.HasValue)
+        if (s_defaultPollInterval.HasValue)
+        {
+            // Loop polling the async operation status at a fixed interval until it completes.
+            // This is used during playback testing to avoid the Azure SDK's default polling delay.
+            while (true)
+            {
+                Response response = await operation.UpdateStatusAsync(cancellationToken).ConfigureAwait(false);
+                if (operation.HasCompleted)
+                {
+                    return response;
+                }
+
+                await Task.Delay(s_defaultPollInterval.Value, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        if (progress is null)
         {
             return await operation.WaitForCompletionResponseAsync(cancellationToken);
         }
         else
-            if (s_defaultPollInterval.HasValue)
+        {
+            Task<Response> completionTask = operation.WaitForCompletionResponseAsync(cancellationToken).AsTask();
+            var startTime = DateTime.UtcNow;
+            using PeriodicTimer progressTimer = new(s_progressPollInterval);
+
+            while (!completionTask.IsCompleted)
             {
-                // Next case: Loop polling the async operation status at a fixed interval until it completes. 
-                // This is used when a default poll interval is set (e.g., during playback testing) to work around 
-                // default behavior of the Azure SDK that waits for 1 second before polling the operation status.
-                while (true)
+                Task<bool> progressTimerTask = progressTimer.WaitForNextTickAsync(cancellationToken).AsTask();
+                if (await Task.WhenAny(completionTask, progressTimerTask).ConfigureAwait(false) == completionTask)
                 {
-                    // We want to poll the operation status at a fixed interval, either because a default poll interval is set or because progress reporting is requested.
-                    Response response = await operation.UpdateStatusAsync(cancellationToken);
-                    if (operation.HasCompleted)
-                    {
-                        return response;
-                    }
-                    await Task.Delay(s_defaultPollInterval.Value, cancellationToken).ConfigureAwait(false);
-                }
-            }
-            else if (progress != null)
-            {
-                // Finally, if progress is specified, we will report progress at a fixed interval while waiting for the operation to complete.
-
-                // Capture the operation completion task and the start time to calculate elapsed time for progress reporting.
-                Task<Response> completionTask = operation.WaitForCompletionResponseAsync(cancellationToken).AsTask();
-                var startTime = DateTime.UtcNow; // Initialize elapsed time to zero
-                using PeriodicTimer progressTimer = new(s_progressPollInterval);
-
-                // While the completion task is not completed, we will wait for either the completion task or the progress timer to tick.
-                while (!completionTask.IsCompleted)
-                {
-                    Task<bool> progressTimerTask = progressTimer.WaitForNextTickAsync(cancellationToken).AsTask();
-                    if (await Task.WhenAny(completionTask, progressTimerTask).ConfigureAwait(false) == completionTask)
-                    {
-                        break;
-                    }
-
-                    if (await progressTimerTask.ConfigureAwait(false))
-                    {
-                        var currentElapsed = DateTime.UtcNow - startTime;
-                        progress.Report($"Still waiting for the operation to complete ({currentElapsed:mm\\:ss} elapsed)...");
-                    }
+                    break;
                 }
 
-                return await completionTask.ConfigureAwait(false);
+                if (await progressTimerTask.ConfigureAwait(false))
+                {
+                    var currentElapsed = DateTime.UtcNow - startTime;
+                    progress.Report($"Still waiting for the operation to complete ({currentElapsed:mm\\:ss} elapsed)...");
+                }
             }
+
+            return await completionTask.ConfigureAwait(false);
+        }
     }
 }

--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
@@ -395,9 +395,20 @@ public abstract class BaseAzureService
     /// <remarks>
     /// The s_defaultPollInterval value is set to TimeSpan.Zero during playback testing to avoid unnecessary delays in test execution. In production, it is null, and the method will wait for the operation to complete without polling unless a progress reporter is provided.
     /// </remarks>
-    private static async Task<Response> WaitForLroCompletionInternalAsync(Operation operation, IProgress<string>? progress, CancellationToken cancellationToken)
+    private static Task<Response> WaitForLroCompletionInternalAsync(
+        Operation operation,
+        IProgress<string>? progress,
+        CancellationToken cancellationToken) =>
+        WaitForLroCompletionInternalAsync(operation, progress, s_defaultPollInterval, s_progressPollInterval, cancellationToken);
+
+    internal static async Task<Response> WaitForLroCompletionInternalAsync(
+        Operation operation,
+        IProgress<string>? progress,
+        TimeSpan? defaultPollInterval,
+        TimeSpan progressPollInterval,
+        CancellationToken cancellationToken)
     {
-        if (s_defaultPollInterval.HasValue)
+        if (defaultPollInterval.HasValue)
         {
             // Loop polling the async operation status at a fixed interval until it completes.
             // This is used during playback testing to avoid the Azure SDK's default polling delay.
@@ -409,19 +420,15 @@ public abstract class BaseAzureService
                     return response;
                 }
 
-                await Task.Delay(s_defaultPollInterval.Value, cancellationToken).ConfigureAwait(false);
+                await Task.Delay(defaultPollInterval.Value, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        if (progress is null)
-        {
-            return await operation.WaitForCompletionResponseAsync(cancellationToken);
-        }
-        else
+        else if (progress is not null)
         {
             Task<Response> completionTask = operation.WaitForCompletionResponseAsync(cancellationToken).AsTask();
             var startTime = DateTime.UtcNow;
-            using PeriodicTimer progressTimer = new(s_progressPollInterval);
+            using PeriodicTimer progressTimer = new(progressPollInterval);
 
             while (!completionTask.IsCompleted)
             {
@@ -439,6 +446,10 @@ public abstract class BaseAzureService
             }
 
             return await completionTask.ConfigureAwait(false);
+        }
+        else
+        {
+            return await operation.WaitForCompletionResponseAsync(cancellationToken);
         }
     }
 }

--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
@@ -298,10 +298,10 @@ public abstract class BaseAzureService
     }
 
     /// <summary>
-    /// Interval at which <see cref="WaitForLroCompletionAsync{T}(Operation{T}, IProgress{string}, CancellationToken)"/> polls
-    /// the operation and reports progress. This keeps the caller (and any MCP client watching for session activity)
-    /// informed while a genuinely long-running Azure operation is still in progress, instead of appearing idle for the
-    /// entire duration of the wait.
+    /// Interval at which <see cref="WaitForLroCompletionAsync{T}(Operation{T}, IProgress{string}, CancellationToken)"/>
+    /// reports progress while the Azure SDK waits for the operation to complete. This keeps the caller (and any MCP client
+    /// watching for session activity) informed while a genuinely long-running Azure operation is still in progress,
+    /// instead of appearing idle for the entire duration of the wait.
     /// </summary>
     private static readonly TimeSpan s_progressPollInterval = TimeSpan.FromSeconds(15);
 
@@ -318,7 +318,7 @@ public abstract class BaseAzureService
 
         if (s_defaultPollInterval.HasValue)
         {
-            await WaitForLroCompletionInternalAsync(operation, cancellationToken).ConfigureAwait(false);
+            await WaitForLroCompletionInternalAsync(operation, null, cancellationToken).ConfigureAwait(false);
         }
         else
         {
@@ -343,7 +343,7 @@ public abstract class BaseAzureService
         ArgumentNullException.ThrowIfNull(operation);
         ArgumentNullException.ThrowIfNull(progress);
 
-        await WaitForLroCompletionWithProgressAsync(operation, progress, cancellationToken).ConfigureAwait(false);
+        await WaitForLroCompletionInternalAsync(operation, progress, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -356,14 +356,7 @@ public abstract class BaseAzureService
     {
         ArgumentNullException.ThrowIfNull(operation);
 
-        if (s_defaultPollInterval.HasValue)
-        {
-            await WaitForLroCompletionInternalAsync(operation, cancellationToken).ConfigureAwait(false);
-        }
-        else
-        {
-            await operation.WaitForCompletionResponseAsync(cancellationToken);
-        }
+        await WaitForLroCompletionInternalAsync(operation, null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -382,40 +375,74 @@ public abstract class BaseAzureService
         ArgumentNullException.ThrowIfNull(operation);
         ArgumentNullException.ThrowIfNull(progress);
 
-        await WaitForLroCompletionWithProgressAsync(operation, progress, cancellationToken).ConfigureAwait(false);
+        await WaitForLroCompletionInternalAsync(operation, progress, cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task<Response> WaitForLroCompletionInternalAsync(Operation operation, CancellationToken cancellationToken)
+
+    /// <summary>
+    /// Waits for the completion of a long-running operation, periodically polling the operation status until it completes.
+    /// 
+    /// There are three cases for how this method behaves:
+    /// 1. If no progress reporter is provided and no default poll interval is set, the method will simply wait for the operation to complete without reporting progress.
+    /// 2. If a progress reporter is provided, the method will report progress at a fixed interval while waiting for the operation to complete.
+    /// 3. If no progress reporter is provided but a default poll interval is set, the method will wait for the specified interval before checking the status again.
+    /// </summary>
+    /// 
+    /// <param name="operation">The long-running operation.</param>
+    /// <param name="progress">A progress callback that reports the status of the operation at regular intervals.</param>
+    /// <param name="cancellationToken">The cancellation token that can cancel the request.</param>
+    /// <returns>The response once the long-running operation completes.</returns>
+    private static async Task<Response> WaitForLroCompletionInternalAsync(Operation operation, IProgress<string>? progress, CancellationToken cancellationToken)
     {
         while (true)
         {
-            Response response = await operation.UpdateStatusAsync(cancellationToken);
-            if (operation.HasCompleted)
+            // Base case: No progress, no default poll interval. Just wait for the operation to complete.
+            if (progress == null && !s_defaultPollInterval.HasValue)
             {
-                return operation.GetRawResponse();
+                return await operation.WaitForCompletionResponseAsync(cancellationToken);
             }
-
-            await Task.Delay(s_defaultPollInterval!.Value, cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    private static async Task<Response> WaitForLroCompletionWithProgressAsync(Operation operation, IProgress<string> progress, CancellationToken cancellationToken)
-    {
-        var pollInterval = s_defaultPollInterval ?? s_progressPollInterval;
-        var elapsed = TimeSpan.Zero;
-
-        while (true)
-        {
-            Response response = await operation.UpdateStatusAsync(cancellationToken).ConfigureAwait(false);
-            if (operation.HasCompleted)
+            else
             {
-                return operation.GetRawResponse();
+                // We want to poll the operation status at a fixed interval, either because a default poll interval is set or because progress reporting is requested.
+                Response response = await operation.UpdateStatusAsync(cancellationToken);
+                if (operation.HasCompleted)
+                {
+                    return operation.GetRawResponse();
+                }
+
+                // Next case: A default poll interval is set. Wait for the specified interval before checking the status again.
+                if (s_defaultPollInterval.HasValue)
+                {
+
+                    await Task.Delay(s_defaultPollInterval!.Value, cancellationToken).ConfigureAwait(false);
+                }
+                else if (progress != null)
+                {
+                    // If progress is specified, we will report progress at a fixed interval while waiting for the operation to complete.
+                    // Capture the operation completion task and the start time to calculate elapsed time for progress reporting.
+                    Task<Response> completionTask = operation.WaitForCompletionResponseAsync(cancellationToken).AsTask();
+                    using PeriodicTimer progressTimer = new(s_progressPollInterval);
+                    var startTime = DateTime.UtcNow; // Initialize elapsed time to zero
+
+                    // While the completion task is not completed, we will wait for either the completion task or the progress timer to tick.
+                    while (!completionTask.IsCompleted)
+                    {
+                        Task<bool> progressTimerTask = progressTimer.WaitForNextTickAsync(cancellationToken).AsTask();
+                        if (await Task.WhenAny(completionTask, progressTimerTask).ConfigureAwait(false) == completionTask)
+                        {
+                            break;
+                        }
+
+                        if (await progressTimerTask.ConfigureAwait(false))
+                        {
+                            var currentElapsed = DateTime.UtcNow - startTime;
+                            progress.Report($"Still waiting for the operation to complete ({currentElapsed:mm\\:ss} elapsed)...");
+                        }
+                    }
+
+                    return await completionTask.ConfigureAwait(false);
+                }
             }
-
-            elapsed += pollInterval;
-            progress.Report($"Still waiting for the operation to complete ({elapsed:mm\\:ss} elapsed)...");
-
-            await Task.Delay(pollInterval, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
@@ -298,6 +298,14 @@ public abstract class BaseAzureService
     }
 
     /// <summary>
+    /// Interval at which <see cref="WaitForLroCompletionAsync{T}(Operation{T}, IProgress{string}, CancellationToken)"/> polls
+    /// the operation and reports progress. This keeps the caller (and any MCP client watching for session activity)
+    /// informed while a genuinely long-running Azure operation is still in progress, instead of appearing idle for the
+    /// entire duration of the wait.
+    /// </summary>
+    private static readonly TimeSpan s_progressPollInterval = TimeSpan.FromSeconds(15);
+
+    /// <summary>
     /// Waits for the completion of a long-running operation, periodically polling the operation status until it completes.
     /// </summary>
     /// <typeparam name="T">The return type.</typeparam>
@@ -316,6 +324,26 @@ public abstract class BaseAzureService
         {
             await operation.WaitForCompletionAsync(cancellationToken);
         }
+    }
+
+    /// <summary>
+    /// Waits for the completion of a long-running operation, periodically polling the operation status until it completes
+    /// while reporting progress to keep the caller informed during long waits.
+    /// </summary>
+    /// <typeparam name="T">The return type.</typeparam>
+    /// <param name="operation">The long-running operation.</param>
+    /// <param name="progress">
+    /// Progress reporter. A status message is reported at a fixed interval while the operation is still running so that
+    /// callers can surface liveness (e.g. via MCP progress notifications) during long waits.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation token that can cancel the request.</param>
+    /// <returns>The response once the long-running operation completes.</returns>
+    protected static async Task WaitForLroCompletionAsync<T>(Operation<T> operation, IProgress<string> progress, CancellationToken cancellationToken = default) where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(progress);
+
+        await WaitForLroCompletionWithProgressAsync(operation, progress, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -338,6 +366,25 @@ public abstract class BaseAzureService
         }
     }
 
+    /// <summary>
+    /// Waits for the completion of a long-running operation, periodically polling the operation status until it completes
+    /// while reporting progress to keep the caller informed during long waits.
+    /// </summary>
+    /// <param name="operation">The long-running operation.</param>
+    /// <param name="progress">
+    /// Progress reporter. A status message is reported at a fixed interval while the operation is still running so that
+    /// callers can surface liveness (e.g. via MCP progress notifications) during long waits.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation token that can cancel the request.</param>
+    /// <returns>The response once the long-running operation completes.</returns>
+    protected static async Task WaitForLroCompletionAsync(Operation operation, IProgress<string> progress, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(progress);
+
+        await WaitForLroCompletionWithProgressAsync(operation, progress, cancellationToken).ConfigureAwait(false);
+    }
+
     private static async Task<Response> WaitForLroCompletionInternalAsync(Operation operation, CancellationToken cancellationToken)
     {
         while (true)
@@ -349,6 +396,26 @@ public abstract class BaseAzureService
             }
 
             await Task.Delay(s_defaultPollInterval!.Value, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<Response> WaitForLroCompletionWithProgressAsync(Operation operation, IProgress<string> progress, CancellationToken cancellationToken)
+    {
+        var pollInterval = s_defaultPollInterval ?? s_progressPollInterval;
+        var elapsed = TimeSpan.Zero;
+
+        while (true)
+        {
+            Response response = await operation.UpdateStatusAsync(cancellationToken).ConfigureAwait(false);
+            if (operation.HasCompleted)
+            {
+                return operation.GetRawResponse();
+            }
+
+            elapsed += pollInterval;
+            progress.Report($"Still waiting for the operation to complete ({elapsed:mm\\:ss} elapsed)...");
+
+            await Task.Delay(pollInterval, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Services/Azure/BaseAzureServiceTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Services/Azure/BaseAzureServiceTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Concurrent;
 using Azure.Core;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Core.Services.Azure.Tenant;
@@ -289,6 +290,69 @@ public class BaseAzureServiceTests
         // Assert
         var expected = expectedTimeout != null ? TimeSpan.FromSeconds(expectedTimeout.Value) : defaultClientOptions.Retry.NetworkTimeout;
         Assert.Equal(expected, clientOptions.Retry.NetworkTimeout);
+    }
+
+    [Fact]
+    public async Task WaitForLroCompletionInternalAsync_DefaultPollInterval_PollsUntilComplete()
+    {
+        var response = Substitute.For<Response>();
+        var operation = new TestOperation<string>("complete", response, updatesBeforeCompletion: 3);
+
+        Response result = await BaseAzureService.WaitForLroCompletionInternalAsync(
+            operation,
+            progress: null,
+            defaultPollInterval: TimeSpan.Zero,
+            progressPollInterval: TimeSpan.FromMilliseconds(10),
+            TestContext.Current.CancellationToken);
+
+        Assert.Same(response, result);
+        Assert.Equal(3, operation.UpdateCount);
+    }
+
+    [Fact]
+    public async Task WaitForLroCompletionInternalAsync_NoProgress_UsesSdkCompletion()
+    {
+        var response = Substitute.For<Response>();
+        var operation = new TestOperation<string>("complete", response, updatesBeforeCompletion: 1);
+
+        Response result = await BaseAzureService.WaitForLroCompletionInternalAsync(
+            operation,
+            progress: null,
+            defaultPollInterval: null,
+            progressPollInterval: TimeSpan.FromMilliseconds(10),
+            TestContext.Current.CancellationToken);
+
+        Assert.Same(response, result);
+        Assert.Equal(1, operation.UpdateCount);
+    }
+
+    [Fact]
+    public async Task WaitForLroCompletionInternalAsync_Progress_ReportsWhileSdkCompletionWaits()
+    {
+        var response = Substitute.For<Response>();
+        var releaseUpdate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var messages = new ConcurrentQueue<string>();
+        var progress = new Progress<string>(message =>
+        {
+            messages.Enqueue(message);
+            releaseUpdate.TrySetResult();
+        });
+        var operation = new TestOperation<string>(
+            "complete",
+            response,
+            updatesBeforeCompletion: 1,
+            cancellationToken => releaseUpdate.Task.WaitAsync(cancellationToken));
+
+        Response result = await BaseAzureService.WaitForLroCompletionInternalAsync(
+            operation,
+            progress,
+            defaultPollInterval: null,
+            progressPollInterval: TimeSpan.FromMilliseconds(10),
+            TestContext.Current.CancellationToken);
+
+        Assert.Same(response, result);
+        Assert.Equal(1, operation.UpdateCount);
+        Assert.Contains(messages, message => message.StartsWith("Still waiting for the operation to complete", StringComparison.Ordinal));
     }
 
     private sealed class TestAzureService(ITenantService tenantService) : BaseAzureService(tenantService)

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Services/Azure/TestOperation.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Services/Azure/TestOperation.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure;
+
+namespace Azure.Mcp.Core.Tests.Services.Azure;
+
+internal sealed class TestOperation<T>(
+    T value,
+    Response response,
+    int updatesBeforeCompletion,
+    Func<CancellationToken, Task>? beforeUpdate = null) : Operation<T> where T : notnull
+{
+    private bool _hasCompleted;
+
+    public int UpdateCount { get; private set; }
+
+    public override string Id => "test-operation";
+
+    public override T Value => value;
+
+    public override bool HasValue => HasCompleted;
+
+    public override bool HasCompleted => _hasCompleted;
+
+    public override Response GetRawResponse() => response;
+
+    public override Response UpdateStatus(CancellationToken cancellationToken = default) =>
+        UpdateStatusAsync(cancellationToken).AsTask().GetAwaiter().GetResult();
+
+    public override async ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default)
+    {
+        UpdateCount++;
+
+        if (beforeUpdate is not null)
+        {
+            await beforeUpdate(cancellationToken);
+        }
+
+        _hasCompleted = UpdateCount >= updatesBeforeCompletion;
+        return response;
+    }
+}

--- a/servers/Azure.Mcp.Server/changelog-entries/larryosterman-eventhubs-namespace-update-progress.yml
+++ b/servers/Azure.Mcp.Server/changelog-entries/larryosterman-eventhubs-namespace-update-progress.yml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bug Fixes"
+    description: "Event Hubs `namespace update` now sends MCP progress notifications while waiting for the ARM operation to complete, preventing long-running namespace updates (e.g. SKU/capacity changes) from appearing idle to the client."

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceUpdateCommand.cs
@@ -9,6 +9,7 @@ using Azure.Mcp.Tools.EventHubs.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Command;
+using ModelContextProtocol;
 
 namespace Azure.Mcp.Tools.EventHubs.Commands.Namespace;
 
@@ -87,6 +88,8 @@ public sealed class NamespaceUpdateCommand(ILogger<NamespaceUpdateCommand> logge
                 }
             }
 
+            IProgress<string> progress = new Progress<string>(msg => _ = NotifyProgressAsync(context, msg, cancellationToken));
+
             var updatedNamespace = await _service.CreateOrUpdateNamespaceAsync(
                 options.Namespace,
                 options.ResourceGroup,
@@ -102,6 +105,7 @@ public sealed class NamespaceUpdateCommand(ILogger<NamespaceUpdateCommand> logge
                 tags,
                 options.Tenant,
                 options.RetryPolicy,
+                progress,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(
@@ -116,6 +120,27 @@ public sealed class NamespaceUpdateCommand(ILogger<NamespaceUpdateCommand> logge
         }
 
         return context.Response;
+    }
+
+    /// <summary>
+    /// Sends a progress notification to the client. Used to keep long-running namespace updates (e.g. SKU/capacity
+    /// changes) from appearing idle to the client while the ARM operation is still in progress.
+    /// </summary>
+    private static async Task NotifyProgressAsync(CommandContext context, string message, CancellationToken cancellationToken)
+    {
+        if (context.McpServer is null || context.ProgressToken is null)
+        {
+            return;
+        }
+
+        await context.McpServer.NotifyProgressAsync(
+            context.ProgressToken.Value,
+            new ProgressNotificationValue
+            {
+                Progress = 0f,
+                Message = message,
+            },
+            cancellationToken: cancellationToken);
     }
 
     public sealed record NamespaceUpdateCommandResult(Models.Namespace Namespace);

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Commands/Namespace/NamespaceUpdateCommand.cs
@@ -88,7 +88,9 @@ public sealed class NamespaceUpdateCommand(ILogger<NamespaceUpdateCommand> logge
                 }
             }
 
-            IProgress<string> progress = new Progress<string>(msg => _ = NotifyProgressAsync(context, msg, cancellationToken));
+            IProgress<string>? progress = context.McpServer is not null && context.ProgressToken is not null
+                ? new Progress<string>(msg => _ = NotifyProgressAsync(context, msg, cancellationToken))
+                : null;
 
             var updatedNamespace = await _service.CreateOrUpdateNamespaceAsync(
                 options.Namespace,

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
@@ -172,6 +172,7 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
         Dictionary<string, string>? tags = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
+        IProgress<string>? progress = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(namespaceName), namespaceName), (nameof(resourceGroup), resourceGroup), (nameof(subscription), subscription));
@@ -241,7 +242,15 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
         // Create or update the namespace
         var operation = await resourceGroupResource.Value.GetEventHubsNamespaces()
             .CreateOrUpdateAsync(WaitUntil.Started, namespaceName, namespaceData, cancellationToken);
-        await WaitForLroCompletionAsync(operation, cancellationToken);
+
+        if (progress != null)
+        {
+            await WaitForLroCompletionAsync(operation, progress, cancellationToken);
+        }
+        else
+        {
+            await WaitForLroCompletionAsync(operation, cancellationToken);
+        }
 
         if (operation?.Value == null)
         {

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/EventHubsService.cs
@@ -478,6 +478,7 @@ public sealed class EventHubsService(ISubscriptionService subscriptionService, I
 
         if (status is not null)
         {
+            // cspell:ignore SENDDISABLED RECEIVEDISABLED
             eventHubData.Status = status.ToUpperInvariant() switch
             {
                 "ACTIVE" => EventHubEntityStatus.Active,

--- a/tools/Azure.Mcp.Tools.EventHubs/src/Services/IEventHubsService.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/src/Services/IEventHubsService.cs
@@ -38,6 +38,7 @@ public interface IEventHubsService
         Dictionary<string, string>? tags = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
+        IProgress<string>? progress = null,
         CancellationToken cancellationToken = default);
 
     Task<bool> DeleteNamespaceAsync(

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.Tests/Namespace/NamespaceUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.Tests/Namespace/NamespaceUpdateCommandTests.cs
@@ -133,7 +133,7 @@ public class NamespaceUpdateCommandTests : SubscriptionCommandUnitTestsBase<Name
             null,
             null,
             Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<IProgress<string>?>(),
+            null,
             Arg.Any<CancellationToken>());
     }
 

--- a/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.Tests/Namespace/NamespaceUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.EventHubs/tests/Azure.Mcp.Tools.EventHubs.Tests/Namespace/NamespaceUpdateCommandTests.cs
@@ -57,6 +57,7 @@ public class NamespaceUpdateCommandTests : SubscriptionCommandUnitTestsBase<Name
                 Arg.Any<Dictionary<string, string>?>(),
                 Arg.Any<string?>(),
                 Arg.Any<RetryPolicyOptions?>(),
+                Arg.Any<IProgress<string>?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(updatedNamespace);
         }
@@ -101,6 +102,7 @@ public class NamespaceUpdateCommandTests : SubscriptionCommandUnitTestsBase<Name
             null, // tags
             null, // tenant
             Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<IProgress<string>?>(),
             Arg.Any<CancellationToken>())
             .Returns(updatedNamespace);
 
@@ -131,6 +133,7 @@ public class NamespaceUpdateCommandTests : SubscriptionCommandUnitTestsBase<Name
             null,
             null,
             Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<IProgress<string>?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -154,6 +157,7 @@ public class NamespaceUpdateCommandTests : SubscriptionCommandUnitTestsBase<Name
             Arg.Any<Dictionary<string, string>?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<IProgress<string>?>(),
             Arg.Any<CancellationToken>())
             .Returns(updatedNamespace);
 
@@ -201,6 +205,7 @@ public class NamespaceUpdateCommandTests : SubscriptionCommandUnitTestsBase<Name
                 tags["team"] == "platform"),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<IProgress<string>?>(),
             Arg.Any<CancellationToken>())
             .Returns(updatedNamespace);
 
@@ -252,6 +257,7 @@ public class NamespaceUpdateCommandTests : SubscriptionCommandUnitTestsBase<Name
             Arg.Any<Dictionary<string, string>?>(),
             null,
             Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<IProgress<string>?>(),
             Arg.Any<CancellationToken>())
             .Returns(updatedNamespace);
 
@@ -286,6 +292,7 @@ public class NamespaceUpdateCommandTests : SubscriptionCommandUnitTestsBase<Name
             Arg.Any<Dictionary<string, string>?>(),
             null,
             Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<IProgress<string>?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -308,6 +315,7 @@ public class NamespaceUpdateCommandTests : SubscriptionCommandUnitTestsBase<Name
             Arg.Any<Dictionary<string, string>?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<IProgress<string>?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Update failed"));
 
@@ -342,6 +350,7 @@ public class NamespaceUpdateCommandTests : SubscriptionCommandUnitTestsBase<Name
             Arg.Any<Dictionary<string, string>?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<IProgress<string>?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new KeyNotFoundException("Namespace not found"));
 
@@ -377,6 +386,7 @@ public class NamespaceUpdateCommandTests : SubscriptionCommandUnitTestsBase<Name
             Arg.Any<Dictionary<string, string>?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<IProgress<string>?>(),
             Arg.Any<CancellationToken>())
             .Returns(updatedNamespace);
 
@@ -405,6 +415,7 @@ public class NamespaceUpdateCommandTests : SubscriptionCommandUnitTestsBase<Name
             null,
             "test-tenant-123",
             Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<IProgress<string>?>(),
             Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
The EventHubs namespace update tool blocks silently while ARM completes the SKU/capacity update, which can genuinely take several minutes. With no MCP activity emitted during that wait, MCP clients (including the Vally eval harness) can conclude the session is idle and time out even though the tool is still legitimately working.

- Add an optional IProgress<string> parameter to BaseAzureService.WaitForLroCompletionAsync (both overloads). When supplied, the LRO poll loop reports a heartbeat status message every 15 seconds while waiting, instead of delegating to the SDK's opaque WaitForCompletionAsync/WaitForCompletionResponseAsync. This is purely additive - existing callers that don't pass progress are unaffected.
- Thread an optional progress parameter through IEventHubsService.CreateOrUpdateNamespaceAsync / EventHubsService.CreateOrUpdateNamespaceAsync.
- NamespaceUpdateCommand now builds an IProgress<string> that forwards to context.McpServer.NotifyProgressAsync (mirroring the existing pattern in InsightsGetCommand), so clients receive periodic progress notifications - resetting client-side inactivity timeouts - while a namespace update is in flight.
- Update NamespaceUpdateCommandTests to account for the new trailing IProgress<string>? parameter on CreateOrUpdateNamespaceAsync.
- Add a changelog entry.

## GitHub issue number?

#3229 

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
