### PR TITLE
Pin .NET 10 version in CI, float locally

### DIFF
--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -24,7 +24,7 @@ steps:
     displayName: 'Resolve .NET SDK version from global.json'
 
   - task: UseDotNet@2
-    displayName: "Use .NET SDK from global.json ($(DotNetSdkVersion))"
+    displayName: "Use .NET SDK from global.json"
     retryCountOnTaskFailure: 3
     inputs:
       version: $(DotNetSdkVersion)

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -5,19 +5,36 @@ parameters:
 
 steps:
   # Need to authenticate so our pipeline can ingest new packages into the feed when restoring.
-- task: NuGetAuthenticate@1
+  - task: NuGetAuthenticate@1
 
-- task: UseDotNet@2
-  displayName: "Use .NET SDK from global.json"
-  retryCountOnTaskFailure: 3
-  inputs:
-    useGlobalJson: true
+  # UseDotNet's useGlobalJson applies the rollForward policy against the set of downloadable
+  # SDKs, so 'feature' installs the newest 10.0.x rather than the version named in global.json.
+  # That drags CI onto same-day SDK releases whose implicit ILLink/ILCompiler packs may not have
+  # reached our NuGet feed yet. Install the exact version instead; rollForward is still honored
+  # when selecting among installed SDKs, so local development is unaffected.
+  - pwsh: |
+      $globalJsonPath = Join-Path '$(Build.SourcesDirectory)' 'global.json'
+      $sdkVersion = (Get-Content $globalJsonPath -Raw | ConvertFrom-Json).sdk.version
+      if (-not $sdkVersion) {
+        Write-Error "Unable to read sdk.version from $globalJsonPath"
+        exit 1
+      }
+      Write-Host "Pinning the .NET SDK install to $sdkVersion (from global.json)"
+      echo "##vso[task.setvariable variable=DotNetSdkVersion]$sdkVersion"
+    displayName: 'Resolve .NET SDK version from global.json'
 
-- ${{ each version in parameters.AdditionalVersions }}:
   - task: UseDotNet@2
-    displayName: "Use .NET SDK ${{ version }}"
+    displayName: "Use .NET SDK from global.json"
     retryCountOnTaskFailure: 3
     inputs:
-      packageType: sdk
-      version: ${{ version }}
+      version: $(DotNetSdkVersion)
       performMultiLevelLookup: true
+
+  - ${{ each version in parameters.AdditionalVersions }}:
+    - task: UseDotNet@2
+      displayName: "Use .NET SDK ${{ version }}"
+      retryCountOnTaskFailure: 3
+      inputs:
+        packageType: sdk
+        version: ${{ version }}
+        performMultiLevelLookup: true

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -24,7 +24,7 @@ steps:
     displayName: 'Resolve .NET SDK version from global.json'
 
   - task: UseDotNet@2
-    displayName: "Use .NET SDK from global.json"
+    displayName: "Use .NET SDK from global.json ($(DotNetSdkVersion))"
     retryCountOnTaskFailure: 3
     inputs:
       version: $(DotNetSdkVersion)

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.302",
-    "rollForward": "feature"
+    "rollForward": "latestFeature"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.302",
-    "rollForward": "disable"
+    "rollForward": "feature"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"


### PR DESCRIPTION
## What does this PR do?

Small tweak to a previous change that pinned .NET 10 in `global.json`, instead CI will pin the version and local development will be allowed to float up to the latest feature version.

See https://github.com/Azure/azure-sdk-for-net/pull/61991, which this was copied from and contains richer details about the change.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
