### PR TITLE
Update eng/common workflow enforcer

### DIFF
--- a/eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
+++ b/eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
@@ -9,28 +9,31 @@ steps:
         # Find the default branch of the repo. The variable value sets in build step.
         Write-Host "Default Branch: $(DefaultBranch)"
 
-        if ((!"$(System.PullRequest.SourceBranch)".StartsWith("sync-eng/common")) -and "$(System.PullRequest.TargetBranch)" -match "^(refs/heads/)?$(DefaultBranch)$")
+        if ((!"$(System.PullRequest.SourceBranch)".StartsWith("sync-eng-common")) -and "$(System.PullRequest.TargetBranch)" -match "^(refs/heads/)?$(DefaultBranch)$")
         {
           $filesInCommonDir = & "eng/common/scripts/get-changedfiles.ps1" -DiffPath 'eng/common/*' -DiffFilterType ""
           if ($filesInCommonDir.Count -gt 0)
           {
             Write-Host "##vso[task.LogIssue type=error;]Changes to files under 'eng/common' directory should not be made in this Repo`n${filesInCommonDir}"
-            Write-Host "##vso[task.LogIssue type=error;]Please follow workflow at https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/common_engsys.md"
+            Write-Host "##vso[task.LogIssue type=error;]Follow the workflow at https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/common_engsys.md"
             exit 1
           }
         }
         if ((!"$(System.PullRequest.SourceBranch)".StartsWith("sync-.github")) -and "$(System.PullRequest.TargetBranch)" -match "^(refs/heads/)?$(DefaultBranch)$")
         {
-          # This list needs to be kept in sync with the FilePatterns listed in eng/pipelines/sync-.github.yml
-          $filePatterns = @(".github/workflows/*event*", ".github/workflows/post-apiview.yml", ".github/skills/azsdk-common-*/**")
+          # These lists need to be kept in sync with eng/pipelines/sync-.github.yml and
+          # eng/pipelines/sync-.github-skills.yml.
+          $workflowFilePatterns = @(".github/workflows/*event*", ".github/workflows/post-apiview.yml", ".github/workflows/protected-files.yml")
+          $skillsFilePatterns = @(".github/skills/azsdk-common-*/**")
+          $filePatterns = @($workflowFilePatterns + $skillsFilePatterns)
           $filesInCommonDir = @()
           foreach ($filePattern in $filePatterns) {
             $filesInCommonDir += & "eng/common/scripts/get-changedfiles.ps1" -DiffPath $filePattern -DiffFilterType ""
           }
           if ($filesInCommonDir.Count -gt 0)
           {
-            Write-Host "##vso[task.LogIssue type=error;]Changes to selected files under '.github/' directory should not be made in this Repo`n${filesInCommonDir}"
-            Write-Host "##vso[task.LogIssue type=error;]Please follow workflow at https://github.com/Azure/azure-sdk-tools/blob/main/doc/workflows/engsys_workflows.md"
+            Write-Host "##vso[task.LogIssue type=error;]Changes to selected workflow and shared skill files under '.github/' should not be made in this Repo`n${filesInCommonDir}"
+            Write-Host "##vso[task.LogIssue type=error;]Follow the workflow at https://github.com/Azure/azure-sdk-tools/blob/main/doc/engsys_workflows_and_skills.md"
             exit 1
           }
         }


### PR DESCRIPTION
This pull request updates the workflow enforcement logic in `eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml` to clarify error messages and improve the handling of protected workflow and skill files. The main changes are grouped below:

**Workflow enforcement logic improvements:**

* Updated the branch name check to use `"sync-eng-common"` instead of `"sync-eng/common"` for consistency with naming conventions.
* Split file pattern checks into two categories: workflow files (`$workflowFilePatterns`) and shared skill files (`$skillsFilePatterns`), and updated `$filePatterns` to include both. This makes the enforcement logic more maintainable and easier to keep in sync with related pipeline files.

**Error message and documentation updates:**

* Clarified error messages to specify that changes to selected workflow and shared skill files under `.github/` are restricted, and updated documentation links to point to the correct workflow and skills documentation.
* Improved the guidance for changes under `eng/common` by updating the error message to instruct contributors to "Follow the workflow" and providing the correct documentation link.