### PR TITLE
Add more robust e2eTestPrompt.md namespace to AssemblyName mapping. Filter prompts that need investigation

### DIFF
--- a/.github/workflows/vally-eval.yml
+++ b/.github/workflows/vally-eval.yml
@@ -84,7 +84,7 @@ jobs:
           ./eng/scripts/Build-Code.ps1 -BuildInfoPath "${{ github.workspace }}/.work/build_info.json" -PlatformName $platformName
 
       - name: Create vally evaluations
-        run: dotnet run --project '${{ github.workspace }}/eng/tools/VallyEvaluator/src/VallyEvaluator.csproj' -- --buildInfo '${{ github.workspace }}/.work/build_info.json'
+        run: dotnet run --project '${{ github.workspace }}/eng/tools/VallyEvaluator/src/VallyEvaluator.csproj' -- --buildInfo '${{ github.workspace }}/.work/build_info.json' --serverName Azure.Mcp.Server
 
       - name: Run vally
         run: |
@@ -97,8 +97,6 @@ jobs:
           $outputPath = "$baseVallyDirectory/vally-results"
 
           $workingDirectory = "${{ github.workspace }}"
-          
-          Copy-Item ./eng/tools/VallyEvaluator/src/Resources/eval.instructions.md "$workingDirectory/AGENTS.md" -Force
 
           ./eng/scripts/Invoke-VallyEvalTests.ps1 -BuildInfoPath $buildInfo -WorkDirectory $workingDirectory -EvalsDirectory $evalsDirectory -OutputPath $outputPath -NumberOfRuns $numberOfRuns -IsDebug:$isDebug
         shell: pwsh

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -350,6 +350,7 @@
     "kusto",
     "lakehouse",
     "lakehouses",
+    "ldstr",
     "liftr",
     "linq",
     "linuxarm",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,7 +252,7 @@ Real product code under unit testing must be passed `Xunit.TestContext.Current.C
 
 ### End-to-end Tests
 
-End-to-end tests are performed manually. Command authors must thoroughly test each command to ensure correct tool invocation and results. At least one prompt per tool is required and should be added to [`/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md).
+End-to-end tests are performed manually. Command authors must thoroughly test each command to ensure correct tool invocation and results. At least one prompt per tool is required and should be added to the server's `/server/<servername>/docs/e2eTestPrompts.md` file.
 
 ### Running evals with vally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,11 +252,11 @@ Real product code under unit testing must be passed `Xunit.TestContext.Current.C
 
 ### End-to-end Tests
 
-End-to-end tests are performed manually. Command authors must thoroughly test each command to ensure correct tool invocation and results. At least one prompt per tool is required and should be added to `/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`.
+End-to-end tests are performed manually. Command authors must thoroughly test each command to ensure correct tool invocation and results. At least one prompt per tool is required and should be added to [`/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md).
 
 ### Running evals with vally
 
-vally is the evaluation framework used to test the performance/accuracy of Azure MCP server and its tools. See `/docs/testing-with-vally.md`.
+vally is the evaluation framework used to test the performance/accuracy of Azure MCP server and its tools. See [`/docs/testing-with-vally.md`](https://github.com/microsoft/mcp/blob/main/docs/testing-with-vally.md).
 
 ### Testing Local Build with VS Code
 

--- a/docs/testing-with-vally.md
+++ b/docs/testing-with-vally.md
@@ -6,6 +6,7 @@ vally is the evaluation framework used to test the performance/accuracy of Azure
 
 * [vally](https://microsoft.github.io/vally/get-started/install/)
 * [Copilot SDK](https://docs.github.com/en/copilot/how-tos/copilot-sdk/setup/local-cli)
+* **Execute `copilot login` before running vally**
 
 ## Authoring an eval spec
 
@@ -36,14 +37,22 @@ stimuli:
 
 ## Running vally locally
 
-In a terminal window:
+In a terminal window, navigate to the repository root:
 
-1. Execute: `copilot login`
-2. Navigate to the repository root
-3. Execute: `./eng/scripts/Build-Local.ps1 -ServerName <<Server Name>>` where `<<Server Name>>` is a server in [servers/](https://github.com/microsoft/mcp/tree/main/servers)
-4. Execute one of the following commands depending on machine's operating system:
+1. Run `./eng/scripts/Build-Local.ps1 -ServerName <<ServerName>>` where `<<ServerName>>` is a server in [servers/](https://github.com/microsoft/mcp/tree/main/servers)
+2. Run one of the following commands depending on machine's operating system:
     * Windows: `vally eval --eval-spec ./tools/Azure.Mcp.Tools.AppConfig/tests/eval.yaml --param ENVIRONMENT=windows`
     * Linux: `vally eval --eval-spec ./tools/Azure.Mcp.Tools.AppConfig/tests/eval.yaml --param ENVIRONMENT=linux`
+
+## Running vally with e2eTestPrompts.md
+
+In a terminal window, navigate to repository root:
+
+1. Choose a value for `<<ServerName>>` that is a server in [servers/](https://github.com/microsoft/mcp/tree/main/servers)
+2. Run `./eng/scripts/Build-Local.ps1 -ServerName <<ServerName>>` 
+3. Run `dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- --serverName <<ServerName>>`
+  * Generates evals from `./servers/<<ServerName>>/docs/e2eTestPrompts.md` into `./.work/vally`
+4. Run `./eng/scripts/Invoke-VallyEvalTests.ps1`
 
 ## Automated runs with GitHub workflow
 

--- a/docs/testing-with-vally.md
+++ b/docs/testing-with-vally.md
@@ -1,19 +1,19 @@
-# Testing with vally
+# Testing with Vally
 
-vally is the evaluation framework used to test the performance/accuracy of Azure MCP server and its tools.
+Vally is the evaluation framework used to test the performance and accuracy of Azure MCP Server and its tools.
 
 ## Prerequisites
 
-* [vally](https://microsoft.github.io/vally/get-started/install/)
+* [Vally](https://microsoft.github.io/vally/get-started/install/)
 * [Copilot SDK](https://docs.github.com/en/copilot/how-tos/copilot-sdk/setup/local-cli)
-* **Execute `copilot login` before running vally**
+* Run `copilot login` before running Vally
 
 ## Authoring an eval spec
 
-* `.vally.yaml` at the root of the repository, it contains settings common to all vally runs.
-* The `eval.yaml` should live under a `./tools/<<tool_namespace>>/tests/` folder to be picked up by our workflow runs.
+* `.vally.yaml` at the repository root contains settings common to all Vally runs.
+* Store a checked-in `eval.yaml` under `./tools/Azure.Mcp.Tools.<ToolArea>/tests/` so the workflow can discover it.
 
-To be picked up by the "vally Evaluations" workflow for automatic testing, it must contain `environment: ${ENVIRONMENT}` like the sample below.  The environments are defined in `.vally.yaml`, and instruct the framework where to find the Azure MCP server.
+To be picked up by the Vally evaluations workflow, a specification must contain `environment: ${ENVIRONMENT}` as shown below. The environments in `.vally.yaml` tell Vally where to find Azure MCP Server for the current operating system.
 
 ```yaml
 name: Azure ACR evaluations
@@ -35,25 +35,46 @@ stimuli:
 * [Writing Eval Specs](https://microsoft.github.io/vally/guides/writing-eval-specs/) contains comprehensive information on authoring an eval.
 * [Grader Catalog](https://microsoft.github.io/vally/reference/graders/) contains all graders shipped with vally.
 
-## Running vally locally
+## Run a checked-in specification locally
 
 In a terminal window, navigate to the repository root:
 
-1. Run `./eng/scripts/Build-Local.ps1 -ServerName <<ServerName>>` where `<<ServerName>>` is a server in [servers/](https://github.com/microsoft/mcp/tree/main/servers)
+1. Run `./eng/scripts/Build-Local.ps1 -ServerName Azure.Mcp.Server`.
 2. Run one of the following commands depending on machine's operating system:
     * Windows: `vally eval --eval-spec ./tools/Azure.Mcp.Tools.AppConfig/tests/eval.yaml --param ENVIRONMENT=windows`
     * Linux: `vally eval --eval-spec ./tools/Azure.Mcp.Tools.AppConfig/tests/eval.yaml --param ENVIRONMENT=linux`
 
-## Running vally with e2eTestPrompts.md
+The repository's `.vally.yaml` currently defines environments only for Azure MCP Server on Windows and Linux. Running another MCP server requires adding an environment that launches that server and passing its environment name through `ENVIRONMENT`.
 
-In a terminal window, navigate to repository root:
+## Run generated end-to-end prompt evaluations
 
-1. Choose a value for `<<ServerName>>` that is a server in [servers/](https://github.com/microsoft/mcp/tree/main/servers)
-2. Run `./eng/scripts/Build-Local.ps1 -ServerName <<ServerName>>` 
-3. Run `dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- --serverName <<ServerName>>`
-  * Generates evals from `./servers/<<ServerName>>/docs/e2eTestPrompts.md` into `./.work/vally`
-4. Run `./eng/scripts/Invoke-VallyEvalTests.ps1`
+VallyEvaluator accepts any server that provides `servers/<ServerName>/docs/e2eTestPrompts.md`. It converts the file's non-interactive prompts into Vally specifications. The following example uses Azure MCP Server because the repository's `.vally.yaml` already defines environments that launch it.
 
-## Automated runs with GitHub workflow
+From the repository root:
 
-A GitHub workflow performs vally evaluations when files under `./tools/<<ToolArea>>` are modified. Runs can be viewed by navigating to https://github.com/microsoft/mcp/actions. To diagnose failures, navigate to "Upload vally results" step and download `vally-results` artifact.
+1. Run `./eng/scripts/Build-Local.ps1 -ServerName Azure.Mcp.Server`.
+2. Generate specifications for every eligible namespace:
+
+   ```powershell
+   dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- --serverName Azure.Mcp.Server
+   ```
+
+   To generate only selected namespaces, append `--namespaces "storage,appconfig"`.
+
+3. Run `./eng/scripts/Invoke-VallyEvalTests.ps1`.
+
+Generated specifications are written to `.work/vally/evals/<namespace>/eval.yaml`. Vally results are written to `.work/vally/vally-results`.
+
+The invocation script also includes checked-in specifications selected by `.work/build_info.json`. If it finds no generated or checked-in specifications, it exits successfully without starting Vally.
+
+To generate specifications for another server, pass its directory name to `--serverName`. For example, `--serverName Fabric.Mcp.Server` reads `servers/Fabric.Mcp.Server/docs/e2eTestPrompts.md`. That prompt file must exist. To execute the generated specifications, `.vally.yaml` must also define an environment that launches the selected server.
+
+### Agent instructions during evaluation
+
+Before invoking Vally, `Invoke-VallyEvalTests.ps1` temporarily replaces `<WorkDirectory>/AGENTS.md` with `eng/tools/VallyEvaluator/src/Resources/eval.instructions.md`. The script restores the original file in a `finally` block after Vally exits. The default working directory is the repository root; a custom `-WorkDirectory` must contain an `AGENTS.md` file.
+
+## Automated workflow
+
+A GitHub workflow runs Vally evaluations for pull requests that modify files matching `tools/Azure.Mcp.*/**`. It uses `.work/build_info.json` to generate and run evaluations for affected Azure tool namespaces. The workflow can also be started manually with a configurable run count and verbose logging.
+
+Runs are available in [GitHub Actions](https://github.com/microsoft/mcp/actions). To diagnose failures, open the **Upload vally results** step and download the `vally-results` artifact.

--- a/eng/scripts/Invoke-VallyEvalTests.ps1
+++ b/eng/scripts/Invoke-VallyEvalTests.ps1
@@ -128,7 +128,7 @@ Write-Host "Getting eval paths from VallyEvaluator"
 $(Get-ChildItem "$EvalsDirectory/**/eval.yaml") | ForEach-Object { $commandArg += "--eval-spec '$($_.FullName)' " }
 
 if ([string]::IsNullOrEmpty($commandArg)) {
-    Write-Host "No eval.yamls found to execute vally from."
+    Write-Host "No eval.yaml files found to execute vally from."
     exit 0
 }
 

--- a/eng/scripts/Invoke-VallyEvalTests.ps1
+++ b/eng/scripts/Invoke-VallyEvalTests.ps1
@@ -65,6 +65,9 @@ if (!$WorkDirectory) {
 
 $workArtifactsDirectory = Join-Path $WorkDirectory ".work"
 $vallyArtifactsDirectory = Join-Path $workArtifactsDirectory "vally"
+$vallyAgentsFile = "$RepoRoot/eng/tools/VallyEvaluator/src/Resources/eval.instructions.md"
+$agentsFile = Join-Path $WorkDirectory "AGENTS.md"
+$temporaryAgentsFile = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
 
 if (!$EvalsDirectory) {
     $EvalsDirectory = Join-Path $vallyArtifactsDirectory "evals"
@@ -124,6 +127,11 @@ $results | ForEach-Object { $commandArg += "--eval-spec '$($_)' " }
 Write-Host "Getting eval paths from VallyEvaluator"
 $(Get-ChildItem "$EvalsDirectory/**/eval.yaml") | ForEach-Object { $commandArg += "--eval-spec '$($_.FullName)' " }
 
+if ([string]::IsNullOrEmpty($commandArg)) {
+    Write-Host "No eval.yamls found to execute vally from."
+    exit 0
+}
+
 $expression = "vally eval --work-dir '$WorkDirectory' --output-dir '$OutputPath' --runs $NumberOfRuns --param ENVIRONMENT=$environment"
 
 if ($IsDebug) {
@@ -132,5 +140,17 @@ if ($IsDebug) {
 
 $expression += " $commandArg"
 
-Write-Host "Running command: $expression"
-Invoke-Expression $expression
+
+Write-Host "Moving existing AGENTS.md to temporary file location... $temporaryAgentsFile" -ForegroundColor Cyan
+Move-Item $agentsFile $temporaryAgentsFile
+
+Write-Host "Replacing AGENTS.md with vally's AGENTS.md file" -ForegroundColor Cyan
+Copy-Item $vallyAgentsFile $agentsFile
+
+try {
+    Write-Host "Running command: $expression"
+    Invoke-Expression $expression
+} finally {
+    Write-Host "Moving original AGENTS.md file back." -ForegroundColor Cyan
+    Move-Item $temporaryAgentsFile $agentsFile -Force
+}

--- a/eng/tools/McpToolEvaluator.Core/src/McpServerInformation.cs
+++ b/eng/tools/McpToolEvaluator.Core/src/McpServerInformation.cs
@@ -145,28 +145,21 @@ public class McpServerInformation
         // ldstr — "load string literal" — is opcode 0x72, followed by a 4-byte operand.
         const byte Ldstr = 0x72;
 
-        // The `i + 4 < il.Length` bound guarantees the 4 operand bytes we're about to read
-        // are actually inside the array (protects ToInt32 if a stray 0x72 sits near the end).
-        for (int i = 0; i + 4 < il.Length; i++)
+        // Skip leading NOPs (debug builds may inject them).
+        int i = 0;
+        while (i < il.Length && il[i] == 0x00)
         {
-            if (il[i] != Ldstr)
-                continue;
-
-            // The 4 operand bytes are a metadata token, stored little-endian (per the spec,
-            // matching x86/x64). ToInt32 reads them in that order.
-            int token = BitConverter.ToInt32(il, i + 1);
-
-            // A metadata token packs a table id in the top byte and a row/offset in the low
-            // 3 bytes. An ldstr token always points into the user-string (#US) heap, whose
-            // table byte is 0x70 — so a real token looks like 0x70000001, 0x7000000A, etc.
-            // Mask off the 0x70 tag to get the raw offset into the heap...
-            var handle = MetadataTokens.UserStringHandle(token & 0x00FFFFFF);
-
-            // ...then dereference that offset to pull the actual UTF-16 string the compiler
-            // stored there. The token was the address; this is the lookup.
-            return mr.GetUserString(handle);
+            i++;
         }
 
-        return null;
+        // Expect the first real instruction to be `ldstr <token>` for expression-bodied getters.
+        if (i + 4 >= il.Length || il[i] != Ldstr)
+        {
+            return null;
+        }
+
+        int token = BitConverter.ToInt32(il, i + 1);
+        var handle = MetadataTokens.UserStringHandle(token & 0x00FFFFFF);
+        return mr.GetUserString(handle);
     }
 }

--- a/eng/tools/McpToolEvaluator.Core/src/McpServerInformation.cs
+++ b/eng/tools/McpToolEvaluator.Core/src/McpServerInformation.cs
@@ -1,0 +1,172 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using McpToolEvaluator.Core.Models;
+
+namespace McpToolEvaluator.Core;
+
+/// <summary>
+/// Contains information about the MCP server, including its name and the tool areas it supports.
+/// </summary>
+public class McpServerInformation
+{
+    public McpServerInformation(string artifactDirectory)
+    {
+        ProbeSetupNames(artifactDirectory);
+    }
+
+    public Dictionary<string, ToolArea> AssemblyNameToToolsMap { get; } = new Dictionary<string, ToolArea>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Scans every managed assembly beside the server's binary folder for "*Setup" classes
+    /// and reads the string literal from their "Name" getter — without loading or
+    /// instantiating anything.
+    ///
+    /// Reads raw metadata on purpose: loading would resolve the whole dependency graph and
+    /// throw if something like Microsoft.Extensions.DependencyInjection isn't present.
+    /// Parsing bytes off disk only ever touches the one file we open. Because nothing is
+    /// instantiated, the only Name we can read is a compile-time literal, i.e. an
+    /// expression-bodied `public string Name => "grafana";`.
+    /// </summary>
+    internal void ProbeSetupNames(string targetPath)
+    {
+        targetPath = Path.GetFullPath(targetPath);
+
+        Console.WriteLine($"Probing {targetPath} for classes...");
+
+        // Scan the folder directly rather than reading the target's AssemblyReferences.
+        // A folder scan can't miss a Setup assembly that the target references but never
+        // uses a type from (the compiler can trim such references out of the metadata).
+        foreach (string dll in Directory.EnumerateFiles(targetPath, "*.dll"))
+        {
+            try
+            {
+                foreach (var toolArea in ProbeAssembly(dll))
+                {
+                    AssemblyNameToToolsMap[toolArea.AssemblyName] = toolArea;
+                }
+            }
+            catch (BadImageFormatException)
+            {
+                // Native DLL (runtime shim, *.native.dll, etc.) sitting alongside the
+                // managed assemblies. Not a .NET assembly, so skip it.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Opens a single assembly's metadata and appends a ToolArea for every "*Setup" type
+    /// that has a Name property returning a string literal.
+    /// </summary>
+    internal static List<ToolArea> ProbeAssembly(string path)
+    {
+        var results = new List<ToolArea>();
+        using var fs = File.OpenRead(path);
+        using var pe = new PEReader(fs);
+
+        // A PE file without a metadata stream is a native image — nothing to read.
+        if (!pe.HasMetadata)
+        {
+            return results;
+        }
+
+        var reader = pe.GetMetadataReader();
+        var assemblyName = reader.GetString(reader.GetAssemblyDefinition().Name);
+
+        foreach (var typeDefinitionHandle in reader.TypeDefinitions)
+        {
+            var typeDefinition = reader.GetTypeDefinition(typeDefinitionHandle);
+
+            if (!reader.GetString(typeDefinition.Name).EndsWith("Setup", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (var propertyDefinitionHandle in typeDefinition.GetProperties())
+            {
+                var propertyDefinition = reader.GetPropertyDefinition(propertyDefinitionHandle);
+                if (reader.GetString(propertyDefinition.Name) != "Name")
+                {
+                    continue;
+                }
+
+                MethodDefinitionHandle getter = propertyDefinition.GetAccessors().Getter;
+                if (getter.IsNil)
+                {
+                    continue; // write-only / no getter
+                }
+
+                var value = ReadLdstrLiteral(pe, reader, reader.GetMethodDefinition(getter));
+                if (value is not null)
+                {
+                    results.Add(new ToolArea { AssemblyName = assemblyName, ToolNamespace = value });
+                }
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Reads the string operand of the first <c>ldstr</c> instruction in a method body.
+    ///
+    /// This is a deliberate SHORTCUT, not a general IL decoder. It is correct only for a
+    /// getter shaped like <c>=> "literal"</c>, whose entire body is two instructions:
+    ///
+    ///     72 xx xx xx xx    ldstr  &lt;token for the string&gt;
+    ///     2A                ret
+    ///
+    /// Everything here is defined by ECMA-335 (the CLI standard):
+    ///   - Partition III  — opcode values and their operand encodings
+    ///   - Partition II §24 — the physical metadata format, incl. the user-string (#US) heap
+    ///
+    /// WHY A BYTE SCAN IS SAFE HERE, BUT NOT IN GENERAL:
+    ///   IL is a flat byte stream with no separators between instructions — you only know
+    ///   where the next instruction begins by knowing how long the current one is. A proper
+    ///   decoder walks instruction-by-instruction from the start, using each opcode's known
+    ///   operand length to step over operand bytes, so it never confuses operand data with
+    ///   an opcode. We skip all that because our target body starts WITH the ldstr opcode —
+    ///   there is no earlier instruction whose operand bytes could coincidentally contain
+    ///   0x72 and fool the scan. For arbitrary getters this assumption breaks; you'd need a
+    ///   real opcode walker (or a library like Cecil that ships an operand-length table).
+    /// </summary>
+    private static string? ReadLdstrLiteral(PEReader pe, MetadataReader mr, MethodDefinition md)
+    {
+        // RVA 0 means the method has no IL body (abstract, extern, etc.).
+        if (md.RelativeVirtualAddress == 0)
+            return null;
+
+        MethodBodyBlock body = pe.GetMethodBody(md.RelativeVirtualAddress);
+        byte[] il = body.GetILBytes()!;
+
+        // ldstr — "load string literal" — is opcode 0x72, followed by a 4-byte operand.
+        const byte Ldstr = 0x72;
+
+        // The `i + 4 < il.Length` bound guarantees the 4 operand bytes we're about to read
+        // are actually inside the array (protects ToInt32 if a stray 0x72 sits near the end).
+        for (int i = 0; i + 4 < il.Length; i++)
+        {
+            if (il[i] != Ldstr)
+                continue;
+
+            // The 4 operand bytes are a metadata token, stored little-endian (per the spec,
+            // matching x86/x64). ToInt32 reads them in that order.
+            int token = BitConverter.ToInt32(il, i + 1);
+
+            // A metadata token packs a table id in the top byte and a row/offset in the low
+            // 3 bytes. An ldstr token always points into the user-string (#US) heap, whose
+            // table byte is 0x70 — so a real token looks like 0x70000001, 0x7000000A, etc.
+            // Mask off the 0x70 tag to get the raw offset into the heap...
+            var handle = MetadataTokens.UserStringHandle(token & 0x00FFFFFF);
+
+            // ...then dereference that offset to pull the actual UTF-16 string the compiler
+            // stored there. The token was the address; this is the lookup.
+            return mr.GetUserString(handle);
+        }
+
+        return null;
+    }
+}

--- a/eng/tools/McpToolEvaluator.Core/src/McpServerInformation.cs
+++ b/eng/tools/McpToolEvaluator.Core/src/McpServerInformation.cs
@@ -18,7 +18,7 @@ public class McpServerInformation
         ProbeSetupNames(artifactDirectory);
     }
 
-    public Dictionary<string, ToolArea> AssemblyNameToToolsMap { get; } = new Dictionary<string, ToolArea>(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, ToolMetadata> AssemblyNameToToolsMap { get; } = new Dictionary<string, ToolMetadata>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Scans every managed assembly beside the server's binary folder for "*Setup" classes
@@ -61,9 +61,9 @@ public class McpServerInformation
     /// Opens a single assembly's metadata and appends a ToolArea for every "*Setup" type
     /// that has a Name property returning a string literal.
     /// </summary>
-    internal static List<ToolArea> ProbeAssembly(string path)
+    internal static List<ToolMetadata> ProbeAssembly(string path)
     {
-        var results = new List<ToolArea>();
+        var results = new List<ToolMetadata>();
         using var fs = File.OpenRead(path);
         using var pe = new PEReader(fs);
 
@@ -102,7 +102,7 @@ public class McpServerInformation
                 var value = ReadLdstrLiteral(pe, reader, reader.GetMethodDefinition(getter));
                 if (value is not null)
                 {
-                    results.Add(new ToolArea { AssemblyName = assemblyName, ToolNamespace = value });
+                    results.Add(new ToolMetadata { AssemblyName = assemblyName, ToolNamespace = value });
                 }
             }
         }

--- a/eng/tools/McpToolEvaluator.Core/src/McpServerMetadata.cs
+++ b/eng/tools/McpToolEvaluator.Core/src/McpServerMetadata.cs
@@ -18,7 +18,7 @@ public class McpServerMetadata
         ProbeSetupNames(artifactDirectory);
     }
 
-    public Dictionary<string, ToolMetadata> AssemblyNameToToolsMap { get; } = new Dictionary<string, ToolMetadata>(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, List<ToolMetadata>> AssemblyNameToToolsMap { get; } = new Dictionary<string, List<ToolMetadata>>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Scans every managed assembly beside the server's binary folder for "*Setup" classes
@@ -46,7 +46,12 @@ public class McpServerMetadata
             {
                 foreach (var toolArea in ProbeAssembly(dll))
                 {
-                    AssemblyNameToToolsMap[toolArea.AssemblyName] = toolArea;
+                    if (!AssemblyNameToToolsMap.TryGetValue(toolArea.AssemblyName, out var list))
+                    {
+                        list = new List<ToolMetadata>();
+                        AssemblyNameToToolsMap[toolArea.AssemblyName] = list;
+                    }
+                    list.Add(toolArea);
                 }
             }
             catch (BadImageFormatException)

--- a/eng/tools/McpToolEvaluator.Core/src/McpServerMetadata.cs
+++ b/eng/tools/McpToolEvaluator.Core/src/McpServerMetadata.cs
@@ -11,9 +11,9 @@ namespace McpToolEvaluator.Core;
 /// <summary>
 /// Contains information about the MCP server, including its name and the tool areas it supports.
 /// </summary>
-public class McpServerInformation
+public class McpServerMetadata
 {
-    public McpServerInformation(string artifactDirectory)
+    public McpServerMetadata(string artifactDirectory)
     {
         ProbeSetupNames(artifactDirectory);
     }

--- a/eng/tools/McpToolEvaluator.Core/src/Models/PromptInteraction.cs
+++ b/eng/tools/McpToolEvaluator.Core/src/Models/PromptInteraction.cs
@@ -14,5 +14,8 @@ public enum PromptInteraction
     ClarificationRequired,
 
     [EnumMember(Value = PromptInteractionExtensions.ContextRequired)]
-    ContextRequired
+    ContextRequired,
+
+    [EnumMember(Value = PromptInteractionExtensions.InvestigationRequired)]
+    InvestigationRequired
 }

--- a/eng/tools/McpToolEvaluator.Core/src/Models/PromptInteractionExtensions.cs
+++ b/eng/tools/McpToolEvaluator.Core/src/Models/PromptInteractionExtensions.cs
@@ -8,6 +8,7 @@ public static class PromptInteractionExtensions
     public const string None = "none";
     public const string ClarificationRequired = "clarification-required";
     public const string ContextRequired = "context-required";
+    public const string InvestigationRequired = "investigation-required";
 
     public static PromptInteraction Parse(string value)
     {
@@ -16,6 +17,7 @@ public static class PromptInteractionExtensions
             None => PromptInteraction.None,
             ClarificationRequired => PromptInteraction.ClarificationRequired,
             ContextRequired => PromptInteraction.ContextRequired,
+            InvestigationRequired => PromptInteraction.InvestigationRequired,
             _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown prompt interaction.")
         };
     }
@@ -27,6 +29,7 @@ public static class PromptInteractionExtensions
             PromptInteraction.None => None,
             PromptInteraction.ClarificationRequired => ClarificationRequired,
             PromptInteraction.ContextRequired => ContextRequired,
+            PromptInteraction.InvestigationRequired => InvestigationRequired,
             _ => throw new ArgumentOutOfRangeException(nameof(interaction), interaction, "Unknown prompt interaction.")
         };
     }

--- a/eng/tools/McpToolEvaluator.Core/src/Models/ToolArea.cs
+++ b/eng/tools/McpToolEvaluator.Core/src/Models/ToolArea.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace McpToolEvaluator.Core.Models;
+
+public record ToolArea
+{
+    public required string AssemblyName { get; init; }
+
+    public required string ToolNamespace { get; init; }
+}

--- a/eng/tools/McpToolEvaluator.Core/src/Models/ToolMetadata.cs
+++ b/eng/tools/McpToolEvaluator.Core/src/Models/ToolMetadata.cs
@@ -3,7 +3,7 @@
 
 namespace McpToolEvaluator.Core.Models;
 
-public record ToolArea
+public record ToolMetadata
 {
     public required string AssemblyName { get; init; }
 

--- a/eng/tools/McpToolEvaluator.Core/src/PromptDatastore.cs
+++ b/eng/tools/McpToolEvaluator.Core/src/PromptDatastore.cs
@@ -13,7 +13,6 @@ public class PromptDatastore
     public PromptDatastore(string promptFilePath)
     {
         prompts = PromptParser.ParseFile(promptFilePath)
-            .Where(prompt => prompt.Interaction == PromptInteraction.None)
             .ToList();
         promptsByNamespace = prompts
             .GroupBy(x => x.Namespace, StringComparer.OrdinalIgnoreCase)

--- a/eng/tools/McpToolEvaluator.Core/tests/McpServerMetadataTests.cs
+++ b/eng/tools/McpToolEvaluator.Core/tests/McpServerMetadataTests.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace McpToolEvaluator.Core.Tests;
+
+public sealed class McpServerMetadataTests
+{
+    [Fact]
+    public void ProbeAssembly_ReturnsLiteralNameSetupClasses()
+    {
+        var assemblyPath = typeof(McpServerMetadataTests).Assembly.Location;
+
+        var result = McpServerMetadata.ProbeAssembly(assemblyPath);
+
+        Assert.Contains(result, m => m.ToolNamespace == "alpha");
+        Assert.Contains(result, m => m.ToolNamespace == "delta");
+    }
+
+    [Fact]
+    public void ProbeAssembly_IgnoresNonLiteralOrInvalidNameShapes()
+    {
+        var assemblyPath = typeof(McpServerMetadataTests).Assembly.Location;
+
+        var result = McpServerMetadata.ProbeAssembly(assemblyPath);
+
+        Assert.DoesNotContain(result, m => m.ToolNamespace == "beta");
+        Assert.DoesNotContain(result, m => m.ToolNamespace == "gamma");
+    }
+
+    [Fact]
+    public void ProbeSetupNames_MapsToolsByAssemblyName()
+    {
+        var tempDirectory = CreateTempDirectory();
+        try
+        {
+            var targetAssemblyPath = Path.Combine(tempDirectory, "McpToolEvaluator.Core.Tests.dll");
+            File.Copy(typeof(McpServerMetadataTests).Assembly.Location, targetAssemblyPath, overwrite: true);
+
+            var metadata = new McpServerMetadata(tempDirectory);
+            var assemblyName = typeof(McpServerMetadataTests).Assembly.GetName().Name!;
+
+            Assert.True(metadata.AssemblyNameToToolsMap.ContainsKey(assemblyName));
+
+            var tools = metadata.AssemblyNameToToolsMap[assemblyName];
+            Assert.Contains(tools, t => t.ToolNamespace == "alpha");
+            Assert.Contains(tools, t => t.ToolNamespace == "delta");
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ProbeSetupNames_SkipsBadImageFormatFiles()
+    {
+        var tempDirectory = CreateTempDirectory();
+        try
+        {
+            var validAssemblyPath = Path.Combine(tempDirectory, "Managed.dll");
+            File.Copy(typeof(McpServerMetadataTests).Assembly.Location, validAssemblyPath, overwrite: true);
+
+            var badImagePath = Path.Combine(tempDirectory, "NativeLike.dll");
+            File.WriteAllText(badImagePath, "not a managed assembly");
+
+            var metadata = new McpServerMetadata(tempDirectory);
+            var assemblyName = typeof(McpServerMetadataTests).Assembly.GetName().Name!;
+
+            Assert.True(metadata.AssemblyNameToToolsMap.ContainsKey(assemblyName));
+            Assert.Contains(metadata.AssemblyNameToToolsMap[assemblyName], t => t.ToolNamespace == "alpha");
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ProbeSetupNames_EmptyDirectory_ReturnsEmptyMap()
+    {
+        var tempDirectory = CreateTempDirectory();
+        try
+        {
+            var metadata = new McpServerMetadata(tempDirectory);
+
+            Assert.Empty(metadata.AssemblyNameToToolsMap);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"mcp-server-metadata-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private sealed class AlphaSetup
+    {
+        public string Name => "alpha";
+    }
+
+    private sealed class DeltaSetup
+    {
+        public string Name => "delta";
+    }
+
+    private sealed class BetaSetup
+    {
+        public string Name { get; } = "beta";
+    }
+
+    private sealed class GammaSetup
+    {
+        public string Name => GetName();
+
+        private static string GetName() => "gamma";
+    }
+
+    private sealed class NonSetup
+    {
+        public string Name => "ignored";
+    }
+
+    private sealed class WriteOnlySetup
+    {
+        public string Name
+        {
+            set
+            {
+            }
+        }
+    }
+}

--- a/eng/tools/McpToolEvaluator.Core/tests/PromptDatastoreTests.cs
+++ b/eng/tools/McpToolEvaluator.Core/tests/PromptDatastoreTests.cs
@@ -20,6 +20,7 @@ public sealed class PromptDatastoreTests : IDisposable
             new("advisor", "advisor_recommendation_list", "list recommendations", "advisor", PromptInteraction.None),
             new("advisor", "advisor_recommendation_apply", "apply recommendations to this template", "advisor", PromptInteraction.ContextRequired),
             new("advisor", "advisor_recommendation_apply", "apply recommendations", "advisor", PromptInteraction.ClarificationRequired),
+            new("advisor", "advisor_recommendation_list", "investigate recommendation routing", "advisor", PromptInteraction.InvestigationRequired),
         };
 
         File.WriteAllText(_tempFile, """
@@ -30,13 +31,14 @@ public sealed class PromptDatastoreTests : IDisposable
             | advisor_recommendation_list | list recommendations | none |
             | advisor_recommendation_apply | apply recommendations to this template | context-required |
             | advisor_recommendation_apply | apply recommendations | clarification-required |
+            | advisor_recommendation_list | investigate recommendation routing | investigation-required |
             """);
 
         var datastore = new PromptDatastore(_tempFile);
         var matching = datastore.GetPromptsByNamespace("advisor");
 
         Assert.NotNull(matching);
-        Assert.Equal(3, matching.Count);
+        Assert.Equal(4, matching.Count);
         foreach (var expected in expectedPrompts)
         {
             var match = matching.FirstOrDefault(p => AreEqual(p, expected));

--- a/eng/tools/McpToolEvaluator.Core/tests/PromptDatastoreTests.cs
+++ b/eng/tools/McpToolEvaluator.Core/tests/PromptDatastoreTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using McpToolEvaluator.Core.Models;
 using Xunit;
 
 namespace McpToolEvaluator.Core.Tests;
@@ -12,8 +13,15 @@ public sealed class PromptDatastoreTests : IDisposable
     public void Dispose() => File.Delete(_tempFile);
 
     [Fact]
-    public void GetPromptsByNamespace_InteractivePrompts_ExcludesInteractivePrompts()
+    public void GetPromptsByNamespace_InteractivePrompts()
     {
+        var expectedPrompts = new List<TestPrompt>
+        {
+            new("advisor", "advisor_recommendation_list", "list recommendations", "advisor", PromptInteraction.None),
+            new("advisor", "advisor_recommendation_apply", "apply recommendations to this template", "advisor", PromptInteraction.ContextRequired),
+            new("advisor", "advisor_recommendation_apply", "apply recommendations", "advisor", PromptInteraction.ClarificationRequired),
+        };
+
         File.WriteAllText(_tempFile, """
             ## advisor
 
@@ -25,8 +33,24 @@ public sealed class PromptDatastoreTests : IDisposable
             """);
 
         var datastore = new PromptDatastore(_tempFile);
+        var matching = datastore.GetPromptsByNamespace("advisor");
 
-        var prompt = Assert.Single(datastore.GetPromptsByNamespace("advisor"));
-        Assert.Equal("list recommendations", prompt.Prompt);
+        Assert.NotNull(matching);
+        Assert.Equal(3, matching.Count);
+        foreach (var expected in expectedPrompts)
+        {
+            var match = matching.FirstOrDefault(p => AreEqual(p, expected));
+
+            Assert.NotNull(match);
+        }
+    }
+
+    private static bool AreEqual(TestPrompt a, TestPrompt b)
+    {
+        return a.Section == b.Section &&
+               a.Tool == b.Tool &&
+               a.Prompt == b.Prompt &&
+               a.Namespace == b.Namespace &&
+               a.Interaction == b.Interaction;
     }
 }

--- a/eng/tools/McpToolEvaluator.Core/tests/PromptInteractionExtensionsTests.cs
+++ b/eng/tools/McpToolEvaluator.Core/tests/PromptInteractionExtensionsTests.cs
@@ -12,6 +12,7 @@ public sealed class PromptInteractionExtensionsTests
     [InlineData(PromptInteraction.None, PromptInteractionExtensions.None)]
     [InlineData(PromptInteraction.ClarificationRequired, PromptInteractionExtensions.ClarificationRequired)]
     [InlineData(PromptInteraction.ContextRequired, PromptInteractionExtensions.ContextRequired)]
+    [InlineData(PromptInteraction.InvestigationRequired, PromptInteractionExtensions.InvestigationRequired)]
     public void Parse_DisplayString_RoundTrips(PromptInteraction interaction, string displayString)
     {
         Assert.Equal(interaction, PromptInteractionExtensions.Parse(displayString));

--- a/eng/tools/McpToolEvaluator.Core/tests/PromptParserTests.cs
+++ b/eng/tools/McpToolEvaluator.Core/tests/PromptParserTests.cs
@@ -144,14 +144,16 @@ public sealed class PromptParserTests : IDisposable
             | advisor_recommendation_list | list recommendations | none |
             | advisor_recommendation_apply | apply recommendations to this template | context-required |
             | advisor_recommendation_apply | apply recommendations | clarification-required |
+            | advisor_recommendation_list | investigate recommendation routing | investigation-required |
             """);
 
         var result = PromptParser.ParseFile(_tempFile);
 
-        Assert.Equal(3, result.Count);
+        Assert.Equal(4, result.Count);
         Assert.Equal(PromptInteraction.None, result[0].Interaction);
         Assert.Equal(PromptInteraction.ContextRequired, result[1].Interaction);
         Assert.Equal(PromptInteraction.ClarificationRequired, result[2].Interaction);
+        Assert.Equal(PromptInteraction.InvestigationRequired, result[3].Interaction);
         Assert.Equal("apply recommendations to this template", result[1].Prompt);
     }
 

--- a/eng/tools/McpToolEvaluator.Core/tests/TestPromptTests.cs
+++ b/eng/tools/McpToolEvaluator.Core/tests/TestPromptTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using McpToolEvaluator.Core.Models;
+using Xunit;
+
+namespace McpToolEvaluator.Core.Tests;
+
+public sealed class TestPromptTests
+{
+    [Fact]
+    public void Constructor_WithAllArguments_SetsAllProperties()
+    {
+        var prompt = new TestPrompt(
+            section: "storage",
+            tool: "storage_account_list",
+            prompt: "list accounts",
+            @namespace: "storage",
+            interaction: PromptInteraction.ContextRequired);
+
+        Assert.Equal("storage", prompt.Section);
+        Assert.Equal("storage_account_list", prompt.Tool);
+        Assert.Equal("list accounts", prompt.Prompt);
+        Assert.Equal("storage", prompt.Namespace);
+        Assert.Equal(PromptInteraction.ContextRequired, prompt.Interaction);
+    }
+
+    [Fact]
+    public void Constructor_WithoutOptionalArguments_UsesDefaults()
+    {
+        var prompt = new TestPrompt("section", "tool", "do work");
+
+        Assert.Equal(string.Empty, prompt.Namespace);
+        Assert.Equal(PromptInteraction.None, prompt.Interaction);
+    }
+}

--- a/eng/tools/McpToolEvaluator.Core/tests/ToolMetadataTests.cs
+++ b/eng/tools/McpToolEvaluator.Core/tests/ToolMetadataTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using McpToolEvaluator.Core.Models;
+using Xunit;
+
+namespace McpToolEvaluator.Core.Tests;
+
+public sealed class ToolMetadataTests
+{
+    [Fact]
+    public void Record_WithSameValues_IsEqual()
+    {
+        var left = new ToolMetadata
+        {
+            AssemblyName = "Azure.Mcp.Tools.Storage",
+            ToolNamespace = "storage"
+        };
+
+        var right = new ToolMetadata
+        {
+            AssemblyName = "Azure.Mcp.Tools.Storage",
+            ToolNamespace = "storage"
+        };
+
+        Assert.Equal(left, right);
+    }
+
+    [Fact]
+    public void Record_WithDifferentValues_IsNotEqual()
+    {
+        var left = new ToolMetadata
+        {
+            AssemblyName = "Azure.Mcp.Tools.Storage",
+            ToolNamespace = "storage"
+        };
+
+        var right = new ToolMetadata
+        {
+            AssemblyName = "Azure.Mcp.Tools.KeyVault",
+            ToolNamespace = "keyvault"
+        };
+
+        Assert.NotEqual(left, right);
+    }
+}

--- a/eng/tools/McpToolEvaluator.Core/tests/UtilitiesTests.cs
+++ b/eng/tools/McpToolEvaluator.Core/tests/UtilitiesTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace McpToolEvaluator.Core.Tests;
+
+public sealed class UtilitiesTests
+{
+    [Fact]
+    public void FindRepoRoot_ReturnsNearestAncestorContainingSolutionMarker()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var nested = Path.Combine(root, "a", "b", "c");
+            Directory.CreateDirectory(nested);
+            File.WriteAllText(Path.Combine(root, "Microsoft.Mcp.slnx"), string.Empty);
+
+            var result = Utilities.FindRepoRoot(nested);
+
+            Assert.Equal(root, result);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FindRepoRoot_ThrowsWhenMarkerDoesNotExist()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var nested = Path.Combine(root, "x", "y");
+            Directory.CreateDirectory(nested);
+
+            var exception = Assert.Throws<InvalidOperationException>(() => Utilities.FindRepoRoot(nested));
+
+            Assert.Contains("Could not find repo root", exception.Message);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"mcp-util-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/eng/tools/VallyEvaluator/README.md
+++ b/eng/tools/VallyEvaluator/README.md
@@ -1,0 +1,97 @@
+# Vally Evaluator
+
+VallyEvaluator generates [Vally](https://microsoft.github.io/vally/) evaluation specifications from the MCP end-to-end prompts maintained in this repository. It converts each non-interactive prompt into a Vally stimulus with a `tool-calls` grader that verifies the expected MCP namespace and command.
+
+The evaluator generates specifications; it does not execute them. Use `eng/scripts/Invoke-VallyEvalTests.ps1` to run the generated specifications with Vally.
+
+## Prerequisites
+
+- The .NET SDK selected by the repository's `global.json`
+- [PowerShell 7](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) to use the repository scripts
+- [Vally](https://microsoft.github.io/vally/get-started/install/) to run evaluations
+- [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-sdk/setup/local-cli), authenticated with `copilot login`
+
+CI installs the Vally CLI with:
+
+```powershell
+npm install --global @microsoft/vally-cli@0.13.0
+```
+
+See [Testing with Vally](../../../docs/testing-with-vally.md) for repository-wide setup and eval authoring guidance.
+
+## Generate Evaluations
+
+Generate evaluations for selected tool namespaces:
+
+```powershell
+dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- --namespaces "storage,appconfig"
+```
+
+Generate evaluations for every namespace represented in the default prompt file:
+
+```powershell
+dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj
+```
+
+By default, the tool reads `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md` and writes one file per namespace under:
+
+```text
+.work/vally/evals/<namespace>/eval.yaml
+```
+
+Existing generated `eval.yaml` files are overwritten. Prompts marked as requiring interaction are excluded because Vally runs must be unattended.
+
+## Command-Line Options
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--namespaces` | Comma-separated tool namespaces to generate, such as `storage,acr`. | All namespaces in the prompt file when build info is not supplied. |
+| `--promptFile` | Path to an end-to-end prompts Markdown file. | `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md` |
+| `--workingDirectory` | Root directory for generated Vally artifacts and server build artifacts. | `<repo-root>/.work` |
+| `--buildInfo` | Path to a `build_info.json` file. Limits generation to namespaces represented by `pathsToTest`. | Not set. |
+| `--serverName` | MCP server entry to select from the build-info file. | `Azure.Mcp.Server` |
+
+When both `--buildInfo` and `--namespaces` are supplied, the generated set is the union of namespaces selected by both options.
+
+### Generate from Build Information
+
+Build-info mode is intended for CI and changed-project evaluation. It requires a build-info file and server artifacts for the current runtime under `<workingDirectory>/build` so the evaluator can map assemblies to tool namespaces.
+
+```powershell
+./eng/scripts/New-BuildInfo.ps1 -ServerName Azure.Mcp.Server
+./eng/scripts/Build-Local.ps1 -ServerName Azure.Mcp.Server
+dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- --buildInfo ./.work/build_info.json
+```
+
+A custom server and working directory can be selected explicitly:
+
+```powershell
+dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- `
+  --buildInfo ./artifacts/build_info.json `
+  --serverName Fabric.Mcp.Server `
+  --workingDirectory ./artifacts
+```
+
+## Run Evaluations
+
+Build the MCP server, generate the specifications, and then invoke the wrapper:
+
+```powershell
+./eng/scripts/Build-Local.ps1 -ServerName Azure.Mcp.Server
+dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- --namespaces "storage,appconfig"
+./eng/scripts/Invoke-VallyEvalTests.ps1
+```
+
+The wrapper reads generated specs from `.work/vally/evals`, includes checked-in `eval.yaml` files referenced by `.work/build_info.json`, and writes results to `.work/vally/vally-results`.
+
+Useful wrapper options include:
+
+```powershell
+./eng/scripts/Invoke-VallyEvalTests.ps1 `
+  -NumberOfRuns 3 `
+  -IsDebug `
+  -OutputPath ./.work/vally/custom-results
+```
+
+For deterministic agent behavior in automated runs, the workflow copies `src/Resources/eval.instructions.md` to the Vally working directory as `AGENTS.md` before invoking Vally.
+

--- a/eng/tools/VallyEvaluator/README.md
+++ b/eng/tools/VallyEvaluator/README.md
@@ -24,16 +24,19 @@ See [Testing with Vally](../../../docs/testing-with-vally.md) for repository-wid
 Generate evaluations for selected tool namespaces:
 
 ```powershell
-dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- --namespaces "storage,appconfig"
+dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- `
+  --serverName Azure.Mcp.Server `
+  --namespaces "storage,appconfig"
 ```
 
-Generate evaluations for every namespace represented in the default prompt file:
+Generate evaluations for every namespace represented in Azure MCP Server's prompt file:
 
 ```powershell
-dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj
+dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- `
+  --serverName Azure.Mcp.Server
 ```
 
-By default, the tool reads `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md` and writes one file per namespace under:
+The tool derives its prompt file from the required server name using `servers/<serverName>/docs/e2eTestPrompts.md`. It writes one file per namespace under:
 
 ```text
 .work/vally/evals/<namespace>/eval.yaml
@@ -41,15 +44,16 @@ By default, the tool reads `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md` and
 
 Existing generated `eval.yaml` files are overwritten. Prompts marked as requiring interaction are excluded because Vally runs must be unattended.
 
+VallyEvaluator is not limited to Azure MCP Server. Any server can be used when it provides the expected prompt file. Generating specifications does not require a matching entry in `.vally.yaml`; executing them does require a Vally environment that launches the selected server.
+
 ## Command-Line Options
 
 | Option | Description | Default |
 | --- | --- | --- |
 | `--namespaces` | Comma-separated tool namespaces to generate, such as `storage,acr`. | All namespaces in the prompt file when build info is not supplied. |
-| `--promptFile` | Path to an end-to-end prompts Markdown file. | `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md` |
 | `--workingDirectory` | Root directory for generated Vally artifacts and server build artifacts. | `<repo-root>/.work` |
 | `--buildInfo` | Path to a `build_info.json` file. Limits generation to namespaces represented by `pathsToTest`. | Not set. |
-| `--serverName` | MCP server entry to select from the build-info file. | `Azure.Mcp.Server` |
+| `--serverName` | Required MCP server name. Selects `servers/<serverName>/docs/e2eTestPrompts.md` and the matching build-info entry. | Required. |
 
 When both `--buildInfo` and `--namespaces` are supplied, the generated set is the union of namespaces selected by both options.
 
@@ -58,9 +62,10 @@ When both `--buildInfo` and `--namespaces` are supplied, the generated set is th
 Build-info mode is intended for CI and changed-project evaluation. It requires a build-info file and server artifacts for the current runtime under `<workingDirectory>/build` so the evaluator can map assemblies to tool namespaces.
 
 ```powershell
-./eng/scripts/New-BuildInfo.ps1 -ServerName Azure.Mcp.Server
 ./eng/scripts/Build-Local.ps1 -ServerName Azure.Mcp.Server
-dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- --buildInfo ./.work/build_info.json
+dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- `
+  --serverName Azure.Mcp.Server `
+  --buildInfo ./.work/build_info.json
 ```
 
 A custom server and working directory can be selected explicitly:
@@ -78,11 +83,15 @@ Build the MCP server, generate the specifications, and then invoke the wrapper:
 
 ```powershell
 ./eng/scripts/Build-Local.ps1 -ServerName Azure.Mcp.Server
-dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- --namespaces "storage,appconfig"
+dotnet run --project ./eng/tools/VallyEvaluator/src/VallyEvaluator.csproj -- `
+  --serverName Azure.Mcp.Server `
+  --namespaces "storage,appconfig"
 ./eng/scripts/Invoke-VallyEvalTests.ps1
 ```
 
 The wrapper reads generated specs from `.work/vally/evals`, includes checked-in `eval.yaml` files referenced by `.work/build_info.json`, and writes results to `.work/vally/vally-results`.
+
+The repository's `.vally.yaml` currently configures Azure MCP Server environments only. Generating specifications for another server also requires a corresponding Vally environment before those specifications can run.
 
 Useful wrapper options include:
 
@@ -93,4 +102,4 @@ Useful wrapper options include:
   -OutputPath ./.work/vally/custom-results
 ```
 
-For deterministic agent behavior in automated runs, the workflow copies `src/Resources/eval.instructions.md` to the Vally working directory as `AGENTS.md` before invoking Vally.
+For deterministic agent behavior, the wrapper temporarily replaces `<WorkDirectory>/AGENTS.md` with `src/Resources/eval.instructions.md` and restores the original file after Vally exits. A custom `-WorkDirectory` must already contain an `AGENTS.md` file. If no generated or checked-in specifications are found, the wrapper exits successfully without invoking Vally.

--- a/eng/tools/VallyEvaluator/README.md
+++ b/eng/tools/VallyEvaluator/README.md
@@ -94,4 +94,3 @@ Useful wrapper options include:
 ```
 
 For deterministic agent behavior in automated runs, the workflow copies `src/Resources/eval.instructions.md` to the Vally working directory as `AGENTS.md` before invoking Vally.
-

--- a/eng/tools/VallyEvaluator/src/Program.cs
+++ b/eng/tools/VallyEvaluator/src/Program.cs
@@ -128,13 +128,13 @@ internal class Program
                     Console.Error.WriteLine($"Namespace not found in MCP server referenced assemblies: {possibleNamespace}. Original: {assemblyName}");
                 }
             else
-            {
-                Console.Error.WriteLine($"Namespace not found.  No MCP server to probe for namespaces: {possibleNamespace}. Original: {split[1]}");
+                {
+                    Console.Error.WriteLine($"Namespace not found.  No MCP server to probe for namespaces: {possibleNamespace}. Original: {split[1]}");
+                }
             }
-        }
 
-        return results.ToList();
-    }
+            return results.ToList();
+        }
 
     internal static Task<McpServerInformation> GetMcpServerInfo(RunConfiguration configuration, BuildInfo buildInfo)
     {

--- a/eng/tools/VallyEvaluator/src/Program.cs
+++ b/eng/tools/VallyEvaluator/src/Program.cs
@@ -19,10 +19,18 @@ internal class Program
         var runConfig = new RunConfiguration();
         configuration.Bind(runConfig);
 
+        runConfig.RepositoryRoot = Utilities.FindRepoRoot(AppContext.BaseDirectory);
+
         if (string.IsNullOrEmpty(runConfig.ServerName))
         {
-            Console.WriteLine("No MCP server specified. Using default: Azure.Mcp.Server");
-            runConfig.ServerName = "Azure.Mcp.Server";
+            Console.Error.WriteLine("No MCP server specified. Please specify using --serverName={{NameOfServer}}.");
+            return -1;
+        }
+
+        if (!Path.Exists(runConfig.PromptFilePath))
+        {
+            Console.Error.WriteLine($"Could not find: '{runConfig.PromptFilePath}' to create prompts from.");
+            return -1;
         }
 
         if (!string.IsNullOrEmpty(runConfig.NamespacesValue))
@@ -35,10 +43,9 @@ internal class Program
             Console.WriteLine("No namespaces specified. Writing evals for all namespaces");
         }
 
-        var repoRoot = Utilities.FindRepoRoot(AppContext.BaseDirectory);
         if (string.IsNullOrEmpty(runConfig.WorkingDirectory))
         {
-            var workDir = Path.Join(repoRoot, ".work");
+            var workDir = Path.Join(runConfig.RepositoryRoot, ".work");
             runConfig.WorkingDirectory = workDir;
             Console.WriteLine("No working directory specified. Using default: " + workDir);
         }
@@ -46,16 +53,6 @@ internal class Program
         if (!Directory.Exists(runConfig.WorkingDirectory))
         {
             Directory.CreateDirectory(runConfig.WorkingDirectory);
-        }
-
-        if (string.IsNullOrEmpty(runConfig.PromptFilePath))
-        {
-            Console.WriteLine("No prompts file specified. Using prompts from Azure.Mcp.Server");
-            runConfig.PromptFilePath = Path.Combine(repoRoot, "servers", "Azure.Mcp.Server", "docs", "e2eTestPrompts.md");
-        }
-        else
-        {
-            runConfig.PromptFilePath = Path.GetFullPath(runConfig.PromptFilePath);
         }
 
         BuildInfo? buildInfo = null;
@@ -79,7 +76,7 @@ internal class Program
         try
         {
             Console.WriteLine($"Creating evals for MCP server: {runConfig.ServerName}");
-            await CreateEvalsAsync(repoRoot, runConfig, buildInfo, mcpServerInformation);
+            await CreateEvalsAsync(runConfig.RepositoryRoot, runConfig, buildInfo, mcpServerInformation);
         }
         catch (Exception ex)
         {
@@ -91,7 +88,7 @@ internal class Program
         return 0;
     }
 
-    internal static List<string> GetTestToolNamespaces(BuildInfo buildInfo, PromptDatastore promptDatastore, McpServerMetadata? mcpServerInformation)
+    internal static List<string> GetToolNamespacesFromBuildInfo(BuildInfo buildInfo, PromptDatastore promptDatastore, McpServerMetadata? mcpServerInformation)
     {
         var promptNamespaces = promptDatastore.GetNamespaces().ToHashSet(StringComparer.InvariantCultureIgnoreCase);
         var results = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
@@ -182,7 +179,7 @@ internal class Program
 
         if (buildInfo != null)
         {
-            var testToolNamespaces = GetTestToolNamespaces(buildInfo, promptDatastore, mcpServerInformation);
+            var testToolNamespaces = GetToolNamespacesFromBuildInfo(buildInfo, promptDatastore, mcpServerInformation);
             if (testToolNamespaces.Count == 0)
             {
                 Console.WriteLine("No valid namespaces found in build info. Exiting.");

--- a/eng/tools/VallyEvaluator/src/Program.cs
+++ b/eng/tools/VallyEvaluator/src/Program.cs
@@ -119,18 +119,14 @@ internal class Program
             else if (mcpServerInformation != null)
             {
                 var assemblyName = split[1];
-                var matching = mcpServerInformation.AssemblyNameToToolsMap.Values
-                    .FirstOrDefault(x => x.AssemblyName.Equals(assemblyName, StringComparison.InvariantCultureIgnoreCase));
-
-                if (matching != null)
+                if (mcpServerInformation.AssemblyNameToToolsMap.TryGetValue(assemblyName, out var matching))
                 {
                     results.Add(matching.ToolNamespace);
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Namespace not found in MCP server referenced assemblies: {possibleNamespace}. Original: {split[1]}");
+                    Console.Error.WriteLine($"Namespace not found in MCP server referenced assemblies: {possibleNamespace}. Original: {assemblyName}");
                 }
-            }
             else
             {
                 Console.Error.WriteLine($"Namespace not found.  No MCP server to probe for namespaces: {possibleNamespace}. Original: {split[1]}");
@@ -164,7 +160,7 @@ internal class Program
             throw new InvalidOperationException($"Artifact path does not exist: {artifactPath}");
         }
 
-        return Task.Run(() => new McpServerInformation(artifactPath));
+        return Task.FromResult(new McpServerInformation(artifactPath));
     }
 
     private static async Task CreateEvalsAsync(string repoRoot, RunConfiguration configuration, BuildInfo? buildInfo = null, McpServerInformation? mcpServerInformation = null)
@@ -173,7 +169,7 @@ internal class Program
         {
             // Assuming that Azure.Mcp.Tools.Acr will also have E2E prompts that are `acr_`
             Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine("WARNING: MCP server information is null. Using assuming that the assembly name and tool area match.");
+            Console.WriteLine("WARNING: MCP server information is null. Assuming the assembly name and tool area match.");
             Console.ResetColor();
         }
 

--- a/eng/tools/VallyEvaluator/src/Program.cs
+++ b/eng/tools/VallyEvaluator/src/Program.cs
@@ -70,7 +70,7 @@ internal class Program
             buildInfo = new BuildInfo(runConfig.BuildInfo);
         }
 
-        McpServerInformation? mcpServerInformation = null;
+        McpServerMetadata? mcpServerInformation = null;
         if (buildInfo != null)
         {
             mcpServerInformation = await GetMcpServerInfo(runConfig, buildInfo);
@@ -91,7 +91,7 @@ internal class Program
         return 0;
     }
 
-    internal static List<string> GetTestToolNamespaces(BuildInfo buildInfo, PromptDatastore promptDatastore, McpServerInformation? mcpServerInformation)
+    internal static List<string> GetTestToolNamespaces(BuildInfo buildInfo, PromptDatastore promptDatastore, McpServerMetadata? mcpServerInformation)
     {
         var promptNamespaces = promptDatastore.GetNamespaces().ToHashSet(StringComparer.InvariantCultureIgnoreCase);
         var results = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
@@ -133,7 +133,7 @@ internal class Program
         return results.ToList();
     }
 
-    internal static Task<McpServerInformation> GetMcpServerInfo(RunConfiguration configuration, BuildInfo buildInfo)
+    internal static Task<McpServerMetadata> GetMcpServerInfo(RunConfiguration configuration, BuildInfo buildInfo)
     {
         var serverInfo = buildInfo.Data.Servers.FirstOrDefault(x => x.Name.Equals(configuration.ServerName, StringComparison.OrdinalIgnoreCase));
         if (serverInfo == null)
@@ -157,10 +157,10 @@ internal class Program
             throw new InvalidOperationException($"Artifact path does not exist: {artifactPath}");
         }
 
-        return Task.FromResult(new McpServerInformation(artifactPath));
+        return Task.FromResult(new McpServerMetadata(artifactPath));
     }
 
-    private static async Task CreateEvalsAsync(string repoRoot, RunConfiguration configuration, BuildInfo? buildInfo = null, McpServerInformation? mcpServerInformation = null)
+    private static async Task CreateEvalsAsync(string repoRoot, RunConfiguration configuration, BuildInfo? buildInfo = null, McpServerMetadata? mcpServerInformation = null)
     {
         if (mcpServerInformation == null)
         {

--- a/eng/tools/VallyEvaluator/src/Program.cs
+++ b/eng/tools/VallyEvaluator/src/Program.cs
@@ -50,7 +50,7 @@ internal class Program
 
         if (string.IsNullOrEmpty(runConfig.PromptFilePath))
         {
-            Console.WriteLine("No prompts file specified specified. Using prompts from Azure.Mcp.Server");
+            Console.WriteLine("No prompts file specified. Using prompts from Azure.Mcp.Server");
             runConfig.PromptFilePath = Path.Combine(repoRoot, "servers", "Azure.Mcp.Server", "docs", "e2eTestPrompts.md");
         }
         else
@@ -127,14 +127,11 @@ internal class Program
                 {
                     Console.Error.WriteLine($"Namespace not found in MCP server referenced assemblies: {possibleNamespace}. Original: {assemblyName}");
                 }
-            else
-                {
-                    Console.Error.WriteLine($"Namespace not found.  No MCP server to probe for namespaces: {possibleNamespace}. Original: {split[1]}");
-                }
             }
-
-            return results.ToList();
         }
+
+        return results.ToList();
+    }
 
     internal static Task<McpServerInformation> GetMcpServerInfo(RunConfiguration configuration, BuildInfo buildInfo)
     {

--- a/eng/tools/VallyEvaluator/src/Program.cs
+++ b/eng/tools/VallyEvaluator/src/Program.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Runtime.InteropServices;
 using McpToolEvaluator.Core;
+using McpToolEvaluator.Core.Models;
 using Microsoft.Extensions.Configuration;
 
 namespace VallyEvaluator;
@@ -17,15 +19,28 @@ internal class Program
         var runConfig = new RunConfiguration();
         configuration.Bind(runConfig);
 
+        if (string.IsNullOrEmpty(runConfig.ServerName))
+        {
+            Console.WriteLine("No MCP server specified. Using default: Azure.Mcp.Server");
+            runConfig.ServerName = "Azure.Mcp.Server";
+        }
+
         if (!string.IsNullOrEmpty(runConfig.NamespacesValue))
         {
+            Console.WriteLine("Using namespaces from command line: " + runConfig.NamespacesValue);
             runConfig.Namespaces = [.. runConfig.NamespacesValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
+        }
+        else
+        {
+            Console.WriteLine("No namespaces specified. Writing evals for all namespaces");
         }
 
         var repoRoot = Utilities.FindRepoRoot(AppContext.BaseDirectory);
         if (string.IsNullOrEmpty(runConfig.WorkingDirectory))
         {
-            runConfig.WorkingDirectory = Path.Join(repoRoot, ".work");
+            var workDir = Path.Join(repoRoot, ".work");
+            runConfig.WorkingDirectory = workDir;
+            Console.WriteLine("No working directory specified. Using default: " + workDir);
         }
 
         if (!Directory.Exists(runConfig.WorkingDirectory))
@@ -33,8 +48,17 @@ internal class Program
             Directory.CreateDirectory(runConfig.WorkingDirectory);
         }
 
-        BuildInfo? buildInfo = null;
+        if (string.IsNullOrEmpty(runConfig.PromptFilePath))
+        {
+            Console.WriteLine("No prompts file specified specified. Using prompts from Azure.Mcp.Server");
+            runConfig.PromptFilePath = Path.Combine(repoRoot, "servers", "Azure.Mcp.Server", "docs", "e2eTestPrompts.md");
+        }
+        else
+        {
+            runConfig.PromptFilePath = Path.GetFullPath(runConfig.PromptFilePath);
+        }
 
+        BuildInfo? buildInfo = null;
         if (!string.IsNullOrEmpty(runConfig.BuildInfo))
         {
             if (!File.Exists(runConfig.BuildInfo))
@@ -46,9 +70,16 @@ internal class Program
             buildInfo = new BuildInfo(runConfig.BuildInfo);
         }
 
+        McpServerInformation? mcpServerInformation = null;
+        if (buildInfo != null)
+        {
+            mcpServerInformation = await GetMcpServerInfo(runConfig, buildInfo);
+        }
+
         try
         {
-            await CreateEvalsAsync(repoRoot, runConfig, buildInfo);
+            Console.WriteLine($"Creating evals for MCP server: {runConfig.ServerName}");
+            await CreateEvalsAsync(repoRoot, runConfig, buildInfo, mcpServerInformation);
         }
         catch (Exception ex)
         {
@@ -60,7 +91,7 @@ internal class Program
         return 0;
     }
 
-    internal static List<string> GetTestToolNamespaces(BuildInfo buildInfo, PromptDatastore promptDatastore)
+    internal static List<string> GetTestToolNamespaces(BuildInfo buildInfo, PromptDatastore promptDatastore, McpServerInformation? mcpServerInformation)
     {
         var promptNamespaces = promptDatastore.GetNamespaces().ToHashSet(StringComparer.InvariantCultureIgnoreCase);
         var results = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
@@ -85,28 +116,68 @@ internal class Program
             {
                 results.Add(possibleNamespace);
             }
+            else if (mcpServerInformation != null)
+            {
+                var assemblyName = split[1];
+                var matching = mcpServerInformation.AssemblyNameToToolsMap.Values
+                    .FirstOrDefault(x => x.AssemblyName.Equals(assemblyName, StringComparison.InvariantCultureIgnoreCase));
+
+                if (matching != null)
+                {
+                    results.Add(matching.ToolNamespace);
+                }
+                else
+                {
+                    Console.Error.WriteLine($"Namespace not found in MCP server referenced assemblies: {possibleNamespace}. Original: {split[1]}");
+                }
+            }
             else
             {
-                Console.Error.WriteLine($"Namespace not found in prompt datastore: {possibleNamespace}. Original: {split[1]}");
+                Console.Error.WriteLine($"Namespace not found.  No MCP server to probe for namespaces: {possibleNamespace}. Original: {split[1]}");
             }
         }
 
         return results.ToList();
     }
 
-    private static async Task CreateEvalsAsync(string repoRoot, RunConfiguration configuration, BuildInfo? buildInfo = null)
+    internal static Task<McpServerInformation> GetMcpServerInfo(RunConfiguration configuration, BuildInfo buildInfo)
     {
-        string promptsPath = string.Empty;
-        if (string.IsNullOrEmpty(configuration.PromptFilePath))
+        var serverInfo = buildInfo.Data.Servers.FirstOrDefault(x => x.Name.Equals(configuration.ServerName, StringComparison.OrdinalIgnoreCase));
+        if (serverInfo == null)
         {
-            promptsPath = Path.Combine(repoRoot, "servers", "Azure.Mcp.Server", "docs", "e2eTestPrompts.md");
-        }
-        else
-        {
-            promptsPath = Path.GetFullPath(configuration.PromptFilePath);
+            throw new InvalidOperationException($"Server information not found for server: {configuration.ServerName}");
         }
 
-        var promptDatastore = new PromptDatastore(promptsPath);
+        var platformInfo = serverInfo.Platforms.FirstOrDefault(p =>
+        {
+            var pIdentifier = $"{p.DotnetOs}-{p.Architecture}";
+            return RuntimeInformation.RuntimeIdentifier.Equals(pIdentifier);
+        });
+        if (platformInfo == null)
+        {
+            throw new InvalidOperationException($"Platform information not found for server: {configuration.ServerName}");
+        }
+
+        var artifactPath = Path.Combine(configuration.BuildDirectory, platformInfo.ArtifactPath);
+        if (!Directory.Exists(artifactPath))
+        {
+            throw new InvalidOperationException($"Artifact path does not exist: {artifactPath}");
+        }
+
+        return Task.Run(() => new McpServerInformation(artifactPath));
+    }
+
+    private static async Task CreateEvalsAsync(string repoRoot, RunConfiguration configuration, BuildInfo? buildInfo = null, McpServerInformation? mcpServerInformation = null)
+    {
+        if (mcpServerInformation == null)
+        {
+            // Assuming that Azure.Mcp.Tools.Acr will also have E2E prompts that are `acr_`
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine("WARNING: MCP server information is null. Using assuming that the assembly name and tool area match.");
+            Console.ResetColor();
+        }
+
+        var promptDatastore = new PromptDatastore(configuration.PromptFilePath);
         var vallyEvalDirectory = Path.Combine(configuration.VallyBaseDirectory, "evals");
 
         Directory.CreateDirectory(vallyEvalDirectory);
@@ -115,7 +186,7 @@ internal class Program
 
         if (buildInfo != null)
         {
-            var testToolNamespaces = GetTestToolNamespaces(buildInfo, promptDatastore);
+            var testToolNamespaces = GetTestToolNamespaces(buildInfo, promptDatastore, mcpServerInformation);
             if (testToolNamespaces.Count == 0)
             {
                 Console.WriteLine("No valid namespaces found in build info. Exiting.");
@@ -147,12 +218,19 @@ internal class Program
 
                     return p;
                 })
-                .OrderBy(p => p.Prompt)
-                .ToList();
+                .OrderBy(p => p.Prompt);
 
-            if (prompts.Count == 0)
+            if (!prompts.Any())
             {
                 Console.WriteLine($"- No prompts found for namespace: {ns}");
+                continue;
+            }
+
+            var noInteractionPrompts = prompts.Where(p => p.Interaction == PromptInteraction.None).ToList();
+
+            if (!noInteractionPrompts.Any())
+            {
+                Console.WriteLine($"- All prompts require interaction for namespace: {ns}");
                 continue;
             }
 
@@ -160,7 +238,7 @@ internal class Program
             Directory.CreateDirectory(outputDirectory);
             var outputFile = Path.Combine(outputDirectory, "eval.yaml");
 
-            await VallyUtilities.WritePromptsAsync(prompts, outputFile, force: true);
+            await VallyUtilities.WritePromptsAsync(noInteractionPrompts, outputFile, force: true);
         }
     }
 }

--- a/eng/tools/VallyEvaluator/src/Program.cs
+++ b/eng/tools/VallyEvaluator/src/Program.cs
@@ -119,9 +119,12 @@ internal class Program
             else if (mcpServerInformation != null)
             {
                 var assemblyName = split[1];
-                if (mcpServerInformation.AssemblyNameToToolsMap.TryGetValue(assemblyName, out var matching))
+                if (mcpServerInformation.AssemblyNameToToolsMap.TryGetValue(assemblyName, out var matchingTools))
                 {
-                    results.Add(matching.ToolNamespace);
+                    foreach (var tool in matchingTools)
+                    {
+                        results.Add(tool.ToolNamespace);
+                    }
                 }
                 else
                 {

--- a/eng/tools/VallyEvaluator/src/Properties/launchSettings.json
+++ b/eng/tools/VallyEvaluator/src/Properties/launchSettings.json
@@ -5,11 +5,11 @@
     },
     "All": {
       "commandName": "Project",
-      "commandLineArgs": "--output=\"./\""
+      "commandLineArgs": "--serverName=Azure.Mcp.Server"
     },
     "Demo": {
       "commandName": "Project",
-      "commandLineArgs": "--output=\"./\" --namespaces=\"storage,appconfig\""
+      "commandLineArgs": "--serverName=Azure.Mcp.Server --namespaces=\"storage,appconfig\""
     }
   }
 }

--- a/eng/tools/VallyEvaluator/src/RunConfiguration.cs
+++ b/eng/tools/VallyEvaluator/src/RunConfiguration.cs
@@ -34,6 +34,12 @@ public class RunConfiguration
     public string BuildInfo { get; set; } = string.Empty;
 
     /// <summary>
+    /// Name of the MCP server to use for evals.  If not set, will default to "Azure.Mcp.Server".
+    /// </summary>
+    [ConfigurationKeyName("serverName")]
+    public string ServerName { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets the base directory for Vally artifacts, which is a subdirectory of the working directory.
     /// </summary>
     public string VallyBaseDirectory
@@ -41,6 +47,17 @@ public class RunConfiguration
         get
         {
             return Path.Combine(WorkingDirectory, "vally");
+        }
+    }
+
+    /// <summary>
+    /// Gets the build directory for server artifacts, which is a subdirectory of the working directory.
+    /// </summary>
+    public string BuildDirectory
+    {
+        get
+        {
+            return Path.Combine(WorkingDirectory, "build");
         }
     }
 }

--- a/eng/tools/VallyEvaluator/src/RunConfiguration.cs
+++ b/eng/tools/VallyEvaluator/src/RunConfiguration.cs
@@ -8,7 +8,7 @@ namespace VallyEvaluator;
 public class RunConfiguration
 {
     /// <summary>
-    /// Tool namespaces to create evaluations for. Comma-separated list. For example: "storage,acr"
+    /// (Optional) Tool namespaces to create evaluations for. Comma-separated list. For example: "storage,acr"
     /// </summary>
     [ConfigurationKeyName("namespaces")]
     public string NamespacesValue { get; set; } = string.Empty;
@@ -16,13 +16,7 @@ public class RunConfiguration
     public List<string> Namespaces { get; set; } = new List<string>();
 
     /// <summary>
-    /// Path to prompts file. If not set, will default to "${repoRoot}/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md"
-    /// </summary>
-    [ConfigurationKeyName("promptFile")]
-    public string PromptFilePath { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Path to working directory where eval files and workspace will be created. If not set, will default to "${repoRoot}/.work"
+    /// (Optional) Path to working directory where eval files and workspace will be created. If not set, will default to "${RepositoryRoot}/.work"
     /// </summary>
     [ConfigurationKeyName("workingDirectory")]
     public string WorkingDirectory { get; set; } = string.Empty;
@@ -34,13 +28,19 @@ public class RunConfiguration
     public string BuildInfo { get; set; } = string.Empty;
 
     /// <summary>
-    /// Name of the MCP server to use for evals.  If not set, will default to "Azure.Mcp.Server".
+    /// (REQUIRED) Name of the MCP server to use for evals.
     /// </summary>
     [ConfigurationKeyName("serverName")]
     public string ServerName { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets the base directory for Vally artifacts, which is a subdirectory of the working directory.
+    /// The root of the repository.
+    /// </summary>
+    public string RepositoryRoot { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the base directory for Vally artifacts, which is a subdirectory of the working directory
+    /// in the format "$(WorkingDirectory)/vally".
     /// </summary>
     public string VallyBaseDirectory
     {
@@ -51,13 +51,26 @@ public class RunConfiguration
     }
 
     /// <summary>
-    /// Gets the build directory for server artifacts, which is a subdirectory of the working directory.
+    /// Gets the build directory for server artifacts, which is a subdirectory of the working directory
+    /// in the format "$(WorkingDirectory)/build".
     /// </summary>
     public string BuildDirectory
     {
         get
         {
             return Path.Combine(WorkingDirectory, "build");
+        }
+    }
+
+    /// <summary>
+    /// Gets the file path for the prompts.  It is constructed from <see cref="ServerName" /> in the
+    /// format "servers/$(ServerName)/docs/e2eTestPrompts.md"
+    /// </summary>
+    public string PromptFilePath
+    {
+        get
+        {
+            return Path.Combine(RepositoryRoot, "servers", ServerName, "docs", "e2eTestPrompts.md");
         }
     }
 }

--- a/eng/tools/VallyEvaluator/tests/VallyUtilitiesTests.cs
+++ b/eng/tools/VallyEvaluator/tests/VallyUtilitiesTests.cs
@@ -1,8 +1,98 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using McpToolEvaluator.Core.Models;
+using Xunit;
+
 namespace VallyEvaluator.Tests;
 
-public class VallyUtilitiesTests
+public sealed class VallyUtilitiesTests
 {
+    [Fact]
+    public void GetToolCallGrader_CreatesRequiredCommandEntry()
+    {
+        var grader = VallyUtilities.GetToolCallGrader("storage", "storage_account_list");
+
+        Assert.Equal("tool-calls", grader.Type);
+        var requiredEntry = Assert.Single(grader.Config.Required);
+        Assert.Equal("storage", requiredEntry.Name);
+        Assert.Equal("storage_account_list", requiredEntry.Args["command"]);
+    }
+
+    [Fact]
+    public async Task WritePromptsAsync_WritesEvaluationYaml()
+    {
+        var outputFile = GetTemporaryFilePath();
+        var prompts = new List<TestPrompt>
+        {
+            new("Storage", "storage_account_list", "List my storage accounts", "storage"),
+            new("Storage", "storage_account_get", "Show my storage account", "storage")
+        };
+
+        try
+        {
+            await VallyUtilities.WritePromptsAsync(prompts, outputFile);
+
+            var yaml = await File.ReadAllTextAsync(outputFile, TestContext.Current.CancellationToken);
+            var evaluation = VallyUtilities.Deserializer.Deserialize<Models.Evaluation>(yaml);
+
+            Assert.Equal("Storage evaluations", evaluation.Name);
+            Assert.Equal("Evaluation of prompts in the section Storage", evaluation.Description);
+            Assert.Equal("capability", evaluation.Type);
+            Assert.Collection(
+                evaluation.Stimuli,
+                stimulus => AssertStimulus(stimulus, "storage evaluation 0", "List my storage accounts", "storage_account_list"),
+                stimulus => AssertStimulus(stimulus, "storage evaluation 1", "Show my storage account", "storage_account_get"));
+        }
+        finally
+        {
+            File.Delete(outputFile);
+        }
+    }
+
+    [Fact]
+    public async Task WritePromptsAsync_WhenFileExistsAndForceIsFalse_DoesNotOverwriteFile()
+    {
+        var outputFile = GetTemporaryFilePath();
+        const string originalContent = "existing content";
+        await File.WriteAllTextAsync(outputFile, originalContent, TestContext.Current.CancellationToken);
+        var prompts = new List<TestPrompt>
+        {
+            new("Storage", "storage_account_list", "List my storage accounts", "storage")
+        };
+
+        try
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => VallyUtilities.WritePromptsAsync(prompts, outputFile));
+
+            Assert.Contains(outputFile, exception.Message);
+            Assert.Equal(
+                originalContent,
+                await File.ReadAllTextAsync(outputFile, TestContext.Current.CancellationToken));
+        }
+        finally
+        {
+            File.Delete(outputFile);
+        }
+    }
+
+    private static string GetTemporaryFilePath() =>
+        Path.Combine(Path.GetTempPath(), $"VallyEvaluatorTests-{Guid.NewGuid():N}.yaml");
+
+    private static void AssertStimulus(
+        Models.Stimulus stimulus,
+        string expectedName,
+        string expectedPrompt,
+        string expectedCommand)
+    {
+        Assert.Equal(expectedName, stimulus.Name);
+        Assert.Equal(expectedPrompt, stimulus.Prompt);
+        Assert.Equal("${ENVIRONMENT}", stimulus.Environment);
+
+        var grader = Assert.Single(stimulus.Graders!);
+        var requiredEntry = Assert.Single(grader.Config.Required);
+        Assert.Equal("storage", requiredEntry.Name);
+        Assert.Equal(expectedCommand, requiredEntry.Args["command"]);
+    }
 }

--- a/eng/tools/VallyEvaluator/tests/VallyUtilitiesTests.cs
+++ b/eng/tools/VallyEvaluator/tests/VallyUtilitiesTests.cs
@@ -51,6 +51,78 @@ public sealed class VallyUtilitiesTests
     }
 
     [Fact]
+    public async Task WritePromptsAsync_WhenFileExistsAndForceIsTrue_OverwritesFile()
+    {
+        var outputFile = GetTemporaryFilePath();
+        await File.WriteAllTextAsync(outputFile, "existing content", TestContext.Current.CancellationToken);
+        var prompts = new List<TestPrompt>
+        {
+            new("Storage", "storage_account_list", "List my storage accounts", "storage")
+        };
+
+        try
+        {
+            await VallyUtilities.WritePromptsAsync(prompts, outputFile, force: true);
+
+            var yaml = await File.ReadAllTextAsync(outputFile, TestContext.Current.CancellationToken);
+            var evaluation = VallyUtilities.Deserializer.Deserialize<Models.Evaluation>(yaml);
+
+            Assert.Equal("Storage evaluations", evaluation.Name);
+            Assert.Single(evaluation.Stimuli);
+            Assert.Equal("List my storage accounts", evaluation.Stimuli[0].Prompt);
+        }
+        finally
+        {
+            File.Delete(outputFile);
+        }
+    }
+
+    [Fact]
+    public async Task WritePromptsAsync_UsesProvidedEnvironment()
+    {
+        var outputFile = GetTemporaryFilePath();
+        const string customEnvironment = "${CUSTOM_ENV}";
+        var prompts = new List<TestPrompt>
+        {
+            new("Storage", "storage_account_list", "List my storage accounts", "storage")
+        };
+
+        try
+        {
+            await VallyUtilities.WritePromptsAsync(prompts, outputFile, environment: customEnvironment);
+
+            var yaml = await File.ReadAllTextAsync(outputFile, TestContext.Current.CancellationToken);
+            var evaluation = VallyUtilities.Deserializer.Deserialize<Models.Evaluation>(yaml);
+
+            var stimulus = Assert.Single(evaluation.Stimuli);
+            Assert.Equal(customEnvironment, stimulus.Environment);
+        }
+        finally
+        {
+            File.Delete(outputFile);
+        }
+    }
+
+    [Fact]
+    public async Task WritePromptsAsync_WhenPromptsAreEmpty_Throws()
+    {
+        var outputFile = GetTemporaryFilePath();
+
+        try
+        {
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                () => VallyUtilities.WritePromptsAsync([], outputFile));
+        }
+        finally
+        {
+            if (File.Exists(outputFile))
+            {
+                File.Delete(outputFile);
+            }
+        }
+    }
+
+    [Fact]
     public async Task WritePromptsAsync_WhenFileExistsAndForceIsFalse_DoesNotOverwriteFile()
     {
         var outputFile = GetTemporaryFilePath();

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -7,6 +7,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 - `none`: The prompt contains enough information for direct tool invocation.
 - `clarification-required`: The user must provide missing command parameters.
 - `context-required`: The user must provide an attachment, project, or other external context. This includes the deployment of Azure resources.
+- `investigation-required`: Tool ownership or command routing requires investigation before this prompt can be evaluated reliably. See https://github.com/microsoft/mcp/issues/3266.
 
 ## Azure Advisor
 
@@ -141,14 +142,14 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | appservice_database_add | Set up database <database_name> for app service <app_name> with connection string <connection_string> under resource group <resource_group> | none |
 | appservice_database_add | Configure database <database_name> for app service <app_name> with the connection string <connection_string> in resource group <resource_group> | none |
 | appservice_webapp_diagnostic_diagnose | Use Azure App Service diagnostics to diagnose web app <webapp> in <resource_group> with detector <detector_name> | none |
-| appservice_webapp_diagnostic_diagnose | Use Azure App Service diagnostics to diagnose web app <webapp> in <resource_group> with detector <detector_name> between <start_time> and <end_time> with interval <interval> | none |
-| appservice_webapp_diagnostic_list | List the Azure App Service diagnostic detectors for web app <webapp> in <resource_group> | none |
+| appservice_webapp_diagnostic_diagnose | Use Azure App Service diagnostics to diagnose web app <webapp> in <resource_group> with detector <detector_name> between <start_time> and <end_time> with interval <interval> | investigation-required |
+| appservice_webapp_diagnostic_list | List the Azure App Service diagnostic detectors for web app <webapp> in <resource_group> | investigation-required |
 | appservice_webapp_change-state | Start the web app <app> in <resource_group> | none |
 | appservice_webapp_change-state | Stop the web app <app> in <resource_group> | none |
 | appservice_webapp_change-state | Restart the web app <app> in <resource_group> | none |
 | appservice_webapp_change-state | Soft restart the web app <app> in <resource_group> waiting for restart to complete | none |
 | appservice_webapp_get | List the web apps in my subscription | none |
-| appservice_webapp_get | Show me the web apps in my <resource_group> resource group | none |
+| appservice_webapp_get | Show me the web apps in my <resource_group> resource group | investigation-required |
 | appservice_webapp_get | Get the details for web app <webapp> in <resource_group> | none |
 | appservice_webapp_deployment_get | List the deployments for web app <webapp> in <resource_group> | none |
 | appservice_webapp_deployment_get | Get the deployment <deployment-id> for web app <webapp> in <resource_group> | none |
@@ -173,7 +174,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 |:----------|:------------|:------------|
 | azurebackup_backup_status | Check backup status for resource <resource_id> in location <location> | none |
 | azurebackup_backup_status | What is the backup status of <resource_id> in location <location> in my subscription? | none |
-| azurebackup_disasterrecovery_enable-crr | Enable cross-region restore on vault <vault_name> in resource group <resource_group> | none |
+| azurebackup_disasterrecovery_enable-crr | Enable cross-region restore on vault <vault_name> in resource group <resource_group> | investigation-required |
 | azurebackup_disasterrecovery_enable-crr | Turn on cross-region restore for vault <vault_name> under resource group <resource_group> | none |
 | azurebackup_governance_find-unprotected | Find unprotected resources of type <resource_type> in my subscription | none |
 | azurebackup_governance_find-unprotected | Show me Azure resources that are not backed up for resource type <resource_type> | none |
@@ -198,7 +199,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | azurebackup_protectableitem_list | List protectable items in vault <vault_name> in resource group <resource_group> |none |
 | azurebackup_protectableitem_list | Show me all items that can be backed up in vault <vault_name> under resource group <resource_group> | none |
 | azurebackup_protecteditem_get | Get protected item details for <item_name> in vault <vault_name> and resource group <resource_group> | none |
-| azurebackup_protecteditem_get | Show backup status of protected item <item_name> in vault <vault_name> under resource group <resource_group> | none |
+| azurebackup_protecteditem_get | Show backup status of protected item <item_name> in vault <vault_name> under resource group <resource_group> | investigation-required |
 | azurebackup_protecteditem_protect | Enable backup protection for <item_name> using policy <policy_name> in vault <vault_name> and resource group <resource_group> | none |
 | azurebackup_protecteditem_protect | Start protecting my Azure VM by enabling backup on <item_name> in vault <vault_name> under resource group <resource_group> | none |
 | azurebackup_protecteditem_undelete | Restore a soft-deleted backup item for datasource <datasource_id> in vault <vault_name> and resource group <resource_group> | none |
@@ -209,12 +210,12 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | azurebackup_security_configure-encryption | Enable CMK encryption on vault <vault_name> using user-assigned identity <identity_id> and key <key_name> from <key_vault_uri> | none |
 | azurebackup_security_configure-encryption | Set up customer-managed encryption for backup vault <vault_name> in <resource_group> | none |
 | azurebackup_security_configure-mua | Enable multi-user authorization on vault <vault_name> in resource group <resource_group> with resource guard <resource_guard_id> | none |
-| azurebackup_security_configure-mua | Disable MUA on vault <vault_name> in resource group <resource_group> | none |
+| azurebackup_security_configure-mua | Disable MUA on vault <vault_name> in resource group <resource_group> | investigation-required |
 | azurebackup_vault_create | Create a Recovery Services vault named <vault_name> in resource group <resource_group> in region <location> with vault-type 'rsv' | none |
 | azurebackup_vault_create | Set up a new backup vault called <vault_name> in <location> under resource group <resource_group> with vault-type 'dpp' | none |
 | azurebackup_vault_get | Get details of Recovery Services vault <vault_name> in resource group <resource_group> | none |
 | azurebackup_vault_get | Show me information about Azure Backup vault <vault_name> in resource group <resource_group> | none |
-| azurebackup_vault_update | Update Azure Backup vault <vault_name> in resource group <resource_group> to enable soft delete | none |
+| azurebackup_vault_update | Update Azure Backup vault <vault_name> in resource group <resource_group> to enable soft delete | investigation-required |
 | azurebackup_vault_update | Change the identity type of Azure Backup vault <vault_name> in resource group <resource_group> to SystemAssigned | none |
 
 ## Azure CLI
@@ -308,7 +309,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | compute_vm_power-state | Stop the running virtual machine <vm-name> and power it off in resource group <resource-group-name> | none |
 | compute_vm_power-state | Deallocate VM <vm-name> in resource group <resource-group-name> to release compute resources while keeping the VM | none |
 | compute_vm_power-state | Restart VM <vm-name> in resource group <resource-group-name> | none |
-| compute_vm_power-state | Stop VM <vm-name> in resource group <resource-group-name> and skip the OS shutdown | none |
+| compute_vm_power-state | Stop VM <vm-name> in resource group <resource-group-name> and skip the OS shutdown | investigation-required |
 | compute_vm_power-state | Start VM <vm-name> in resource group <resource-group-name> without waiting for completion | none |
 | compute_vm_power-state | Power off and shut down VM <vm-name> in resource group <resource-group-name> | none |
 | compute_vm_power-state | Deallocate and power off VM <vm-name> to stop billing for compute resources while preserving the VM | none |
@@ -370,7 +371,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | compute_disk_update | Update the throughput of disk <disk-name> in resource group <resource-group> to 500 MBps | none |
 | compute_disk_update | Change the performance tier of disk <disk-name> in resource group <resource-group> to P40 | none |
 | compute_disk_update | Update disk <disk-name> in resource group <resource-group> to use disk encryption set <disk-encryption-set-id> | none |
-| compute_disk_update | Change the encryption type of disk <disk-name> in resource group <resource-group> to EncryptionAtRestWithPlatformAndCustomerKeys | none |
+| compute_disk_update | Change the encryption type of disk <disk-name> in resource group <resource-group> to EncryptionAtRestWithPlatformAndCustomerKeys | investigation-required |
 | compute_disk_update | Set disk access on disk <disk-name> in resource group <resource-group> to <disk-access-resource-id> with network access policy AllowPrivate | none |
 | compute_disk_update | Update disk <disk-name> to Standard_LRS SKU with 512 GB size and tags env=dev | none |
 
@@ -516,7 +517,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | eventhubs_eventhub_update | Update my event hub <event_hub_name> in my namespace <namespace_name> and resource group <resource_group_name> | clarification-required |
 | eventhubs_namespace_delete | Delete Azure Event Hubs namespace <namespace_name> in resource group <resource_group_name> | none |
 | eventhubs_namespace_get | List all Event Hubs namespaces in my subscription | none |
-| eventhubs_namespace_get | Get the details of my namespace <namespace_name> in my resource group <resource_group_name> | none |
+| eventhubs_namespace_get | Get the details of my namespace <namespace_name> in my resource group <resource_group_name> | investigation-required |
 | eventhubs_namespace_update | Create a new Azure Event Hubs namespace <namespace_name> in resource group <resource_group_name> | none |
 | eventhubs_namespace_update | Update my namespace <namespace_name> in my resource group <resource_group_name> | clarification-required |
 
@@ -541,9 +542,9 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | fileshares_fileshare_check-name-availability | Check if file share name <file_share_name> is available in <location> in subscription <subscription> | none |
 | fileshares_fileshare_check-name-availability | Is the file share name <file_share_name> available in <location>? | none |
 | fileshares_fileshare_check-name-availability | Verify availability of file share name <file_share_name> in <location> | none |
-| fileshares_rec | Get Azure Files provisioning recommendations for file share <file_share_name> in resource group <resource_group_name> | none |
+| fileshares_rec | Get Azure Files provisioning recommendations for file share <file_share_name> in resource group <resource_group_name> | investigation-required |
 | fileshares_rec | Show me provisioning recommendations for file share <file_share_name> | none |
-| fileshares_rec | Get the Azure Files recommended provisioning settings for file share <file_share_name> | none |
+| fileshares_rec | Get the Azure Files recommended provisioning settings for file share <file_share_name> | investigation-required |
 | fileshares_fileshare_snapshot_create | Create a snapshot of file share <file_share_name> in resource group <resource_group_name> | none |
 | fileshares_fileshare_snapshot_create | Create a snapshot for file share <file_share_name> in resource group <resource_group_name> | none |
 | fileshares_fileshare_snapshot_create | Take a snapshot of file share <file_share_name> | none |
@@ -813,7 +814,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | monitor_healthmodels_get | Show me the health model <health_model_name> in resource group <resource_group> | none |
 | monitor_healthmodels_list | List the Azure Monitor health models in my subscription | none |
 | monitor_healthmodels_list | What health models are in resource group <resource_group>? | none |
-| monitor_instrumentation_get-learning-resource | Get the onboarding learning resource at path <resource_path> | none |
+| monitor_instrumentation_get-learning-resource | Get the onboarding learning resource at path <resource_path> | investigation-required |
 | monitor_instrumentation_get-learning-resource | Show me the content of the Azure Monitor onboarding learning resource at path <resource_path> | none |
 | monitor_instrumentation_get-learning-resource | Use Azure Monitor instrumentation onboarding to get the learning resource file at path <resource_path> | none |
 | monitor_instrumentation_get-learning-resource | List all available Azure Monitor onboarding learning resources | none |
@@ -825,10 +826,10 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | monitor_instrumentation_orchestrator-start | Start Azure Monitor instrumentation orchestration for workspace <workspace_path> | none |
 | monitor_instrumentation_orchestrator-start | Analyze workspace <workspace_path> and return the first Azure Monitor instrumentation step | none |
 | monitor_instrumentation_orchestrator-start | Begin guided Azure Monitor onboarding for project at <workspace_path> and give me step one | none |
-| monitor_instrumentation_send-brownfield-analysis | Send brownfield code analysis findings JSON <findings_json> to Azure Monitor instrumentation session <session_id> after analysis was requested | none |
+| monitor_instrumentation_send-brownfield-analysis | Send brownfield code analysis findings JSON <findings_json> to Azure Monitor instrumentation session <session_id> after analysis was requested | investigation-required |
 | monitor_instrumentation_send-brownfield-analysis | Submit brownfield analysis findings <findings_json> to Azure Monitor instrumentation session <session_id> | none |
 | monitor_instrumentation_send-brownfield-analysis | Send completed brownfield telemetry analysis <findings_json> to Azure Monitor instrumentation onboarding session <session_id> | none |
-| monitor_instrumentation_send-enhancement-select | Submit enhancement selection keys <enhancement_keys> for Azure Monitor instrumentation session <session_id> after enhancement options are presented | none |
+| monitor_instrumentation_send-enhancement-select | Submit enhancement selection keys <enhancement_keys> for Azure Monitor instrumentation session <session_id> after enhancement options are presented | investigation-required |
 | monitor_instrumentation_send-enhancement-select | Continue instrumentation enhancement flow by sending selected keys <enhancement_keys> to session <session_id> | none |
 | monitor_instrumentation_send-enhancement-select | Send chosen enhancement option keys <enhancement_keys> to Azure Monitor instrumentation onboarding session <session_id> | none |
 | monitor_metrics_definitions | Get metric definitions for <resource_type> <resource_name> from the namespace | none |
@@ -837,7 +838,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | monitor_metrics_query | Analyze the performance trends and response times for Application Insights resource <resource_name> over the last <time_period> | none |
 | monitor_metrics_query | Check the availability metrics for my Application Insights resource <resource_name> for the last <time_period> | none |
 | monitor_metrics_query | Get the <aggregation_type> <metric_name> metric for <resource_type> <resource_name> over the last <time_period> with intervals | none |
-| monitor_metrics_query | Investigate error rates and failed requests for Application Insights resource <resource_name> for the last <time_period> | none |
+| monitor_metrics_query | Investigate error rates and failed requests for Application Insights resource <resource_name> for the last <time_period> | investigation-required |
 | monitor_metrics_query | Query the <metric_name> metric for <resource_type> <resource_name> for the last <time_period> | none |
 | monitor_metrics_query | What's the request per second rate for my Application Insights resource <resource_name> over the last <time_period> | none |
 | monitor_resource_log_query | Show me the logs for the past hour for the resource <resource_name> in the Log Analytics workspace <workspace_name> | none |
@@ -1063,7 +1064,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | sreagent_agents_list | List all Azure SRE Agent resources in my subscription | none |
 | sreagent_agents_get | Show me the details of SRE Agent <agent_name> in resource group <resource_group> | none |
 | sreagent_agents_create | Use SRE Agent sub-agent management to create sub-agent <name> on SRE Agent <agent_name> | none |
-| sreagent_agents_delete | Use SRE Agent sub-agent management to delete sub-agent <name> from SRE Agent <agent_name> | none |
+| sreagent_agents_delete | Use SRE Agent sub-agent management to delete sub-agent <name> from SRE Agent <agent_name> | investigation-required |
 | sreagent_agents_tools_list | List the custom tools attached to SRE Agent <agent_name> | none |
 | sreagent_agents_tools_get | Get the definition of custom tool <tool_name> from SRE Agent <agent_name> | none |
 | sreagent_agents_tools_create | Create a custom tool called <tool_name> on SRE Agent <agent_name> | none |
@@ -1110,7 +1111,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | sreagent_docs_memories_add | Add a document called <name> to the SRE Agent knowledge base | none |
 | sreagent_docs_memories_delete | Confirm and delete knowledge base document <name> from SRE Agent <agent_name> | none |
 | sreagent_docs_memories_reindex | Reindex the knowledge base documents for SRE Agent <agent_name> | none |
-| sreagent_architecture_plan | Use SRE Agent architecture planning for these requirements: <requirements> | none |
+| sreagent_architecture_plan | Use SRE Agent architecture planning for these requirements: <requirements> | investigation-required |
 | sreagent_commonprompts_list | List the common prompts on SRE Agent <agent_name> | none |
 | sreagent_commonprompts_get | Show me the common prompt <prompt_name> on SRE Agent <agent_name> | none |
 | sreagent_commonprompts_create | Create a common prompt called <prompt_name> on SRE Agent <agent_name> | none |
@@ -1273,7 +1274,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | foundryextensions_openai_embeddings-create | Generate embeddings for the text "Azure OpenAI Service" using my Microsoft Foundry resource | none |
 | foundryextensions_openai_embeddings-create | Create vector embeddings for my text using my Microsoft Foundry resource | none |
 | foundryextensions_openai_models-list | List all available OpenAI models in my Microsoft Foundry resource | none |
-| foundryextensions_openai_models-list | Use Microsoft Foundry Extensions to list the OpenAI model deployments in my Microsoft Foundry resource | none |
+| foundryextensions_openai_models-list | Use Microsoft Foundry Extensions to list the OpenAI model deployments in my Microsoft Foundry resource | investigation-required |
 | foundryextensions_resource_get | Use Microsoft Foundry Extensions to list all Microsoft Foundry resources in my subscription | none |
 | foundryextensions_resource_get | Use Microsoft Foundry Extensions to list Microsoft Foundry resources in resource group <resource_group_name> | none |
 | foundryextensions_resource_get | Use Microsoft Foundry Extensions to get details for resource <resource_name> in resource group <resource_group_name> | none |


### PR DESCRIPTION
## What does this PR do?

Improves VallyEvaluator namespace selection when an MCP tool assembly name does not directly match its prompt namespace.  For example, `Azure.Mcp.Tools.AzureIsv`'s namespace is `datadog`, which cannot be easily inferred when parsing e2eTestPrompts.md

Adds Interaction.InvestigationRequired value for prompts that require change (either with tool description or the prompt itself.)

The evaluator now:
- Maps changed tool projects from `build_info.json` to their registered MCP tool area namespaces.
- Selects the server artifact matching the current runtime and supports choosing a server with `--serverName`.
- Adds a VallyEvaluator README covering setup, generation options, build-info mode, and local execution.

## GitHub issue number?

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
