### PR TITLE
Prepare for Fabric MCP Server 1.3.0 release

### DIFF
--- a/servers/Fabric.Mcp.Server/CHANGELOG.md
+++ b/servers/Fabric.Mcp.Server/CHANGELOG.md
@@ -5,15 +5,24 @@ All notable changes to the Microsoft Fabric MCP Server will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.3.0 (Unreleased)
+## 1.3.0 (2026-08-10)
 
 ### Features Added
 
 ### Breaking Changes
 
+- Removed unused parameters from Fabric tools. [[#3097](https://github.com/microsoft/mcp/pull/3097)]
+- Removed legacy tool design creation. [[#3137](https://github.com/microsoft/mcp/pull/3137)]
+
 ### Bugs Fixed
 
 ### Other Changes
+
+- Updated Fabric REST API specifications and item definition documentation. [[#3234](https://github.com/microsoft/mcp/pull/3234)]
+
+#### Dependency Updates
+
+- Updated `@microsoft/vscode-azext-utils` from ~2 to ~4 (4.1.1) and `@vscode/vsce` from 3.7.1 to 3.9.2 in the VS Code extension. [[#3001](https://github.com/microsoft/mcp/pull/3001)]
 
 ## 1.2.0 (2026-07-08)
 

--- a/servers/Fabric.Mcp.Server/changelog-entries/1783387640737.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1783387640737.yaml
@@ -1,4 +1,0 @@
-changes:
-  - section: "Other Changes"
-    description: "Updated @microsoft/vscode-azext-utils from ~2 to ~4 (4.1.1) and @vscode/vsce from 3.7.1 to 3.9.2 in the VS Code extension."
-    subsection: "Dependency Updates"

--- a/servers/Fabric.Mcp.Server/changelog-entries/1784327317889.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1784327317889.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Breaking Changes"
-    description: "Removed unused parameters from Fabric tools."

--- a/servers/Fabric.Mcp.Server/changelog-entries/1784810153338.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1784810153338.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Breaking Changes"
-    description: "Removed legacy tool design creation."

--- a/servers/Fabric.Mcp.Server/changelog-entries/1784924959831.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1784924959831.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Other Changes"
-    description: "Added new telemetry collection for 'IsLearn' (indicates if the tool call attempted learning), 'ToolSource' (indication on where the invoked tool is from), 'ToolParameters' (the names of the tool parameters), and 'ToolAnnotations' (the annotations of the tool)."

--- a/servers/Fabric.Mcp.Server/changelog-entries/1785438721114.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1785438721114.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Other Changes"
-    description: "Removed IServiceProvider from CommandContext and downstream locations where no longer used."

--- a/servers/Fabric.Mcp.Server/changelog-entries/1786364288228.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1786364288228.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Other Changes"
-    description: "Updated Fabric REST API specifications and item definition documentation"

--- a/servers/Fabric.Mcp.Server/vscode/CHANGELOG.md
+++ b/servers/Fabric.Mcp.Server/vscode/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History
 
+## 1.3.0 (2026-08-10) (pre-release)
+
+### Changed
+
+- **Breaking:** Removed unused parameters from Fabric tools. [[#3097](https://github.com/microsoft/mcp/pull/3097)]
+- **Breaking:** Removed legacy tool design creation. [[#3137](https://github.com/microsoft/mcp/pull/3137)]
+- Updated Fabric REST API specifications and item definition documentation. [[#3234](https://github.com/microsoft/mcp/pull/3234)]
+- Updated `@microsoft/vscode-azext-utils` from ~2 to ~4 (4.1.1) and `@vscode/vsce` from 3.7.1 to 3.9.2. [[#3001](https://github.com/microsoft/mcp/pull/3001)]
+
 ## 1.2.0 (2026-07-08)
 
 ### Added


### PR DESCRIPTION
## Description

Prepare for the Microsoft Fabric MCP Server **1.3.0** release.

- Compiled the user-facing changelog entries into the `1.3.0 (2026-08-10)` section of `servers/Fabric.Mcp.Server/CHANGELOG.md`.
- Synced the VS Code extension changelog (`vscode/CHANGELOG.md`) with a `1.3.0 (pre-release)` section.
- Removed the consumed `changelog-entries/*.yaml` files.

### Changelog decisions

Per Fabric's policy of documenting only user-facing changes, the following entries were included:

- **Breaking:** Removed unused parameters from Fabric tools (#3097)
- **Breaking:** Removed legacy tool design creation (#3137)
- **Other:** Updated Fabric REST API specifications and item definition documentation (#3234)
- **Dependency Updates:** `@microsoft/vscode-azext-utils` and `@vscode/vsce` in the VS Code extension (#3001)

The following entries shipped this cycle but were omitted from the changelog as non-user-facing internal changes:

- New telemetry collection instrumentation (#3156)
- Removed `IServiceProvider` from `CommandContext` (#3185)

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
