### PR TITLE
[ConfidentialLedger] Opt out of live test matrix pending a shared test ledger

### DIFF
--- a/tools/Azure.Mcp.Tools.ConfidentialLedger/tests/Azure.Mcp.Tools.ConfidentialLedger.Tests/Azure.Mcp.Tools.ConfidentialLedger.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.ConfidentialLedger/tests/Azure.Mcp.Tools.ConfidentialLedger.Tests/Azure.Mcp.Tools.ConfidentialLedger.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
     <OutputType>Exe</OutputType>
-    <HasLiveTests>true</HasLiveTests>
+    <HasLiveTests>false</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
### What

Sets `<HasLiveTests>false</HasLiveTests>` for the Confidential Ledger tool area. This removes the area from the live test matrix in `eng/scripts/New-BuildInfo.ps1`, so CI no longer provisions an Azure Confidential Ledger for this area.

No other file changes. `test-resources.bicep`, `test-resources-post.ps1` and the `[LiveTestOnly]` tests are all retained, so re-enabling is a one-word revert.

### Why

Each live run provisions a real Azure Confidential Ledger. That resource is heavier than most test resources in this repo: it stands up a 3-replica CCF cluster on confidential (SNP) hardware and takes roughly 8 minutes to create.

Measured from the service side over the last 30 days, this suite created **102 ledgers across 24 active days (~4.25/day)**. Two properties of that load are the problem:

- **A floor of exactly 2 per pipeline run.** `eng/pipelines/templates/jobs/live-test.yml` deploys test resources, runs the stdio pass, removes them, then deploys again with `UseHttpTransport = true` for the http pass. `UseHttpTransport` resolves (via `New-TestSettings` -> `.testsettings.json` -> `LiveTestSettingsFixture` -> `McpTestUtilities.CreateMcpClientAsync`) to the single environment variable `MCP_TEST_TRANSPORT=http`, which selects how the *local MCP server process* is launched. It is not a parameter of `test-resources.bicep`, so the second ledger is identical in shape to the first.
- **Bursts on fan-out days.** Changes under `eng/`, `core/*.Mcp.Core/src/`, or `Directory.Build|Packages.props` cause every tool area to live-test, so a pipeline-only change provisions a ledger. Daily creates spike to 9-13 on those days versus a baseline of 2.

Azure Confidential Ledger is a small service, and this erratic burst shape is harder on provisioning capacity than a higher but steady rate would be. Several recent bursts coincided with regional provisioning failures, which surfaced as incidents on the Confidential Ledger on-call rotation rather than as failures visible to this repo.

Opting out is the smallest change that removes the load, and it is entirely within this tool area — it requires no change to `eng/`.

### Coverage impact

Retained (unit tests, unaffected — `<HasUnitTests>` is unchanged):

- `LedgerEntryAppendCommandTests` — command execution and result deserialization
- `LedgerEntryGetCommandTests` — transaction-id and collection-id paths, argument validation, and the SSRF ledger-name rejection theories

Paused (the three `[LiveTestOnly]` tests in `ConfidentialLedgerCommandTests.cs`):

- `Should_append_entry_successfully`
- `Should_append_entry_with_collection_id`
- `Should_get_entry`

These remain in source and are unmodified.

### Follow-up

We would like to restore live coverage without per-run provisioning. The three live tests are self-contained — each appends an entry carrying a fresh `Guid`/timestamp and reads it back by the `transactionId` it just received, and none assert on aggregate ledger state — so they do not require a freshly created ledger and are safe to run against a shared, long-lived one, including under concurrent PRs.

We are happy to stand up a persistent ledger owned by the Azure Confidential Ledger team and grant the `azure-sdk-tests-public` service principal the `Administrator` role on it. This area's `test-resources.bicep` would then become an outputs-only template that emits `CONFIDENTIAL_LEDGER_NAME` / `CONFIDENTIAL_LEDGER_URL` for that ledger. `test-resources-post.ps1` reads only `DeploymentOutputs` and would need no change. That restores full live coverage at zero provisioning cost. We will send it as a separate PR if you are open to the approach.

### Notes for reviewers

- This PR touches only `tools/Azure.Mcp.Tools.ConfidentialLedger/`, so it does not trigger the fan-out path, and because the change takes effect in the same run it provisions no ledger.
- `hasLiveTests: false` is an existing, documented state — `eng/README.md` shows several areas already in it.
- No consistency check couples `HasLiveTests` to the presence of `test-resources.bicep`; the live-matrix condition treats them as independent (`!HasLiveTests -or !HasTestResources`).
