### PR TITLE
Rename OneLake tools to kebab-case for naming consistency

### DIFF
--- a/servers/Fabric.Mcp.Server/README.md
+++ b/servers/Fabric.Mcp.Server/README.md
@@ -248,54 +248,54 @@ The Fabric MCP Server exposes tools organized into three categories:
 
 | Tool Name | Description |
 |-----------|-------------|
-| `onelake_list_workspaces` | Lists available Microsoft Fabric workspaces. |
-| `onelake_list_items` | Lists workspace items with high-level metadata. |
-| `onelake_list_items_dfs` | Lists Fabric items via the DFS endpoint. |
-| `onelake_list_files` | Lists files using the hierarchical file-list endpoint. |
-| `onelake_download_file` | Downloads a OneLake file. |
-| `onelake_upload_file` | Uploads a file to OneLake storage. |
-| `onelake_delete_file` | Deletes a file from OneLake storage. |
-| `onelake_create_directory` | Creates a directory via the DFS endpoint. |
-| `onelake_delete_directory` | Deletes a directory (optionally recursive). |
-| `onelake_get_table_config` | Retrieves table API configuration for a workspace item. |
-| `onelake_list_table_namespaces` | Lists table namespaces (schemas) exposed through the table API. |
-| `onelake_get_table_namespace` | Retrieves metadata for a specific namespace. |
-| `onelake_list_tables` | Lists tables published within a namespace. |
-| `onelake_get_table` | Retrieves the definition for a specific table. |
+| `onelake_list-workspaces` | Lists available Microsoft Fabric workspaces. |
+| `onelake_list-items` | Lists workspace items with high-level metadata. |
+| `onelake_list-items-dfs` | Lists Fabric items via the DFS endpoint. |
+| `onelake_list-files` | Lists files using the hierarchical file-list endpoint. |
+| `onelake_download-file` | Downloads a OneLake file. |
+| `onelake_upload-file` | Uploads a file to OneLake storage. |
+| `onelake_delete-file` | Deletes a file from OneLake storage. |
+| `onelake_create-directory` | Creates a directory via the DFS endpoint. |
+| `onelake_delete-directory` | Deletes a directory (optionally recursive). |
+| `onelake_get-table-config` | Retrieves table API configuration for a workspace item. |
+| `onelake_list-table-namespaces` | Lists table namespaces (schemas) exposed through the table API. |
+| `onelake_get-table-namespace` | Retrieves metadata for a specific namespace. |
+| `onelake_list-tables` | Lists tables published within a namespace. |
+| `onelake_get-table` | Retrieves the definition for a specific table. |
 
 ### OneLake Security — Data Access Roles
 
 | Tool Name | Description |
 |-----------|-------------|
-| `onelake_list_data_access_roles` | Lists all data access roles defined on a single item. |
-| `onelake_get_data_access_role` | Gets the full definition of a single data access role (members, permissions, decision rules). |
-| `onelake_create_or_update_data_access_role` | Upserts a single data access role on a single item. |
-| `onelake_delete_data_access_role` | Deletes a single data access role from an item. |
+| `onelake_list-data-access-roles` | Lists all data access roles defined on a single item. |
+| `onelake_get-data-access-role` | Gets the full definition of a single data access role (members, permissions, decision rules). |
+| `onelake_create-or-update-data-access-role` | Upserts a single data access role on a single item. |
+| `onelake_delete-data-access-role` | Deletes a single data access role from an item. |
 
 ### OneLake Shortcuts
 
 | Tool Name | Description |
 |-----------|-------------|
-| `onelake_list_shortcuts` | Lists shortcuts defined within an item. Hides DW-managed shortcuts by default (`--include-managed` to show). |
-| `onelake_get_shortcut` | Gets the properties of a single shortcut. |
-| `onelake_create_shortcut_onelake` | Creates a shortcut pointing to another OneLake location. |
-| `onelake_create_shortcut_adls_gen2` | Creates a shortcut pointing to Azure Data Lake Storage Gen2. |
-| `onelake_create_shortcut_amazon_s3` | Creates a shortcut pointing to Amazon S3. |
-| `onelake_create_shortcut_azure_blob` | Creates a shortcut pointing to Azure Blob Storage. |
-| `onelake_create_shortcut_gcs` | Creates a shortcut pointing to Google Cloud Storage. |
-| `onelake_create_shortcut_s3_compatible` | Creates a shortcut pointing to S3-compatible storage. |
-| `onelake_create_shortcut_dataverse` | Creates a shortcut pointing to a Dataverse environment. |
-| `onelake_create_shortcut_onedrive_sharepoint` | Creates a shortcut pointing to OneDrive/SharePoint Online. |
-| `onelake_delete_shortcut` | Deletes a single shortcut from an item (preserves destination data). |
-| `onelake_reset_shortcut_cache` | Drops cached shortcut reads, forcing re-resolution from destination. |
+| `onelake_list-shortcuts` | Lists shortcuts defined within an item. Hides DW-managed shortcuts by default (`--include-managed` to show). |
+| `onelake_get-shortcut` | Gets the properties of a single shortcut. |
+| `onelake_create-shortcut-onelake` | Creates a shortcut pointing to another OneLake location. |
+| `onelake_create-shortcut-adls-gen2` | Creates a shortcut pointing to Azure Data Lake Storage Gen2. |
+| `onelake_create-shortcut-amazon-s3` | Creates a shortcut pointing to Amazon S3. |
+| `onelake_create-shortcut-azure-blob` | Creates a shortcut pointing to Azure Blob Storage. |
+| `onelake_create-shortcut-gcs` | Creates a shortcut pointing to Google Cloud Storage. |
+| `onelake_create-shortcut-s3-compatible` | Creates a shortcut pointing to S3-compatible storage. |
+| `onelake_create-shortcut-dataverse` | Creates a shortcut pointing to a Dataverse environment. |
+| `onelake_create-shortcut-onedrive-sharepoint` | Creates a shortcut pointing to OneDrive/SharePoint Online. |
+| `onelake_delete-shortcut` | Deletes a single shortcut from an item (preserves destination data). |
+| `onelake_reset-shortcut-cache` | Drops cached shortcut reads, forcing re-resolution from destination. |
 
 ### OneLake Settings
 
 | Tool Name | Description |
 |-----------|-------------|
-| `onelake_get_settings` | Gets OneLake settings for a workspace (diagnostics + immutability policy). |
-| `onelake_modify_diagnostics` | Modifies diagnostic logging configuration (status, destination lakehouse) at workspace scope. |
-| `onelake_modify_immutability_policy` | Modifies the workspace-level OneLake immutability policy (scope, retention days). |
+| `onelake_get-settings` | Gets OneLake settings for a workspace (diagnostics + immutability policy). |
+| `onelake_modify-diagnostics` | Modifies diagnostic logging configuration (status, destination lakehouse) at workspace scope. |
+| `onelake_modify-immutability-policy` | Modifies the workspace-level OneLake immutability policy (scope, retention days). |
 
 ### Core Fabric Operations
 

--- a/servers/Fabric.Mcp.Server/changelog-entries/onelake-tool-name-kebab-case.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/onelake-tool-name-kebab-case.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Breaking Changes"
+    description: "Renamed all `onelake` tools to use kebab-case, matching the `<namespace>_<tool-name>` convention already used by the `core`, `docs`, and `datafactory` namespaces. For example, `onelake_list_workspaces` is now `onelake_list-workspaces` and `onelake_create_shortcut_adls_gen2` is now `onelake_create-shortcut-adls-gen2`. The `onelake_confirm_delete` prompt is now `onelake_confirm-delete`."

--- a/tools/Fabric.Mcp.Tools.OneLake/README.md
+++ b/tools/Fabric.Mcp.Tools.OneLake/README.md
@@ -721,14 +721,14 @@ Eight per-target tools provide flat, typed options instead of requiring a JSON b
 
 | Tool | Target Type |
 |------|-------------|
-| `create_shortcut_onelake` | Another OneLake location |
-| `create_shortcut_adls_gen2` | Azure Data Lake Storage Gen2 |
-| `create_shortcut_amazon_s3` | Amazon S3 |
-| `create_shortcut_azure_blob` | Azure Blob Storage |
-| `create_shortcut_gcs` | Google Cloud Storage |
-| `create_shortcut_s3_compatible` | S3-compatible storage |
-| `create_shortcut_dataverse` | Dataverse environment |
-| `create_shortcut_onedrive_sharepoint` | OneDrive / SharePoint Online |
+| `create-shortcut-onelake` | Another OneLake location |
+| `create-shortcut-adls-gen2` | Azure Data Lake Storage Gen2 |
+| `create-shortcut-amazon-s3` | Amazon S3 |
+| `create-shortcut-azure-blob` | Azure Blob Storage |
+| `create-shortcut-gcs` | Google Cloud Storage |
+| `create-shortcut-s3-compatible` | S3-compatible storage |
+| `create-shortcut-dataverse` | Dataverse environment |
+| `create-shortcut-onedrive-sharepoint` | OneDrive / SharePoint Online |
 
 **Common parameters (all per-target tools):**
 - `--workspace-id`: Workspace ID (GUID)

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/BlobGetCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/BlobGetCommand.cs
@@ -16,7 +16,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.File;
 
 [CommandMetadata(
     Id = "75d6cb4c-4e81-4e69-a4ec-eca53a7dacd9",
-    Name = "download_file",
+    Name = "download-file",
     Title = "Download OneLake File",
     Description = "Downloads a file from OneLake storage. Use this when the user needs to retrieve file content or metadata. Returns base64 content, metadata, and text when applicable.",
     Destructive = false,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/BlobPutCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/BlobPutCommand.cs
@@ -15,7 +15,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.File;
 
 [CommandMetadata(
     Id = "f6b3249d-6481-4e80-9d34-0d6867718dd7",
-    Name = "upload_file",
+    Name = "upload-file",
     Title = "Upload OneLake File",
     Description = "Uploads a file to OneLake storage from inline content or local file path. Use this when the user needs to store data in OneLake. Supports overwrite control and content type specification.",
     Destructive = true,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/DirectoryCreateCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/DirectoryCreateCommand.cs
@@ -17,7 +17,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.File;
 /// </summary>
 [CommandMetadata(
     Id = "0c4cf0f4-2ef4-4f1d-9f80-24fd7636d5fe",
-    Name = "create_directory",
+    Name = "create-directory",
     Title = "Create OneLake Directory",
     Description = "Creates a directory in OneLake storage. Use this when the user needs to organize files or prepare folder structures. Can create nested directory paths.",
     Destructive = false,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/DirectoryDeleteCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/DirectoryDeleteCommand.cs
@@ -13,7 +13,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.File;
 
 [CommandMetadata(
     Id = "86991cd6-75fa-4870-9d99-f986ba9f5f73",
-    Name = "delete_directory",
+    Name = "delete-directory",
     Title = "Delete OneLake Directory",
     Description = "Deletes a directory from OneLake storage. Use this when the user wants to remove a folder. Use recursive flag to delete non-empty directories.",
     Destructive = true,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/FileDeleteCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/FileDeleteCommand.cs
@@ -13,7 +13,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.File;
 
 [CommandMetadata(
     Id = "0aa3f887-0085-4141-8e34-f0cf1ed44f71",
-    Name = "delete_file",
+    Name = "delete-file",
     Title = "Delete OneLake File",
     Description = "Deletes a file from OneLake storage. Use this when the user wants to remove a specific file. Permanently removes the file at the specified path.",
     Destructive = true,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/PathListCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/File/PathListCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.File;
 
 [CommandMetadata(
     Id = "3bf1b82d-ff44-4984-9b97-0e6d9e4917a3",
-    Name = "list_files",
+    Name = "list-files",
     Title = "List OneLake Path Structure",
     Description = """
         List files and directories in OneLake storage using a filesystem-style hierarchical view, similar to Azure Data Lake Storage Gen2.

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Item/OneLakeItemDataListCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Item/OneLakeItemDataListCommand.cs
@@ -17,7 +17,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Item;
 /// </summary>
 [CommandMetadata(
     Id = "8925d0c4-becf-4b5a-8af1-3e998c1058ec",
-    Name = "list_items_dfs",
+    Name = "list-items-dfs",
     Title = "List OneLake Items (Data API)",
     Description = "List OneLake items in a workspace using the OneLake DFS (Data Lake File System) data API.",
     Destructive = false,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Item/OneLakeItemListCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Item/OneLakeItemListCommand.cs
@@ -17,7 +17,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Item;
 /// </summary>
 [CommandMetadata(
     Id = "61eb86d8-3879-4d2d-969a-6c96f2e0ce0d",
-    Name = "list_items",
+    Name = "list-items",
     Title = "List OneLake Items",
     Description = "Lists OneLake items in a Fabric workspace using the high-level OneLake API. Use this when the user needs to see what items exist in a workspace. Returns item names, types, and metadata.",
     Destructive = false,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Item/OneLakeItemListDfsCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Item/OneLakeItemListDfsCommand.cs
@@ -17,7 +17,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Item;
 /// </summary>
 [CommandMetadata(
     Id = "7e7566ab-0984-4f1e-a8be-45a0184a59e5",
-    Name = "onelake-item-list-dfs",
+    Name = "list-item-paths-dfs",
     Title = "List OneLake Items (DFS)",
     Description = "List OneLake items in a workspace using the OneLake DFS (Data Lake File System) API",
     Destructive = false,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Security/DataAccessRoleCreateOrUpdateCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Security/DataAccessRoleCreateOrUpdateCommand.cs
@@ -13,7 +13,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Security;
 
 [CommandMetadata(
     Id = "a1b2c3d4-1001-4000-8000-000000000003",
-    Name = "create_or_update_data_access_role",
+    Name = "create-or-update-data-access-role",
     Title = "Create or Update OneLake Data Access Role",
     Description = """
         Upsert a single data access role on a single item. Use flat options (--name,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Security/DataAccessRoleDeleteCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Security/DataAccessRoleDeleteCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Security;
 
 [CommandMetadata(
     Id = "a1b2c3d4-1001-4000-8000-000000000004",
-    Name = "delete_data_access_role",
+    Name = "delete-data-access-role",
     Title = "Delete OneLake Data Access Role",
     Description = """
         Delete a single data access role from a single item. Scoped to one role

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Security/DataAccessRoleGetCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Security/DataAccessRoleGetCommand.cs
@@ -12,13 +12,13 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Security;
 
 [CommandMetadata(
     Id = "a1b2c3d4-1001-4000-8000-000000000002",
-    Name = "get_data_access_role",
+    Name = "get-data-access-role",
     Title = "Get OneLake Data Access Role",
     Description = """
         Get the full definition of a single data access role on a single item —
         members, permissions, decision rules. Scoped to one role on one item per
-        call. Use after onelake_list_data_access_roles once you know which role
-        you need on which item. Distinct from onelake_get_principal_access,
+        call. Use after onelake_list-data-access-roles once you know which role
+        you need on which item. Distinct from onelake_get-principal-access,
         which returns the effective (resolved) access for a given principal
         across all roles on an item. Caller must be a workspace Admin or Member
         on the item's workspace. Requires OneLake.Read.All.

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Security/DataAccessRoleListCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Security/DataAccessRoleListCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Security;
 
 [CommandMetadata(
     Id = "a1b2c3d4-1001-4000-8000-000000000001",
-    Name = "list_data_access_roles",
+    Name = "list-data-access-roles",
     Title = "List OneLake Data Access Roles",
     Description = """
         List all data access roles defined on a single item (Lakehouse / Warehouse) —

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Settings/DiagnosticsModifyCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Settings/DiagnosticsModifyCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Settings;
 
 [CommandMetadata(
     Id = "a1b2c3d4-3001-4000-8000-000000000002",
-    Name = "modify_diagnostics",
+    Name = "modify-diagnostics",
     Title = "Modify OneLake Diagnostics",
     Description = """
         Enable or disable workspace-level OneLake diagnostic logging. When enabling,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Settings/ImmutabilityPolicyModifyCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Settings/ImmutabilityPolicyModifyCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Settings;
 
 [CommandMetadata(
     Id = "a1b2c3d4-3001-4000-8000-000000000003",
-    Name = "modify_immutability_policy",
+    Name = "modify-immutability-policy",
     Title = "Modify OneLake Immutability Policy",
     Description = """
         Modify the workspace-level OneLake immutability policy. Once enabled,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Settings/SettingsGetCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Settings/SettingsGetCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Settings;
 
 [CommandMetadata(
     Id = "a1b2c3d4-3001-4000-8000-000000000001",
-    Name = "get_settings",
+    Name = "get-settings",
     Title = "Get OneLake Settings",
     Description = """
         Get the OneLake settings for a workspace — diagnostics configuration and

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateAdlsGen2Command.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateAdlsGen2Command.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Shortcut;
 
 [CommandMetadata(
     Id = "a1b2c3d4-2001-4000-8000-000000000011",
-    Name = "create_shortcut_adls_gen2",
+    Name = "create-shortcut-adls-gen2",
     Title = "Create OneLake Shortcut (ADLS Gen2 Target)",
     Description = """
         Create a shortcut pointing to an Azure Data Lake Storage Gen2 location.

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateAmazonS3Command.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateAmazonS3Command.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Shortcut;
 
 [CommandMetadata(
     Id = "a1b2c3d4-2001-4000-8000-000000000012",
-    Name = "create_shortcut_amazon_s3",
+    Name = "create-shortcut-amazon-s3",
     Title = "Create OneLake Shortcut (Amazon S3 Target)",
     Description = """
         Create a shortcut pointing to an Amazon S3 location. Requires a connection

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateAzureBlobCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateAzureBlobCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Shortcut;
 
 [CommandMetadata(
     Id = "a1b2c3d4-2001-4000-8000-000000000013",
-    Name = "create_shortcut_azure_blob",
+    Name = "create-shortcut-azure-blob",
     Title = "Create OneLake Shortcut (Azure Blob Storage Target)",
     Description = """
         Create a shortcut pointing to an Azure Blob Storage location. Requires a

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateDataverseCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateDataverseCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Shortcut;
 
 [CommandMetadata(
     Id = "a1b2c3d4-2001-4000-8000-000000000016",
-    Name = "create_shortcut_dataverse",
+    Name = "create-shortcut-dataverse",
     Title = "Create OneLake Shortcut (Dataverse Target)",
     Description = """
         Create a shortcut pointing to a Dataverse environment. Requires the

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateGcsCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateGcsCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Shortcut;
 
 [CommandMetadata(
     Id = "a1b2c3d4-2001-4000-8000-000000000014",
-    Name = "create_shortcut_gcs",
+    Name = "create-shortcut-gcs",
     Title = "Create OneLake Shortcut (Google Cloud Storage Target)",
     Description = """
         Create a shortcut pointing to a Google Cloud Storage location. Requires a

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateOneDriveSharePointCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateOneDriveSharePointCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Shortcut;
 
 [CommandMetadata(
     Id = "a1b2c3d4-2001-4000-8000-000000000017",
-    Name = "create_shortcut_onedrive_sharepoint",
+    Name = "create-shortcut-onedrive-sharepoint",
     Title = "Create OneLake Shortcut (OneDrive/SharePoint Target)",
     Description = """
         Create a shortcut pointing to a OneDrive or SharePoint Online location.

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateOneLakeCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateOneLakeCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Shortcut;
 
 [CommandMetadata(
     Id = "a1b2c3d4-2001-4000-8000-000000000010",
-    Name = "create_shortcut_onelake",
+    Name = "create-shortcut-onelake",
     Title = "Create OneLake Shortcut (OneLake Target)",
     Description = """
         Create a shortcut pointing to another OneLake location. Specify the target

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateS3CompatibleCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutCreateS3CompatibleCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Shortcut;
 
 [CommandMetadata(
     Id = "a1b2c3d4-2001-4000-8000-000000000015",
-    Name = "create_shortcut_s3_compatible",
+    Name = "create-shortcut-s3-compatible",
     Title = "Create OneLake Shortcut (S3 Compatible Target)",
     Description = """
         Create a shortcut pointing to an S3-compatible storage location. Requires

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutDeleteCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutDeleteCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Shortcut;
 
 [CommandMetadata(
     Id = "a1b2c3d4-2001-4000-8000-000000000004",
-    Name = "delete_shortcut",
+    Name = "delete-shortcut",
     Title = "Delete OneLake Shortcut",
     Description = """
         Delete a single shortcut from an item. Destructive but the destination

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutGetCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutGetCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Shortcut;
 
 [CommandMetadata(
     Id = "a1b2c3d4-2001-4000-8000-000000000002",
-    Name = "get_shortcut",
+    Name = "get-shortcut",
     Title = "Get OneLake Shortcut",
     Description = """
         Get the properties of a single shortcut (name, path, target,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutListCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutListCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Shortcut;
 
 [CommandMetadata(
     Id = "a1b2c3d4-2001-4000-8000-000000000001",
-    Name = "list_shortcuts",
+    Name = "list-shortcuts",
     Title = "List OneLake Shortcuts",
     Description = """
         List shortcuts defined within an item, recursing through subfolders.

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutResetCacheCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Shortcut/ShortcutResetCacheCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Shortcut;
 
 [CommandMetadata(
     Id = "a1b2c3d4-2001-4000-8000-000000000005",
-    Name = "reset_shortcut_cache",
+    Name = "reset-shortcut-cache",
     Title = "Reset OneLake Shortcut Cache",
     Description = """
         Drop cached shortcut reads for a workspace, forcing the next read to

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Table/TableConfigGetCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Table/TableConfigGetCommand.cs
@@ -13,7 +13,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Table;
 
 [CommandMetadata(
     Id = "bc15c475-0329-4cc3-aaa8-0e9f3fbde6f8",
-    Name = "get_table_config",
+    Name = "get-table-config",
     Title = "Get OneLake Table Configuration",
     Description = "Retrieves table API configuration for OneLake. Use this when the user needs to understand table access settings.",
     Destructive = false,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Table/TableGetCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Table/TableGetCommand.cs
@@ -13,7 +13,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Table;
 
 [CommandMetadata(
     Id = "19bb5a6a-2a09-410c-bfa0-312986c6acc6",
-    Name = "get_table",
+    Name = "get-table",
     Title = "Get OneLake Table",
     Description = "Retrieves table definition from OneLake. Use this when the user needs table schema or metadata.",
     Destructive = false,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Table/TableListCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Table/TableListCommand.cs
@@ -13,7 +13,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Table;
 
 [CommandMetadata(
     Id = "7b1688e5-2a16-475d-8fd1-9bf3b0acf4f7",
-    Name = "list_tables",
+    Name = "list-tables",
     Title = "List OneLake Tables",
     Description = "Lists tables in OneLake. Use this when the user needs to see available tables.",
     Destructive = false,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Table/TableNamespaceGetCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Table/TableNamespaceGetCommand.cs
@@ -13,7 +13,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Table;
 
 [CommandMetadata(
     Id = "a86298d1-7475-4ea8-8c1b-e4c54ac2b896",
-    Name = "get_table_namespace",
+    Name = "get-table-namespace",
     Title = "Get OneLake Table Namespace",
     Description = "Retrieves metadata for a specific table namespace. Use this when the user needs details about a namespace.",
     Destructive = false,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Table/TableNamespaceListCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Table/TableNamespaceListCommand.cs
@@ -13,7 +13,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Table;
 
 [CommandMetadata(
     Id = "173cfc00-7c12-486d-a0e7-c0d4c1de23fd",
-    Name = "list_table_namespaces",
+    Name = "list-table-namespaces",
     Title = "List OneLake Table Namespaces",
     Description = "Lists table namespaces in OneLake. Use this when the user needs to discover available table namespaces.",
     Destructive = false,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Workspace/OneLakeWorkspaceListCommand.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Commands/Workspace/OneLakeWorkspaceListCommand.cs
@@ -12,7 +12,7 @@ namespace Fabric.Mcp.Tools.OneLake.Commands.Workspace;
 
 [CommandMetadata(
     Id = "5f005a27-9838-4c09-9785-55ce49963c97",
-    Name = "list_workspaces",
+    Name = "list-workspaces",
     Title = "List OneLake Workspaces",
     Description = "Lists all Fabric workspaces accessible via OneLake data plane API. Use this when the user needs to view available workspaces or select a workspace for data operations. Returns workspace names and IDs.",
     Destructive = false,

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Prompts/OneLakePrompts.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Prompts/OneLakePrompts.cs
@@ -20,7 +20,7 @@ public sealed class OneLakePrompts
     {
         var header =
 $@"You will list items in OneLake:
-- ALWAYS call tool 'onelake_list_items' with: workspace, lakehouse, path.
+- ALWAYS call tool 'onelake_list-items' with: workspace, lakehouse, path.
 - Use paging: set maxResults (<=100) and iterate cursors if provided.
 - Do NOT assume paths exist; handle 404s gracefully.";
 
@@ -79,7 +79,7 @@ sql:
         return [new ChatMessage(ChatRole.User, content)];
     }
 
-    [McpServerPrompt(Name = "onelake_confirm_delete")]
+    [McpServerPrompt(Name = "onelake_confirm-delete")]
     [Description("Ask the user to confirm destructive OneLake delete operations before invoking tools.")]
     public static ChatMessage[] ConfirmDelete(
         [Description("Fabric workspace ID or name")] string workspace,

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/File/BlobGetCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/File/BlobGetCommandTests.cs
@@ -30,7 +30,7 @@ public class BlobGetCommandTests : CommandUnitTestsBase<BlobGetCommand, IOneLake
     [Fact]
     public void Constructor_InitializesMetadata()
     {
-        Assert.Equal("download_file", Command.Name);
+        Assert.Equal("download-file", Command.Name);
         Assert.True(Command.Metadata.ReadOnly);
         Assert.True(Command.Metadata.Idempotent);
         Assert.False(Command.Metadata.Destructive);

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/File/BlobPutCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/File/BlobPutCommandTests.cs
@@ -17,7 +17,7 @@ public class BlobPutCommandTests : CommandUnitTestsBase<BlobPutCommand, IOneLake
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("upload_file", Command.Name);
+        Assert.Equal("upload-file", Command.Name);
         Assert.Contains("Uploads a file to OneLake storage", Command.Description, StringComparison.OrdinalIgnoreCase);
         Assert.False(Command.Metadata.ReadOnly);
         Assert.True(Command.Metadata.Destructive);
@@ -26,7 +26,7 @@ public class BlobPutCommandTests : CommandUnitTestsBase<BlobPutCommand, IOneLake
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("upload_file", CommandDefinition.Name);
+        Assert.Equal("upload-file", CommandDefinition.Name);
         Assert.NotEmpty(CommandDefinition.Options);
     }
 

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/File/DirectoryCreateCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/File/DirectoryCreateCommandTests.cs
@@ -15,7 +15,7 @@ public class DirectoryCreateCommandTests : CommandUnitTestsBase<DirectoryCreateC
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("create_directory", Command.Name);
+        Assert.Equal("create-directory", Command.Name);
         Assert.Equal("Create OneLake Directory", Command.Title);
         Assert.False(Command.Metadata.ReadOnly);
         Assert.False(Command.Metadata.Destructive);
@@ -27,7 +27,7 @@ public class DirectoryCreateCommandTests : CommandUnitTestsBase<DirectoryCreateC
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("create_directory", CommandDefinition.Name);
+        Assert.Equal("create-directory", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/File/DirectoryDeleteCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/File/DirectoryDeleteCommandTests.cs
@@ -15,7 +15,7 @@ public class DirectoryDeleteCommandTests : CommandUnitTestsBase<DirectoryDeleteC
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("delete_directory", Command.Name);
+        Assert.Equal("delete-directory", Command.Name);
         Assert.Equal("Delete OneLake Directory", Command.Title);
         Assert.False(Command.Metadata.ReadOnly);
         Assert.True(Command.Metadata.Destructive);
@@ -27,7 +27,7 @@ public class DirectoryDeleteCommandTests : CommandUnitTestsBase<DirectoryDeleteC
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("delete_directory", CommandDefinition.Name);
+        Assert.Equal("delete-directory", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/File/PathListCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/File/PathListCommandTests.cs
@@ -13,7 +13,7 @@ public class PathListCommandTests : CommandUnitTestsBase<PathListCommand, IOneLa
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("list_files", Command.Name);
+        Assert.Equal("list-files", Command.Name);
         Assert.Equal("List OneLake Path Structure", Command.Title);
         Assert.True(Command.Metadata.ReadOnly);
         Assert.False(Command.Metadata.Destructive);
@@ -25,7 +25,7 @@ public class PathListCommandTests : CommandUnitTestsBase<PathListCommand, IOneLa
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("list_files", CommandDefinition.Name);
+        Assert.Equal("list-files", CommandDefinition.Name);
         Assert.NotEmpty(CommandDefinition.Options);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Description);

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Item/OneLakeItemDataListCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Item/OneLakeItemDataListCommandTests.cs
@@ -13,7 +13,7 @@ public class OneLakeItemDataListCommandTests : CommandUnitTestsBase<OneLakeItemD
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("list_items_dfs", Command.Name);
+        Assert.Equal("list-items-dfs", Command.Name);
         Assert.Equal("List OneLake Items (Data API)", Command.Title);
         Assert.True(Command.Metadata.ReadOnly);
         Assert.False(Command.Metadata.Destructive);
@@ -25,7 +25,7 @@ public class OneLakeItemDataListCommandTests : CommandUnitTestsBase<OneLakeItemD
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("list_items_dfs", CommandDefinition.Name);
+        Assert.Equal("list-items-dfs", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Item/OneLakeItemListCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Item/OneLakeItemListCommandTests.cs
@@ -13,7 +13,7 @@ public class OneLakeItemListCommandTests : CommandUnitTestsBase<OneLakeItemListC
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("list_items", Command.Name);
+        Assert.Equal("list-items", Command.Name);
         Assert.Equal("List OneLake Items", Command.Title);
         Assert.True(Command.Metadata.ReadOnly);
         Assert.False(Command.Metadata.Destructive);
@@ -25,7 +25,7 @@ public class OneLakeItemListCommandTests : CommandUnitTestsBase<OneLakeItemListC
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("list_items", CommandDefinition.Name);
+        Assert.Equal("list-items", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Security/DataAccessRoleCreateOrUpdateCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Security/DataAccessRoleCreateOrUpdateCommandTests.cs
@@ -17,7 +17,7 @@ public class DataAccessRoleCreateOrUpdateCommandTests : CommandUnitTestsBase<Dat
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("create_or_update_data_access_role", Command.Name);
+        Assert.Equal("create-or-update-data-access-role", Command.Name);
         Assert.Equal("Create or Update OneLake Data Access Role", Command.Title);
         Assert.Contains("Upsert a single data access role", Command.Description);
         Assert.False(Command.Metadata.ReadOnly);
@@ -28,7 +28,7 @@ public class DataAccessRoleCreateOrUpdateCommandTests : CommandUnitTestsBase<Dat
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("create_or_update_data_access_role", CommandDefinition.Name);
+        Assert.Equal("create-or-update-data-access-role", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Security/DataAccessRoleDeleteCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Security/DataAccessRoleDeleteCommandTests.cs
@@ -13,7 +13,7 @@ public class DataAccessRoleDeleteCommandTests : CommandUnitTestsBase<DataAccessR
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("delete_data_access_role", Command.Name);
+        Assert.Equal("delete-data-access-role", Command.Name);
         Assert.Equal("Delete OneLake Data Access Role", Command.Title);
         Assert.Contains("Delete a single data access role", Command.Description);
         Assert.False(Command.Metadata.ReadOnly);
@@ -24,7 +24,7 @@ public class DataAccessRoleDeleteCommandTests : CommandUnitTestsBase<DataAccessR
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("delete_data_access_role", CommandDefinition.Name);
+        Assert.Equal("delete-data-access-role", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Security/DataAccessRoleGetCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Security/DataAccessRoleGetCommandTests.cs
@@ -13,7 +13,7 @@ public class DataAccessRoleGetCommandTests : CommandUnitTestsBase<DataAccessRole
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("get_data_access_role", Command.Name);
+        Assert.Equal("get-data-access-role", Command.Name);
         Assert.Equal("Get OneLake Data Access Role", Command.Title);
         Assert.Contains("Get the full definition of a single data access role", Command.Description);
         Assert.True(Command.Metadata.ReadOnly);
@@ -24,7 +24,7 @@ public class DataAccessRoleGetCommandTests : CommandUnitTestsBase<DataAccessRole
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("get_data_access_role", CommandDefinition.Name);
+        Assert.Equal("get-data-access-role", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Security/DataAccessRoleListCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Security/DataAccessRoleListCommandTests.cs
@@ -13,7 +13,7 @@ public class DataAccessRoleListCommandTests : CommandUnitTestsBase<DataAccessRol
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("list_data_access_roles", Command.Name);
+        Assert.Equal("list-data-access-roles", Command.Name);
         Assert.Equal("List OneLake Data Access Roles", Command.Title);
         Assert.Contains("List all data access roles", Command.Description);
         Assert.True(Command.Metadata.ReadOnly);
@@ -24,7 +24,7 @@ public class DataAccessRoleListCommandTests : CommandUnitTestsBase<DataAccessRol
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("list_data_access_roles", CommandDefinition.Name);
+        Assert.Equal("list-data-access-roles", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Settings/DiagnosticsModifyCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Settings/DiagnosticsModifyCommandTests.cs
@@ -17,7 +17,7 @@ public class DiagnosticsModifyCommandTests : CommandUnitTestsBase<DiagnosticsMod
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("modify_diagnostics", Command.Name);
+        Assert.Equal("modify-diagnostics", Command.Name);
         Assert.Equal("Modify OneLake Diagnostics", Command.Title);
         Assert.Contains("Enable or disable workspace-level OneLake diagnostic logging", Command.Description);
         Assert.False(Command.Metadata.ReadOnly);
@@ -28,7 +28,7 @@ public class DiagnosticsModifyCommandTests : CommandUnitTestsBase<DiagnosticsMod
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("modify_diagnostics", CommandDefinition.Name);
+        Assert.Equal("modify-diagnostics", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Settings/ImmutabilityPolicyModifyCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Settings/ImmutabilityPolicyModifyCommandTests.cs
@@ -17,7 +17,7 @@ public class ImmutabilityPolicyModifyCommandTests : CommandUnitTestsBase<Immutab
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("modify_immutability_policy", Command.Name);
+        Assert.Equal("modify-immutability-policy", Command.Name);
         Assert.Equal("Modify OneLake Immutability Policy", Command.Title);
         Assert.Contains("Modify the workspace-level OneLake immutability policy", Command.Description);
         Assert.False(Command.Metadata.ReadOnly);
@@ -28,7 +28,7 @@ public class ImmutabilityPolicyModifyCommandTests : CommandUnitTestsBase<Immutab
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("modify_immutability_policy", CommandDefinition.Name);
+        Assert.Equal("modify-immutability-policy", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Settings/SettingsGetCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Settings/SettingsGetCommandTests.cs
@@ -13,7 +13,7 @@ public class SettingsGetCommandTests : CommandUnitTestsBase<SettingsGetCommand, 
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("get_settings", Command.Name);
+        Assert.Equal("get-settings", Command.Name);
         Assert.Equal("Get OneLake Settings", Command.Title);
         Assert.Contains("Get the OneLake settings for a workspace", Command.Description);
         Assert.True(Command.Metadata.ReadOnly);
@@ -24,7 +24,7 @@ public class SettingsGetCommandTests : CommandUnitTestsBase<SettingsGetCommand, 
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("get_settings", CommandDefinition.Name);
+        Assert.Equal("get-settings", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Shortcut/ShortcutDeleteCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Shortcut/ShortcutDeleteCommandTests.cs
@@ -13,7 +13,7 @@ public class ShortcutDeleteCommandTests : CommandUnitTestsBase<ShortcutDeleteCom
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("delete_shortcut", Command.Name);
+        Assert.Equal("delete-shortcut", Command.Name);
         Assert.Equal("Delete OneLake Shortcut", Command.Title);
         Assert.Contains("Delete a single shortcut from an item", Command.Description);
         Assert.False(Command.Metadata.ReadOnly);
@@ -24,7 +24,7 @@ public class ShortcutDeleteCommandTests : CommandUnitTestsBase<ShortcutDeleteCom
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("delete_shortcut", CommandDefinition.Name);
+        Assert.Equal("delete-shortcut", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Shortcut/ShortcutGetCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Shortcut/ShortcutGetCommandTests.cs
@@ -13,7 +13,7 @@ public class ShortcutGetCommandTests : CommandUnitTestsBase<ShortcutGetCommand, 
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("get_shortcut", Command.Name);
+        Assert.Equal("get-shortcut", Command.Name);
         Assert.Equal("Get OneLake Shortcut", Command.Title);
         Assert.Contains("Get the properties of a single shortcut", Command.Description);
         Assert.True(Command.Metadata.ReadOnly);
@@ -24,7 +24,7 @@ public class ShortcutGetCommandTests : CommandUnitTestsBase<ShortcutGetCommand, 
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("get_shortcut", CommandDefinition.Name);
+        Assert.Equal("get-shortcut", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Shortcut/ShortcutListCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Shortcut/ShortcutListCommandTests.cs
@@ -13,7 +13,7 @@ public class ShortcutListCommandTests : CommandUnitTestsBase<ShortcutListCommand
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("list_shortcuts", Command.Name);
+        Assert.Equal("list-shortcuts", Command.Name);
         Assert.Equal("List OneLake Shortcuts", Command.Title);
         Assert.Contains("List shortcuts defined within an item", Command.Description);
         Assert.True(Command.Metadata.ReadOnly);
@@ -24,7 +24,7 @@ public class ShortcutListCommandTests : CommandUnitTestsBase<ShortcutListCommand
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("list_shortcuts", CommandDefinition.Name);
+        Assert.Equal("list-shortcuts", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Shortcut/ShortcutResetCacheCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Shortcut/ShortcutResetCacheCommandTests.cs
@@ -18,7 +18,7 @@ public class ShortcutResetCacheCommandTests : CommandUnitTestsBase<ShortcutReset
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("reset_shortcut_cache", Command.Name);
+        Assert.Equal("reset-shortcut-cache", Command.Name);
         Assert.Equal("Reset OneLake Shortcut Cache", Command.Title);
         Assert.Contains("Drop cached shortcut reads", Command.Description);
         Assert.False(Command.Metadata.ReadOnly);
@@ -29,7 +29,7 @@ public class ShortcutResetCacheCommandTests : CommandUnitTestsBase<ShortcutReset
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("reset_shortcut_cache", CommandDefinition.Name);
+        Assert.Equal("reset-shortcut-cache", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);
     }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Table/TableConfigGetCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Table/TableConfigGetCommandTests.cs
@@ -18,7 +18,7 @@ public class TableConfigGetCommandTests : CommandUnitTestsBase<TableConfigGetCom
     [Fact]
     public void Constructor_InitializesMetadata()
     {
-        Assert.Equal("get_table_config", Command.Name);
+        Assert.Equal("get-table-config", Command.Name);
         Assert.True(Command.Metadata.ReadOnly);
         Assert.True(Command.Metadata.Idempotent);
         Assert.False(Command.Metadata.Destructive);
@@ -27,7 +27,7 @@ public class TableConfigGetCommandTests : CommandUnitTestsBase<TableConfigGetCom
     [Fact]
     public void GetCommand_ReturnsConfiguredCommand()
     {
-        Assert.Equal("get_table_config", CommandDefinition.Name);
+        Assert.Equal("get-table-config", CommandDefinition.Name);
         Assert.NotEmpty(CommandDefinition.Options);
     }
 

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Table/TableGetCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Table/TableGetCommandTests.cs
@@ -18,7 +18,7 @@ public class TableGetCommandTests : CommandUnitTestsBase<TableGetCommand, IOneLa
     [Fact]
     public void Constructor_InitializesMetadata()
     {
-        Assert.Equal("get_table", Command.Name);
+        Assert.Equal("get-table", Command.Name);
         Assert.True(Command.Metadata.ReadOnly);
         Assert.True(Command.Metadata.Idempotent);
         Assert.False(Command.Metadata.Destructive);
@@ -27,7 +27,7 @@ public class TableGetCommandTests : CommandUnitTestsBase<TableGetCommand, IOneLa
     [Fact]
     public void GetCommand_ReturnsConfiguredCommand()
     {
-        Assert.Equal("get_table", CommandDefinition.Name);
+        Assert.Equal("get-table", CommandDefinition.Name);
         Assert.NotEmpty(CommandDefinition.Options);
     }
 

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Table/TableListCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Table/TableListCommandTests.cs
@@ -18,7 +18,7 @@ public class TableListCommandTests : CommandUnitTestsBase<TableListCommand, IOne
     [Fact]
     public void Constructor_InitializesMetadata()
     {
-        Assert.Equal("list_tables", Command.Name);
+        Assert.Equal("list-tables", Command.Name);
         Assert.True(Command.Metadata.ReadOnly);
         Assert.True(Command.Metadata.Idempotent);
         Assert.False(Command.Metadata.Destructive);
@@ -27,7 +27,7 @@ public class TableListCommandTests : CommandUnitTestsBase<TableListCommand, IOne
     [Fact]
     public void GetCommand_ReturnsConfiguredCommand()
     {
-        Assert.Equal("list_tables", CommandDefinition.Name);
+        Assert.Equal("list-tables", CommandDefinition.Name);
         Assert.NotEmpty(CommandDefinition.Options);
     }
 

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Table/TableNamespaceGetCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Table/TableNamespaceGetCommandTests.cs
@@ -18,7 +18,7 @@ public class TableNamespaceGetCommandTests : CommandUnitTestsBase<TableNamespace
     [Fact]
     public void Constructor_InitializesMetadata()
     {
-        Assert.Equal("get_table_namespace", Command.Name);
+        Assert.Equal("get-table-namespace", Command.Name);
         Assert.True(Command.Metadata.ReadOnly);
         Assert.True(Command.Metadata.Idempotent);
         Assert.False(Command.Metadata.Destructive);
@@ -27,7 +27,7 @@ public class TableNamespaceGetCommandTests : CommandUnitTestsBase<TableNamespace
     [Fact]
     public void GetCommand_ReturnsConfiguredCommand()
     {
-        Assert.Equal("get_table_namespace", CommandDefinition.Name);
+        Assert.Equal("get-table-namespace", CommandDefinition.Name);
         Assert.NotEmpty(CommandDefinition.Options);
     }
 

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Table/TableNamespaceListCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Table/TableNamespaceListCommandTests.cs
@@ -18,7 +18,7 @@ public class TableNamespaceListCommandTests : CommandUnitTestsBase<TableNamespac
     [Fact]
     public void Constructor_InitializesMetadata()
     {
-        Assert.Equal("list_table_namespaces", Command.Name);
+        Assert.Equal("list-table-namespaces", Command.Name);
         Assert.True(Command.Metadata.ReadOnly);
         Assert.True(Command.Metadata.Idempotent);
         Assert.False(Command.Metadata.Destructive);
@@ -27,7 +27,7 @@ public class TableNamespaceListCommandTests : CommandUnitTestsBase<TableNamespac
     [Fact]
     public void GetCommand_ReturnsConfiguredCommand()
     {
-        Assert.Equal("list_table_namespaces", CommandDefinition.Name);
+        Assert.Equal("list-table-namespaces", CommandDefinition.Name);
         Assert.NotEmpty(CommandDefinition.Options);
     }
 

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Workspace/OneLakeWorkspaceListCommandTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Workspace/OneLakeWorkspaceListCommandTests.cs
@@ -13,7 +13,7 @@ public class OneLakeWorkspaceListCommandTests : CommandUnitTestsBase<OneLakeWork
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
     {
-        Assert.Equal("list_workspaces", Command.Name);
+        Assert.Equal("list-workspaces", Command.Name);
         Assert.Equal("List OneLake Workspaces", Command.Title);
         Assert.True(Command.Metadata.ReadOnly);
         Assert.False(Command.Metadata.Destructive);
@@ -25,7 +25,7 @@ public class OneLakeWorkspaceListCommandTests : CommandUnitTestsBase<OneLakeWork
     [Fact]
     public void GetCommand_ReturnsValidCommand()
     {
-        Assert.Equal("list_workspaces", CommandDefinition.Name);
+        Assert.Equal("list-workspaces", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Options);

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/FabricOneLakeSetupTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/FabricOneLakeSetupTests.cs
@@ -45,36 +45,36 @@ public class FabricOneLakeSetupTests
         // Act
         var rootGroup = setup.RegisterCommands(provider);
 
-        // Assert - flat structure with verb_object naming
-        Assert.True(rootGroup.Commands.ContainsKey("list_workspaces"), "Should have list_workspaces command");
-        Assert.True(rootGroup.Commands.ContainsKey("list_items"), "Should have list_items command");
-        Assert.True(rootGroup.Commands.ContainsKey("list_items_dfs"), "Should have list_items_dfs command");
-        Assert.True(rootGroup.Commands.ContainsKey("list_files"), "Should have list_files command");
-        Assert.True(rootGroup.Commands.ContainsKey("download_file"), "Should have download_file command");
-        Assert.True(rootGroup.Commands.ContainsKey("upload_file"), "Should have upload_file command");
-        Assert.True(rootGroup.Commands.ContainsKey("delete_file"), "Should have delete_file command");
-        Assert.True(rootGroup.Commands.ContainsKey("create_directory"), "Should have create_directory command");
-        Assert.True(rootGroup.Commands.ContainsKey("delete_directory"), "Should have delete_directory command");
+        // Assert - flat structure with kebab-case verb-object naming
+        Assert.True(rootGroup.Commands.ContainsKey("list-workspaces"), "Should have list-workspaces command");
+        Assert.True(rootGroup.Commands.ContainsKey("list-items"), "Should have list-items command");
+        Assert.True(rootGroup.Commands.ContainsKey("list-items-dfs"), "Should have list-items-dfs command");
+        Assert.True(rootGroup.Commands.ContainsKey("list-files"), "Should have list-files command");
+        Assert.True(rootGroup.Commands.ContainsKey("download-file"), "Should have download-file command");
+        Assert.True(rootGroup.Commands.ContainsKey("upload-file"), "Should have upload-file command");
+        Assert.True(rootGroup.Commands.ContainsKey("delete-file"), "Should have delete-file command");
+        Assert.True(rootGroup.Commands.ContainsKey("create-directory"), "Should have create-directory command");
+        Assert.True(rootGroup.Commands.ContainsKey("delete-directory"), "Should have delete-directory command");
 
         // Table commands
-        Assert.True(rootGroup.Commands.ContainsKey("get_table_config"), "Should have get_table_config command");
-        Assert.True(rootGroup.Commands.ContainsKey("list_tables"), "Should have list_tables command");
-        Assert.True(rootGroup.Commands.ContainsKey("get_table"), "Should have get_table command");
-        Assert.True(rootGroup.Commands.ContainsKey("list_table_namespaces"), "Should have list_table_namespaces command");
-        Assert.True(rootGroup.Commands.ContainsKey("get_table_namespace"), "Should have get_table_namespace command");
+        Assert.True(rootGroup.Commands.ContainsKey("get-table-config"), "Should have get-table-config command");
+        Assert.True(rootGroup.Commands.ContainsKey("list-tables"), "Should have list-tables command");
+        Assert.True(rootGroup.Commands.ContainsKey("get-table"), "Should have get-table command");
+        Assert.True(rootGroup.Commands.ContainsKey("list-table-namespaces"), "Should have list-table-namespaces command");
+        Assert.True(rootGroup.Commands.ContainsKey("get-table-namespace"), "Should have get-table-namespace command");
 
         // Shortcut commands
-        Assert.True(rootGroup.Commands.ContainsKey("list_shortcuts"), "Should have list_shortcuts command");
-        Assert.True(rootGroup.Commands.ContainsKey("get_shortcut"), "Should have get_shortcut command");
-        Assert.True(rootGroup.Commands.ContainsKey("delete_shortcut"), "Should have delete_shortcut command");
-        Assert.True(rootGroup.Commands.ContainsKey("reset_shortcut_cache"), "Should have reset_shortcut_cache command");
-        Assert.True(rootGroup.Commands.ContainsKey("create_shortcut_onelake"), "Should have create_shortcut_onelake command");
-        Assert.True(rootGroup.Commands.ContainsKey("create_shortcut_adls_gen2"), "Should have create_shortcut_adls_gen2 command");
-        Assert.True(rootGroup.Commands.ContainsKey("create_shortcut_amazon_s3"), "Should have create_shortcut_amazon_s3 command");
-        Assert.True(rootGroup.Commands.ContainsKey("create_shortcut_azure_blob"), "Should have create_shortcut_azure_blob command");
-        Assert.True(rootGroup.Commands.ContainsKey("create_shortcut_gcs"), "Should have create_shortcut_gcs command");
-        Assert.True(rootGroup.Commands.ContainsKey("create_shortcut_s3_compatible"), "Should have create_shortcut_s3_compatible command");
-        Assert.True(rootGroup.Commands.ContainsKey("create_shortcut_dataverse"), "Should have create_shortcut_dataverse command");
-        Assert.True(rootGroup.Commands.ContainsKey("create_shortcut_onedrive_sharepoint"), "Should have create_shortcut_onedrive_sharepoint command");
+        Assert.True(rootGroup.Commands.ContainsKey("list-shortcuts"), "Should have list-shortcuts command");
+        Assert.True(rootGroup.Commands.ContainsKey("get-shortcut"), "Should have get-shortcut command");
+        Assert.True(rootGroup.Commands.ContainsKey("delete-shortcut"), "Should have delete-shortcut command");
+        Assert.True(rootGroup.Commands.ContainsKey("reset-shortcut-cache"), "Should have reset-shortcut-cache command");
+        Assert.True(rootGroup.Commands.ContainsKey("create-shortcut-onelake"), "Should have create-shortcut-onelake command");
+        Assert.True(rootGroup.Commands.ContainsKey("create-shortcut-adls-gen2"), "Should have create-shortcut-adls-gen2 command");
+        Assert.True(rootGroup.Commands.ContainsKey("create-shortcut-amazon-s3"), "Should have create-shortcut-amazon-s3 command");
+        Assert.True(rootGroup.Commands.ContainsKey("create-shortcut-azure-blob"), "Should have create-shortcut-azure-blob command");
+        Assert.True(rootGroup.Commands.ContainsKey("create-shortcut-gcs"), "Should have create-shortcut-gcs command");
+        Assert.True(rootGroup.Commands.ContainsKey("create-shortcut-s3-compatible"), "Should have create-shortcut-s3-compatible command");
+        Assert.True(rootGroup.Commands.ContainsKey("create-shortcut-dataverse"), "Should have create-shortcut-dataverse command");
+        Assert.True(rootGroup.Commands.ContainsKey("create-shortcut-onedrive-sharepoint"), "Should have create-shortcut-onedrive-sharepoint command");
     }
 }


### PR DESCRIPTION
## Description

All `onelake` tool names used snake_case leaf names, while every other namespace in the Fabric MCP server uses kebab-case. This makes `onelake` the sole outlier in the `<namespace>_<tool-name-in-kebab-case>` convention:

| Namespace | Style | Example |
| --- | --- | --- |
| `core` | kebab-case | `core_search-catalog` |
| `docs` | kebab-case | `docs_best-practices` |
| `datafactory` | kebab-case | `datafactory_list-pipelines` |
| `onelake` | **snake_case** | `onelake_list_workspaces` |

This PR converts all 34 OneLake command names to kebab-case. Fabric's convention is flat + verb-first, so verbs stay leading (`list-workspaces`, not `workspace-list`) — only the casing changes.

Examples:

- `onelake_list_workspaces` → `onelake_list-workspaces`
- `onelake_get_table_config` → `onelake_get-table-config`
- `onelake_create_shortcut_adls_gen2` → `onelake_create-shortcut-adls-gen2`
- `onelake_create_or_update_data_access_role` → `onelake_create-or-update-data-access-role`

### Additional fix

`OneLakeItemListDfsCommand` had `Name = "onelake-item-list-dfs"`, which would have rendered as the namespace-duplicated tool `onelake_onelake-item-list-dfs`. Renamed to `list-item-paths-dfs`. It cannot reuse `list-items-dfs`, which belongs to the registered `OneLakeItemDataListCommand`. The command is not registered in `FabricOneLakeSetup`, so this name was never exposed to clients.

### Also updated

- Unit tests: 24 per-command name assertions plus the 28 `ContainsKey` assertions in `FabricOneLakeSetupTests`
- Tool tables in `servers/Fabric.Mcp.Server/README.md` and `tools/Fabric.Mcp.Tools.OneLake/README.md`
- Tool names embedded in the `get-data-access-role` description and in `OneLakePrompts`
- Prompt `onelake_confirm_delete` → `onelake_confirm-delete` (its sibling `onelake_best-practices` was already kebab-case)
- Breaking Changes changelog entry

## Breaking change

Yes. Client configurations referencing OneLake tools by name need updating. Note that several of these names were already inconsistent with the shipped v1 tool names, so some callers may be pinned to older names regardless.

## Validation

`dotnet build` could not be run locally: `global.json` pins SDK `10.0.400`, and this machine has only 10.0.111 and 10.0.303 installed. This is a pre-existing environment gap unrelated to the change. Verified instead via the language server (no diagnostics on edited files) and a repo-wide grep confirming zero remaining snake_case OneLake tool identifiers. **CI build and unit test results should be confirmed before merge.**

## Out of scope (pre-existing issues found, not changed)

- `OneLakePrompts` instructs the model to `Use tool 'onelake_execute_sql'`, but no such tool exists in the toolset — a dangling reference that will cause failed tool calls.
- Four commands are registered in DI but never added to the command group, so they are unreachable: `FileReadCommand` (`read`), `FileWriteCommand` (`write`), `BlobListCommand` (`list`), `BlobDeleteCommand` (`delete`).

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
