### PR TITLE
Add AMLFS expansion job commands

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/remakar-amlfs-expansion-jobs.yml
+++ b/servers/Azure.Mcp.Server/changelog-entries/remakar-amlfs-expansion-jobs.yml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Features Added"
+    description: "Added AMLFS expansion job commands (create, get, delete) to resize Azure Managed Lustre filesystem storage capacity"

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3332,6 +3332,28 @@ azmcp managedlustre fs subnetsize validate --subscription <subscription> \
 azmcp managedlustre fs sku get --subscription <subscription> \
                                             --location <location>
 
+# Create an expansion job to increase the storage capacity of an Azure Managed Lustre filesystem
+# ✅ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
+azmcp managedlustre fs expansion create --subscription <subscription> \
+                                        --resource-group <resource-group> \
+                                        --filesystem-name <filesystem-name> \
+                                        --new-size <new-size-tib> \
+                                        [--expansion-job-name <expansion-job-name>]
+
+# Get expansion job details for an Azure Managed Lustre filesystem. Returns a specific job if expansion-job-name is provided, otherwise lists all expansion jobs.
+# ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
+azmcp managedlustre fs expansion get --subscription <subscription> \
+                                     --resource-group <resource-group> \
+                                     --filesystem-name <filesystem-name> \
+                                     [--expansion-job-name <expansion-job-name>]
+
+# Delete an expansion job for an Azure Managed Lustre filesystem
+# ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
+azmcp managedlustre fs expansion delete --subscription <subscription> \
+                                        --resource-group <resource-group> \
+                                        --filesystem-name <filesystem-name> \
+                                        --expansion-job-name <expansion-job-name>
+
 # Create an autoexport job for an Azure Managed Lustre filesystem
 # ✅ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp managedlustre fs blob autoexport create --subscription <subscription> \

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -733,6 +733,10 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | managedlustre_fs_list | List the Azure Managed Lustre filesystems in my subscription <subscription_name> | none |
 | managedlustre_fs_list | List the Azure Managed Lustre filesystems in my resource group <resource_group_name> | none |
 | managedlustre_fs_sku_get | List the Azure Managed Lustre SKUs available in location <location> | none |
+| managedlustre_fs_expansion_create | Create an expansion job to increase the storage capacity of the Azure Managed Lustre filesystem <filesystem_name> to <new_size_tib> TiB in resource group <resource_group_name> | none |
+| managedlustre_fs_expansion_get | Get the details of expansion job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
+| managedlustre_fs_expansion_get | List all expansion jobs for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
+| managedlustre_fs_expansion_delete | Delete the expansion job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
 | managedlustre_fs_blob_autoexport_create | Create an autoexport job for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
 | managedlustre_fs_blob_autoexport_cancel | Cancel the autoexport job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
 | managedlustre_fs_blob_autoexport_get | Get the details of autoexport job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -729,25 +729,29 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 
 | Tool Name | Test Prompt | Interaction |
 |:----------|:------------|:------------|
-| managedlustre_fs_create | Create an Azure Managed Lustre filesystem with name <filesystem_name>, size <filesystem_size>, SKU <sku>, and subnet <subnet_id> for availability zone <zone> in location <location>. Maintenance should occur on <maintenance_window_day> at <maintenance_window_time> | none |
-| managedlustre_fs_list | List the Azure Managed Lustre filesystems in my subscription <subscription_name> | none |
-| managedlustre_fs_list | List the Azure Managed Lustre filesystems in my resource group <resource_group_name> | none |
-| managedlustre_fs_sku_get | List the Azure Managed Lustre SKUs available in location <location> | none |
-| managedlustre_fs_blob_autoexport_create | Create an autoexport job for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
 | managedlustre_fs_blob_autoexport_cancel | Cancel the autoexport job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
+| managedlustre_fs_blob_autoexport_create | Create an autoexport job for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
+| managedlustre_fs_blob_autoexport_delete | Delete the autoexport job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
 | managedlustre_fs_blob_autoexport_get | Get the details of autoexport job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
 | managedlustre_fs_blob_autoexport_get | Show the list of autoexport jobs for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
-| managedlustre_fs_blob_autoexport_delete | Delete the autoexport job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
-| managedlustre_fs_blob_autoimport_create | Create an autoimport job for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
 | managedlustre_fs_blob_autoimport_cancel | Cancel the autoimport job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
+| managedlustre_fs_blob_autoimport_create | Create an autoimport job for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
 | managedlustre_fs_blob_autoimport_delete | Delete the autoimport job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
 | managedlustre_fs_blob_autoimport_get | Get the details of autoimport job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
 | managedlustre_fs_blob_autoimport_get | Get the details of all the autoimport jobs for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
+| managedlustre_fs_blob_import_cancel | Cancel the one-time import job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
 | managedlustre_fs_blob_import_create | Create a one-time import job for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
+| managedlustre_fs_blob_import_delete | Delete the one-time import job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
 | managedlustre_fs_blob_import_get | Get the details of import job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
 | managedlustre_fs_blob_import_get | List all one-time import jobs for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
-| managedlustre_fs_blob_import_cancel | Cancel the one-time import job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
-| managedlustre_fs_blob_import_delete | Delete the one-time import job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
+| managedlustre_fs_create | Create an Azure Managed Lustre filesystem with name <filesystem_name>, size <filesystem_size>, SKU <sku>, and subnet <subnet_id> for availability zone <zone> in location <location>. Maintenance should occur on <maintenance_window_day> at <maintenance_window_time> | none |
+| managedlustre_fs_expansion_create | Create an expansion job to increase the storage capacity of the Azure Managed Lustre filesystem <filesystem_name> to <new_size_tib> TiB in resource group <resource_group_name> | none |
+| managedlustre_fs_expansion_delete | Delete the expansion job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
+| managedlustre_fs_expansion_get | Get the details of expansion job <job_name> for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
+| managedlustre_fs_expansion_get | List all expansion jobs for the Azure Managed Lustre filesystem <filesystem_name> in resource group <resource_group_name> | none |
+| managedlustre_fs_list | List the Azure Managed Lustre filesystems in my subscription <subscription_name> | none |
+| managedlustre_fs_list | List the Azure Managed Lustre filesystems in my resource group <resource_group_name> | none |
+| managedlustre_fs_sku_get | List the Azure Managed Lustre SKUs available in location <location> | none |
 | managedlustre_fs_subnetsize_ask | Tell me how many IP addresses I need for an Azure Managed Lustre filesystem of size <filesystem_size> using the SKU <sku> | none |
 | managedlustre_fs_subnetsize_validate | Validate if the network <subnet_id> can host Azure Managed Lustre filesystem of size <filesystem_size> using the SKU <sku> | none |
 | managedlustre_fs_update | Update the maintenance window of the Azure Managed Lustre filesystem <filesystem_name> to <maintenance_window_day> at <maintenance_window_time> | none |

--- a/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json
+++ b/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json
@@ -1668,6 +1668,7 @@
         "managedlustre_fs_blob_autoexport_get",
         "managedlustre_fs_blob_autoimport_get",
         "managedlustre_fs_blob_import_get",
+        "managedlustre_fs_expansion_get",
         "storage_account_get",
         "storage_blob_container_get",
         "storage_blob_get",
@@ -1914,7 +1915,8 @@
         "managedlustre_fs_create",
         "managedlustre_fs_blob_autoexport_create",
         "managedlustre_fs_blob_autoimport_create",
-        "managedlustre_fs_blob_import_create"
+        "managedlustre_fs_blob_import_create",
+        "managedlustre_fs_expansion_create"
       ]
     },
     {
@@ -1952,7 +1954,7 @@
     },
     {
       "name": "manage_azure_managed_lustre_sync_jobs",
-      "description": "Manage Azure Managed Lustre data synchronization jobs including canceling and deleting autoimport, autoexport, and one-time import jobs that sync data between Lustre filesystems and Azure Blob Storage.",
+      "description": "Manage Azure Managed Lustre data synchronization and expansion jobs including canceling and deleting autoimport, autoexport, one-time import, and expansion jobs that manage data sync and storage capacity for Lustre filesystems.",
       "toolMetadata": {
         "destructive": {
           "value": true,
@@ -1985,7 +1987,8 @@
         "managedlustre_fs_blob_autoimport_cancel",
         "managedlustre_fs_blob_autoimport_delete",
         "managedlustre_fs_blob_import_cancel",
-        "managedlustre_fs_blob_import_delete"
+        "managedlustre_fs_blob_import_delete",
+        "managedlustre_fs_expansion_delete"
       ]
     },
     {

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ExpansionJob/ExpansionJobCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ExpansionJob/ExpansionJobCreateCommand.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Commands.Subscription;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Tools.ManagedLustre.Options.FileSystem.ExpansionJob;
+using Azure.Mcp.Tools.ManagedLustre.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ExpansionJob;
+
+[CommandMetadata(
+    Id = "e4f592ba-405a-492f-92dc-7fd8a7d4220b",
+    Name = "create",
+    Title = "Create Azure Managed Lustre Expansion Job",
+    Description = """
+        Creates an expansion job to increase the storage capacity of an Azure Managed Lustre (AMLFS) file system. The expansion job resizes the filesystem to the specified new capacity in TiB. The new size must be a multiple of the SKU step size and greater than the current storage capacity.
+        Required options:
+        - filesystem-name: The name of the AMLFS filesystem
+        - new-size: The new storage capacity in TiB after expansion
+        - resource-group: The resource group containing the filesystem
+        - subscription: The subscription containing the filesystem
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ExpansionJobCreateCommand(IManagedLustreService service, ILogger<ExpansionJobCreateCommand> logger, ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<ExpansionJobCreateOptions, ExpansionJobCreateCommand.ExpansionJobCreateResult>(subscriptionResolver)
+{
+    private readonly IManagedLustreService _service = service;
+    private readonly ILogger<ExpansionJobCreateCommand> _logger = logger;
+
+    public override void ValidateOptions(ExpansionJobCreateOptions options, ValidationResult validationResult)
+    {
+        base.ValidateOptions(options, validationResult);
+
+        if (!float.IsFinite(options.NewSize) || options.NewSize <= 0)
+        {
+            validationResult.Errors.Add("The new-size option must be a finite value greater than zero.");
+        }
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ExpansionJobCreateOptions options, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var jobName = await _service.CreateExpansionJobAsync(
+                options.Subscription!,
+                options.ResourceGroup,
+                options.FilesystemName,
+                options.NewSize,
+                options.ExpansionJobName,
+                options.Tenant,
+                options.RetryPolicy,
+                cancellationToken);
+
+            context.Response.Results = ResponseResult.Create(new(jobName), ManagedLustreJsonContext.Default.ExpansionJobCreateResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating expansion job for AMLFS filesystem {FileSystem}.",
+                options.FilesystemName);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    public sealed record ExpansionJobCreateResult(string JobName);
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ExpansionJob/ExpansionJobCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ExpansionJob/ExpansionJobCreateCommand.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Commands.Subscription;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Tools.ManagedLustre.Options.FileSystem.ExpansionJob;
+using Azure.Mcp.Tools.ManagedLustre.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ExpansionJob;
+
+[CommandMetadata(
+    Id = "e4f592ba-405a-492f-92dc-7fd8a7d4220b",
+    Name = "create",
+    Title = "Create Azure Managed Lustre Expansion Job",
+    Description = """
+        Creates an expansion job to increase the storage capacity of an Azure Managed Lustre (AMLFS) file system. The expansion job resizes the filesystem to the specified new capacity in TiB. The new size must be a multiple of the SKU step size and greater than the current storage capacity.
+        """,
+    Destructive = true,
+    Idempotent = false,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ExpansionJobCreateCommand(IManagedLustreService service, ILogger<ExpansionJobCreateCommand> logger, ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<ExpansionJobCreateOptions, ExpansionJobCreateCommand.ExpansionJobCreateResult>(subscriptionResolver)
+{
+    private readonly IManagedLustreService _service = service;
+    private readonly ILogger<ExpansionJobCreateCommand> _logger = logger;
+
+    public override void ValidateOptions(ExpansionJobCreateOptions options, ValidationResult validationResult)
+    {
+        base.ValidateOptions(options, validationResult);
+
+        if (!float.IsFinite(options.NewSize) || options.NewSize <= 0)
+        {
+            validationResult.Errors.Add("The new-size option must be a finite value greater than zero.");
+        }
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ExpansionJobCreateOptions options, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var jobName = await _service.CreateExpansionJobAsync(
+                options.Subscription!,
+                options.ResourceGroup,
+                options.FilesystemName,
+                options.NewSize,
+                options.ExpansionJobName,
+                options.Tenant,
+                options.RetryPolicy,
+                cancellationToken);
+
+            context.Response.Results = ResponseResult.Create(new(jobName), ManagedLustreJsonContext.Default.ExpansionJobCreateResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating expansion job for AMLFS filesystem {FileSystem}.",
+                options.FilesystemName);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    public sealed record ExpansionJobCreateResult(string JobName);
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ExpansionJob/ExpansionJobDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ExpansionJob/ExpansionJobDeleteCommand.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Commands.Subscription;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Tools.ManagedLustre.Options.FileSystem.ExpansionJob;
+using Azure.Mcp.Tools.ManagedLustre.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ExpansionJob;
+
+[CommandMetadata(
+    Id = "dbdda79a-6858-4b32-96f1-413d0078bff1",
+    Name = "delete",
+    Title = "Delete Azure Managed Lustre Expansion Job",
+    Description = """
+        Deletes an expansion job for an Azure Managed Lustre filesystem. This permanently removes the expansion job record from the filesystem. Use this to clean up completed, failed, or cancelled expansion jobs.
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ExpansionJobDeleteCommand(IManagedLustreService service, ILogger<ExpansionJobDeleteCommand> logger, ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<ExpansionJobDeleteOptions, ExpansionJobDeleteCommand.ExpansionJobDeleteResult>(subscriptionResolver)
+{
+    private readonly IManagedLustreService _service = service;
+    private readonly ILogger<ExpansionJobDeleteCommand> _logger = logger;
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ExpansionJobDeleteOptions options, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var deleted = await _service.DeleteExpansionJobAsync(
+                options.Subscription!,
+                options.ResourceGroup,
+                options.FilesystemName,
+                options.ExpansionJobName,
+                options.Tenant,
+                options.RetryPolicy,
+                cancellationToken);
+
+            var message = deleted
+                ? $"Expansion job '{options.ExpansionJobName}' was successfully deleted."
+                : $"Expansion job '{options.ExpansionJobName}' was not found. Nothing was deleted.";
+
+            context.Response.Results = ResponseResult.Create(
+                new(options.ExpansionJobName, deleted, message),
+                ManagedLustreJsonContext.Default.ExpansionJobDeleteResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting expansion job {JobName} for AMLFS filesystem {FileSystem}.",
+                options.ExpansionJobName, options.FilesystemName);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    public sealed record ExpansionJobDeleteResult(string JobName, bool Deleted, string Message);
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ExpansionJob/ExpansionJobDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ExpansionJob/ExpansionJobDeleteCommand.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Commands.Subscription;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Tools.ManagedLustre.Options.FileSystem.ExpansionJob;
+using Azure.Mcp.Tools.ManagedLustre.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ExpansionJob;
+
+[CommandMetadata(
+    Id = "dbdda79a-6858-4b32-96f1-413d0078bff1",
+    Name = "delete",
+    Title = "Delete Azure Managed Lustre Expansion Job",
+    Description = """
+        Deletes an expansion job for an Azure Managed Lustre filesystem. This permanently removes the expansion job record from the filesystem. Use this to clean up completed, failed, or cancelled expansion jobs.
+        Required options:
+        - filesystem-name: The name of the AMLFS filesystem
+        - expansion-job-name: The name of the expansion job to delete
+        - resource-group: The resource group containing the filesystem
+        - subscription: The subscription containing the filesystem
+        """,
+    Destructive = true,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = false,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ExpansionJobDeleteCommand(IManagedLustreService service, ILogger<ExpansionJobDeleteCommand> logger, ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<ExpansionJobDeleteOptions, ExpansionJobDeleteCommand.ExpansionJobDeleteResult>(subscriptionResolver)
+{
+    private readonly IManagedLustreService _service = service;
+    private readonly ILogger<ExpansionJobDeleteCommand> _logger = logger;
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ExpansionJobDeleteOptions options, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _service.DeleteExpansionJobAsync(
+                options.Subscription!,
+                options.ResourceGroup,
+                options.FilesystemName,
+                options.ExpansionJobName,
+                options.Tenant,
+                options.RetryPolicy,
+                cancellationToken);
+
+            context.Response.Results = ResponseResult.Create(new(options.ExpansionJobName, "Deleted"), ManagedLustreJsonContext.Default.ExpansionJobDeleteResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting expansion job {JobName} for AMLFS filesystem {FileSystem}.",
+                options.ExpansionJobName, options.FilesystemName);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    public sealed record ExpansionJobDeleteResult(string JobName, string Status);
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ExpansionJob/ExpansionJobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ExpansionJob/ExpansionJobGetCommand.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using Azure.Mcp.Core.Commands.Subscription;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Tools.ManagedLustre.Options.FileSystem.ExpansionJob;
+using Azure.Mcp.Tools.ManagedLustre.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ExpansionJob;
+
+[CommandMetadata(
+    Id = "09eeab98-b2d5-4c8a-8bac-89dec00a3afd",
+    Name = "get",
+    Title = "Get Azure Managed Lustre Expansion Job",
+    Description = """
+        Gets the details of expansion jobs for an Azure Managed Lustre filesystem. Use this to retrieve the status, progress, and configuration of expansion operations that resize the filesystem storage capacity. If expansion-job-name is provided, returns details of a specific job; otherwise returns all expansion jobs for the filesystem.
+        Required options:
+        - filesystem-name: The name of the AMLFS filesystem
+        - resource-group: The resource group containing the filesystem
+        - subscription: The subscription containing the filesystem
+        Optional options:
+        - expansion-job-name: The name of a specific expansion job (if omitted, all jobs are returned)
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ExpansionJobGetCommand(IManagedLustreService service, ILogger<ExpansionJobGetCommand> logger, ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<ExpansionJobGetOptions, ExpansionJobGetCommand.ExpansionJobGetResult>(subscriptionResolver)
+{
+    private readonly IManagedLustreService _service = service;
+    private readonly ILogger<ExpansionJobGetCommand> _logger = logger;
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ExpansionJobGetOptions options, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(options.ExpansionJobName))
+            {
+                var result = await _service.GetExpansionJobAsync(
+                    options.Subscription!,
+                    options.ResourceGroup,
+                    options.FilesystemName,
+                    options.ExpansionJobName,
+                    options.Tenant,
+                    options.RetryPolicy,
+                    cancellationToken);
+
+                context.Response.Results = ResponseResult.Create(new(result, null), ManagedLustreJsonContext.Default.ExpansionJobGetResult);
+            }
+            else
+            {
+                var results = await _service.ListExpansionJobsAsync(
+                    options.Subscription!,
+                    options.ResourceGroup,
+                    options.FilesystemName,
+                    options.Tenant,
+                    options.RetryPolicy,
+                    cancellationToken);
+
+                context.Response.Results = ResponseResult.Create(new(null, results ?? []), ManagedLustreJsonContext.Default.ExpansionJobGetResult);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting expansion job {JobName} for AMLFS filesystem {FileSystemName}.", options.ExpansionJobName, options.FilesystemName);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    public sealed record ExpansionJobGetResult(
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] Models.ExpansionJob? Job,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] List<Models.ExpansionJob>? Jobs);
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ExpansionJob/ExpansionJobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/FileSystem/ExpansionJob/ExpansionJobGetCommand.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using Azure.Mcp.Core.Commands.Subscription;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Tools.ManagedLustre.Options.FileSystem.ExpansionJob;
+using Azure.Mcp.Tools.ManagedLustre.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ExpansionJob;
+
+[CommandMetadata(
+    Id = "09eeab98-b2d5-4c8a-8bac-89dec00a3afd",
+    Name = "get",
+    Title = "Get Azure Managed Lustre Expansion Job",
+    Description = """
+        Gets the details of expansion jobs for an Azure Managed Lustre filesystem. Use this to retrieve the status, progress, and configuration of expansion operations that resize the filesystem storage capacity. If expansion-job-name is provided, returns details of a specific job; otherwise returns all expansion jobs for the filesystem.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class ExpansionJobGetCommand(IManagedLustreService service, ILogger<ExpansionJobGetCommand> logger, ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<ExpansionJobGetOptions, ExpansionJobGetCommand.ExpansionJobGetResult>(subscriptionResolver)
+{
+    private readonly IManagedLustreService _service = service;
+    private readonly ILogger<ExpansionJobGetCommand> _logger = logger;
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ExpansionJobGetOptions options, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(options.ExpansionJobName))
+            {
+                var result = await _service.GetExpansionJobAsync(
+                    options.Subscription!,
+                    options.ResourceGroup,
+                    options.FilesystemName,
+                    options.ExpansionJobName,
+                    options.Tenant,
+                    options.RetryPolicy,
+                    cancellationToken);
+
+                context.Response.Results = ResponseResult.Create(new(result, null), ManagedLustreJsonContext.Default.ExpansionJobGetResult);
+            }
+            else
+            {
+                var results = await _service.ListExpansionJobsAsync(
+                    options.Subscription!,
+                    options.ResourceGroup,
+                    options.FilesystemName,
+                    options.Tenant,
+                    options.RetryPolicy,
+                    cancellationToken);
+
+                context.Response.Results = ResponseResult.Create(new(null, results ?? []), ManagedLustreJsonContext.Default.ExpansionJobGetResult);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting expansion job {JobName} for AMLFS filesystem {FileSystemName}.", options.ExpansionJobName, options.FilesystemName);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    public sealed record ExpansionJobGetResult(
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] Models.ExpansionJob? Job,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] List<Models.ExpansionJob>? Jobs);
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/ManagedLustreJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Commands/ManagedLustreJsonContext.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem;
 using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.AutoexportJob;
 using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.AutoimportJob;
+using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ExpansionJob;
 using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ImportJob;
 using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.Sku;
 using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.SubnetSize;
@@ -43,5 +44,11 @@ namespace Azure.Mcp.Tools.ManagedLustre.Commands;
 [JsonSerializable(typeof(SkuGetCommand.SkuGetResult))]
 [JsonSerializable(typeof(SubnetSizeAskCommand.FileSystemSubnetSizeResult))]
 [JsonSerializable(typeof(SubnetSizeValidateCommand.FileSystemCheckSubnetResult))]
+[JsonSerializable(typeof(ExpansionJobCreateCommand.ExpansionJobCreateResult))]
+[JsonSerializable(typeof(ExpansionJobGetCommand.ExpansionJobGetResult))]
+[JsonSerializable(typeof(ExpansionJobDeleteCommand.ExpansionJobDeleteResult))]
+[JsonSerializable(typeof(ExpansionJob))]
+[JsonSerializable(typeof(ExpansionJobProperties))]
+[JsonSerializable(typeof(ExpansionJobStatus))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 internal partial class ManagedLustreJsonContext : JsonSerializerContext;

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/ManagedLustreSetup.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/ManagedLustreSetup.cs
@@ -4,6 +4,7 @@
 using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem;
 using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.AutoexportJob;
 using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.AutoimportJob;
+using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ExpansionJob;
 using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ImportJob;
 using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.Sku;
 using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.SubnetSize;
@@ -42,6 +43,9 @@ public class ManagedLustreSetup : IAreaSetup
         services.AddSingleton<ImportJobCancelCommand>();
         services.AddSingleton<ImportJobGetCommand>();
         services.AddSingleton<ImportJobDeleteCommand>();
+        services.AddSingleton<ExpansionJobCreateCommand>();
+        services.AddSingleton<ExpansionJobGetCommand>();
+        services.AddSingleton<ExpansionJobDeleteCommand>();
     }
 
     public CommandGroup RegisterCommands(IServiceProvider serviceProvider)
@@ -90,6 +94,13 @@ public class ManagedLustreSetup : IAreaSetup
         blobImport.AddCommand<ImportJobCancelCommand>(serviceProvider);
         blobImport.AddCommand<ImportJobGetCommand>(serviceProvider);
         blobImport.AddCommand<ImportJobDeleteCommand>(serviceProvider);
+
+        var expansion = new CommandGroup("expansion", "Expansion job operations for Azure Managed Lustre - Commands for creating jobs to expand (resize) the storage capacity of an AMLFS filesystem.");
+        fileSystem.AddSubGroup(expansion);
+
+        expansion.AddCommand<ExpansionJobCreateCommand>(serviceProvider);
+        expansion.AddCommand<ExpansionJobGetCommand>(serviceProvider);
+        expansion.AddCommand<ExpansionJobDeleteCommand>(serviceProvider);
 
         return managedLustre;
     }

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Models/ExpansionJob.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Models/ExpansionJob.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.ManagedLustre.Models;
+
+public class ExpansionJob
+{
+    public string? Name { get; set; }
+    public string? Id { get; set; }
+    public string? Type { get; set; }
+    public string? Location { get; set; }
+    public ExpansionJobProperties? Properties { get; set; }
+}
+
+public class ExpansionJobProperties
+{
+    public string? ProvisioningState { get; set; }
+    public float? NewStorageCapacityTiB { get; set; }
+    public ExpansionJobStatus? Status { get; set; }
+}
+
+public class ExpansionJobStatus
+{
+    public string? State { get; set; }
+    public string? StatusCode { get; set; }
+    public string? StatusMessage { get; set; }
+    public float? PercentComplete { get; set; }
+    public DateTime? StartTimeUTC { get; set; }
+    public DateTime? CompletionTimeUTC { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Models/ExpansionJob.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Models/ExpansionJob.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.ManagedLustre.Models;
+
+public sealed record ExpansionJob
+{
+    public string? Name { get; init; }
+    public string? Id { get; init; }
+    public string? Type { get; init; }
+    public string? Location { get; init; }
+    public ExpansionJobProperties? Properties { get; init; }
+}
+
+public sealed record ExpansionJobProperties
+{
+    public string? ProvisioningState { get; init; }
+    public float? NewStorageCapacityTiB { get; init; }
+    public ExpansionJobStatus? Status { get; init; }
+}
+
+public sealed record ExpansionJobStatus
+{
+    public string? State { get; init; }
+    public string? StatusCode { get; init; }
+    public string? StatusMessage { get; init; }
+    public float? PercentComplete { get; init; }
+    public DateTime? StartTimeUTC { get; init; }
+    public DateTime? CompletionTimeUTC { get; init; }
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Options/FileSystem/ExpansionJob/ExpansionJobCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Options/FileSystem/ExpansionJob/ExpansionJobCreateOptions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Options;
+using Microsoft.Mcp.Core.Options;
+
+namespace Azure.Mcp.Tools.ManagedLustre.Options.FileSystem.ExpansionJob;
+
+public sealed class ExpansionJobCreateOptions : ISubscriptionOption
+{
+    [Option(Description = ManagedLustreOptionDescriptions.FileSystemName)]
+    public required string FilesystemName { get; set; }
+
+    [Option(Description = ManagedLustreOptionDescriptions.ExpansionJobName)]
+    public string? ExpansionJobName { get; set; }
+
+    [Option(Description = ManagedLustreOptionDescriptions.NewSize)]
+    public required float NewSize { get; set; }
+
+    [Option(Description = OptionDescriptions.ResourceGroup)]
+    public required string ResourceGroup { get; set; }
+
+    [Option(Description = OptionDescriptions.Subscription)]
+    public string? Subscription { get; set; }
+
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
+    [OptionContainer(Prefix = "retry")]
+    public RetryPolicyOptions? RetryPolicy { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Options/FileSystem/ExpansionJob/ExpansionJobDeleteOptions.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Options/FileSystem/ExpansionJob/ExpansionJobDeleteOptions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Options;
+using Microsoft.Mcp.Core.Options;
+
+namespace Azure.Mcp.Tools.ManagedLustre.Options.FileSystem.ExpansionJob;
+
+public sealed class ExpansionJobDeleteOptions : ISubscriptionOption
+{
+    [Option(Description = ManagedLustreOptionDescriptions.FileSystemName)]
+    public required string FilesystemName { get; set; }
+
+    [Option(Description = ManagedLustreOptionDescriptions.ExpansionJobName)]
+    public required string ExpansionJobName { get; set; }
+
+    [Option(Description = OptionDescriptions.ResourceGroup)]
+    public required string ResourceGroup { get; set; }
+
+    [Option(Description = OptionDescriptions.Subscription)]
+    public string? Subscription { get; set; }
+
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
+    [OptionContainer(Prefix = "retry")]
+    public RetryPolicyOptions? RetryPolicy { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Options/FileSystem/ExpansionJob/ExpansionJobGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Options/FileSystem/ExpansionJob/ExpansionJobGetOptions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Options;
+using Microsoft.Mcp.Core.Options;
+
+namespace Azure.Mcp.Tools.ManagedLustre.Options.FileSystem.ExpansionJob;
+
+public sealed class ExpansionJobGetOptions : ISubscriptionOption
+{
+    [Option(Description = ManagedLustreOptionDescriptions.FileSystemName)]
+    public required string FilesystemName { get; set; }
+
+    [Option(Description = ManagedLustreOptionDescriptions.ExpansionJobName)]
+    public string? ExpansionJobName { get; set; }
+
+    [Option(Description = OptionDescriptions.ResourceGroup)]
+    public required string ResourceGroup { get; set; }
+
+    [Option(Description = OptionDescriptions.Subscription)]
+    public string? Subscription { get; set; }
+
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+
+    [OptionContainer(Prefix = "retry")]
+    public RetryPolicyOptions? RetryPolicy { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Options/ManagedLustreOptionDescriptions.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Options/ManagedLustreOptionDescriptions.cs
@@ -21,5 +21,7 @@ internal static class ManagedLustreOptionDescriptions
     internal const string AutoexportJobName = "The name of the autoexport job";
     internal const string AutoimportJobName = "The name of the autoimport job";
     internal const string ImportJobName = "The name of the import job";
+    internal const string ExpansionJobName = "The name of the expansion job";
+    internal const string NewSize = "The new storage capacity in TiB for the AML file system after expansion. Must be a multiple of the SKU step size and greater than the current storage capacity. Example: --new-size 64";
     internal const string AdminStatus = "The administrative status of the auto import job. Enable: job is active. Disable: disables the current active auto import job. Default: Enable. Allowed values: Enable, Disable.";
 }

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/IManagedLustreService.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/IManagedLustreService.cs
@@ -226,5 +226,42 @@ public interface IManagedLustreService
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
+
+    // Expansion jobs
+    Task<string> CreateExpansionJobAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        float newSizeTiB,
+        string? jobName = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<Models.ExpansionJob> GetExpansionJobAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<List<Models.ExpansionJob>> ListExpansionJobsAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteExpansionJobAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
 }
 

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/IManagedLustreService.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/IManagedLustreService.cs
@@ -226,5 +226,41 @@ public interface IManagedLustreService
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
-}
 
+    // Expansion jobs
+    Task<string> CreateExpansionJobAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        float newSizeTiB,
+        string? jobName = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<Models.ExpansionJob> GetExpansionJobAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<List<Models.ExpansionJob>> ListExpansionJobsAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> DeleteExpansionJobAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default);
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/ManagedLustreService.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/ManagedLustreService.cs
@@ -1239,5 +1239,175 @@ public sealed class ManagedLustreService(IAzureService azureService, ILogger<Man
             throw;
         }
     }
-}
 
+    private static Models.ExpansionJob MapExpansionJob(AmlFileSystemExpansionJobResource job)
+    {
+        var data = job.Data;
+        return new()
+        {
+            Name = data.Name,
+            Id = data.Id?.ToString(),
+            Type = data.ResourceType.ToString(),
+            Location = data.Location.ToString(),
+            Properties = new()
+            {
+                ProvisioningState = data.ProvisioningState?.ToString(),
+                NewStorageCapacityTiB = data.NewStorageCapacityTiB,
+                Status = new()
+                {
+                    State = data.State?.ToString(),
+                    StatusCode = data.StatusCode,
+                    StatusMessage = data.StatusMessage,
+                    PercentComplete = data.PercentComplete,
+                    StartTimeUTC = data.StartedOn?.UtcDateTime,
+                    CompletionTimeUTC = data.CompletedOn?.UtcDateTime
+                }
+            }
+        };
+    }
+
+    public async Task<string> CreateExpansionJobAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        float newSizeTiB,
+        string? jobName = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(filesystemName), filesystemName));
+
+        var rg = await AzureService.GetResourceGroupResource(subscription, resourceGroup, tenant, retryPolicy, cancellationToken)
+            ?? throw new Exception($"Resource group '{resourceGroup}' not found");
+
+        var fs = await rg.GetAmlFileSystemAsync(filesystemName, cancellationToken: cancellationToken);
+        if (fs?.Value == null)
+        {
+            throw new Exception($"Filesystem '{filesystemName}' not found in resource group '{resourceGroup}'");
+        }
+
+        jobName ??= $"expansion-{DateTime.UtcNow:yyyyMMddHHmmss}";
+
+        var expansionJobData = new AmlFileSystemExpansionJobData(fs.Value.Data.Location)
+        {
+            NewStorageCapacityTiB = newSizeTiB
+        };
+
+        var createOperation = await fs.Value.GetAmlFileSystemExpansionJobs().CreateOrUpdateAsync(
+            WaitUntil.Started,
+            jobName,
+            expansionJobData,
+            cancellationToken);
+        await WaitForLroCompletionAsync(createOperation, cancellationToken);
+
+        return createOperation.Value.Data.Name;
+    }
+
+    public async Task<Models.ExpansionJob> GetExpansionJobAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(filesystemName), filesystemName),
+            (nameof(jobName), jobName));
+
+        var rg = await AzureService.GetResourceGroupResource(subscription, resourceGroup, tenant, retryPolicy, cancellationToken)
+            ?? throw new Exception($"Resource group '{resourceGroup}' not found");
+
+        var fs = await rg.GetAmlFileSystemAsync(filesystemName, cancellationToken: cancellationToken);
+        if (fs?.Value == null)
+        {
+            throw new Exception($"Filesystem '{filesystemName}' not found in resource group '{resourceGroup}'");
+        }
+
+        try
+        {
+            var job = await fs.Value.GetAmlFileSystemExpansionJobs().GetAsync(jobName, cancellationToken: cancellationToken);
+            return MapExpansionJob(job.Value);
+        }
+        catch (RequestFailedException rfe) when (rfe.Status == 404)
+        {
+            _logger.LogWarning(rfe, "Expansion job '{JobName}' not found for filesystem '{FileSystemName}' in resource group '{ResourceGroup}'.", jobName, filesystemName, resourceGroup);
+            throw;
+        }
+    }
+
+    public async Task<List<Models.ExpansionJob>> ListExpansionJobsAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(filesystemName), filesystemName));
+
+        var rg = await AzureService.GetResourceGroupResource(subscription, resourceGroup, tenant, retryPolicy, cancellationToken)
+            ?? throw new Exception($"Resource group '{resourceGroup}' not found");
+
+        var fs = await rg.GetAmlFileSystemAsync(filesystemName, cancellationToken: cancellationToken);
+        if (fs?.Value == null)
+        {
+            throw new Exception($"Filesystem '{filesystemName}' not found in resource group '{resourceGroup}'");
+        }
+
+        var results = new List<Models.ExpansionJob>();
+        await foreach (var job in fs.Value.GetAmlFileSystemExpansionJobs().GetAllAsync(cancellationToken: cancellationToken))
+        {
+            results.Add(MapExpansionJob(job));
+        }
+
+        return results;
+    }
+
+    public async Task DeleteExpansionJobAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(filesystemName), filesystemName),
+            (nameof(jobName), jobName));
+
+        var rg = await AzureService.GetResourceGroupResource(subscription, resourceGroup, tenant, retryPolicy, cancellationToken)
+            ?? throw new Exception($"Resource group '{resourceGroup}' not found");
+
+        var fs = await rg.GetAmlFileSystemAsync(filesystemName, cancellationToken: cancellationToken);
+        if (fs?.Value == null)
+        {
+            throw new Exception($"Filesystem '{filesystemName}' not found in resource group '{resourceGroup}'");
+        }
+
+        try
+        {
+            var job = await fs.Value.GetAmlFileSystemExpansionJobs().GetAsync(jobName, cancellationToken: cancellationToken);
+            var deleteOperation = await job.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
+            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
+        }
+        catch (RequestFailedException rfe) when (rfe.Status == 404)
+        {
+            _logger.LogWarning(rfe, "Expansion job '{JobName}' not found for filesystem '{FileSystemName}'.", jobName, filesystemName);
+            throw;
+        }
+    }
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/ManagedLustreService.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/src/Services/ManagedLustreService.cs
@@ -1239,5 +1239,176 @@ public sealed class ManagedLustreService(IAzureService azureService, ILogger<Man
             throw;
         }
     }
-}
 
+    private static Models.ExpansionJob MapExpansionJob(AmlFileSystemExpansionJobResource job)
+    {
+        var data = job.Data;
+        return new()
+        {
+            Name = data.Name,
+            Id = data.Id?.ToString(),
+            Type = data.ResourceType.ToString(),
+            Location = data.Location.ToString(),
+            Properties = new()
+            {
+                ProvisioningState = data.ProvisioningState?.ToString(),
+                NewStorageCapacityTiB = data.NewStorageCapacityTiB,
+                Status = new()
+                {
+                    State = data.State?.ToString(),
+                    StatusCode = data.StatusCode,
+                    StatusMessage = data.StatusMessage,
+                    PercentComplete = data.PercentComplete,
+                    StartTimeUTC = data.StartedOn?.UtcDateTime,
+                    CompletionTimeUTC = data.CompletedOn?.UtcDateTime
+                }
+            }
+        };
+    }
+
+    public async Task<string> CreateExpansionJobAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        float newSizeTiB,
+        string? jobName = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(filesystemName), filesystemName));
+
+        var rg = await AzureService.GetResourceGroupResource(subscription, resourceGroup, tenant, retryPolicy, cancellationToken)
+            ?? throw new Exception($"Resource group '{resourceGroup}' not found");
+
+        var fs = await rg.GetAmlFileSystemAsync(filesystemName, cancellationToken: cancellationToken);
+        if (fs?.Value == null)
+        {
+            throw new Exception($"Filesystem '{filesystemName}' not found in resource group '{resourceGroup}'");
+        }
+
+        jobName ??= $"expansion-{DateTime.UtcNow:yyyyMMddHHmmss}";
+
+        var expansionJobData = new AmlFileSystemExpansionJobData(fs.Value.Data.Location)
+        {
+            NewStorageCapacityTiB = newSizeTiB
+        };
+
+        var createOperation = await fs.Value.GetAmlFileSystemExpansionJobs().CreateOrUpdateAsync(
+            WaitUntil.Started,
+            jobName,
+            expansionJobData,
+            cancellationToken);
+        await WaitForLroCompletionAsync(createOperation, cancellationToken);
+
+        return createOperation.Value.Data.Name;
+    }
+
+    public async Task<Models.ExpansionJob> GetExpansionJobAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(filesystemName), filesystemName),
+            (nameof(jobName), jobName));
+
+        var rg = await AzureService.GetResourceGroupResource(subscription, resourceGroup, tenant, retryPolicy, cancellationToken)
+            ?? throw new Exception($"Resource group '{resourceGroup}' not found");
+
+        var fs = await rg.GetAmlFileSystemAsync(filesystemName, cancellationToken: cancellationToken);
+        if (fs?.Value == null)
+        {
+            throw new Exception($"Filesystem '{filesystemName}' not found in resource group '{resourceGroup}'");
+        }
+
+        try
+        {
+            var job = await fs.Value.GetAmlFileSystemExpansionJobs().GetAsync(jobName, cancellationToken: cancellationToken);
+            return MapExpansionJob(job.Value);
+        }
+        catch (RequestFailedException rfe) when (rfe.Status == 404)
+        {
+            _logger.LogWarning(rfe, "Expansion job '{JobName}' not found for filesystem '{FileSystemName}' in resource group '{ResourceGroup}'.", jobName, filesystemName, resourceGroup);
+            throw;
+        }
+    }
+
+    public async Task<List<Models.ExpansionJob>> ListExpansionJobsAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(filesystemName), filesystemName));
+
+        var rg = await AzureService.GetResourceGroupResource(subscription, resourceGroup, tenant, retryPolicy, cancellationToken)
+            ?? throw new Exception($"Resource group '{resourceGroup}' not found");
+
+        var fs = await rg.GetAmlFileSystemAsync(filesystemName, cancellationToken: cancellationToken);
+        if (fs?.Value == null)
+        {
+            throw new Exception($"Filesystem '{filesystemName}' not found in resource group '{resourceGroup}'");
+        }
+
+        var results = new List<Models.ExpansionJob>();
+        await foreach (var job in fs.Value.GetAmlFileSystemExpansionJobs().GetAllAsync(cancellationToken: cancellationToken))
+        {
+            results.Add(MapExpansionJob(job));
+        }
+
+        return results;
+    }
+
+    public async Task<bool> DeleteExpansionJobAsync(
+        string subscription,
+        string resourceGroup,
+        string filesystemName,
+        string jobName,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(resourceGroup), resourceGroup),
+            (nameof(filesystemName), filesystemName),
+            (nameof(jobName), jobName));
+
+        var rg = await AzureService.GetResourceGroupResource(subscription, resourceGroup, tenant, retryPolicy, cancellationToken)
+            ?? throw new Exception($"Resource group '{resourceGroup}' not found");
+
+        var fs = await rg.GetAmlFileSystemAsync(filesystemName, cancellationToken: cancellationToken);
+        if (fs?.Value == null)
+        {
+            throw new Exception($"Filesystem '{filesystemName}' not found in resource group '{resourceGroup}'");
+        }
+
+        try
+        {
+            var job = await fs.Value.GetAmlFileSystemExpansionJobs().GetAsync(jobName, cancellationToken: cancellationToken);
+            var deleteOperation = await job.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
+            await WaitForLroCompletionAsync(deleteOperation, cancellationToken);
+            return true;
+        }
+        catch (RequestFailedException rfe) when (rfe.Status == 404)
+        {
+            _logger.LogDebug(rfe, "Expansion job '{JobName}' not found for filesystem '{FileSystemName}'.", jobName, filesystemName);
+            return false;
+        }
+    }
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/FileSystem/ExpansionJob/ExpansionJobCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/FileSystem/ExpansionJob/ExpansionJobCreateCommandTests.cs
@@ -1,0 +1,258 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Azure.Mcp.Tests.Commands;
+using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ExpansionJob;
+using Azure.Mcp.Tools.ManagedLustre.Options.FileSystem.ExpansionJob;
+using Azure.Mcp.Tools.ManagedLustre.Services;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Azure.Mcp.Tools.ManagedLustre.Tests.FileSystem.ExpansionJob;
+
+public class ExpansionJobCreateCommandTests : SubscriptionCommandUnitTestsBase<ExpansionJobCreateCommand, IManagedLustreService>
+{
+    private readonly string _subscription = "sub123";
+    private readonly string _resourceGroup = "rg1";
+    private readonly string _fileSystemName = "fs1";
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        Assert.Equal("create", CommandDefinition.Name);
+        Assert.False(string.IsNullOrWhiteSpace(CommandDefinition.Description));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Succeeds_WithRequiredParameters()
+    {
+        // Arrange
+        Service.CreateExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<float>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns("expansion-20250107120000");
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--new-size", "64");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+
+        await Service.Received(1).CreateExpansionJobAsync(
+            Arg.Is(_subscription),
+            Arg.Is(_resourceGroup),
+            Arg.Is(_fileSystemName),
+            Arg.Is(64f),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("--subscription sub123 --filesystem-name fs1 --new-size 64", false)] // missing resource-group
+    [InlineData("--subscription sub123 --resource-group rg1 --new-size 64", false)] // missing filesystem-name
+    [InlineData("--subscription sub123 --resource-group rg1 --filesystem-name fs1", false)] // missing new-size
+    public async Task ExecuteAsync_ValidationErrors_Return400(string argLine, bool shouldSucceed)
+    {
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(argLine.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+        // Assert
+        var expectedStatus = shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest;
+        Assert.Equal(expectedStatus, response.Status);
+        if (!shouldSucceed)
+        {
+            Assert.Contains("required", response.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("NaN")]
+    public async Task ExecuteAsync_InvalidNewSize_Returns400(string newSize)
+    {
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--new-size", newSize);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("finite value greater than zero", response.Message, StringComparison.OrdinalIgnoreCase);
+        await Service.DidNotReceiveWithAnyArgs().CreateExpansionJobAsync(
+            default!,
+            default!,
+            default!,
+            default,
+            default,
+            default,
+            default,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void ValidateOptions_InfiniteNewSize_AddsValidationError()
+    {
+        foreach (var newSize in new[] { float.PositiveInfinity, float.NegativeInfinity })
+        {
+            var options = new ExpansionJobCreateOptions
+            {
+                Subscription = _subscription,
+                ResourceGroup = _resourceGroup,
+                FilesystemName = _fileSystemName,
+                NewSize = newSize
+            };
+            var validationResult = new ValidationResult();
+
+            Command.ValidateOptions(options, validationResult);
+
+            Assert.Contains(validationResult.Errors, error =>
+                error.Contains("finite value greater than zero", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrows_RequestFailed_UsesStatusCode()
+    {
+        // Arrange
+        Service.CreateExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<float>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(404, "not found"));
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--new-size", "64");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.Status);
+        Assert.Contains("not found", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrows_GenericException_Returns500()
+    {
+        // Arrange
+        Service.CreateExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<float>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("boom"));
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--new-size", "64");
+
+        // Assert
+        Assert.True((int)response.Status >= 500);
+        Assert.Contains("boom", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task BindOptions_BindsOptionsCorrectly()
+    {
+        // Arrange
+        Service.CreateExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<float>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns("expansion-20250107120000");
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--new-size", "128");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).CreateExpansionJobAsync(
+            Arg.Is(_subscription),
+            Arg.Is(_resourceGroup),
+            Arg.Is(_fileSystemName),
+            Arg.Is(128f),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Succeeds_WithJobName()
+    {
+        // Arrange
+        var jobName = "my-expansion-job";
+        Service.CreateExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<float>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(jobName);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--new-size", "64",
+            "--expansion-job-name", jobName);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).CreateExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Is(64f),
+            Arg.Is(jobName),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/FileSystem/ExpansionJob/ExpansionJobDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/FileSystem/ExpansionJob/ExpansionJobDeleteCommandTests.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Azure.Mcp.Tests.Commands;
+using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ExpansionJob;
+using Azure.Mcp.Tools.ManagedLustre.Services;
+using Microsoft.Mcp.Core.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Azure.Mcp.Tools.ManagedLustre.Tests.FileSystem.ExpansionJob;
+
+public class ExpansionJobDeleteCommandTests : SubscriptionCommandUnitTestsBase<ExpansionJobDeleteCommand, IManagedLustreService>
+{
+    private readonly string _subscription = "sub123";
+    private readonly string _resourceGroup = "rg1";
+    private readonly string _fileSystemName = "fs1";
+    private readonly string _jobName = "expansion-001";
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        Assert.Equal("delete", CommandDefinition.Name);
+        Assert.False(string.IsNullOrWhiteSpace(CommandDefinition.Description));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Succeeds_WithRequiredParameters()
+    {
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--expansion-job-name", _jobName);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+
+        await Service.Received(1).DeleteExpansionJobAsync(
+            Arg.Is(_subscription),
+            Arg.Is(_resourceGroup),
+            Arg.Is(_fileSystemName),
+            Arg.Is(_jobName),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("--subscription sub123 --filesystem-name fs1 --expansion-job-name j1", false)] // missing resource-group
+    [InlineData("--subscription sub123 --resource-group rg1 --expansion-job-name j1", false)] // missing filesystem-name
+    [InlineData("--subscription sub123 --resource-group rg1 --filesystem-name fs1", false)] // missing expansion-job-name
+    public async Task ExecuteAsync_ValidationErrors_Return400(string argLine, bool shouldSucceed)
+    {
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(argLine.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+        // Assert
+        var expectedStatus = shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest;
+        Assert.Equal(expectedStatus, response.Status);
+        if (!shouldSucceed)
+        {
+            Assert.Contains("required", response.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrows_RequestFailed_UsesStatusCode()
+    {
+        // Arrange
+        Service.DeleteExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(404, "not found"));
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--expansion-job-name", _jobName);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.Status);
+        Assert.Contains("not found", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrows_GenericException_Returns500()
+    {
+        // Arrange
+        Service.DeleteExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("boom"));
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--expansion-job-name", _jobName);
+
+        // Assert
+        Assert.True((int)response.Status >= 500);
+        Assert.Contains("boom", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task BindOptions_BindsOptionsCorrectly()
+    {
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--expansion-job-name", _jobName);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).DeleteExpansionJobAsync(
+            Arg.Is(_subscription),
+            Arg.Is(_resourceGroup),
+            Arg.Is(_fileSystemName),
+            Arg.Is(_jobName),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/FileSystem/ExpansionJob/ExpansionJobDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/FileSystem/ExpansionJob/ExpansionJobDeleteCommandTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Azure.Mcp.Tests.Commands;
+using Azure.Mcp.Tools.ManagedLustre.Commands;
+using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ExpansionJob;
+using Azure.Mcp.Tools.ManagedLustre.Services;
+using Microsoft.Mcp.Core.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Azure.Mcp.Tools.ManagedLustre.Tests.FileSystem.ExpansionJob;
+
+public class ExpansionJobDeleteCommandTests : SubscriptionCommandUnitTestsBase<ExpansionJobDeleteCommand, IManagedLustreService>
+{
+    private readonly string _subscription = "sub123";
+    private readonly string _resourceGroup = "rg1";
+    private readonly string _fileSystemName = "fs1";
+    private readonly string _jobName = "expansion-001";
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        Assert.Equal("delete", CommandDefinition.Name);
+        Assert.False(string.IsNullOrWhiteSpace(CommandDefinition.Description));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Succeeds_WithRequiredParameters()
+    {
+        // Arrange
+        Service.DeleteExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--expansion-job-name", _jobName);
+
+        // Assert
+        var result = ValidateAndDeserializeResponse(
+            response,
+            ManagedLustreJsonContext.Default.ExpansionJobDeleteResult);
+        Assert.True(result.Deleted);
+        Assert.Contains("successfully deleted", result.Message, StringComparison.OrdinalIgnoreCase);
+
+        await Service.Received(1).DeleteExpansionJobAsync(
+            Arg.Is(_subscription),
+            Arg.Is(_resourceGroup),
+            Arg.Is(_fileSystemName),
+            Arg.Is(_jobName),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("--subscription sub123 --filesystem-name fs1 --expansion-job-name j1", false)] // missing resource-group
+    [InlineData("--subscription sub123 --resource-group rg1 --expansion-job-name j1", false)] // missing filesystem-name
+    [InlineData("--subscription sub123 --resource-group rg1 --filesystem-name fs1", false)] // missing expansion-job-name
+    public async Task ExecuteAsync_ValidationErrors_Return400(string argLine, bool shouldSucceed)
+    {
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(argLine.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+        // Assert
+        var expectedStatus = shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest;
+        Assert.Equal(expectedStatus, response.Status);
+        if (!shouldSucceed)
+        {
+            Assert.Contains("required", response.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_JobNotFound_ReturnsSuccess()
+    {
+        // Arrange
+        Service.DeleteExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--expansion-job-name", _jobName);
+
+        // Assert
+        var result = ValidateAndDeserializeResponse(
+            response,
+            ManagedLustreJsonContext.Default.ExpansionJobDeleteResult);
+        Assert.False(result.Deleted);
+        Assert.Contains("Nothing was deleted", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrows_GenericException_Returns500()
+    {
+        // Arrange
+        Service.DeleteExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("boom"));
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--expansion-job-name", _jobName);
+
+        // Assert
+        Assert.True((int)response.Status >= 500);
+        Assert.Contains("boom", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task BindOptions_BindsOptionsCorrectly()
+    {
+        // Arrange
+        Service.DeleteExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--expansion-job-name", _jobName);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).DeleteExpansionJobAsync(
+            Arg.Is(_subscription),
+            Arg.Is(_resourceGroup),
+            Arg.Is(_fileSystemName),
+            Arg.Is(_jobName),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/FileSystem/ExpansionJob/ExpansionJobGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/FileSystem/ExpansionJob/ExpansionJobGetCommandTests.cs
@@ -1,0 +1,220 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Azure.Mcp.Tests.Commands;
+using Azure.Mcp.Tools.ManagedLustre.Commands.FileSystem.ExpansionJob;
+using Azure.Mcp.Tools.ManagedLustre.Services;
+using Microsoft.Mcp.Core.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Azure.Mcp.Tools.ManagedLustre.Tests.FileSystem.ExpansionJob;
+
+public class ExpansionJobGetCommandTests : SubscriptionCommandUnitTestsBase<ExpansionJobGetCommand, IManagedLustreService>
+{
+    private readonly string _subscription = "sub123";
+    private readonly string _resourceGroup = "rg1";
+    private readonly string _fileSystemName = "fs1";
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        Assert.Equal("get", CommandDefinition.Name);
+        Assert.False(string.IsNullOrWhiteSpace(CommandDefinition.Description));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_GetSpecificJob_Succeeds()
+    {
+        // Arrange
+        var jobName = "expansion-001";
+        var expansionJob = new Models.ExpansionJob
+        {
+            Name = jobName,
+            Id = "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.StorageCache/amlFilesystems/fs1/expansionJobs/expansion-001",
+            Properties = new Models.ExpansionJobProperties
+            {
+                ProvisioningState = "Succeeded",
+                NewStorageCapacityTiB = 128,
+                Status = new Models.ExpansionJobStatus
+                {
+                    State = "Completed",
+                    PercentComplete = 100
+                }
+            }
+        };
+
+        Service.GetExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expansionJob);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--expansion-job-name", jobName);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+
+        await Service.Received(1).GetExpansionJobAsync(
+            Arg.Is(_subscription),
+            Arg.Is(_resourceGroup),
+            Arg.Is(_fileSystemName),
+            Arg.Is(jobName),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ListAllJobs_Succeeds()
+    {
+        // Arrange
+        var jobs = new List<Models.ExpansionJob>
+        {
+            new() { Name = "expansion-001", Properties = new() { NewStorageCapacityTiB = 128 } },
+            new() { Name = "expansion-002", Properties = new() { NewStorageCapacityTiB = 256 } }
+        };
+
+        Service.ListExpansionJobsAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(jobs);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        Assert.NotNull(response.Results);
+
+        await Service.Received(1).ListExpansionJobsAsync(
+            Arg.Is(_subscription),
+            Arg.Is(_resourceGroup),
+            Arg.Is(_fileSystemName),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("--subscription sub123 --filesystem-name fs1", false)] // missing resource-group
+    [InlineData("--subscription sub123 --resource-group rg1", false)] // missing filesystem-name
+    public async Task ExecuteAsync_ValidationErrors_Return400(string argLine, bool shouldSucceed)
+    {
+        // Arrange & Act
+        var response = await ExecuteCommandAsync(argLine.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+        // Assert
+        var expectedStatus = shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest;
+        Assert.Equal(expectedStatus, response.Status);
+        if (!shouldSucceed)
+        {
+            Assert.Contains("required", response.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrows_RequestFailed_UsesStatusCode()
+    {
+        // Arrange
+        Service.GetExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(404, "not found"));
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--expansion-job-name", "nonexistent");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.Status);
+        Assert.Contains("not found", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrows_GenericException_Returns500()
+    {
+        // Arrange
+        Service.ListExpansionJobsAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("boom"));
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName);
+
+        // Assert
+        Assert.True((int)response.Status >= 500);
+        Assert.Contains("boom", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task BindOptions_BindsOptionsCorrectly()
+    {
+        // Arrange
+        var jobName = "my-expansion-job";
+        var expansionJob = new Models.ExpansionJob { Name = jobName };
+
+        Service.GetExpansionJobAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expansionJob);
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription", _subscription,
+            "--resource-group", _resourceGroup,
+            "--filesystem-name", _fileSystemName,
+            "--expansion-job-name", jobName);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).GetExpansionJobAsync(
+            Arg.Is(_subscription),
+            Arg.Is(_resourceGroup),
+            Arg.Is(_fileSystemName),
+            Arg.Is(jobName),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/ManagedLustreCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/ManagedLustreCommandTests.cs
@@ -41,9 +41,22 @@ public partial class ManagedLustreCommandTests(ITestOutputHelper output, TestPro
         .. base.BodyKeySanitizers,
         new BodyKeySanitizer(new BodyKeySanitizerBody("$..encryptionSettings.keyEncryptionKey.keyUrl")
         {
-            Value = "sanitized",
-            Regex = "https://(.*?)\\.",
-            GroupForReplace = "1"
+            Value = "https://Sanitized.vault.azure.net/keys/Sanitized/Sanitized"
+        })
+    ];
+
+    public override List<GeneralRegexSanitizer> GeneralRegexSanitizers =>
+    [
+        .. base.GeneralRegexSanitizers,
+        new GeneralRegexSanitizer(new GeneralRegexSanitizerBody
+        {
+            Regex = "(?i)resourcegroups/[^/\"?]+",
+            Value = "resourceGroups/Sanitized"
+        }),
+        new GeneralRegexSanitizer(new GeneralRegexSanitizerBody
+        {
+            Regex = "https://[^./]+\\.vault\\.azure\\.net/keys/[^/\"?]+/[^/\"?]+",
+            Value = "https://Sanitized.vault.azure.net/keys/Sanitized/Sanitized"
         })
     ];
 
@@ -578,6 +591,131 @@ public partial class ManagedLustreCommandTests(ITestOutputHelper output, TestPro
 
         var importDeleteJobName = importDeleteResult.AssertProperty("jobName");
         Assert.Contains(importJobNameStr, importDeleteJobName.GetRawText());
+
+        // Wait for filesystem to stabilize after deleting import job and before creating expansion job
+        await Task.Delay(PollInterval(15_000), TestContext.Current.CancellationToken);
+
+        // Test expansion job lifecycle
+        var expansionJobNameStr = $"expansion-{fsName}";
+        var expansionCreateResult = await CallToolAsync(
+            "managedlustre_fs_expansion_create",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", resourceGroupName },
+                { "filesystem-name", fsName },
+                { "new-size", 8 },
+                { "expansion-job-name", expansionJobNameStr },
+                { "tenant", Settings.TenantId }
+            });
+
+        var expansionJobName = expansionCreateResult.AssertProperty("jobName");
+        Assert.Equal(JsonValueKind.String, expansionJobName.ValueKind);
+        Assert.False(string.IsNullOrWhiteSpace(expansionJobName.GetString()));
+
+        // Wait for expansion job to complete before listing/getting
+        var expansionMaxWaitTime = TimeSpan.FromMinutes(30);
+        var expansionStartTime = DateTime.UtcNow;
+        var expansionCompleted = false;
+
+        while (DateTime.UtcNow - expansionStartTime < expansionMaxWaitTime)
+        {
+            var expansionCheckResult = await CallToolAsync(
+                "managedlustre_fs_expansion_get",
+                new()
+                {
+                    { "subscription", Settings.SubscriptionId },
+                    { "resource-group", resourceGroupName },
+                    { "filesystem-name", fsName },
+                    { "expansion-job-name", expansionJobNameStr },
+                    { "tenant", Settings.TenantId }
+                });
+
+            var expansionCheckJob = expansionCheckResult.AssertProperty("job");
+            var expansionCheckJobText = expansionCheckJob.GetRawText();
+            Output.WriteLine($"Expansion job status: {expansionCheckJobText}");
+
+            var expansionState = expansionCheckJob
+                .AssertProperty("properties")
+                .AssertProperty("status")
+                .AssertProperty("state")
+                .GetString();
+
+            if (string.Equals(expansionState, "Completed", StringComparison.OrdinalIgnoreCase))
+            {
+                expansionCompleted = true;
+                break;
+            }
+
+            Assert.False(
+                string.Equals(expansionState, "Failed", StringComparison.OrdinalIgnoreCase),
+                $"Expansion job '{expansionJobNameStr}' failed: {expansionCheckJobText}");
+
+            await Task.Delay(PollInterval(30_000), TestContext.Current.CancellationToken);
+        }
+
+        Assert.True(expansionCompleted, $"Expansion job '{expansionJobNameStr}' did not complete within {expansionMaxWaitTime.TotalMinutes} minutes.");
+
+        // List expansion jobs (get without expansion-job-name returns all jobs)
+        var expansionListResult = await CallToolAsync(
+            "managedlustre_fs_expansion_get",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", resourceGroupName },
+                { "filesystem-name", fsName },
+                { "tenant", Settings.TenantId }
+                // Intentionally omitting expansion-job-name to list all jobs
+            });
+
+        var expansionJobs = expansionListResult.AssertProperty("jobs");
+        Assert.Equal(JsonValueKind.Array, expansionJobs.ValueKind);
+        var foundExpansion = false;
+        var expansionJobTexts = expansionJobs.EnumerateArray().Select(job => job.GetRawText());
+        foreach (var jobText in expansionJobTexts)
+        {
+            Output.WriteLine($"Checking expansion job: {jobText}");
+            if (jobText.Contains(expansionJobNameStr))
+            {
+                Output.WriteLine($"Found expansion job containing: '{expansionJobNameStr}'");
+                foundExpansion = true;
+                break;
+            }
+        }
+        Assert.True(foundExpansion, $"Expected to find expansion job '{expansionJobNameStr}' in the list.");
+
+        // Get expansion job
+        var expansionGetResult = await CallToolAsync(
+            "managedlustre_fs_expansion_get",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", resourceGroupName },
+                { "filesystem-name", fsName },
+                { "expansion-job-name", expansionJobNameStr },
+                { "tenant", Settings.TenantId }
+            });
+
+        var expansionJob = expansionGetResult.AssertProperty("job");
+        Assert.Equal(JsonValueKind.Object, expansionJob.ValueKind);
+        var expansionJobText = expansionJob.GetRawText();
+        Assert.Contains(expansionJobNameStr, expansionJobText);
+
+        // Delete expansion job
+        var expansionDeleteResult = await CallToolAsync(
+            "managedlustre_fs_expansion_delete",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", resourceGroupName },
+                { "filesystem-name", fsName },
+                { "expansion-job-name", expansionJobNameStr },
+                { "tenant", Settings.TenantId }
+            });
+
+        var expansionDeleteJobName = expansionDeleteResult.AssertProperty("jobName");
+        Assert.Contains(expansionJobNameStr, expansionDeleteJobName.GetRawText());
+        Assert.True(expansionDeleteResult.AssertProperty("deleted").GetBoolean());
     }
 
     [Fact]
@@ -775,10 +913,10 @@ public partial class ManagedLustreCommandTests(ITestOutputHelper output, TestPro
     private string SanitizeAndRecordBaseName(string baseName, string name) => SanitizeAndRecord(baseName, name, val => "Sanitized");
 
     private string SanitizeAndRecordResourceGroupName(string resourceGroupName, string name)
-        => SanitizeAndRecord(resourceGroupName, name, val => Regex.Replace(val, @"^([^-]+)-.*", "$1-Sanitized"));
+        => SanitizeAndRecord(resourceGroupName, name, val => "Sanitized");
 
     private string SanitizeAndRecordKeyVaultUri(string keyUri, string name)
-        => SanitizeAndRecord(keyUri, name, val => Regex.Replace(val, "https://.*?\\.", "https://Sanitized."));
+        => SanitizeAndRecord(keyUri, name, val => "https://Sanitized.vault.azure.net/keys/Sanitized/Sanitized");
 
     private string SanitizeAndRecordSubnetId(string subnetId, string name)
         => SanitizeAndRecordWithSubscription(subnetId, name, "/virtualNetworks/.*?-vnet/subnets", "/virtualNetworks/Sanitized-vnet/subnets");
@@ -808,6 +946,7 @@ public partial class ManagedLustreCommandTests(ITestOutputHelper output, TestPro
         => SanitizeAndRecord(unsanitizedValue, name, val =>
         {
             var sanitizedValue = SubscriptionSanitizationRegex().Replace(val, $"/subscriptions/{Guid.Empty}/resourceGroups");
+            sanitizedValue = ResourceGroupSanitizationRegex().Replace(sanitizedValue, "/resourceGroups/Sanitized/");
             return Regex.Replace(sanitizedValue, replaceRegex, replacement);
         });
 
@@ -834,4 +973,7 @@ public partial class ManagedLustreCommandTests(ITestOutputHelper output, TestPro
 
     [GeneratedRegex("/subscriptions/(.*?)/resourceGroups")]
     private static partial Regex SubscriptionSanitizationRegex();
+
+    [GeneratedRegex("/resourceGroups/[^/]+/", RegexOptions.IgnoreCase)]
+    private static partial Regex ResourceGroupSanitizationRegex();
 }

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/ManagedLustreCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/ManagedLustreCommandTests.cs
@@ -24,30 +24,48 @@ public partial class ManagedLustreCommandTests(ITestOutputHelper output, TestPro
         "X-MSEdge-Ref"
     ];
 
+    private List<HeaderRegexSanitizer>? _headerRegexSanitizers;
+    private List<BodyKeySanitizer>? _bodyKeySanitizers;
+    private List<GeneralRegexSanitizer>? _generalRegexSanitizers;
+    private List<UriRegexSanitizer>? _uriRegexSanitizers;
+
     // Keep the default sanitizers defined in RecordedCommandTestsBase and add the following headers to be sanitized:
     // - x-ms-correlation-request-id
     // - x-ms-operation-identifier
     // - x-ms-routing-request-id
     // - x-ms-served-by
     // - X-MSEdge-Ref
-    public override List<HeaderRegexSanitizer> HeaderRegexSanitizers =>
+    public override List<HeaderRegexSanitizer> HeaderRegexSanitizers => _headerRegexSanitizers ??=
     [
         .. base.HeaderRegexSanitizers,
         .. _sanitizedHeaders.Select(h => new HeaderRegexSanitizer(new HeaderRegexSanitizerBody(h)))
     ];
 
-    public override List<BodyKeySanitizer> BodyKeySanitizers =>
+    public override List<BodyKeySanitizer> BodyKeySanitizers => _bodyKeySanitizers ??=
     [
         .. base.BodyKeySanitizers,
         new BodyKeySanitizer(new BodyKeySanitizerBody("$..encryptionSettings.keyEncryptionKey.keyUrl")
         {
-            Value = "sanitized",
-            Regex = "https://(.*?)\\.",
-            GroupForReplace = "1"
+            Value = "https://Sanitized.vault.azure.net/keys/Sanitized/Sanitized"
         })
     ];
 
-    public override List<UriRegexSanitizer> UriRegexSanitizers =>
+    public override List<GeneralRegexSanitizer> GeneralRegexSanitizers => _generalRegexSanitizers ??=
+    [
+        .. base.GeneralRegexSanitizers,
+        new GeneralRegexSanitizer(new GeneralRegexSanitizerBody
+        {
+            Regex = "(?i)resourcegroups/[^/\"?]+",
+            Value = "resourceGroups/Sanitized"
+        }),
+        new GeneralRegexSanitizer(new GeneralRegexSanitizerBody
+        {
+            Regex = "https://[^./]+\\.vault\\.azure\\.net/keys/[^/\"?]+/[^/\"?]+",
+            Value = "https://Sanitized.vault.azure.net/keys/Sanitized/Sanitized"
+        })
+    ];
+
+    public override List<UriRegexSanitizer> UriRegexSanitizers => _uriRegexSanitizers ??=
     [
         .. base.UriRegexSanitizers,
         // Sanitize operation IDs in ascOperations URLs
@@ -578,6 +596,132 @@ public partial class ManagedLustreCommandTests(ITestOutputHelper output, TestPro
 
         var importDeleteJobName = importDeleteResult.AssertProperty("jobName");
         Assert.Contains(importJobNameStr, importDeleteJobName.GetRawText());
+
+        // Wait for filesystem to stabilize after deleting import job and before creating expansion job
+        await Task.Delay(PollInterval(15_000), TestContext.Current.CancellationToken);
+
+        // Test expansion job lifecycle
+        var expansionJobNameStr = $"expansion-{fsName}";
+        var expansionCreateResult = await CallToolAsync(
+            "managedlustre_fs_expansion_create",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", resourceGroupName },
+                { "filesystem-name", fsName },
+                { "new-size", 8 },
+                { "expansion-job-name", expansionJobNameStr },
+                { "tenant", Settings.TenantId }
+            });
+
+        var expansionJobName = expansionCreateResult.AssertProperty("jobName");
+        Assert.Equal(JsonValueKind.String, expansionJobName.ValueKind);
+        Assert.False(string.IsNullOrWhiteSpace(expansionJobName.GetString()));
+
+        // Wait for expansion job to complete before listing/getting
+        var expansionMaxWaitTime = TimeSpan.FromMinutes(30);
+        var expansionStartTime = DateTime.UtcNow;
+        var expansionCompleted = false;
+
+        while (DateTime.UtcNow - expansionStartTime < expansionMaxWaitTime)
+        {
+            var expansionCheckResult = await CallToolAsync(
+                "managedlustre_fs_expansion_get",
+                new()
+                {
+                    { "subscription", Settings.SubscriptionId },
+                    { "resource-group", resourceGroupName },
+                    { "filesystem-name", fsName },
+                    { "expansion-job-name", expansionJobNameStr },
+                    { "tenant", Settings.TenantId }
+                });
+
+            var expansionCheckJob = expansionCheckResult.AssertProperty("job");
+            var expansionCheckJobText = expansionCheckJob.GetRawText();
+            Output.WriteLine($"Expansion job status: {expansionCheckJobText}");
+
+            var expansionState = expansionCheckJob
+                .AssertProperty("properties")
+                .AssertProperty("status")
+                .AssertProperty("state")
+                .GetString();
+
+            if (string.Equals(expansionState, "Completed", StringComparison.OrdinalIgnoreCase))
+            {
+                expansionCompleted = true;
+                break;
+            }
+
+            Assert.False(
+                string.Equals(expansionState, "Failed", StringComparison.OrdinalIgnoreCase),
+                $"Expansion job '{expansionJobNameStr}' failed: {expansionCheckJobText}");
+
+            await Task.Delay(PollInterval(30_000), TestContext.Current.CancellationToken);
+        }
+
+        Assert.True(expansionCompleted, $"Expansion job '{expansionJobNameStr}' did not complete within {expansionMaxWaitTime.TotalMinutes} minutes.");
+
+        // List expansion jobs (get without expansion-job-name returns all jobs)
+        var expansionListResult = await CallToolAsync(
+            "managedlustre_fs_expansion_get",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", resourceGroupName },
+                { "filesystem-name", fsName },
+                { "tenant", Settings.TenantId }
+                // Intentionally omitting expansion-job-name to list all jobs
+            });
+
+        var expansionJobs = expansionListResult.AssertProperty("jobs");
+        Assert.Equal(JsonValueKind.Array, expansionJobs.ValueKind);
+        var foundExpansion = false;
+        var expansionJobTexts = expansionJobs.EnumerateArray().Select(job => job.GetRawText());
+        foreach (var jobText in expansionJobTexts)
+        {
+            Output.WriteLine($"Checking expansion job: {jobText}");
+            if (jobText.Contains(expansionJobNameStr))
+            {
+                Output.WriteLine($"Found expansion job containing: '{expansionJobNameStr}'");
+                foundExpansion = true;
+                break;
+            }
+        }
+        Assert.True(foundExpansion, $"Expected to find expansion job '{expansionJobNameStr}' in the list.");
+
+        // Get expansion job
+        var expansionGetResult = await CallToolAsync(
+            "managedlustre_fs_expansion_get",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", resourceGroupName },
+                { "filesystem-name", fsName },
+                { "expansion-job-name", expansionJobNameStr },
+                { "tenant", Settings.TenantId }
+            });
+
+        var expansionJob = expansionGetResult.AssertProperty("job");
+        Assert.Equal(JsonValueKind.Object, expansionJob.ValueKind);
+        var expansionJobText = expansionJob.GetRawText();
+        Assert.Contains(expansionJobNameStr, expansionJobText);
+
+        // Delete expansion job
+        var expansionDeleteResult = await CallToolAsync(
+            "managedlustre_fs_expansion_delete",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", resourceGroupName },
+                { "filesystem-name", fsName },
+                { "expansion-job-name", expansionJobNameStr },
+                { "tenant", Settings.TenantId }
+            });
+
+        var expansionDeleteJobName = expansionDeleteResult.AssertProperty("jobName");
+        Assert.Contains(expansionJobNameStr, expansionDeleteJobName.GetRawText());
+        var expansionDeleteStatus = expansionDeleteResult.AssertProperty("status");
+        Assert.Equal("Deleted", expansionDeleteStatus.GetString());
     }
 
     [Fact]
@@ -775,10 +919,10 @@ public partial class ManagedLustreCommandTests(ITestOutputHelper output, TestPro
     private string SanitizeAndRecordBaseName(string baseName, string name) => SanitizeAndRecord(baseName, name, val => "Sanitized");
 
     private string SanitizeAndRecordResourceGroupName(string resourceGroupName, string name)
-        => SanitizeAndRecord(resourceGroupName, name, val => Regex.Replace(val, @"^([^-]+)-.*", "$1-Sanitized"));
+        => SanitizeAndRecord(resourceGroupName, name, val => "Sanitized");
 
     private string SanitizeAndRecordKeyVaultUri(string keyUri, string name)
-        => SanitizeAndRecord(keyUri, name, val => Regex.Replace(val, "https://.*?\\.", "https://Sanitized."));
+        => SanitizeAndRecord(keyUri, name, val => "https://Sanitized.vault.azure.net/keys/Sanitized/Sanitized");
 
     private string SanitizeAndRecordSubnetId(string subnetId, string name)
         => SanitizeAndRecordWithSubscription(subnetId, name, "/virtualNetworks/.*?-vnet/subnets", "/virtualNetworks/Sanitized-vnet/subnets");
@@ -808,6 +952,7 @@ public partial class ManagedLustreCommandTests(ITestOutputHelper output, TestPro
         => SanitizeAndRecord(unsanitizedValue, name, val =>
         {
             var sanitizedValue = SubscriptionSanitizationRegex().Replace(val, $"/subscriptions/{Guid.Empty}/resourceGroups");
+            sanitizedValue = ResourceGroupSanitizationRegex().Replace(sanitizedValue, "/resourceGroups/Sanitized/");
             return Regex.Replace(sanitizedValue, replaceRegex, replacement);
         });
 
@@ -834,4 +979,7 @@ public partial class ManagedLustreCommandTests(ITestOutputHelper output, TestPro
 
     [GeneratedRegex("/subscriptions/(.*?)/resourceGroups")]
     private static partial Regex SubscriptionSanitizationRegex();
+
+    [GeneratedRegex("/resourceGroups/[^/]+/", RegexOptions.IgnoreCase)]
+    private static partial Regex ResourceGroupSanitizationRegex();
 }

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/assets.json
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/Azure.Mcp.Tools.ManagedLustre.Tests/assets.json
@@ -2,5 +2,5 @@
     "AssetsRepo": "Azure/azure-sdk-assets",
     "AssetsRepoPrefixPath": "",
     "TagPrefix": "Azure.Mcp.Tools.ManagedLustre.Tests",
-    "Tag": "Azure.Mcp.Tools.ManagedLustre.Tests_e19abc8a84"
+    "Tag": "Azure.Mcp.Tools.ManagedLustre.Tests_72f369d8cc"
 }

--- a/tools/Azure.Mcp.Tools.ManagedLustre/tests/test-resources.bicep
+++ b/tools/Azure.Mcp.Tools.ManagedLustre/tests/test-resources.bicep
@@ -37,6 +37,7 @@ param testApplicationUamiId string = ''
 param hpcCacheRpObjectId string
 
 var kvCryptoUserRoleDefinitionId = '14b46e9e-c2b7-41b4-b07b-48a6ebf60603'
+var readerRoleDefinitionId = 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
 
 var userAssignedName = '${baseName}-uai'
 
@@ -60,6 +61,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
         name: 'amlfs'
         properties: {
           addressPrefix: amlfsSubnetPrefix
+          defaultOutboundAccess: false
           natGateway: {
             id: natGateway.id
           }
@@ -71,6 +73,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
         name: 'amlfs-small'
         properties: {
           addressPrefix: amlfsSubnetSmallPrefix
+          defaultOutboundAccess: false
           natGateway: {
             id: natGateway.id
           }
@@ -156,6 +159,16 @@ resource storageBlobDataContributorRole 'Microsoft.Authorization/roleAssignments
   }
 }
 
+// Expansion requires the HPC Cache RP to read the virtual network and subnet.
+resource hpcCacheRpReaderRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, readerRoleDefinitionId, 'hpc-cache-rp-reader')
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', readerRoleDefinitionId)
+    principalId: hpcCacheRpObjectId
+    principalType: 'ServicePrincipal'
+  }
+}
+
 resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2025-01-01' = {
   parent: storageAccount
   name: 'default'
@@ -221,6 +234,7 @@ resource keyVaultKey 'Microsoft.KeyVault/vaults/keys@2024-11-01' = {
 resource amlfs 'Microsoft.StorageCache/amlFilesystems@2024-07-01' = {
   name: baseName
   location: location
+  zones: ['1']
   sku: {
     name: amlfsSku
   }


### PR DESCRIPTION
## What does this PR do?

Adds create, get/list, and delete commands for Azure Managed Lustre expansion jobs so users can increase filesystem storage capacity and monitor expansion progress.

The change includes:
- ARM service integration and AOT-safe response serialization.
- Command registration, consolidated-tool mappings, command documentation, and end-to-end prompts.
- Unit tests and recorded lifecycle tests.
- Test-resource permissions required by the HPC Cache Resource Provider to inject expansion NICs.

Official Azure CLI reference: https://learn.microsoft.com/cli/azure/amlfs/expansion?view=azure-cli-latest

## GitHub issue number?

N/A

## Validation

- Managed Lustre test project build succeeded with no warnings.
- All 226 Managed Lustre tests passed in playback mode.
- Expansion create, get/list, completion polling, and delete were exercised against live Azure resources.
- Test recordings were published as `Azure.Mcp.Tools.ManagedLustre.Tests_72f369d8cc`.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
