### PR TITLE
Prepare for August 20 Release

### DIFF
--- a/servers/Azure.Mcp.Server/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/CHANGELOG.md
@@ -2,15 +2,23 @@
 
 The Azure MCP Server updates automatically by default whenever a new release comes out 🚀. We ship updates twice a week on Tuesdays and Thursdays 😊
 
-## 3.0.0-beta.37 (Unreleased)
+## 3.0.0-beta.37 (2026-08-20)
 
 ### Features Added
 
-### Breaking Changes
+- `azurebackup vault get` now accepts an optional `--expand` parameter (comma-separated: `security`, `mua`, `all`) to include extended vault posture fields (encryption key URI, cross-region restore state, MUA resource guard link). For DPP vaults, `encryptionState` is also returned from the service. RSV vaults omit `encryptionState` because the Recovery Services vault GET API does not return an explicit state field. Default output shape is unchanged. [[#1718](https://github.com/microsoft/mcp/pull/1718)]
+- Added the `azmcp resilience recovery plan create` command to create or fully update a Zonal recovery plan with an explicitly selected system-assigned, user-assigned, or combined identity. Updates can switch identity types while preserving existing recovery groups. [[#3268](https://github.com/microsoft/mcp/pull/3268)]
+- Added the `azmcp resilience recovery plan delete` command to delete a recovery plan from an Azure service group. The command is idempotent and reports whether a plan was deleted. [[#3268](https://github.com/microsoft/mcp/pull/3268)]
+- Added the `azmcp resilience recovery plan update-resources` command to include, exclude, configure, or remove recovery resources, including their recovery groups, associated identities, and protection settings. The command validates mandatory protection settings before first inclusion while preserving existing settings on sparse updates. [[#3268](https://github.com/microsoft/mcp/pull/3268)]
 
 ### Bugs Fixed
 
+- Fixed `azmcp eventgrid events publish` so that failures publishing events to an Event Grid topic now propagate as errors (with the correct HTTP status code) instead of being swallowed and reported as a successful (HTTP 200) response with a `Failed` status. [[#3326](https://github.com/microsoft/mcp/pull/3326)]
+
 ### Other Changes
+
+- Updated capture of `ToolParameters` for multi-step server modes. [[#3296](https://github.com/microsoft/mcp/pull/3296)]
+- Improved Event Grid performance by looking up a topic or system topic directly by name when a resource group is supplied, instead of enumerating every topic in the resource group. [[#3308](https://github.com/microsoft/mcp/pull/3308)]
 
 ## 3.0.0-beta.36 (2026-08-18)
 

--- a/servers/Azure.Mcp.Server/changelog-entries/1771011595893.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1771011595893.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Features Added"
-    description: "`azurebackup vault get` now accepts an optional `--expand` parameter (comma-separated: `security`, `mua`, `all`) to include extended vault posture fields (encryption key URI, cross-region restore state, MUA resource guard link). For DPP vaults, `encryptionState` is also returned from the service. RSV vaults omit `encryptionState` because the Recovery Services vault GET API does not return an explicit state field. Default output shape is unchanged."

--- a/servers/Azure.Mcp.Server/changelog-entries/1787000478263.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1787000478263.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Other Changes"
-    description: "Updated capture of ToolParameters for multi-step server modes."

--- a/servers/Azure.Mcp.Server/changelog-entries/copilot-eventgrid-direct-topic-lookup.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/copilot-eventgrid-direct-topic-lookup.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Other Changes"
-    description: "Improved Event Grid performance by looking up a topic or system topic directly by name when a resource group is supplied, instead of enumerating every topic in the resource group."

--- a/servers/Azure.Mcp.Server/changelog-entries/copilot-eventgrid-publish-propagate-exceptions.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/copilot-eventgrid-publish-propagate-exceptions.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Bugs Fixed"
-    description: "Fixed `azmcp eventgrid events publish` so that failures publishing events to an Event Grid topic now propagate as errors (with the correct HTTP status code) instead of being swallowed and reported as a successful (HTTP 200) response with a `Failed` status."

--- a/servers/Azure.Mcp.Server/changelog-entries/resilience-recovery-plan-commands.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/resilience-recovery-plan-commands.yaml
@@ -1,7 +1,0 @@
-changes:
-  - section: "Features Added"
-    description: "Added the 'azmcp resilience recovery plan create' command to create or fully update a Zonal recovery plan with an explicitly selected system-assigned, user-assigned, or combined identity. Updates can switch identity types while preserving existing recovery groups."
-  - section: "Features Added"
-    description: "Added the 'azmcp resilience recovery plan delete' command to delete a recovery plan from an Azure service group. The command is idempotent and reports whether a plan was deleted."
-  - section: "Features Added"
-    description: "Added the 'azmcp resilience recovery plan update-resources' command to include, exclude, configure, or remove recovery resources, including their recovery groups, associated identities, and protection settings. The command validates mandatory protection settings before first inclusion while preserving existing settings on sparse updates."

--- a/servers/Azure.Mcp.Server/vscode/CHANGELOG.md
+++ b/servers/Azure.Mcp.Server/vscode/CHANGELOG.md
@@ -6,6 +6,25 @@
 
 
 
+
+## 3.0.37 (2026-08-20) (pre-release)
+
+### Added
+
+- `azurebackup vault get` now accepts an optional `--expand` parameter (comma-separated: `security`, `mua`, `all`) to include extended vault posture fields (encryption key URI, cross-region restore state, MUA resource guard link). For DPP vaults, `encryptionState` is also returned from the service. RSV vaults omit `encryptionState` because the Recovery Services vault GET API does not return an explicit state field. Default output shape is unchanged. [[#1718](https://github.com/microsoft/mcp/pull/1718)]
+- Added the `azmcp resilience recovery plan create` command to create or fully update a Zonal recovery plan with an explicitly selected system-assigned, user-assigned, or combined identity. Updates can switch identity types while preserving existing recovery groups. [[#3268](https://github.com/microsoft/mcp/pull/3268)]
+- Added the `azmcp resilience recovery plan delete` command to delete a recovery plan from an Azure service group. The command is idempotent and reports whether a plan was deleted. [[#3268](https://github.com/microsoft/mcp/pull/3268)]
+- Added the `azmcp resilience recovery plan update-resources` command to include, exclude, configure, or remove recovery resources, including their recovery groups, associated identities, and protection settings. The command validates mandatory protection settings before first inclusion while preserving existing settings on sparse updates. [[#3268](https://github.com/microsoft/mcp/pull/3268)]
+
+### Changed
+
+- Updated capture of `ToolParameters` for multi-step server modes. [[#3296](https://github.com/microsoft/mcp/pull/3296)]
+- Improved Event Grid performance by looking up a topic or system topic directly by name when a resource group is supplied, instead of enumerating every topic in the resource group. [[#3308](https://github.com/microsoft/mcp/pull/3308)]
+
+### Fixed
+
+- Fixed `azmcp eventgrid events publish` so that failures publishing events to an Event Grid topic now propagate as errors (with the correct HTTP status code) instead of being swallowed and reported as a successful (HTTP 200) response with a `Failed` status. [[#3326](https://github.com/microsoft/mcp/pull/3326)]
+
 ## 3.0.36 (2026-08-18) (pre-release)
 
 ### Added


### PR DESCRIPTION
## Summary

- Finalizes Azure MCP Server `3.0.0-beta.37` and VS Code extension `3.0.37` for the August 20, 2026 release.
- Adds recovery plan create, delete, and resource-update commands plus expanded Azure Backup vault posture details.
- Includes Event Grid error propagation and lookup performance fixes, along with multi-step `ToolParameters` telemetry capture.
- Removes the five compiled changelog entry files while preserving the example template.

## Validation

- `./eng/scripts/Compile-Changelog.ps1 -ChangelogPath "servers/Azure.Mcp.Server/CHANGELOG.md"`
- `.\eng\common\spelling\Invoke-Cspell.ps1` against both generated changelogs
- Release header, compiled-entry cleanup, diff scope, and `git diff --check` validation

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.