### PR TITLE
Thread tenant ID through per-request credentials (#1770)

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/g2vinay-tenant-credential-threading.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/g2vinay-tenant-credential-threading.yaml
@@ -1,0 +1,5 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed `azmcp applicationinsights recommendation list` ignoring the `--tenant` option when creating the credential used to read Application Insights profiler data, which could cause requests to fail when the target tenant differed from the credential's default tenant."
+  - section: "Features Added"
+    description: "Added a `--tenant` option to the Azure Deploy, MySQL, PostgreSQL, Quota, and Azure AI Search commands that authenticate with per-request credentials, and propagated it through to credential creation so requests target the specified tenant."

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/ApplicationInsightsService.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/ApplicationInsightsService.cs
@@ -38,7 +38,7 @@ public class ApplicationInsightsService(IAzureService azureService, IProfilerDat
         List<JsonNode> results = [];
         var components = await GetApplicationInsightsComponentsAsync(subscription, resourceGroup, tenant, retryPolicy, cancellationToken).ConfigureAwait(false);
 
-        var insights = await _profilerDataClient.GetInsightsAsync(resourceIds: components.Select(c => c.Id), cancellationToken: cancellationToken).ConfigureAwait(false);
+        var insights = await _profilerDataClient.GetInsightsAsync(resourceIds: components.Select(c => c.Id), tenant: tenant, cancellationToken: cancellationToken).ConfigureAwait(false);
         results.AddRange(insights);
 
         // Return all results for this resource group (outer method enforces global max)

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/IProfilerDataService.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/IProfilerDataService.cs
@@ -11,5 +11,5 @@ public interface IProfilerDataService
     /// <summary>
     /// Get code optimization recommendations from multiple application insights resources.
     /// </summary>
-    Task<IEnumerable<JsonNode>> GetInsightsAsync(IEnumerable<ResourceIdentifier> resourceIds, DateTime? startDateTimeUtc = null, DateTime? endDateTimeUtc = null, CancellationToken cancellationToken = default);
+    Task<IEnumerable<JsonNode>> GetInsightsAsync(IEnumerable<ResourceIdentifier> resourceIds, DateTime? startDateTimeUtc = null, DateTime? endDateTimeUtc = null, string? tenant = null, CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/ProfilerDataService.cs
+++ b/tools/Azure.Mcp.Tools.ApplicationInsights/src/Services/ProfilerDataService.cs
@@ -29,7 +29,7 @@ public class ProfilerDataService(ILogger<ProfilerDataService> logger, IAzureServ
 
     private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-    public async Task<IEnumerable<JsonNode>> GetInsightsAsync(IEnumerable<ResourceIdentifier> resourceIds, DateTime? startDateTimeUtc = null, DateTime? endDateTimeUtc = null, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<JsonNode>> GetInsightsAsync(IEnumerable<ResourceIdentifier> resourceIds, DateTime? startDateTimeUtc = null, DateTime? endDateTimeUtc = null, string? tenant = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(resourceIds);
 
@@ -41,16 +41,17 @@ public class ProfilerDataService(ILogger<ProfilerDataService> logger, IAzureServ
         List<Guid> appIds = [];
         foreach (ResourceIdentifier resourceId in resourceIds)
         {
-            appIds.Add(await ResolveAppIdAsync(resourceId, cancellationToken).ConfigureAwait(false));
+            appIds.Add(await ResolveAppIdAsync(resourceId, cancellationToken, tenant).ConfigureAwait(false));
         }
 
-        return await GetInsightsAsync(appIds, startDateTimeUtc, endDateTimeUtc, cancellationToken).ConfigureAwait(false);
+        return await GetInsightsAsync(appIds, startDateTimeUtc, endDateTimeUtc, tenant, cancellationToken).ConfigureAwait(false);
     }
 
     private Task<IEnumerable<JsonNode>> GetInsightsAsync(
         IEnumerable<Guid> appIds,
         DateTime? startDateTimeUtc = null,
         DateTime? endDateTimeUtc = null,
+        string? tenant = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(appIds);
@@ -60,10 +61,10 @@ public class ProfilerDataService(ILogger<ProfilerDataService> logger, IAzureServ
             throw new ArgumentException($"'{nameof(appIds)}' cannot be empty.", nameof(appIds));
         }
 
-        return GetInsightsImpAsync(appIds, startDateTimeUtc, endDateTimeUtc, cancellationToken);
+        return GetInsightsImpAsync(appIds, startDateTimeUtc, endDateTimeUtc, tenant, cancellationToken);
     }
 
-    private async Task<IEnumerable<JsonNode>> GetInsightsImpAsync(IEnumerable<Guid> appIds, DateTime? startDateTimeUtc, DateTime? endDateTimeUtc, CancellationToken cancellationToken)
+    private async Task<IEnumerable<JsonNode>> GetInsightsImpAsync(IEnumerable<Guid> appIds, DateTime? startDateTimeUtc, DateTime? endDateTimeUtc, string? tenant, CancellationToken cancellationToken)
     {
         endDateTimeUtc ??= DateTime.UtcNow;
         startDateTimeUtc ??= endDateTimeUtc.Value.AddDays(-1);
@@ -81,7 +82,7 @@ public class ProfilerDataService(ILogger<ProfilerDataService> logger, IAzureServ
         };
 
         using JsonContent appsPostBody = JsonContent.Create(bulkAppsPostBody, ApplicationInsightsJsonContext.Default.BulkAppsPostBody, mediaType: MediaTypeHeaderValue.Parse("application/json"));
-        using HttpResponseMessage response = await PostAsync(path, queries, apiVersion: "2025-01-07-preview", clientRequestId: null, appsPostBody, additionalHeaders: null, cancellationToken: cancellationToken).ConfigureAwait(false);
+        using HttpResponseMessage response = await PostAsync(path, queries, apiVersion: "2025-01-07-preview", clientRequestId: null, appsPostBody, additionalHeaders: null, tenant: tenant, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return await JsonSerializer.DeserializeAsync(
             await response.Content.ReadAsStreamAsync(cancellationToken),
@@ -89,7 +90,7 @@ public class ProfilerDataService(ILogger<ProfilerDataService> logger, IAzureServ
             cancellationToken).ConfigureAwait(false) ?? [];
     }
 
-    private async Task<HttpRequestMessage> CreateRequestAsync(HttpMethod method, string path, IDictionary<string, string>? queries, string apiVersion, string? clientRequestId, HttpContent? httpContent, IDictionary<string, IEnumerable<string>>? additionalHeaders, CancellationToken cancellationToken)
+    private async Task<HttpRequestMessage> CreateRequestAsync(HttpMethod method, string path, IDictionary<string, string>? queries, string apiVersion, string? clientRequestId, HttpContent? httpContent, IDictionary<string, IEnumerable<string>>? additionalHeaders, string? tenant, CancellationToken cancellationToken)
     {
         UriBuilder uriBuilder = new(GetDiagnosticServiceEndpoint())
         {
@@ -116,7 +117,7 @@ public class ProfilerDataService(ILogger<ProfilerDataService> logger, IAzureServ
         };
         string clientRequestIdLocal = clientRequestId ?? Guid.NewGuid().ToString();
         TokenRequestContext tokenRequestContext = new(scopes, clientRequestIdLocal);
-        TokenCredential tokenCredential = await GetCredential(null, cancellationToken).ConfigureAwait(false);
+        TokenCredential tokenCredential = await GetCredential(tenant, cancellationToken).ConfigureAwait(false);
         AccessToken accessToken = await tokenCredential.GetTokenAsync(tokenRequestContext, cancellationToken).ConfigureAwait(false);
 
         request.Headers.Authorization = new("Bearer", accessToken.Token);
@@ -152,10 +153,11 @@ public class ProfilerDataService(ILogger<ProfilerDataService> logger, IAzureServ
     /// <param name="clientRequestId">Optional client request ID.</param>
     /// <param name="httpContent">The content of the incoming request.</param>
     /// <param name="additionalHeaders">Additional headers to be added to the request</param>
+    /// <param name="tenant">Optional tenant ID or name used to acquire the access token.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
-    internal async ValueTask<HttpResponseMessage> PostAsync(string path, IDictionary<string, string>? queries, string apiVersion, string? clientRequestId, HttpContent? httpContent, IDictionary<string, IEnumerable<string>>? additionalHeaders, CancellationToken cancellationToken)
+    internal async ValueTask<HttpResponseMessage> PostAsync(string path, IDictionary<string, string>? queries, string apiVersion, string? clientRequestId, HttpContent? httpContent, IDictionary<string, IEnumerable<string>>? additionalHeaders, string? tenant, CancellationToken cancellationToken)
     {
-        using HttpRequestMessage request = await CreateRequestAsync(HttpMethod.Post, path, queries, apiVersion, clientRequestId, httpContent, additionalHeaders, cancellationToken);
+        using HttpRequestMessage request = await CreateRequestAsync(HttpMethod.Post, path, queries, apiVersion, clientRequestId, httpContent, additionalHeaders, tenant, cancellationToken);
         var client = AzureService.GetClient();
         return await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }

--- a/tools/Azure.Mcp.Tools.Deploy/src/Commands/App/LogsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/src/Commands/App/LogsGetCommand.cs
@@ -37,6 +37,7 @@ public sealed class LogsGetCommand(ILogger<LogsGetCommand> logger, IDeployServic
                 options.AzdEnvName,
                 options.Subscription!,
                 options.Limit,
+                options.Tenant,
                 cancellationToken);
 
             context.Response.Message = result;

--- a/tools/Azure.Mcp.Tools.Deploy/src/Options/App/LogsGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/src/Options/App/LogsGetOptions.cs
@@ -17,6 +17,9 @@ public sealed class LogsGetOptions : ISubscriptionOption
     [Option(Description = "The maximum row number of logs to retrieve. Use this to get a specific number of logs or to avoid the retrieved logs from reaching token limit. Default is 200.", DefaultValue = 200)]
     public int? Limit { get; set; }
 
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Deploy/src/Services/DeployService.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/src/Services/DeployService.cs
@@ -15,10 +15,11 @@ public class DeployService(IAzureService azureService) : BaseAzureService(azureS
          string azdEnvName,
          string subscriptionId,
          int? limit = null,
+         string? tenant = null,
          CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(cancellationToken: cancellationToken);
-        var logsQueryClient = await CreateLogsQueryClientAsync(cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
+        var logsQueryClient = await CreateLogsQueryClientAsync(tenant, cancellationToken);
 
         string result = await AzdResourceLogService.GetAzdResourceLogsAsync(
             armClient,
@@ -31,9 +32,9 @@ public class DeployService(IAzureService azureService) : BaseAzureService(azureS
         return result;
     }
 
-    private async Task<LogsQueryClient> CreateLogsQueryClientAsync(CancellationToken cancellationToken)
+    private async Task<LogsQueryClient> CreateLogsQueryClientAsync(string? tenant, CancellationToken cancellationToken)
     {
-        var credential = await GetCredential(null, cancellationToken);
+        var credential = await GetCredential(tenant, cancellationToken);
         var options = AddDefaultPolicies(new LogsQueryClientOptions());
         options.Transport = new HttpClientTransport(AzureService.GetClient());
         return new(credential, options);

--- a/tools/Azure.Mcp.Tools.Deploy/src/Services/IDeployService.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/src/Services/IDeployService.cs
@@ -9,5 +9,7 @@ public interface IDeployService
         string workspaceFolder,
         string azdEnvName,
         string subscriptionId,
-        int? limit = null, CancellationToken cancellationToken = default);
+        int? limit = null,
+        string? tenant = null,
+        CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.Tests/Commands/App/LogsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.Tests/Commands/App/LogsGetCommandTests.cs
@@ -23,6 +23,7 @@ public class LogsGetCommandTests : SubscriptionCommandUnitTestsBase<LogsGetComma
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<int?>(),
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedLogs);
 
@@ -50,6 +51,7 @@ public class LogsGetCommandTests : SubscriptionCommandUnitTestsBase<LogsGetComma
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<int?>(),
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedLogs);
 
@@ -76,6 +78,7 @@ public class LogsGetCommandTests : SubscriptionCommandUnitTestsBase<LogsGetComma
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<int?>(),
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns("No logs found.");
 
@@ -102,6 +105,7 @@ public class LogsGetCommandTests : SubscriptionCommandUnitTestsBase<LogsGetComma
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<int?>(),
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(errorMessage);
 
@@ -127,6 +131,7 @@ public class LogsGetCommandTests : SubscriptionCommandUnitTestsBase<LogsGetComma
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<int?>(),
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Failed to connect to Azure"));
 

--- a/tools/Azure.Mcp.Tools.MySql/src/Commands/Database/DatabaseQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Commands/Database/DatabaseQueryCommand.cs
@@ -32,7 +32,7 @@ public sealed class DatabaseQueryCommand(ILogger<DatabaseQueryCommand> logger, I
     {
         try
         {
-            var result = await _mysqlService.ExecuteQueryAsync(options.Subscription!, options.ResourceGroup, options.User, options.Server, options.Database, options.Query, cancellationToken);
+            var result = await _mysqlService.ExecuteQueryAsync(options.Subscription!, options.ResourceGroup, options.User, options.Server, options.Database, options.Query, options.Tenant, cancellationToken);
             context.Response.Results = ResponseResult.Create(new(result ?? []), MySqlJsonContext.Default.DatabaseQueryCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.MySql/src/Commands/MySqlListCommand.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Commands/MySqlListCommand.cs
@@ -59,6 +59,7 @@ public sealed class MySqlListCommand(ILogger<MySqlListCommand> logger, IMySqlSer
                     options.User!,
                     options.Server!,
                     options.Database!,
+                    options.Tenant,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(
@@ -73,6 +74,7 @@ public sealed class MySqlListCommand(ILogger<MySqlListCommand> logger, IMySqlSer
                     options.ResourceGroup ?? string.Empty,
                     options.User!,
                     options.Server!,
+                    options.Tenant,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(
@@ -85,6 +87,7 @@ public sealed class MySqlListCommand(ILogger<MySqlListCommand> logger, IMySqlSer
                 List<string> servers = await _mysqlService.ListServersAsync(
                     options.Subscription!,
                     options.ResourceGroup,
+                    options.Tenant,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(
@@ -96,6 +99,7 @@ public sealed class MySqlListCommand(ILogger<MySqlListCommand> logger, IMySqlSer
                 // List all servers in the subscription
                 List<string> servers = await _mysqlService.ListServersInSubscriptionAsync(
                     options.Subscription!,
+                    options.Tenant,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.MySql/src/Commands/Server/ServerConfigGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Commands/Server/ServerConfigGetCommand.cs
@@ -32,7 +32,7 @@ public sealed class ServerConfigGetCommand(ILogger<ServerConfigGetCommand> logge
     {
         try
         {
-            var config = await _mysqlService.GetServerConfigAsync(options.Subscription!, options.ResourceGroup, options.Server, cancellationToken);
+            var config = await _mysqlService.GetServerConfigAsync(options.Subscription!, options.ResourceGroup, options.Server, options.Tenant, cancellationToken);
             context.Response.Results = !string.IsNullOrEmpty(config) ?
                 ResponseResult.Create(new(config), MySqlJsonContext.Default.ServerConfigGetCommandResult) :
                 null;

--- a/tools/Azure.Mcp.Tools.MySql/src/Commands/Server/ServerParamGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Commands/Server/ServerParamGetCommand.cs
@@ -32,7 +32,7 @@ public sealed class ServerParamGetCommand(ILogger<ServerParamGetCommand> logger,
     {
         try
         {
-            var paramValue = await _mysqlService.GetServerParameterAsync(options.Subscription!, options.ResourceGroup, options.Server, options.Param, cancellationToken);
+            var paramValue = await _mysqlService.GetServerParameterAsync(options.Subscription!, options.ResourceGroup, options.Server, options.Param, options.Tenant, cancellationToken);
             context.Response.Results = !string.IsNullOrEmpty(paramValue) ?
                 ResponseResult.Create(new(options.Param!, paramValue), MySqlJsonContext.Default.ServerParamGetCommandResult) :
                 null;

--- a/tools/Azure.Mcp.Tools.MySql/src/Commands/Server/ServerParamSetCommand.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Commands/Server/ServerParamSetCommand.cs
@@ -32,7 +32,7 @@ public sealed class ServerParamSetCommand(ILogger<ServerParamSetCommand> logger,
     {
         try
         {
-            var result = await _mysqlService.SetServerParameterAsync(options.Subscription!, options.ResourceGroup, options.Server, options.Param, options.Value, cancellationToken);
+            var result = await _mysqlService.SetServerParameterAsync(options.Subscription!, options.ResourceGroup, options.Server, options.Param, options.Value, options.Tenant, cancellationToken);
             context.Response.Results = !string.IsNullOrEmpty(result) ?
                 ResponseResult.Create(new(options.Param!, result), MySqlJsonContext.Default.ServerParamSetCommandResult) :
                 null;

--- a/tools/Azure.Mcp.Tools.MySql/src/Commands/Table/TableSchemaGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Commands/Table/TableSchemaGetCommand.cs
@@ -32,7 +32,7 @@ public sealed class TableSchemaGetCommand(ILogger<TableSchemaGetCommand> logger,
     {
         try
         {
-            var schema = await _mysqlService.GetTableSchemaAsync(options.Subscription!, options.ResourceGroup, options.User, options.Server, options.Database, options.Table, cancellationToken);
+            var schema = await _mysqlService.GetTableSchemaAsync(options.Subscription!, options.ResourceGroup, options.User, options.Server, options.Database, options.Table, options.Tenant, cancellationToken);
             context.Response.Results = ResponseResult.Create(new(schema ?? []), MySqlJsonContext.Default.TableSchemaGetCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.MySql/src/Options/BaseMySqlOptions.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Options/BaseMySqlOptions.cs
@@ -17,6 +17,9 @@ public class MySqlServerOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.ResourceGroup)]
     public required string ResourceGroup { get; set; }
 
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.MySql/src/Options/MySqlListOptions.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Options/MySqlListOptions.cs
@@ -20,6 +20,9 @@ public sealed class MySqlListOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.ResourceGroup)]
     public string? ResourceGroup { get; set; }
 
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.MySql/src/Services/IMySqlService.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Services/IMySqlService.cs
@@ -5,15 +5,15 @@ namespace Azure.Mcp.Tools.MySql.Services;
 
 public interface IMySqlService
 {
-    Task<List<string>> ListDatabasesAsync(string subscriptionId, string resourceGroup, string user, string server, CancellationToken cancellationToken);
-    Task<List<string>> ExecuteQueryAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string query, CancellationToken cancellationToken);
+    Task<List<string>> ListDatabasesAsync(string subscriptionId, string resourceGroup, string user, string server, string? tenant, CancellationToken cancellationToken);
+    Task<List<string>> ExecuteQueryAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string query, string? tenant, CancellationToken cancellationToken);
 
-    Task<TableListResult> GetTablesAsync(string subscriptionId, string resourceGroup, string user, string server, string database, CancellationToken cancellationToken);
-    Task<List<string>> GetTableSchemaAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string table, CancellationToken cancellationToken);
+    Task<TableListResult> GetTablesAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string? tenant, CancellationToken cancellationToken);
+    Task<List<string>> GetTableSchemaAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string table, string? tenant, CancellationToken cancellationToken);
 
-    Task<List<string>> ListServersAsync(string subscriptionId, string resourceGroup, CancellationToken cancellationToken);
-    Task<List<string>> ListServersInSubscriptionAsync(string subscriptionId, CancellationToken cancellationToken);
-    Task<string> GetServerConfigAsync(string subscriptionId, string resourceGroup, string server, CancellationToken cancellationToken);
-    Task<string> GetServerParameterAsync(string subscriptionId, string resourceGroup, string server, string param, CancellationToken cancellationToken);
-    Task<string> SetServerParameterAsync(string subscription, string resourceGroup, string server, string param, string value, CancellationToken cancellationToken);
+    Task<List<string>> ListServersAsync(string subscriptionId, string resourceGroup, string? tenant, CancellationToken cancellationToken);
+    Task<List<string>> ListServersInSubscriptionAsync(string subscriptionId, string? tenant, CancellationToken cancellationToken);
+    Task<string> GetServerConfigAsync(string subscriptionId, string resourceGroup, string server, string? tenant, CancellationToken cancellationToken);
+    Task<string> GetServerParameterAsync(string subscriptionId, string resourceGroup, string server, string param, string? tenant, CancellationToken cancellationToken);
+    Task<string> SetServerParameterAsync(string subscription, string resourceGroup, string server, string param, string value, string? tenant, CancellationToken cancellationToken);
 }

--- a/tools/Azure.Mcp.Tools.MySql/src/Services/MySqlService.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Services/MySqlService.cs
@@ -77,9 +77,9 @@ public sealed class MySqlService(IAzureService azureService)
         @"\b(" + string.Join("|", ObfuscationFunctions.Select(Regex.Escape)) + @")\s*\(",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    private async Task<string> GetEntraIdAccessTokenAsync(CancellationToken cancellationToken)
+    private async Task<string> GetEntraIdAccessTokenAsync(string? tenant, CancellationToken cancellationToken)
     {
-        var tokenCredential = await GetCredential(null, cancellationToken);
+        var tokenCredential = await GetCredential(tenant, cancellationToken);
         var accessToken = await tokenCredential.GetTokenAsync(new([GetOpenSourceRDBMSScope()]), cancellationToken);
         return accessToken.Token;
     }
@@ -133,10 +133,10 @@ public sealed class MySqlService(IAzureService azureService)
         return server;
     }
 
-    private async Task<string> BuildConnectionStringAsync(string server, string user, string database, CancellationToken cancellationToken)
+    private async Task<string> BuildConnectionStringAsync(string server, string user, string database, string? tenant, CancellationToken cancellationToken)
     {
         var host = NormalizeServerName(server);
-        var entraIdAccessToken = await GetEntraIdAccessTokenAsync(cancellationToken);
+        var entraIdAccessToken = await GetEntraIdAccessTokenAsync(tenant, cancellationToken);
         return BuildConnectionString(host, database, user, entraIdAccessToken);
     }
 
@@ -225,9 +225,9 @@ public sealed class MySqlService(IAzureService azureService)
     internal static (string Query, List<(string Name, string Value)> Parameters) ParameterizeStringLiterals(string query) =>
         SqlQueryParameterizer.Parameterize(query, SqlQueryParameterizer.SqlDialect.MySql);
 
-    public async Task<List<string>> ListDatabasesAsync(string subscriptionId, string resourceGroup, string user, string server, CancellationToken cancellationToken)
+    public async Task<List<string>> ListDatabasesAsync(string subscriptionId, string resourceGroup, string user, string server, string? tenant, CancellationToken cancellationToken)
     {
-        var connectionString = await BuildConnectionStringAsync(server, user, "mysql", cancellationToken);
+        var connectionString = await BuildConnectionStringAsync(server, user, "mysql", tenant, cancellationToken);
 
         await using var resource = await MySqlResource.CreateAsync(connectionString, cancellationToken);
         var query = "SHOW DATABASES;";
@@ -254,13 +254,13 @@ public sealed class MySqlService(IAzureService azureService)
         return dbs;
     }
 
-    public async Task<List<string>> ExecuteQueryAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string query, CancellationToken cancellationToken)
+    public async Task<List<string>> ExecuteQueryAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string query, string? tenant, CancellationToken cancellationToken)
     {
         ValidateQuerySafety(query);
 
         var (parameterizedQuery, queryParameters) = ParameterizeStringLiterals(query);
 
-        var connectionString = await BuildConnectionStringAsync(server, user, database, cancellationToken);
+        var connectionString = await BuildConnectionStringAsync(server, user, database, tenant, cancellationToken);
 
         await using var resource = await MySqlResource.CreateAsync(connectionString, cancellationToken);
         await using var command = new MySqlCommand(parameterizedQuery, resource.Connection);
@@ -300,9 +300,9 @@ public sealed class MySqlService(IAzureService azureService)
         return rows;
     }
 
-    public async Task<List<string>> GetTableSchemaAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string table, CancellationToken cancellationToken)
+    public async Task<List<string>> GetTableSchemaAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string table, string? tenant, CancellationToken cancellationToken)
     {
-        var connectionString = await BuildConnectionStringAsync(server, user, database, cancellationToken);
+        var connectionString = await BuildConnectionStringAsync(server, user, database, tenant, cancellationToken);
 
         await using var resource = await MySqlResource.CreateAsync(connectionString, cancellationToken);
         var query = "SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = @table;";
@@ -317,9 +317,9 @@ public sealed class MySqlService(IAzureService azureService)
         return schema;
     }
 
-    public async Task<List<string>> ListServersAsync(string subscriptionId, string resourceGroup, CancellationToken cancellationToken)
+    public async Task<List<string>> ListServersAsync(string subscriptionId, string resourceGroup, string? tenant, CancellationToken cancellationToken)
     {
-        var rg = await AzureService.GetResourceGroupResource(subscriptionId, resourceGroup, null, null, cancellationToken)
+        var rg = await AzureService.GetResourceGroupResource(subscriptionId, resourceGroup, tenant, null, cancellationToken)
             ?? throw new KeyNotFoundException($"Resource group '{resourceGroup}' not found.");
 
         var serverList = new List<string>();
@@ -330,9 +330,9 @@ public sealed class MySqlService(IAzureService azureService)
         return serverList;
     }
 
-    public async Task<List<string>> ListServersInSubscriptionAsync(string subscriptionId, CancellationToken cancellationToken)
+    public async Task<List<string>> ListServersInSubscriptionAsync(string subscriptionId, string? tenant, CancellationToken cancellationToken)
     {
-        var subscriptionResource = await AzureService.GetSubscription(subscriptionId, cancellationToken: cancellationToken);
+        var subscriptionResource = await AzureService.GetSubscription(subscriptionId, tenant, cancellationToken: cancellationToken);
         var serverList = new List<string>();
         await foreach (MySqlFlexibleServerResource server in subscriptionResource.GetMySqlFlexibleServersAsync(cancellationToken: cancellationToken))
         {
@@ -341,9 +341,9 @@ public sealed class MySqlService(IAzureService azureService)
         return serverList;
     }
 
-    public async Task<TableListResult> GetTablesAsync(string subscriptionId, string resourceGroup, string user, string server, string database, CancellationToken cancellationToken)
+    public async Task<TableListResult> GetTablesAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string? tenant, CancellationToken cancellationToken)
     {
-        var connectionString = await BuildConnectionStringAsync(server, user, database, cancellationToken);
+        var connectionString = await BuildConnectionStringAsync(server, user, database, tenant, cancellationToken);
 
         await using var resource = await MySqlResource.CreateAsync(connectionString, cancellationToken);
         var query = "SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE();";
@@ -362,9 +362,9 @@ public sealed class MySqlService(IAzureService azureService)
         return new TableListResult(tables, isTruncated);
     }
 
-    public async Task<string> GetServerConfigAsync(string subscriptionId, string resourceGroup, string server, CancellationToken cancellationToken)
+    public async Task<string> GetServerConfigAsync(string subscriptionId, string resourceGroup, string server, string? tenant, CancellationToken cancellationToken)
     {
-        var rg = await AzureService.GetResourceGroupResource(subscriptionId, resourceGroup, null, null, cancellationToken)
+        var rg = await AzureService.GetResourceGroupResource(subscriptionId, resourceGroup, tenant, null, cancellationToken)
             ?? throw new KeyNotFoundException($"Resource group '{resourceGroup}' not found.");
 
         var mysqlServer = await rg.GetMySqlFlexibleServerAsync(server, cancellationToken);
@@ -382,9 +382,9 @@ public sealed class MySqlService(IAzureService azureService)
         return System.Text.Json.JsonSerializer.Serialize(config, MySqlJsonContext.Default.ServerConfigGetResult);
     }
 
-    public async Task<string> GetServerParameterAsync(string subscriptionId, string resourceGroup, string server, string param, CancellationToken cancellationToken)
+    public async Task<string> GetServerParameterAsync(string subscriptionId, string resourceGroup, string server, string param, string? tenant, CancellationToken cancellationToken)
     {
-        var rg = await AzureService.GetResourceGroupResource(subscriptionId, resourceGroup, null, null, cancellationToken)
+        var rg = await AzureService.GetResourceGroupResource(subscriptionId, resourceGroup, tenant, null, cancellationToken)
             ?? throw new KeyNotFoundException($"Resource group '{resourceGroup}' not found.");
 
         var mysqlServer = await rg.GetMySqlFlexibleServerAsync(server, cancellationToken);
@@ -397,9 +397,9 @@ public sealed class MySqlService(IAzureService azureService)
         return configResponse.Value.Data.Value;
     }
 
-    public async Task<string> SetServerParameterAsync(string subscriptionId, string resourceGroup, string server, string param, string value, CancellationToken cancellationToken)
+    public async Task<string> SetServerParameterAsync(string subscriptionId, string resourceGroup, string server, string param, string value, string? tenant, CancellationToken cancellationToken)
     {
-        var rg = await AzureService.GetResourceGroupResource(subscriptionId, resourceGroup, null, null, cancellationToken)
+        var rg = await AzureService.GetResourceGroupResource(subscriptionId, resourceGroup, tenant, null, cancellationToken)
             ?? throw new KeyNotFoundException($"Resource group '{resourceGroup}' not found.");
 
         var mysqlServer = await rg.GetMySqlFlexibleServerAsync(server, cancellationToken);

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Database/DatabaseQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Database/DatabaseQueryCommandTests.cs
@@ -18,7 +18,7 @@ public class DatabaseQueryCommandTests : SubscriptionCommandUnitTestsBase<Databa
     public async Task ExecuteAsync_ReturnsResults_WhenQuerySucceeds()
     {
         var expectedResults = new List<string> { "id, name", "1, John", "2, Jane" };
-        Service.ExecuteQueryAsync("sub123", "rg1", "user1", "server1", "db1", "SELECT * FROM users", Arg.Any<CancellationToken>()).Returns(expectedResults);
+        Service.ExecuteQueryAsync("sub123", "rg1", "user1", "server1", "db1", "SELECT * FROM users", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedResults);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -35,7 +35,7 @@ public class DatabaseQueryCommandTests : SubscriptionCommandUnitTestsBase<Databa
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenQueryFails()
     {
-        Service.ExecuteQueryAsync("sub123", "rg1", "user1", "server1", "db1", "INVALID SQL", Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException("Syntax error"));
+        Service.ExecuteQueryAsync("sub123", "rg1", "user1", "server1", "db1", "INVALID SQL", Arg.Any<string?>(), Arg.Any<CancellationToken>()).ThrowsAsync(new InvalidOperationException("Syntax error"));
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/MySqlListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/MySqlListCommandTests.cs
@@ -17,7 +17,7 @@ public class MySqlListCommandTests : SubscriptionCommandUnitTestsBase<MySqlListC
     public async Task ExecuteAsync_ListsServersInSubscription_WhenNoResourceGroupOrServerProvided()
     {
         var expectedServers = new List<string> { "mysql-server-1", "mysql-server-2", "mysql-server-3" };
-        Service.ListServersInSubscriptionAsync("sub123", Arg.Any<CancellationToken>()).Returns(expectedServers);
+        Service.ListServersInSubscriptionAsync("sub123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedServers);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123");
@@ -39,7 +39,7 @@ public class MySqlListCommandTests : SubscriptionCommandUnitTestsBase<MySqlListC
     public async Task ExecuteAsync_ListsServersInResourceGroup_WhenResourceGroupProvided()
     {
         var expectedServers = new List<string> { "mysql-server-1", "mysql-server-2" };
-        Service.ListServersAsync("sub123", "rg1", Arg.Any<CancellationToken>()).Returns(expectedServers);
+        Service.ListServersAsync("sub123", "rg1", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedServers);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -55,7 +55,7 @@ public class MySqlListCommandTests : SubscriptionCommandUnitTestsBase<MySqlListC
     public async Task ExecuteAsync_ListsDatabases_WhenServerProvided()
     {
         var expectedDatabases = new List<string> { "db1", "db2", "db3" };
-        Service.ListDatabasesAsync("sub123", Arg.Any<string>(), "user1", "server1", Arg.Any<CancellationToken>()).Returns(expectedDatabases);
+        Service.ListDatabasesAsync("sub123", Arg.Any<string>(), "user1", "server1", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedDatabases);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -72,7 +72,7 @@ public class MySqlListCommandTests : SubscriptionCommandUnitTestsBase<MySqlListC
     public async Task ExecuteAsync_ListsTables_WhenServerAndDatabaseProvided()
     {
         var expectedTables = new List<string> { "users", "products", "orders" };
-        Service.GetTablesAsync("sub123", Arg.Any<string>(), "user1", "server1", "db1", Arg.Any<CancellationToken>())
+        Service.GetTablesAsync("sub123", Arg.Any<string>(), "user1", "server1", "db1", Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new TableListResult(expectedTables, false));
 
         var response = await ExecuteCommandAsync(
@@ -91,7 +91,7 @@ public class MySqlListCommandTests : SubscriptionCommandUnitTestsBase<MySqlListC
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoServersExistInSubscription()
     {
-        Service.ListServersInSubscriptionAsync("sub123", Arg.Any<CancellationToken>()).Returns([]);
+        Service.ListServersInSubscriptionAsync("sub123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns([]);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123");
@@ -106,7 +106,7 @@ public class MySqlListCommandTests : SubscriptionCommandUnitTestsBase<MySqlListC
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoServersExistInResourceGroup()
     {
-        Service.ListServersAsync("sub123", "rg1", Arg.Any<CancellationToken>()).Returns([]);
+        Service.ListServersAsync("sub123", "rg1", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns([]);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -122,7 +122,7 @@ public class MySqlListCommandTests : SubscriptionCommandUnitTestsBase<MySqlListC
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoDatabasesExist()
     {
-        Service.ListDatabasesAsync("sub123", Arg.Any<string>(), "user1", "server1", Arg.Any<CancellationToken>()).Returns([]);
+        Service.ListDatabasesAsync("sub123", Arg.Any<string>(), "user1", "server1", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns([]);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -139,7 +139,7 @@ public class MySqlListCommandTests : SubscriptionCommandUnitTestsBase<MySqlListC
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoTablesExist()
     {
-        Service.GetTablesAsync("sub123", Arg.Any<string>(), "user1", "server1", "db1", Arg.Any<CancellationToken>())
+        Service.GetTablesAsync("sub123", Arg.Any<string>(), "user1", "server1", "db1", Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new TableListResult([], false));
 
         var response = await ExecuteCommandAsync(
@@ -159,7 +159,7 @@ public class MySqlListCommandTests : SubscriptionCommandUnitTestsBase<MySqlListC
     [Fact]
     public async Task ExecuteAsync_SetsTablesTruncated_WhenTableResultsAreTruncated()
     {
-        Service.GetTablesAsync("sub123", Arg.Any<string>(), "user1", "server1", "db1", Arg.Any<CancellationToken>())
+        Service.GetTablesAsync("sub123", Arg.Any<string>(), "user1", "server1", "db1", Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new TableListResult(["users"], true));
 
         var response = await ExecuteCommandAsync(
@@ -177,7 +177,7 @@ public class MySqlListCommandTests : SubscriptionCommandUnitTestsBase<MySqlListC
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenListServersInSubscriptionThrows()
     {
-        Service.ListServersInSubscriptionAsync("sub123", Arg.Any<CancellationToken>())
+        Service.ListServersInSubscriptionAsync("sub123", Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
         var response = await ExecuteCommandAsync(
@@ -191,7 +191,7 @@ public class MySqlListCommandTests : SubscriptionCommandUnitTestsBase<MySqlListC
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenListServersInResourceGroupThrows()
     {
-        Service.ListServersAsync("sub123", "rg1", Arg.Any<CancellationToken>())
+        Service.ListServersAsync("sub123", "rg1", Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
         var response = await ExecuteCommandAsync(
@@ -206,7 +206,7 @@ public class MySqlListCommandTests : SubscriptionCommandUnitTestsBase<MySqlListC
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenListDatabasesThrows()
     {
-        Service.ListDatabasesAsync("sub123", Arg.Any<string>(), "user1", "server1", Arg.Any<CancellationToken>())
+        Service.ListDatabasesAsync("sub123", Arg.Any<string>(), "user1", "server1", Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
         var response = await ExecuteCommandAsync(
@@ -222,7 +222,7 @@ public class MySqlListCommandTests : SubscriptionCommandUnitTestsBase<MySqlListC
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenGetTablesThrows()
     {
-        Service.GetTablesAsync("sub123", Arg.Any<string>(), "user1", "server1", "db1", Arg.Any<CancellationToken>())
+        Service.GetTablesAsync("sub123", Arg.Any<string>(), "user1", "server1", "db1", Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Server/ServerConfigGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Server/ServerConfigGetCommandTests.cs
@@ -29,7 +29,7 @@ public class ServerConfigGetCommandTests : SubscriptionCommandUnitTestsBase<Serv
             GeoRedundantBackup = "Disabled"
         }, MySqlJsonContext.Default.ServerConfigGetResult);
 
-        Service.GetServerConfigAsync("sub123", "rg1", "test-server", Arg.Any<CancellationToken>()).Returns(expectedConfig);
+        Service.GetServerConfigAsync("sub123", "rg1", "test-server", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedConfig);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -43,7 +43,7 @@ public class ServerConfigGetCommandTests : SubscriptionCommandUnitTestsBase<Serv
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenServiceThrows()
     {
-        Service.GetServerConfigAsync("sub123", "rg1", "test-server", Arg.Any<CancellationToken>())
+        Service.GetServerConfigAsync("sub123", "rg1", "test-server", Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Server/ServerParamGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Server/ServerParamGetCommandTests.cs
@@ -18,7 +18,7 @@ public class ServerParamGetCommandTests : SubscriptionCommandUnitTestsBase<Serve
     public async Task ExecuteAsync_ReturnsParameter_WhenSuccessful()
     {
         var expectedValue = "ON";
-        Service.GetServerParameterAsync("sub123", "rg1", "test-server", "max_connections", Arg.Any<CancellationToken>()).Returns(expectedValue);
+        Service.GetServerParameterAsync("sub123", "rg1", "test-server", "max_connections", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedValue);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -34,7 +34,7 @@ public class ServerParamGetCommandTests : SubscriptionCommandUnitTestsBase<Serve
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenServiceThrows()
     {
-        Service.GetServerParameterAsync("sub123", "rg1", "test-server", "invalid_param", Arg.Any<CancellationToken>())
+        Service.GetServerParameterAsync("sub123", "rg1", "test-server", "invalid_param", Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Parameter 'invalid_param' not found."));
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Server/ServerParamSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Server/ServerParamSetCommandTests.cs
@@ -18,7 +18,7 @@ public class ServerParamSetCommandTests : SubscriptionCommandUnitTestsBase<Serve
     public async Task ExecuteAsync_SetsParameter_WhenSuccessful()
     {
         var newValue = "100";
-        Service.SetServerParameterAsync("sub123", "rg1", "test-server", "max_connections", newValue, Arg.Any<CancellationToken>()).Returns(newValue);
+        Service.SetServerParameterAsync("sub123", "rg1", "test-server", "max_connections", newValue, Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(newValue);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -35,7 +35,7 @@ public class ServerParamSetCommandTests : SubscriptionCommandUnitTestsBase<Serve
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenServiceThrows()
     {
-        Service.SetServerParameterAsync("sub123", "rg1", "test-server", "invalid_param", "100", Arg.Any<CancellationToken>())
+        Service.SetServerParameterAsync("sub123", "rg1", "test-server", "invalid_param", "100", Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Parameter 'invalid_param' not found."));
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Services/MySqlServiceServerNameValidationTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Services/MySqlServiceServerNameValidationTests.cs
@@ -38,6 +38,7 @@ public class MySqlServiceServerNameValidationTests
             _mysqlService.ListDatabasesAsync(
                 "test-sub", "test-rg", "test-user",
                 maliciousServer,
+                null,
                 TestContext.Current.CancellationToken));
 
         Assert.Contains("not a valid Azure Database for MySQL hostname", ex.Message);
@@ -52,6 +53,7 @@ public class MySqlServiceServerNameValidationTests
             _mysqlService.ExecuteQueryAsync(
                 "test-sub", "test-rg", "test-user",
                 maliciousServer, "testdb", "SELECT 1",
+                null,
                 TestContext.Current.CancellationToken));
 
         Assert.Contains("not a valid Azure Database for MySQL hostname", ex.Message);
@@ -66,6 +68,7 @@ public class MySqlServiceServerNameValidationTests
             _mysqlService.GetTablesAsync(
                 "test-sub", "test-rg", "test-user",
                 maliciousServer, "testdb",
+                null,
                 TestContext.Current.CancellationToken));
 
         Assert.Contains("not a valid Azure Database for MySQL hostname", ex.Message);
@@ -80,6 +83,7 @@ public class MySqlServiceServerNameValidationTests
             _mysqlService.GetTableSchemaAsync(
                 "test-sub", "test-rg", "test-user",
                 maliciousServer, "testdb", "test_table",
+                null,
                 TestContext.Current.CancellationToken));
 
         Assert.Contains("not a valid Azure Database for MySQL hostname", ex.Message);

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Services/MySqlServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Services/MySqlServiceTests.cs
@@ -42,7 +42,7 @@ public class MySqlServiceTests
         _azureService.GetResourceGroupResource("sub123", "rg1", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>()).ThrowsAsync(exception);
 
         var thrownException = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _mysqlService.ListServersAsync("sub123", "rg1", TestContext.Current.CancellationToken));
+            _mysqlService.ListServersAsync("sub123", "rg1", null, TestContext.Current.CancellationToken));
 
         Assert.Equal(exception, thrownException);
     }
@@ -54,7 +54,7 @@ public class MySqlServiceTests
         _azureService.GetSubscription("sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>()).ThrowsAsync(exception);
 
         var thrownException = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _mysqlService.ListServersInSubscriptionAsync("sub123", TestContext.Current.CancellationToken));
+            _mysqlService.ListServersInSubscriptionAsync("sub123", null, TestContext.Current.CancellationToken));
 
         Assert.Equal(exception, thrownException);
     }
@@ -66,7 +66,7 @@ public class MySqlServiceTests
             .Returns(Task.FromResult<Azure.ResourceManager.Resources.ResourceGroupResource?>(null));
 
         var ex = await Assert.ThrowsAsync<KeyNotFoundException>(() =>
-            _mysqlService.ListServersAsync("sub123", "missing-rg", TestContext.Current.CancellationToken));
+            _mysqlService.ListServersAsync("sub123", "missing-rg", null, TestContext.Current.CancellationToken));
 
         Assert.Contains("missing-rg", ex.Message);
     }
@@ -78,7 +78,7 @@ public class MySqlServiceTests
             .Returns(Task.FromResult<Azure.ResourceManager.Resources.ResourceGroupResource?>(null));
 
         var ex = await Assert.ThrowsAsync<KeyNotFoundException>(() =>
-            _mysqlService.GetServerConfigAsync("sub123", "missing-rg", "some-server", TestContext.Current.CancellationToken));
+            _mysqlService.GetServerConfigAsync("sub123", "missing-rg", "some-server", null, TestContext.Current.CancellationToken));
 
         Assert.Contains("missing-rg", ex.Message);
     }
@@ -90,7 +90,7 @@ public class MySqlServiceTests
             .Returns(Task.FromResult<Azure.ResourceManager.Resources.ResourceGroupResource?>(null));
 
         var ex = await Assert.ThrowsAsync<KeyNotFoundException>(() =>
-            _mysqlService.GetServerParameterAsync("sub123", "missing-rg", "some-server", "some-param", TestContext.Current.CancellationToken));
+            _mysqlService.GetServerParameterAsync("sub123", "missing-rg", "some-server", "some-param", null, TestContext.Current.CancellationToken));
 
         Assert.Contains("missing-rg", ex.Message);
     }
@@ -102,7 +102,7 @@ public class MySqlServiceTests
             .Returns(Task.FromResult<Azure.ResourceManager.Resources.ResourceGroupResource?>(null));
 
         var ex = await Assert.ThrowsAsync<KeyNotFoundException>(() =>
-            _mysqlService.SetServerParameterAsync("sub123", "missing-rg", "some-server", "some-param", "some-value", TestContext.Current.CancellationToken));
+            _mysqlService.SetServerParameterAsync("sub123", "missing-rg", "some-server", "some-param", "some-value", null, TestContext.Current.CancellationToken));
 
         Assert.Contains("missing-rg", ex.Message);
     }

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Table/TableSchemaGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Table/TableSchemaGetCommandTests.cs
@@ -18,7 +18,7 @@ public class TableSchemaGetCommandTests : SubscriptionCommandUnitTestsBase<Table
     public async Task ExecuteAsync_ReturnsSchema_WhenSuccessful()
     {
         var expectedSchema = new List<string> { "id INT PRIMARY KEY", "name VARCHAR(100) NOT NULL", "email VARCHAR(255)" };
-        Service.GetTableSchemaAsync("sub123", "rg1", "user1", "server1", "db1", "users", Arg.Any<CancellationToken>()).Returns(expectedSchema);
+        Service.GetTableSchemaAsync("sub123", "rg1", "user1", "server1", "db1", "users", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedSchema);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -35,7 +35,7 @@ public class TableSchemaGetCommandTests : SubscriptionCommandUnitTestsBase<Table
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenTableNotFound()
     {
-        Service.GetTableSchemaAsync("sub123", "rg1", "user1", "server1", "db1", "nonexistent", Arg.Any<CancellationToken>()).ThrowsAsync(new ArgumentException("Table not found"));
+        Service.GetTableSchemaAsync("sub123", "rg1", "user1", "server1", "db1", "nonexistent", Arg.Any<string?>(), Arg.Any<CancellationToken>()).ThrowsAsync(new ArgumentException("Table not found"));
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Database/DatabaseQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Database/DatabaseQueryCommand.cs
@@ -40,6 +40,7 @@ public sealed class DatabaseQueryCommand(IPostgresService postgresService, ILogg
                 options.Server,
                 options.Database,
                 options.Query,
+                options.Tenant,
                 cancellationToken);
             context.Response.Results = ResponseResult.Create(new(queryResult ?? []), PostgresJsonContext.Default.DatabaseQueryCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/PostgresListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/PostgresListCommand.cs
@@ -60,6 +60,7 @@ public sealed class PostgresListCommand(IPostgresService postgresService, ILogge
                     options.Server!,
                     options.Database!,
                     string.IsNullOrEmpty(options.Schema) ? "public" : options.Schema,
+                    options.Tenant,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(
@@ -74,6 +75,7 @@ public sealed class PostgresListCommand(IPostgresService postgresService, ILogge
                     options.User!,
                     options.Password,
                     options.Server!,
+                    options.Tenant,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(
@@ -86,6 +88,7 @@ public sealed class PostgresListCommand(IPostgresService postgresService, ILogge
                 List<string> servers = await _postgresService.ListServersAsync(
                     options.Subscription!,
                     options.ResourceGroup,
+                    options.Tenant,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Table/TableSchemaGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Table/TableSchemaGetCommand.cs
@@ -38,6 +38,7 @@ public sealed class TableSchemaGetCommand(IPostgresService postgresService, ILog
                 options.Server,
                 options.Database,
                 options.Table,
+                options.Tenant,
                 cancellationToken);
             context.Response.Results = ResponseResult.Create(new(schema ?? []), PostgresJsonContext.Default.TableSchemaGetCommandResult);
         }

--- a/tools/Azure.Mcp.Tools.Postgres/src/Options/Database/DatabaseQueryOptions.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Options/Database/DatabaseQueryOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Postgres.Options.Database;
@@ -24,4 +25,7 @@ public sealed class DatabaseQueryOptions
 
     [Option(Description = PostgresOptionDefinitions.DatabaseDescription)]
     public required string Database { get; set; }
+
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/src/Options/PostgresListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Options/PostgresListOptions.cs
@@ -29,6 +29,9 @@ public sealed class PostgresListOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.ResourceGroup)]
     public string? ResourceGroup { get; set; }
 
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/src/Options/Table/TableSchemaGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Options/Table/TableSchemaGetOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Postgres.Options.Table;
@@ -24,4 +25,7 @@ public sealed class TableSchemaGetOptions
 
     [Option(Description = PostgresOptionDefinitions.DatabaseDescription)]
     public required string Database { get; set; }
+
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/src/Services/IPostgresService.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Services/IPostgresService.cs
@@ -12,6 +12,7 @@ public interface IPostgresService
         string user,
         string? password,
         string server,
+        string? tenant,
         CancellationToken cancellationToken);
 
     Task<List<string>> ExecuteQueryAsync(
@@ -21,6 +22,7 @@ public interface IPostgresService
         string server,
         string database,
         string query,
+        string? tenant,
         CancellationToken cancellationToken);
 
     Task<TableListResult> ListTablesAsync(
@@ -30,6 +32,7 @@ public interface IPostgresService
         string server,
         string database,
         string schema,
+        string? tenant,
         CancellationToken cancellationToken);
 
     Task<List<string>> GetTableSchemaAsync(
@@ -39,11 +42,13 @@ public interface IPostgresService
         string server,
         string database,
         string table,
+        string? tenant,
         CancellationToken cancellationToken);
 
     Task<List<string>> ListServersAsync(
         string subscriptionId,
         string? resourceGroup,
+        string? tenant,
         CancellationToken cancellationToken);
 
     Task<string> GetServerConfigAsync(

--- a/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
@@ -26,9 +26,9 @@ public class PostgresService(IAzureService azureService, IEntraTokenProvider ent
 
     internal const int MaxRowCount = 10_000;
 
-    private async Task<string> GetEntraIdAccessTokenAsync(CancellationToken cancellationToken)
+    private async Task<string> GetEntraIdAccessTokenAsync(string? tenant, CancellationToken cancellationToken)
     {
-        var tokenCredential = await GetCredential(null, cancellationToken);
+        var tokenCredential = await GetCredential(tenant, cancellationToken);
         var accessToken = await _entraTokenAuth.GetEntraToken(tokenCredential, cancellationToken);
 
         return accessToken.Token;
@@ -73,9 +73,10 @@ public class PostgresService(IAzureService azureService, IEntraTokenProvider ent
         string user,
         string? password,
         string server,
+        string? tenant,
         CancellationToken cancellationToken)
     {
-        string? passwordToUse = await GetPassword(authType, password, cancellationToken);
+        string? passwordToUse = await GetPassword(authType, password, tenant, cancellationToken);
         var host = NormalizeServerName(server);
         var connectionString = BuildConnectionString(host, "postgres", user, passwordToUse);
 
@@ -107,9 +108,10 @@ public class PostgresService(IAzureService azureService, IEntraTokenProvider ent
         string server,
         string database,
         string query,
+        string? tenant,
         CancellationToken cancellationToken)
     {
-        string? passwordToUse = await GetPassword(authType, password, cancellationToken);
+        string? passwordToUse = await GetPassword(authType, password, tenant, cancellationToken);
         var host = NormalizeServerName(server);
         var connectionString = BuildConnectionString(host, database, user, passwordToUse);
 
@@ -163,9 +165,10 @@ public class PostgresService(IAzureService azureService, IEntraTokenProvider ent
         string server,
         string database,
         string schema,
+        string? tenant,
         CancellationToken cancellationToken)
     {
-        string? passwordToUse = await GetPassword(authType, password, cancellationToken);
+        string? passwordToUse = await GetPassword(authType, password, tenant, cancellationToken);
         var host = NormalizeServerName(server);
         var connectionString = BuildConnectionString(host, database, user, passwordToUse);
 
@@ -198,9 +201,10 @@ public class PostgresService(IAzureService azureService, IEntraTokenProvider ent
         string server,
         string database,
         string table,
+        string? tenant,
         CancellationToken cancellationToken)
     {
-        string? passwordToUse = await GetPassword(authType, password, cancellationToken);
+        string? passwordToUse = await GetPassword(authType, password, tenant, cancellationToken);
         var host = NormalizeServerName(server);
         var connectionString = BuildConnectionString(host, database, user, passwordToUse);
 
@@ -220,6 +224,7 @@ public class PostgresService(IAzureService azureService, IEntraTokenProvider ent
     public async Task<List<string>> ListServersAsync(
         string subscriptionId,
         string? resourceGroup,
+        string? tenant,
         CancellationToken cancellationToken)
     {
         var serverList = new List<string>();
@@ -227,14 +232,14 @@ public class PostgresService(IAzureService azureService, IEntraTokenProvider ent
         if (string.IsNullOrEmpty(resourceGroup))
         {
             // List all Flexible Servers across the entire subscription
-            var subscription = await AzureService.GetSubscription(subscriptionId, cancellationToken: cancellationToken);
+            var subscription = await AzureService.GetSubscription(subscriptionId, tenant, cancellationToken: cancellationToken);
             await foreach (var name in ListSubscriptionServerNamesAsync(subscription, cancellationToken))
                 serverList.Add(name);
         }
         else
         {
             // List Flexible Servers scoped to the given resource group
-            var rg = await AzureService.GetResourceGroupResource(subscriptionId, resourceGroup, cancellationToken: cancellationToken);
+            var rg = await AzureService.GetResourceGroupResource(subscriptionId, resourceGroup, tenant, cancellationToken: cancellationToken);
             if (rg == null)
                 throw new Exception($"Resource group '{resourceGroup}' not found.");
             await foreach (var name in ListResourceGroupServerNamesAsync(rg, cancellationToken))
@@ -364,11 +369,11 @@ public class PostgresService(IAzureService azureService, IEntraTokenProvider ent
     internal static (string Query, List<(string Name, string Value)> Parameters) ParameterizeStringLiterals(string query) =>
         SqlQueryParameterizer.Parameterize(query, SqlQueryParameterizer.SqlDialect.Standard);
 
-    private async Task<string> GetPassword(string authType, string? password, CancellationToken cancellationToken)
+    private async Task<string> GetPassword(string authType, string? password, string? tenant, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(authType) || AuthTypes.MicrosoftEntra.Equals(authType, StringComparison.InvariantCultureIgnoreCase))
         {
-            return await GetEntraIdAccessTokenAsync(cancellationToken);
+            return await GetEntraIdAccessTokenAsync(tenant, cancellationToken);
         }
 
         if (AuthTypes.PostgreSQL.Equals(authType, StringComparison.InvariantCultureIgnoreCase))

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Database/DatabaseQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Database/DatabaseQueryCommandTests.cs
@@ -22,7 +22,7 @@ public class DatabaseQueryCommandTests : CommandUnitTestsBase<DatabaseQueryComma
     {
         var expectedResults = new List<string> { "result1", "result2" };
 
-        Service.ExecuteQueryAsync(AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "SELECT * FROM test;", Arg.Any<CancellationToken>())
+        Service.ExecuteQueryAsync(AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "SELECT * FROM test;", null, Arg.Any<CancellationToken>())
             .Returns(expectedResults);
 
         var response = await ExecuteCommandAsync(
@@ -39,7 +39,7 @@ public class DatabaseQueryCommandTests : CommandUnitTestsBase<DatabaseQueryComma
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenQueryFails()
     {
-        Service.ExecuteQueryAsync(AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "SELECT * FROM test;", Arg.Any<CancellationToken>())
+        Service.ExecuteQueryAsync(AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "SELECT * FROM test;", null, Arg.Any<CancellationToken>())
             .Returns([]);
 
         var response = await ExecuteCommandAsync(
@@ -139,7 +139,7 @@ public class DatabaseQueryCommandTests : CommandUnitTestsBase<DatabaseQueryComma
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status); // CommandValidationException => 400
         // Service should never be called for invalid queries.
-        await Service.DidNotReceive().ExecuteQueryAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await Service.DidNotReceive().ExecuteQueryAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -155,7 +155,7 @@ public class DatabaseQueryCommandTests : CommandUnitTestsBase<DatabaseQueryComma
 
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
-        await Service.DidNotReceive().ExecuteQueryAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await Service.DidNotReceive().ExecuteQueryAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 }
 

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/PostgresListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/PostgresListCommandTests.cs
@@ -26,7 +26,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
     public async Task ExecuteAsync_ListsServers_WhenNoServerOrDatabaseProvided()
     {
         var expectedServers = new List<string> { "postgres-server-1", "postgres-server-2", "postgres-server-3" };
-        Service.ListServersAsync("sub123", "rg1", Arg.Any<CancellationToken>()).Returns(expectedServers);
+        Service.ListServersAsync("sub123", "rg1", null, Arg.Any<CancellationToken>()).Returns(expectedServers);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -43,7 +43,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
     public async Task ExecuteAsync_ListsAllServersInSubscription_WhenNoResourceGroupProvided()
     {
         var expectedServers = new List<string> { "postgres-server-1", "postgres-server-2" };
-        Service.ListServersAsync("sub123", null, Arg.Any<CancellationToken>()).Returns(expectedServers);
+        Service.ListServersAsync("sub123", null, null, Arg.Any<CancellationToken>()).Returns(expectedServers);
 
         var response = await ExecuteCommandAsync("--subscription", "sub123");
 
@@ -75,6 +75,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
             "user1",
             null,
             "server1",
+            null,
             Arg.Any<CancellationToken>())
             .Returns(new DatabaseListResult(expectedDatabases, false));
 
@@ -104,6 +105,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
             "server1",
             "db1",
             "public",
+            null,
             Arg.Any<CancellationToken>())
             .Returns(new TableListResult(expectedTables, false));
 
@@ -134,6 +136,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
             "server1",
             "db1",
             "public",
+            null,
             Arg.Any<CancellationToken>())
             .Returns(new TableListResult(expectedTables, true));
 
@@ -162,6 +165,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
             "user1",
             null,
             "server1",
+            null,
             Arg.Any<CancellationToken>())
             .Returns(new DatabaseListResult(expectedDatabases, true));
 
@@ -183,7 +187,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
     [Fact]
     public async Task ExecuteAsync_ReturnsNull_WhenNoServersExist()
     {
-        Service.ListServersAsync("sub123", "rg1", Arg.Any<CancellationToken>()).Returns([]);
+        Service.ListServersAsync("sub123", "rg1", null, Arg.Any<CancellationToken>()).Returns([]);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
@@ -205,6 +209,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
             "user1",
             null,
             "server1",
+            null,
             Arg.Any<CancellationToken>())
             .Returns(new DatabaseListResult([], false));
 
@@ -233,6 +238,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
             "server1",
             "db1",
             "public",
+            null,
             Arg.Any<CancellationToken>())
             .Returns(new TableListResult([], false));
 
@@ -264,6 +270,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
             "server1",
             "db1",
             "analytics",
+            null,
             Arg.Any<CancellationToken>())
             .Returns(new TableListResult(expectedTables, false));
 
@@ -282,7 +289,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
         Assert.Null(result.Databases);
         Assert.Equal(expectedTables, result.Tables);
         await Service.Received(1).ListTablesAsync(
-            AuthTypes.MicrosoftEntra, "user1", null, "server1", "db1", "analytics", Arg.Any<CancellationToken>());
+            AuthTypes.MicrosoftEntra, "user1", null, "server1", "db1", "analytics", null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -295,6 +302,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
             "server1",
             "db1",
             "public",
+            null,
             Arg.Any<CancellationToken>())
             .Returns(new TableListResult(["users"], false));
 
@@ -309,14 +317,14 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
         ValidateAndDeserializeResponse(response, PostgresJsonContext.Default.PostgresListCommandResult);
 
         await Service.Received(1).ListTablesAsync(
-            AuthTypes.MicrosoftEntra, "user1", null, "server1", "db1", "public", Arg.Any<CancellationToken>());
+            AuthTypes.MicrosoftEntra, "user1", null, "server1", "db1", "public", null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsError_WhenListServersThrows()
     {
         var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
-        Service.ListServersAsync("sub123", "rg1", Arg.Any<CancellationToken>())
+        Service.ListServersAsync("sub123", "rg1", null, Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         var response = await ExecuteCommandAsync(
@@ -337,6 +345,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
             "user1",
             null,
             "server1",
+            null,
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -363,6 +372,7 @@ public class PostgresListCommandTests : SubscriptionCommandUnitTestsBase<Postgre
             "server1",
             "db1",
             "public",
+            null,
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceConnectionStringInjectionTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceConnectionStringInjectionTests.cs
@@ -65,6 +65,7 @@ public class PostgresServiceConnectionStringInjectionTests
         await _postgresService.ExecuteQueryAsync(
             AuthTypes.MicrosoftEntra, "test-user", null,
             "legitimate-server", maliciousDatabase, "SELECT 1",
+            null,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -82,6 +83,7 @@ public class PostgresServiceConnectionStringInjectionTests
         await _postgresService.ListTablesAsync(
             AuthTypes.MicrosoftEntra, "test-user", null,
             "legitimate-server", maliciousDatabase, "public",
+            null,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -99,6 +101,7 @@ public class PostgresServiceConnectionStringInjectionTests
         await _postgresService.GetTableSchemaAsync(
             AuthTypes.MicrosoftEntra, "test-user", null,
             "legitimate-server", maliciousDatabase, "some_table",
+            null,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -118,6 +121,7 @@ public class PostgresServiceConnectionStringInjectionTests
         await _postgresService.ExecuteQueryAsync(
             AuthTypes.MicrosoftEntra, "test-user", null,
             legitimateServer, maliciousDatabase, "SELECT 1",
+            null,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -139,6 +143,7 @@ public class PostgresServiceConnectionStringInjectionTests
         await _postgresService.ExecuteQueryAsync(
             AuthTypes.MicrosoftEntra, "test-user", null,
             "safe-server", maliciousDatabase, "SELECT 1",
+            null,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -157,6 +162,7 @@ public class PostgresServiceConnectionStringInjectionTests
         await _postgresService.ExecuteQueryAsync(
             AuthTypes.MicrosoftEntra, "test-user", null,
             "safe-server", "mydb", "SELECT 1",
+            null,
             TestContext.Current.CancellationToken);
 
         // Assert — BuildConnectionString must enforce SslMode.Require so connections

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceParameterizedQueryTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceParameterizedQueryTests.cs
@@ -64,7 +64,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert - Method should accept these parameters without throwing
         // The actual parameterization is tested through integration tests
-        var task = _postgresService.GetTableSchemaAsync(authType, user, password, server, database, tableName, TestContext.Current.CancellationToken);
+        var task = _postgresService.GetTableSchemaAsync(authType, user, password, server, database, tableName, null, TestContext.Current.CancellationToken);
 
         // The method will fail at the connection stage, but that's expected in unit tests
         // What we're testing is that the method signature accepts these parameters correctly
@@ -91,7 +91,7 @@ public class PostgresServiceParameterizedQueryTests
         // Act & Assert
         // The method should not throw due to SQL injection attempts
         // With proper parameterization, malicious input is treated as a literal table name
-        var task = _postgresService.GetTableSchemaAsync(authType, user, password, server, database, maliciousTableName, TestContext.Current.CancellationToken);
+        var task = _postgresService.GetTableSchemaAsync(authType, user, password, server, database, maliciousTableName, null, TestContext.Current.CancellationToken);
 
         // The method will fail at the connection stage, but importantly,
         // it won't fail due to SQL parsing errors caused by injection attempts
@@ -111,7 +111,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // Should handle special characters safely through parameterization
-        var task = _postgresService.GetTableSchemaAsync(authType, user, password, server, database, tableName, TestContext.Current.CancellationToken);
+        var task = _postgresService.GetTableSchemaAsync(authType, user, password, server, database, tableName, null, TestContext.Current.CancellationToken);
         Assert.NotNull(task);
     }
 
@@ -129,7 +129,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // Should handle empty/whitespace table names without security issues
-        var task = _postgresService.GetTableSchemaAsync(authType, user, password, server, database, tableName, TestContext.Current.CancellationToken);
+        var task = _postgresService.GetTableSchemaAsync(authType, user, password, server, database, tableName, null, TestContext.Current.CancellationToken);
         Assert.NotNull(task);
     }
 
@@ -145,7 +145,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // Should handle null table name without security issues
-        var task = _postgresService.GetTableSchemaAsync(authType, user, password, server, database, null!, TestContext.Current.CancellationToken);
+        var task = _postgresService.GetTableSchemaAsync(authType, user, password, server, database, null!, null, TestContext.Current.CancellationToken);
         Assert.NotNull(task);
     }
 
@@ -163,7 +163,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // The method should fail validation before attempting to connect to database
-        var task = _postgresService.ExecuteQueryAsync(authType, user, password, server, database, maliciousQuery, TestContext.Current.CancellationToken);
+        var task = _postgresService.ExecuteQueryAsync(authType, user, password, server, database, maliciousQuery, null, TestContext.Current.CancellationToken);
 
         // We expect this to eventually throw due to validation, not due to database connection
         // The validation should catch dangerous queries before any database interaction
@@ -185,7 +185,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // Valid queries should pass validation and proceed to connection attempt
-        var task = _postgresService.ExecuteQueryAsync(authType, user, password, server, database, validQuery, TestContext.Current.CancellationToken);
+        var task = _postgresService.ExecuteQueryAsync(authType, user, password, server, database, validQuery, null, TestContext.Current.CancellationToken);
         Assert.NotNull(task);
     }
 
@@ -213,7 +213,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // The method should accept complex queries with vector operations and Azure OpenAI functions
-        var task = _postgresService.ExecuteQueryAsync(authType, user, password, server, database, vectorQuery, TestContext.Current.CancellationToken);
+        var task = _postgresService.ExecuteQueryAsync(authType, user, password, server, database, vectorQuery, null, TestContext.Current.CancellationToken);
 
         // Verify the task is created successfully (will fail at connection stage in unit test)
         Assert.NotNull(task);
@@ -237,7 +237,7 @@ public class PostgresServiceParameterizedQueryTests
 
         // Act & Assert
         // Should accept queries with various vector similarity operators
-        var task = _postgresService.ExecuteQueryAsync(authType, user, password, server, database, vectorQuery, TestContext.Current.CancellationToken);
+        var task = _postgresService.ExecuteQueryAsync(authType, user, password, server, database, vectorQuery, null, TestContext.Current.CancellationToken);
         Assert.NotNull(task);
     }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceRowLimitTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceRowLimitTests.cs
@@ -54,7 +54,7 @@ public class PostgresServiceRowLimitTests
         StubReader(rowCount: 3, columnName: "datname");
 
         var result = await _postgresService.ListDatabasesAsync(
-            AuthType, User, null, Server, TestContext.Current.CancellationToken);
+            AuthType, User, null, Server, null, TestContext.Current.CancellationToken);
 
         Assert.Equal(3, result.Databases.Count);
         Assert.False(result.IsTruncated);
@@ -67,7 +67,7 @@ public class PostgresServiceRowLimitTests
         StubReader(rowCount: MaxRowCount, columnName: "datname");
 
         var result = await _postgresService.ListDatabasesAsync(
-            AuthType, User, null, Server, TestContext.Current.CancellationToken);
+            AuthType, User, null, Server, null, TestContext.Current.CancellationToken);
 
         Assert.Equal(MaxRowCount, result.Databases.Count);
         Assert.False(result.IsTruncated);
@@ -80,7 +80,7 @@ public class PostgresServiceRowLimitTests
         StubReader(rowCount: MaxRowCount + 1, columnName: "datname");
 
         var result = await _postgresService.ListDatabasesAsync(
-            AuthType, User, null, Server, TestContext.Current.CancellationToken);
+            AuthType, User, null, Server, null, TestContext.Current.CancellationToken);
 
         Assert.Equal(MaxRowCount, result.Databases.Count);
         Assert.True(result.IsTruncated);
@@ -92,7 +92,7 @@ public class PostgresServiceRowLimitTests
         StubReader(rowCount: 5, columnName: "table_name");
 
         var result = await _postgresService.ListTablesAsync(
-            AuthType, User, null, Server, Database, Schema, TestContext.Current.CancellationToken);
+            AuthType, User, null, Server, Database, Schema, null, TestContext.Current.CancellationToken);
 
         Assert.Equal(5, result.Tables.Count);
         Assert.False(result.IsTruncated);
@@ -105,7 +105,7 @@ public class PostgresServiceRowLimitTests
         StubReader(rowCount: MaxRowCount, columnName: "table_name");
 
         var result = await _postgresService.ListTablesAsync(
-            AuthType, User, null, Server, Database, Schema, TestContext.Current.CancellationToken);
+            AuthType, User, null, Server, Database, Schema, null, TestContext.Current.CancellationToken);
 
         Assert.Equal(MaxRowCount, result.Tables.Count);
         Assert.False(result.IsTruncated);
@@ -118,7 +118,7 @@ public class PostgresServiceRowLimitTests
         StubReader(rowCount: MaxRowCount + 1, columnName: "table_name");
 
         var result = await _postgresService.ListTablesAsync(
-            AuthType, User, null, Server, Database, Schema, TestContext.Current.CancellationToken);
+            AuthType, User, null, Server, Database, Schema, null, TestContext.Current.CancellationToken);
 
         Assert.Equal(MaxRowCount, result.Tables.Count);
         Assert.True(result.IsTruncated);

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceServerNameValidationTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceServerNameValidationTests.cs
@@ -55,6 +55,7 @@ public class PostgresServiceServerNameValidationTests
             _postgresService.ExecuteQueryAsync(
                 AuthTypes.MicrosoftEntra, "test-user", null,
                 maliciousServer, "testdb", "SELECT 1",
+                null,
                 TestContext.Current.CancellationToken));
 
         Assert.Contains("not a valid Azure Database for PostgreSQL hostname", ex.Message);
@@ -69,6 +70,7 @@ public class PostgresServiceServerNameValidationTests
             _postgresService.ListDatabasesAsync(
                 AuthTypes.MicrosoftEntra, "test-user", null,
                 maliciousServer,
+                null,
                 TestContext.Current.CancellationToken));
 
         Assert.Contains("not a valid Azure Database for PostgreSQL hostname", ex.Message);
@@ -83,6 +85,7 @@ public class PostgresServiceServerNameValidationTests
             _postgresService.ListTablesAsync(
                 AuthTypes.MicrosoftEntra, "test-user", null,
                 maliciousServer, "testdb", "public",
+                null,
                 TestContext.Current.CancellationToken));
 
         Assert.Contains("not a valid Azure Database for PostgreSQL hostname", ex.Message);
@@ -97,6 +100,7 @@ public class PostgresServiceServerNameValidationTests
             _postgresService.GetTableSchemaAsync(
                 AuthTypes.MicrosoftEntra, "test-user", null,
                 maliciousServer, "testdb", "test_table",
+                null,
                 TestContext.Current.CancellationToken));
 
         Assert.Contains("not a valid Azure Database for PostgreSQL hostname", ex.Message);
@@ -113,6 +117,7 @@ public class PostgresServiceServerNameValidationTests
         await _postgresService.ExecuteQueryAsync(
             AuthTypes.MicrosoftEntra, "test-user", null,
             validServer, "testdb", "SELECT 1",
+            null,
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(_capturedConnectionString);
@@ -127,6 +132,7 @@ public class PostgresServiceServerNameValidationTests
         await _postgresService.ExecuteQueryAsync(
             AuthTypes.MicrosoftEntra, "test-user", null,
             "myserver", "testdb", "SELECT 1",
+            null,
             TestContext.Current.CancellationToken);
 
         Assert.NotNull(_capturedConnectionString);

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceTests.cs
@@ -77,7 +77,7 @@ public class PostgresServiceTests
         // Act
         CommandValidationException exception = await Assert.ThrowsAsync<CommandValidationException>(async () =>
         {
-            await _postgresService.ExecuteQueryAsync(authType, user, null, server, database, query, TestContext.Current.CancellationToken);
+            await _postgresService.ExecuteQueryAsync(authType, user, null, server, database, query, null, TestContext.Current.CancellationToken);
         });
 
         // Assert
@@ -101,7 +101,7 @@ public class PostgresServiceTests
                 [typeof(string), typeof(int), typeof(InvalidCastItem)]));
 
         // Act
-        List<string> rows = await _postgresService.ExecuteQueryAsync(authType, user, null, server, database, query, TestContext.Current.CancellationToken);
+        List<string> rows = await _postgresService.ExecuteQueryAsync(authType, user, null, server, database, query, null, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(4, rows.Count);
@@ -124,7 +124,7 @@ public class PostgresServiceTests
                 [typeof(string), typeof(int), typeof(InvalidCastItem)]));
 
         // Act
-        List<string> rows = await _postgresService.ExecuteQueryAsync(authType, user, null, server, database, query, TestContext.Current.CancellationToken);
+        List<string> rows = await _postgresService.ExecuteQueryAsync(authType, user, null, server, database, query, null, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(rows);
@@ -143,7 +143,7 @@ public class PostgresServiceTests
             resourceGroupServers: []);
 
         // Act
-        var result = await sut.ListServersAsync(subscriptionId, null, TestContext.Current.CancellationToken);
+        var result = await sut.ListServersAsync(subscriptionId, null, null, TestContext.Current.CancellationToken);
 
         // Assert — subscription service was called, RG service was not
         Assert.Equal(expected, result);
@@ -167,7 +167,7 @@ public class PostgresServiceTests
             resourceGroupServers: expected);
 
         // Act
-        var result = await sut.ListServersAsync(subscriptionId, resourceGroup, TestContext.Current.CancellationToken);
+        var result = await sut.ListServersAsync(subscriptionId, resourceGroup, null, TestContext.Current.CancellationToken);
 
         // Assert — RG service was called, subscription service was not
         Assert.Equal(expected, result);
@@ -191,7 +191,7 @@ public class PostgresServiceTests
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<Exception>(
-            () => sut.ListServersAsync(subscriptionId, resourceGroup, TestContext.Current.CancellationToken));
+            () => sut.ListServersAsync(subscriptionId, resourceGroup, null, TestContext.Current.CancellationToken));
         Assert.Contains(resourceGroup, ex.Message);
     }
 
@@ -205,7 +205,7 @@ public class PostgresServiceTests
         _dbProvider.GetCommand(Arg.Do<string>(q => capturedQuery = q), Arg.Any<IPostgresResource>())
             .Returns(command);
 
-        await _postgresService.ListTablesAsync(authType, user, null, server, database, "analytics", TestContext.Current.CancellationToken);
+        await _postgresService.ListTablesAsync(authType, user, null, server, database, "analytics", null, TestContext.Current.CancellationToken);
 
         Assert.NotNull(capturedQuery);
         Assert.Contains("@schema", capturedQuery);

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Table/TableSchemaGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Table/TableSchemaGetCommandTests.cs
@@ -19,7 +19,7 @@ public class TableSchemaGetCommandTests : CommandUnitTestsBase<TableSchemaGetCom
     public async Task ExecuteAsync_ReturnsSchema_WhenSchemaExists()
     {
         var expectedSchema = new List<string>(["CREATE TABLE test (id INT);"]);
-        Service.GetTableSchemaAsync(AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "table123", Arg.Any<CancellationToken>()).Returns(expectedSchema);
+        Service.GetTableSchemaAsync(AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "table123", null, Arg.Any<CancellationToken>()).Returns(expectedSchema);
 
         var response = await ExecuteCommandAsync(
             $"--{PostgresOptionDefinitions.AuthTypeText}", AuthTypes.MicrosoftEntra,
@@ -35,7 +35,7 @@ public class TableSchemaGetCommandTests : CommandUnitTestsBase<TableSchemaGetCom
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenSchemaDoesNotExist()
     {
-        Service.GetTableSchemaAsync(AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "table123", Arg.Any<CancellationToken>()).Returns([]);
+        Service.GetTableSchemaAsync(AuthTypes.MicrosoftEntra, "user1", null, "server1", "db123", "table123", null, Arg.Any<CancellationToken>()).Returns([]);
 
         var response = await ExecuteCommandAsync(
             $"--{PostgresOptionDefinitions.AuthTypeText}", AuthTypes.MicrosoftEntra,

--- a/tools/Azure.Mcp.Tools.Quota/src/Commands/Region/AvailabilityListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Commands/Region/AvailabilityListCommand.cs
@@ -55,6 +55,7 @@ public sealed class AvailabilityListCommand(ILogger<AvailabilityListCommand> log
                 options.CognitiveServiceModelName,
                 options.CognitiveServiceModelVersion,
                 options.CognitiveServiceDeploymentSkuName,
+                options.Tenant,
                 cancellationToken);
 
             _logger.LogInformation("Region check result: {ToolResult}", toolResult);

--- a/tools/Azure.Mcp.Tools.Quota/src/Commands/Usage/CheckCommand.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Commands/Usage/CheckCommand.cs
@@ -55,6 +55,7 @@ public sealed class CheckCommand(ILogger<CheckCommand> logger, IQuotaService quo
                 resourceTypes,
                 options.Subscription!,
                 options.Region,
+                options.Tenant,
                 cancellationToken);
 
             _logger.LogInformation("Quota check result: {ToolResult}", toolResult);

--- a/tools/Azure.Mcp.Tools.Quota/src/Options/Region/AvailabilityListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Options/Region/AvailabilityListOptions.cs
@@ -20,6 +20,9 @@ public sealed class AvailabilityListOptions : ISubscriptionOption
     [Option(Description = "Optional deployment SKU name for cognitive services. Only needed when Microsoft.CognitiveServices is included in resource types.")]
     public string? CognitiveServiceDeploymentSkuName { get; set; }
 
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Quota/src/Options/Usage/CheckOptions.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Options/Usage/CheckOptions.cs
@@ -14,6 +14,9 @@ public sealed class CheckOptions : ISubscriptionOption
     [Option(Description = "Comma-separated list of Azure resource types that are going to be deployed. E.g. 'Microsoft.App/containerApps,Microsoft.Web/sites,Microsoft.CognitiveServices/accounts', etc.")]
     public required string ResourceTypes { get; set; }
 
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/IQuotaService.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/IQuotaService.cs
@@ -11,6 +11,7 @@ public interface IQuotaService
         List<string> resourceTypes,
         string subscriptionId,
         string location,
+        string? tenant,
         CancellationToken cancellationToken);
 
     Task<List<string>> GetAvailableRegionsForResourceTypesAsync(
@@ -19,5 +20,6 @@ public interface IQuotaService
         string? cognitiveServiceModelName = null,
         string? cognitiveServiceModelVersion = null,
         string? cognitiveServiceDeploymentSkuName = null,
+        string? tenant = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Quota/src/Services/QuotaService.cs
+++ b/tools/Azure.Mcp.Tools.Quota/src/Services/QuotaService.cs
@@ -17,9 +17,10 @@ public class QuotaService(IAzureService azureService, ILoggerFactory loggerFacto
         List<string> resourceTypes,
         string subscriptionId,
         string location,
+        string? tenant,
         CancellationToken cancellationToken)
     {
-        TokenCredential credential = await GetCredential(null, cancellationToken);
+        TokenCredential credential = await GetCredential(tenant, cancellationToken);
         return await AzureQuotaService.GetAzureQuotaAsync(
             credential,
             resourceTypes,
@@ -36,9 +37,10 @@ public class QuotaService(IAzureService azureService, ILoggerFactory loggerFacto
         string? cognitiveServiceModelName = null,
         string? cognitiveServiceModelVersion = null,
         string? cognitiveServiceDeploymentSkuName = null,
+        string? tenant = null,
         CancellationToken cancellationToken = default)
     {
-        ArmClient armClient = await CreateArmClientAsync(cancellationToken: cancellationToken);
+        ArmClient armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
 
         // Create cognitive service properties if any of the parameters are provided
         CognitiveServiceProperties? cognitiveServiceProperties = null;

--- a/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.Tests/Commands/Region/AvailabilityListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.Tests/Commands/Region/AvailabilityListCommandTests.cs
@@ -39,6 +39,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedRegions);
 
@@ -56,6 +57,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
             null,
             null,
             null,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
 
         // Verify the response structure
@@ -96,6 +98,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
             cognitiveServiceModelName,
             Arg.Any<string?>(),
             cognitiveServiceDeploymentSkuName,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedRegions);
 
@@ -116,6 +119,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
             cognitiveServiceModelName,
             null,
             cognitiveServiceDeploymentSkuName,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
 
         // Verify the response structure
@@ -155,6 +159,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -169,6 +174,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
         Service.GetAvailableRegionsForResourceTypesAsync(
             Arg.Any<string[]>(),
             subscriptionId,
+            Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -205,6 +211,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedRegions);
 
@@ -228,6 +235,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
             null,
             null,
             null,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -241,6 +249,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
         Service.GetAvailableRegionsForResourceTypesAsync(
             Arg.Any<string[]>(),
             subscriptionId,
+            Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -276,6 +285,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
             cognitiveServiceModelName,
             cognitiveServiceModelVersion,
             cognitiveServiceDeploymentSkuName,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedRegions);
 
@@ -300,6 +310,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
             cognitiveServiceModelName,
             cognitiveServiceModelVersion,
             cognitiveServiceDeploymentSkuName,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -319,6 +330,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
                 array.Contains("MICROSOFT.Storage/storageaccounts") &&
                 array.Contains("Microsoft.COMPUTE/VirtualMachines")),
             subscriptionId,
+            Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
@@ -345,6 +357,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
             null,
             null,
             null,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -377,6 +390,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedRegions);
 
@@ -393,6 +407,7 @@ public sealed class AvailabilityListCommandTests : SubscriptionCommandUnitTestsB
             null,
             null,
             null,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
 
         // Verify the response structure

--- a/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.Tests/Commands/Usage/CheckCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.Tests/Commands/Usage/CheckCommandTests.cs
@@ -50,6 +50,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
                 list.Contains("Microsoft.Storage/storageAccounts")),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedQuotaInfo);
 
@@ -68,6 +69,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
                 list.Contains("Microsoft.Storage/storageAccounts")),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
 
         // Verify the response structure
@@ -103,6 +105,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
             Arg.Any<List<string>>(),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -130,6 +133,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
             Arg.Any<List<string>>(),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(expectedException);
 
@@ -168,6 +172,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
                 list.Contains("Microsoft.Compute/virtualMachines")),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedQuotaInfo);
 
@@ -190,6 +195,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
                 list.Contains("Microsoft.Compute/virtualMachines")),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -205,6 +211,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
             Arg.Any<List<string>>(),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -261,6 +268,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
                 list.Contains("Microsoft.Compute/VirtualMachines")),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedQuotaInfo);
 
@@ -284,6 +292,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
                 list.Contains("Microsoft.Compute/VirtualMachines")),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -312,6 +321,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
                 list.Contains("Microsoft.UnsupportedProvider/resourceType")),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedQuotaInfo);
 
@@ -329,6 +339,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
                 list.Contains("Microsoft.UnsupportedProvider/resourceType")),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
 
         // Verify the response structure
@@ -372,6 +383,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
             Arg.Is<List<string>>(list => list.Count == 50),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedQuotaInfo);
 
@@ -387,6 +399,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
             Arg.Is<List<string>>(list => list.Count == 50),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
 
         // Verify the response contains all expected resource types
@@ -421,6 +434,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
                 list.Contains("Microsoft.Storage/storageAccounts")),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedQuotaInfo);
 
@@ -438,6 +452,7 @@ public sealed class CheckCommandTests : SubscriptionCommandUnitTestsBase<CheckCo
                 list.Contains("Microsoft.Storage/storageAccounts")),
             subscriptionId,
             region,
+            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
 
         // Verify the response structure contains descriptive error in Description

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexGetCommand.cs
@@ -38,6 +38,7 @@ public sealed class IndexGetCommand(ILogger<IndexGetCommand> logger, ISearchServ
             var indexes = await _searchService.GetIndexDetails(
                 options.Service,
                 options.Index,
+                options.Tenant,
                 options.RetryPolicy,
                 cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexQueryCommand.cs
@@ -38,6 +38,7 @@ public sealed class IndexQueryCommand(ILogger<IndexQueryCommand> logger, ISearch
                 options.Service,
                 options.Index,
                 options.Query,
+                options.Tenant,
                 options.RetryPolicy,
                 cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseGetCommand.cs
@@ -37,7 +37,7 @@ public sealed class KnowledgeBaseGetCommand(ILogger<KnowledgeBaseGetCommand> log
     {
         try
         {
-            var bases = await _searchService.ListKnowledgeBases(options.Service, options.KnowledgeBase, options.RetryPolicy, cancellationToken);
+            var bases = await _searchService.ListKnowledgeBases(options.Service, options.KnowledgeBase, options.Tenant, options.RetryPolicy, cancellationToken);
             context.Response.Results = ResponseResult.Create(new(bases ?? []), SearchJsonContext.Default.KnowledgeBaseGetCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseRetrieveCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeBaseRetrieveCommand.cs
@@ -85,7 +85,7 @@ public sealed class KnowledgeBaseRetrieveCommand(ILogger<KnowledgeBaseRetrieveCo
 
         try
         {
-            var result = await _searchService.RetrieveFromKnowledgeBase(options.Service, options.KnowledgeBase, options.Query, parsedMessages, options.RetryPolicy, cancellationToken);
+            var result = await _searchService.RetrieveFromKnowledgeBase(options.Service, options.KnowledgeBase, options.Query, parsedMessages, options.Tenant, options.RetryPolicy, cancellationToken);
             context.Response.Results = ResponseResult.Create(new(result), SearchJsonContext.Default.KnowledgeBaseRetrieveCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeSourceGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Commands/Knowledge/KnowledgeSourceGetCommand.cs
@@ -39,7 +39,7 @@ public sealed class KnowledgeSourceGetCommand(ILogger<KnowledgeSourceGetCommand>
     {
         try
         {
-            var sources = await _searchService.ListKnowledgeSources(options.Service, options.KnowledgeSource, options.RetryPolicy, cancellationToken);
+            var sources = await _searchService.ListKnowledgeSources(options.Service, options.KnowledgeSource, options.Tenant, options.RetryPolicy, cancellationToken);
             context.Response.Results = ResponseResult.Create(new(sources ?? []), SearchJsonContext.Default.KnowledgeSourceGetCommandResult);
         }
         catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Search/src/Options/Index/IndexGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Options/Index/IndexGetOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Search.Options.Index;
@@ -12,6 +13,9 @@ public sealed class IndexGetOptions
 
     [Option(Description = SearchOptionDescriptions.Index)]
     public string? Index { get; set; }
+
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
 
     [OptionContainer(Prefix = "retry")]
     public RetryPolicyOptions? RetryPolicy { get; set; }

--- a/tools/Azure.Mcp.Tools.Search/src/Options/Index/IndexQueryOptions.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Options/Index/IndexQueryOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Search.Options.Index;
@@ -15,6 +16,9 @@ public sealed class IndexQueryOptions
 
     [Option(Description = SearchOptionDescriptions.Index)]
     public required string Index { get; set; }
+
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
 
     [OptionContainer(Prefix = "retry")]
     public RetryPolicyOptions? RetryPolicy { get; set; }

--- a/tools/Azure.Mcp.Tools.Search/src/Options/Knowledge/KnowledgeBaseGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Options/Knowledge/KnowledgeBaseGetOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Search.Options.Knowledge;
@@ -12,6 +13,9 @@ public sealed class KnowledgeBaseGetOptions
 
     [Option(Description = SearchOptionDescriptions.Service)]
     public required string Service { get; set; }
+
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
 
     [OptionContainer(Prefix = "retry")]
     public RetryPolicyOptions? RetryPolicy { get; set; }

--- a/tools/Azure.Mcp.Tools.Search/src/Options/Knowledge/KnowledgeBaseRetrieveOptions.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Options/Knowledge/KnowledgeBaseRetrieveOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Search.Options.Knowledge;
@@ -18,6 +19,9 @@ public sealed class KnowledgeBaseRetrieveOptions
 
     [Option(Description = SearchOptionDescriptions.Service)]
     public required string Service { get; set; }
+
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
 
     [OptionContainer(Prefix = "retry")]
     public RetryPolicyOptions? RetryPolicy { get; set; }

--- a/tools/Azure.Mcp.Tools.Search/src/Options/Knowledge/KnowledgeSourceGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Options/Knowledge/KnowledgeSourceGetOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Search.Options.Knowledge;
@@ -12,6 +13,9 @@ public sealed class KnowledgeSourceGetOptions
 
     [Option(Description = SearchOptionDescriptions.Service)]
     public required string Service { get; set; }
+
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
 
     [OptionContainer(Prefix = "retry")]
     public RetryPolicyOptions? RetryPolicy { get; set; }

--- a/tools/Azure.Mcp.Tools.Search/src/Services/ISearchService.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Services/ISearchService.cs
@@ -19,18 +19,21 @@ public interface ISearchService
     Task<List<IndexInfo>> GetIndexDetails(
         string serviceName,
         string? indexName,
+        string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<KnowledgeSourceInfo>> ListKnowledgeSources(
         string serviceName,
         string? knowledgeSourceName = null,
+        string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<KnowledgeBaseInfo>> ListKnowledgeBases(
         string serviceName,
         string? knowledgeBaseName = null,
+        string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
@@ -38,6 +41,7 @@ public interface ISearchService
         string serviceName,
         string indexName,
         string searchText,
+        string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
@@ -46,6 +50,7 @@ public interface ISearchService
         string baseName,
         string? query,
         IEnumerable<(string role, string message)>? messages,
+        string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
+++ b/tools/Azure.Mcp.Tools.Search/src/Services/SearchService.cs
@@ -95,6 +95,7 @@ public sealed partial class SearchService(ICacheService cacheService, IAzureServ
     public async Task<List<IndexInfo>> GetIndexDetails(
         string serviceName,
         string? indexName,
+        string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
@@ -104,7 +105,7 @@ public sealed partial class SearchService(ICacheService cacheService, IAzureServ
 
         if (string.IsNullOrEmpty(indexName))
         {
-            var searchClient = await GetSearchIndexClient(serviceName, retryPolicy, cancellationToken);
+            var searchClient = await GetSearchIndexClient(serviceName, tenant, retryPolicy, cancellationToken);
             await foreach (var index in searchClient.GetIndexesAsync(cancellationToken: cancellationToken))
             {
                 indexes.Add(MapToIndexInfo(index));
@@ -113,7 +114,7 @@ public sealed partial class SearchService(ICacheService cacheService, IAzureServ
         }
         else
         {
-            var searchClient = await GetSearchIndexClient(serviceName, retryPolicy, cancellationToken);
+            var searchClient = await GetSearchIndexClient(serviceName, tenant, retryPolicy, cancellationToken);
             var index = await searchClient.GetIndexAsync(indexName, cancellationToken: cancellationToken);
 
             indexes.Add(MapToIndexInfo(index.Value));
@@ -126,6 +127,7 @@ public sealed partial class SearchService(ICacheService cacheService, IAzureServ
         string serviceName,
         string indexName,
         string searchText,
+        string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
@@ -134,7 +136,7 @@ public sealed partial class SearchService(ICacheService cacheService, IAzureServ
             (nameof(indexName), indexName),
             (nameof(searchText), searchText));
 
-        var searchClient = await GetSearchIndexClient(serviceName, retryPolicy, cancellationToken);
+        var searchClient = await GetSearchIndexClient(serviceName, tenant, retryPolicy, cancellationToken);
         var indexDefinition = await searchClient.GetIndexAsync(indexName, cancellationToken: cancellationToken);
         var client = searchClient.GetSearchClient(indexName);
 
@@ -157,13 +159,14 @@ public sealed partial class SearchService(ICacheService cacheService, IAzureServ
     public async Task<List<KnowledgeSourceInfo>> ListKnowledgeSources(
         string serviceName,
         string? knowledgeSourceName = null,
+        string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(serviceName), serviceName));
 
         var sources = new List<KnowledgeSourceInfo>();
-        var searchClient = await GetSearchIndexClient(serviceName, retryPolicy, cancellationToken);
+        var searchClient = await GetSearchIndexClient(serviceName, tenant, retryPolicy, cancellationToken);
 
         if (string.IsNullOrEmpty(knowledgeSourceName))
         {
@@ -187,13 +190,14 @@ public sealed partial class SearchService(ICacheService cacheService, IAzureServ
     public async Task<List<KnowledgeBaseInfo>> ListKnowledgeBases(
         string serviceName,
         string? knowledgeBaseName = null,
+        string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(serviceName), serviceName));
 
         var bases = new List<KnowledgeBaseInfo>();
-        var searchClient = await GetSearchIndexClient(serviceName, retryPolicy, cancellationToken);
+        var searchClient = await GetSearchIndexClient(serviceName, tenant, retryPolicy, cancellationToken);
 
         if (string.IsNullOrEmpty(knowledgeBaseName))
         {
@@ -222,12 +226,13 @@ public sealed partial class SearchService(ICacheService cacheService, IAzureServ
         string baseName,
         string? query,
         IEnumerable<(string role, string message)>? messages,
+        string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(serviceName), serviceName), (nameof(baseName), baseName));
 
-        var searchClient = await GetSearchIndexClient(serviceName, retryPolicy, cancellationToken);
+        var searchClient = await GetSearchIndexClient(serviceName, tenant, retryPolicy, cancellationToken);
 
         var knowledgeBase = await searchClient.GetKnowledgeBaseAsync(baseName, cancellationToken: cancellationToken);
         if (knowledgeBase?.Value == null)
@@ -240,7 +245,7 @@ public sealed partial class SearchService(ICacheService cacheService, IAzureServ
         clientOptions.Audience = GetSearchAudience();
         ConfigureRetryPolicy(clientOptions, retryPolicy);
 
-        var knowledgeBaseClient = new KnowledgeBaseRetrievalClient(searchClient.Endpoint, baseName, await GetCredential(null, cancellationToken), clientOptions);
+        var knowledgeBaseClient = new KnowledgeBaseRetrievalClient(searchClient.Endpoint, baseName, await GetCredential(tenant, cancellationToken), clientOptions);
         var useMinimalReasoning = knowledgeBase.Value.RetrievalReasoningEffort is KnowledgeRetrievalMinimalReasoningEffort;
         var request = BuildKnowledgeBaseRetrievalRequest(useMinimalReasoning, query, messages);
 
@@ -336,14 +341,16 @@ public sealed partial class SearchService(ICacheService cacheService, IAzureServ
         return vectorizableFields;
     }
 
-    private async Task<SearchIndexClient> GetSearchIndexClient(string serviceName, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken = default)
+    private async Task<SearchIndexClient> GetSearchIndexClient(string serviceName, string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken = default)
     {
         ValidateServiceName(serviceName);
-        var key = CacheKeyBuilder.Build(SearchServicesCacheKey, serviceName, AzureService.CloudConfiguration.CloudType.ToString());
+        var key = string.IsNullOrEmpty(tenant)
+            ? CacheKeyBuilder.Build(SearchServicesCacheKey, serviceName, AzureService.CloudConfiguration.CloudType.ToString())
+            : CacheKeyBuilder.Build(SearchServicesCacheKey, serviceName, tenant, AzureService.CloudConfiguration.CloudType.ToString());
         var searchClient = await _cacheService.GetAsync<SearchIndexClient>(CacheGroup, key, s_cacheDurationClients, cancellationToken);
         if (searchClient == null)
         {
-            var credential = await GetCredential(null, cancellationToken);
+            var credential = await GetCredential(tenant, cancellationToken);
 
             var clientOptions = AddDefaultPolicies(new SearchClientOptions());
             clientOptions.Transport = new HttpClientTransport(AzureService.GetClient());

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/Index/IndexGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/Index/IndexGetCommandTests.cs
@@ -27,6 +27,7 @@ public class IndexGetCommandTests : CommandUnitTestsBase<IndexGetCommand, ISearc
         Service.GetIndexDetails(
             Arg.Is("service123"),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedIndexes);
@@ -44,6 +45,7 @@ public class IndexGetCommandTests : CommandUnitTestsBase<IndexGetCommand, ISearc
         Service.GetIndexDetails(
             Arg.Any<string>(),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
@@ -64,6 +66,7 @@ public class IndexGetCommandTests : CommandUnitTestsBase<IndexGetCommand, ISearc
         Service.GetIndexDetails(
             Arg.Is(serviceName),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
@@ -87,6 +90,7 @@ public class IndexGetCommandTests : CommandUnitTestsBase<IndexGetCommand, ISearc
         Service.GetIndexDetails(
             Arg.Is(serviceName),
             Arg.Is(indexName),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([expectedDefinition]);
@@ -113,6 +117,7 @@ public class IndexGetCommandTests : CommandUnitTestsBase<IndexGetCommand, ISearc
         Service.GetIndexDetails(
             Arg.Is(serviceName),
             Arg.Is(indexName),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
@@ -137,6 +142,7 @@ public class IndexGetCommandTests : CommandUnitTestsBase<IndexGetCommand, ISearc
         Service.GetIndexDetails(
             Arg.Is(serviceName),
             Arg.Is(indexName),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/Index/IndexQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/Index/IndexQueryCommandTests.cs
@@ -43,6 +43,7 @@ public class IndexQueryCommandTests : CommandUnitTestsBase<IndexQueryCommand, IS
             Arg.Is(serviceName),
             Arg.Is(indexName),
             Arg.Is(queryText),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResults);
@@ -73,6 +74,7 @@ public class IndexQueryCommandTests : CommandUnitTestsBase<IndexQueryCommand, IS
             Arg.Is(serviceName),
             Arg.Is(indexName),
             Arg.Is(queryText),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/Knowledge/KnowledgeBaseGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/Knowledge/KnowledgeBaseGetCommandTests.cs
@@ -28,6 +28,7 @@ public class KnowledgeBaseGetCommandTests : CommandUnitTestsBase<KnowledgeBaseGe
         Service.ListKnowledgeBases(
             Arg.Is("service123"),
             Arg.Is((string?)null),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedBases);
@@ -53,6 +54,7 @@ public class KnowledgeBaseGetCommandTests : CommandUnitTestsBase<KnowledgeBaseGe
         Service.ListKnowledgeBases(
             Arg.Is("service123"),
             Arg.Is("base1"),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns([expectedBase]);
@@ -70,6 +72,7 @@ public class KnowledgeBaseGetCommandTests : CommandUnitTestsBase<KnowledgeBaseGe
     {
         Service.ListKnowledgeBases(
             Arg.Any<string>(),
+            Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
@@ -90,6 +93,7 @@ public class KnowledgeBaseGetCommandTests : CommandUnitTestsBase<KnowledgeBaseGe
 
         Service.ListKnowledgeBases(
             Arg.Is(serviceName),
+            Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/Knowledge/KnowledgeBaseRetrieveCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/Knowledge/KnowledgeBaseRetrieveCommandTests.cs
@@ -23,6 +23,7 @@ public class KnowledgeBaseRetrieveCommandTests : CommandUnitTestsBase<KnowledgeB
             Arg.Is("base1"),
             Arg.Is("life"),
             Arg.Is<List<(string role, string message)>?>(m => m == null),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(json);
@@ -45,6 +46,7 @@ public class KnowledgeBaseRetrieveCommandTests : CommandUnitTestsBase<KnowledgeB
             Arg.Is("base1"),
             Arg.Is<string?>(q => q == null),
             Arg.Is<List<(string role, string message)>?>(m => m != null && m.Count == 1 && m[0].role == "user"),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(json);
@@ -99,6 +101,7 @@ public class KnowledgeBaseRetrieveCommandTests : CommandUnitTestsBase<KnowledgeB
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<List<(string role, string message)>?>(),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test failure"));

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/Knowledge/KnowledgeSourceGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/Knowledge/KnowledgeSourceGetCommandTests.cs
@@ -28,6 +28,7 @@ public class KnowledgeSourceGetCommandTests : CommandUnitTestsBase<KnowledgeSour
         Service.ListKnowledgeSources(
             Arg.Is("service123"),
             Arg.Is((string?)null),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedSources);
@@ -47,6 +48,7 @@ public class KnowledgeSourceGetCommandTests : CommandUnitTestsBase<KnowledgeSour
         Service.ListKnowledgeSources(
             Arg.Is("service123"),
             Arg.Is("source1"),
+            Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns([expectedSource]);
@@ -64,6 +66,7 @@ public class KnowledgeSourceGetCommandTests : CommandUnitTestsBase<KnowledgeSour
     {
         Service.ListKnowledgeSources(
             Arg.Any<string>(),
+            Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>()).Returns([]);
@@ -83,6 +86,7 @@ public class KnowledgeSourceGetCommandTests : CommandUnitTestsBase<KnowledgeSour
 
         Service.ListKnowledgeSources(
             Arg.Is(serviceName),
+            Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())


### PR DESCRIPTION
## What does this PR do?

Addresses #1770: tools that authenticate with **per-request `TokenCredential`s** must honor the `--tenant` option so the credential is created for the tenant the request targets. When a tool ignored the tenant, requests could fail whenever the target tenant differed from the credential's default tenant.

This PR audits the tools in that class and threads the tenant through to credential creation:

- **Bug fix — `applicationinsights recommendation list`**: the command already accepted `--tenant`, but the service layer dropped it when creating the credential used to read profiler data. The tenant now flows through to `GetCredential(tenant)`.
- **Feature — added `--tenant`** to the commands in the following areas and propagated it to credential creation: **Deploy**, **MySQL**, **PostgreSQL**, **Quota**, and **Azure AI Search**.

Each service now creates its per-request credential (and, where applicable, its ARM / data-plane clients) for the specified tenant, and tenant is included in credential cache keys where clients are cached.

> **Note on "one tool per PR":** this issue is intentionally cross-cutting — it asks to review *all* tools in the per-request-credential class — so the change spans several tools by design. Each tool's change is small and mechanical: thread an optional `tenant` parameter through to credential creation.

### Follow-ups (tracked separately, out of scope here)
- **SQL** (`Azure.Mcp.Tools.Sql`) — same per-request-credential class; not yet threaded. Planned as a dedicated follow-up.
- **Confidential Ledger** and **Speech** — endpoint-based commands that build a credential from an endpoint only (no subscription/tenant option today). Hardening these to accept/enforce a tenant is deferred API design.
