### PR TITLE
Fix github Login for MCPB publishing

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -102,6 +102,7 @@
         "globaltool",
         "glsl",
         "gmsa",
+        "issecret",
         "itemdefinition",
         "kubelet",
         "laskewitz",

--- a/eng/pipelines/templates/jobs/mcpb/release-mcpb.yml
+++ b/eng/pipelines/templates/jobs/mcpb/release-mcpb.yml
@@ -21,7 +21,7 @@ jobs:
   dependsOn: ${{ parameters.DependsOn }}
   condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
   variables:
-    GH_TOKEN: $[ dependencies.TagRepository.outputs['GenerateGitHubToken.GH_TOKEN'] ]
+    GH_TOKEN: $[ dependencies.TagRepository.outputs['ExportGitHubTokenForMcpb.GH_TOKEN'] ]
   templateContext:
     type: releaseJob
     isProduction: true

--- a/eng/pipelines/templates/jobs/release.yml
+++ b/eng/pipelines/templates/jobs/release.yml
@@ -38,6 +38,13 @@ jobs:
       ExportAsOutputVariable: true
 
   - pwsh: |
+      Write-Host "##vso[task.setvariable variable=GH_TOKEN;issecret=true;isOutput=true]$env:GH_TOKEN"
+    name: ExportGitHubTokenForMcpb
+    displayName: "Export GitHub token for MCPB publishing"
+    env:
+      GH_TOKEN: $(GH_TOKEN)
+
+  - pwsh: |
       $buildInfoPath = "$(Pipeline.Workspace)/build_info/build_info.json"
       $buildInfo = Get-Content -Raw -Path $buildInfoPath | ConvertFrom-Json
 

--- a/eng/scripts/Pack-Mcpb.ps1
+++ b/eng/scripts/Pack-Mcpb.ps1
@@ -154,18 +154,6 @@ Processing MCPB packaging:
         LogInfo "Copying trimmed binaries from $platformDirectory..."
         Copy-Item -Path "$platformDirectory/*" -Destination "$stagingDir/server" -Recurse
 
-        # Preserve the executable permission in Unix MCPB bundles.
-        if ($platform.operatingSystem -ne 'windows') {
-            $stagedExecutablePath = "$stagingDir/server/$($server.cliName)$($platform.extension)"
-            LogInfo "Setting executable permission on $stagedExecutablePath..."
-            & chmod +x $stagedExecutablePath
-            if ($LASTEXITCODE -ne 0) {
-                LogError "Failed to set executable permission on $stagedExecutablePath"
-                $exitCode = 1
-                continue
-            }
-        }
-
         # Copy and update manifest.json for this platform
         # The source manifest uses platform-agnostic paths (no extension), so we need to add
         # the correct extension for this platform's executable

--- a/eng/scripts/Pack-Mcpb.ps1
+++ b/eng/scripts/Pack-Mcpb.ps1
@@ -154,6 +154,18 @@ Processing MCPB packaging:
         LogInfo "Copying trimmed binaries from $platformDirectory..."
         Copy-Item -Path "$platformDirectory/*" -Destination "$stagingDir/server" -Recurse
 
+        # Preserve the executable permission in Unix MCPB bundles.
+        if ($platform.operatingSystem -ne 'windows') {
+            $stagedExecutablePath = "$stagingDir/server/$($server.cliName)$($platform.extension)"
+            LogInfo "Setting executable permission on $stagedExecutablePath..."
+            & chmod +x $stagedExecutablePath
+            if ($LASTEXITCODE -ne 0) {
+                LogError "Failed to set executable permission on $stagedExecutablePath"
+                $exitCode = 1
+                continue
+            }
+        }
+
         # Copy and update manifest.json for this platform
         # The source manifest uses platform-agnostic paths (no extension), so we need to add
         # the correct extension for this platform's executable


### PR DESCRIPTION
## What does this PR do?
Fix github login for MCPB publishing by using a token variable exported by release job

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
