### PR TITLE
docs: correct email sender option name

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -1210,7 +1210,7 @@ azmcp communication email send --endpoint "https://mycomms.communication.azure.c
 
 **Options:**
 -   `--endpoint`: Azure Communication Services endpoint URL (required)
--   `--sender`: Email address to send from, must be from a verified domain (required)
+-   `--from`: Email address to send from, must be from a verified domain (required)
 -   `--to`: Recipient email address(es), comma-separated for multiple recipients (required)
 -   `--subject`: Email subject line (required)
 -   `--message`: Email content body (required)


### PR DESCRIPTION
## Summary

- correct the Email Send options table to document `--from`
- align the option entry with the command examples and `EmailSendOptions.From`

## Validation

- confirmed the current Email Send examples use `--from`
- confirmed `EmailSendOptions` exposes the `From` option
- verified the branch is one commit ahead of `main` with one documentation line changed

Closes #3125
