### PR TITLE
Optimize FindTopic methods in EventGrid Tool

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/copilot-eventgrid-direct-topic-lookup.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/copilot-eventgrid-direct-topic-lookup.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Other Changes"
+    description: "Improved Event Grid performance by looking up a topic or system topic directly by name when a resource group is supplied, instead of enumerating every topic in the resource group."

--- a/tools/Azure.Mcp.Tools.EventGrid/src/Services/EventGridService.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/src/Services/EventGridService.cs
@@ -364,26 +364,19 @@ public class EventGridService(IAzureService azureService, ILogger<EventGridServi
     {
         if (!string.IsNullOrEmpty(resourceGroup))
         {
-            // Search in specific resource group
+            // Direct lookup in the specific resource group instead of enumerating every topic
             var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
 
-            await foreach (var topic in resourceGroupResource.Value.GetEventGridTopics().GetAllAsync(cancellationToken: cancellationToken))
-            {
-                if (topic.Data.Name.Equals(topicName, StringComparisons.ResourceName))
-                {
-                    return topic;
-                }
-            }
+            return await GetIfExists(
+                () => resourceGroupResource.Value.GetEventGridTopics().GetIfExistsAsync(topicName, cancellationToken));
         }
-        else
+
+        // Search in all resource groups
+        await foreach (var topic in subscriptionResource.GetEventGridTopicsAsync(cancellationToken: cancellationToken))
         {
-            // Search in all resource groups
-            await foreach (var topic in subscriptionResource.GetEventGridTopicsAsync(cancellationToken: cancellationToken))
+            if (topic.Data.Name.Equals(topicName, StringComparisons.ResourceName))
             {
-                if (topic.Data.Name.Equals(topicName, StringComparisons.ResourceName))
-                {
-                    return topic;
-                }
+                return topic;
             }
         }
 
@@ -398,30 +391,34 @@ public class EventGridService(IAzureService azureService, ILogger<EventGridServi
     {
         if (!string.IsNullOrEmpty(resourceGroup))
         {
-            // Search in specific resource group
+            // Direct lookup in the specific resource group instead of enumerating every system topic
             var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
 
-            await foreach (var systemTopic in resourceGroupResource.Value.GetSystemTopics().GetAllAsync(cancellationToken: cancellationToken))
-            {
-                if (systemTopic.Data.Name.Equals(topicName, StringComparisons.ResourceName))
-                {
-                    return systemTopic;
-                }
-            }
+            return await GetIfExists(
+                () => resourceGroupResource.Value.GetSystemTopics().GetIfExistsAsync(topicName, cancellationToken));
         }
-        else
+
+        // Search in all resource groups
+        await foreach (var systemTopic in subscriptionResource.GetSystemTopicsAsync(cancellationToken: cancellationToken))
         {
-            // Search in all resource groups
-            await foreach (var systemTopic in subscriptionResource.GetSystemTopicsAsync(cancellationToken: cancellationToken))
+            if (systemTopic.Data.Name.Equals(topicName, StringComparisons.ResourceName))
             {
-                if (systemTopic.Data.Name.Equals(topicName, StringComparisons.ResourceName))
-                {
-                    return systemTopic;
-                }
+                return systemTopic;
             }
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Invokes a <c>GetIfExistsAsync</c> lookup and normalizes "not found" results to <see langword="null"/>.
+    /// The returned <see cref="NullableResponse{T}"/> throws from its <c>Value</c> getter when the resource
+    /// does not exist, so <c>HasValue</c> is checked first.
+    /// </summary>
+    private static async Task<T?> GetIfExists<T>(Func<Task<NullableResponse<T>>> getIfExistsAsync) where T : class
+    {
+        var response = await getIfExistsAsync();
+        return response.HasValue ? response.Value : null;
     }
 
     private static EventGridTopicInfo CreateTopicInfo(EventGridTopicData topicData) => new(

--- a/tools/Azure.Mcp.Tools.EventGrid/src/Services/EventGridService.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/src/Services/EventGridService.cs
@@ -367,8 +367,24 @@ public class EventGridService(IAzureService azureService, ILogger<EventGridServi
             // Direct lookup in the specific resource group instead of enumerating every topic
             var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
 
-            return await GetIfExists(
-                () => resourceGroupResource.Value.GetEventGridTopics().GetIfExistsAsync(topicName, cancellationToken));
+            var topics = resourceGroupResource.Value.GetEventGridTopics();
+            var directMatch = await GetIfExists(() => topics.GetIfExistsAsync(topicName, cancellationToken));
+
+            if (directMatch != null)
+            {
+                return directMatch;
+            }
+
+            // Fall back to enumeration so casing differences still resolve the topic
+            await foreach (var topic in topics.GetAllAsync(cancellationToken: cancellationToken))
+            {
+                if (topic.Data.Name.Equals(topicName, StringComparisons.ResourceName))
+                {
+                    return topic;
+                }
+            }
+
+            return null;
         }
 
         // Search in all resource groups
@@ -394,8 +410,24 @@ public class EventGridService(IAzureService azureService, ILogger<EventGridServi
             // Direct lookup in the specific resource group instead of enumerating every system topic
             var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
 
-            return await GetIfExists(
-                () => resourceGroupResource.Value.GetSystemTopics().GetIfExistsAsync(topicName, cancellationToken));
+            var systemTopics = resourceGroupResource.Value.GetSystemTopics();
+            var directMatch = await GetIfExists(() => systemTopics.GetIfExistsAsync(topicName, cancellationToken));
+
+            if (directMatch != null)
+            {
+                return directMatch;
+            }
+
+            // Fall back to enumeration so casing differences still resolve the system topic
+            await foreach (var systemTopic in systemTopics.GetAllAsync(cancellationToken: cancellationToken))
+            {
+                if (systemTopic.Data.Name.Equals(topicName, StringComparisons.ResourceName))
+                {
+                    return systemTopic;
+                }
+            }
+
+            return null;
         }
 
         // Search in all resource groups


### PR DESCRIPTION
## What does this PR do?
Updates EventGrid Tool so that for FindTopic and FindSystemTopic when resourceGroup is set, topic is resolved with a single ARM GetIfExistsAsync call instead of listing and filtering. The subscription-wide linear scan remains as the fallback path, since ARM offers no direct cross-resource-group lookup.



## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [x] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
