### PR TITLE
Add SelfContainedLiveTests concept to test CSPROJs

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Azure.Mcp.Core.Tests.csproj
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Azure.Mcp.Core.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Azure.Mcp.Core.csproj" />

--- a/eng/pipelines/templates/jobs/analyze.yml
+++ b/eng/pipelines/templates/jobs/analyze.yml
@@ -6,6 +6,7 @@ jobs:
   steps:
   - checkout: self
     fetchDepth: 0
+    fetchTags: false
 
   - template: /eng/pipelines/templates/steps/install-dotnet.yml
 

--- a/eng/pipelines/templates/jobs/build.yml
+++ b/eng/pipelines/templates/jobs/build.yml
@@ -51,6 +51,8 @@ jobs:
     displayName: 'Download build info artifact'
 
   - checkout: self
+    fetchDepth: 1
+    fetchTags: false
 
   - template: /eng/pipelines/templates/steps/install-dotnet.yml
 

--- a/eng/pipelines/templates/jobs/initialize.yml
+++ b/eng/pipelines/templates/jobs/initialize.yml
@@ -14,6 +14,7 @@ jobs:
   steps:
   - checkout: self
     fetchDepth: 0
+    fetchTags: false
 
   - template: /eng/pipelines/templates/steps/install-dotnet.yml
 

--- a/eng/pipelines/templates/jobs/live-test.yml
+++ b/eng/pipelines/templates/jobs/live-test.yml
@@ -29,20 +29,6 @@ jobs:
 
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
 
-  - pwsh: |
-      $serverName = $env:SERVERNAME
-
-      if ([string]::IsNullOrWhiteSpace($serverName)) {
-        ./eng/scripts/Build-Local.ps1 -VerifyNpx
-      }
-      else {
-        ./eng/scripts/Build-Local.ps1 -ServerName $serverName -VerifyNpx
-      }
-
-      exit $LastExitCode
-    displayName: "Build local package"
-    workingDirectory: $(Build.SourcesDirectory)
-
   - pwsh: >
       ./eng/scripts/Test-Code.ps1
       -TestType 'Live'
@@ -83,7 +69,7 @@ jobs:
 
   # Only perform a second deployment of test resources if the live tests are not self-contained.
   # Self-contained live tests do not require a fresh set of test resources to be deployed.
-  - ${{ if ne(variables['hasSelfContainedLiveTests'], 'true') }}:
+  - ${{ if ne(variables['HasSelfContainedLiveTests'], 'true') }}:
     - template: /eng/common/TestResources/remove-test-resources.yml
       parameters:
         ServiceConnection: azure-sdk-tests-public

--- a/eng/pipelines/templates/jobs/live-test.yml
+++ b/eng/pipelines/templates/jobs/live-test.yml
@@ -79,17 +79,20 @@ jobs:
       pwsh: true
       workingDirectory: $(Build.SourcesDirectory)
 
-  - template: /eng/common/TestResources/remove-test-resources.yml
-    parameters:
-      ServiceConnection: azure-sdk-tests-public
+  # Only perform a second deployment of test resources if the live tests are not self-contained.
+  # Self-contained live tests do not require a fresh set of test resources to be deployed.
+  - ${{ if ne(variables['SelfContainedLiveTests'], true) }}:
+    - template: /eng/common/TestResources/remove-test-resources.yml
+      parameters:
+        ServiceConnection: azure-sdk-tests-public
 
-  - template: /eng/common/TestResources/deploy-test-resources.yml
-    parameters:
-      ServiceConnection: azure-sdk-tests-public
-      PersistOidcToken: true
-      TestResourcesDirectory: $(Build.SourcesDirectory)/$(TestResourcesPath)
-      AdditionalParameters: "@{ UseHttpTransport = true }"
-      SkipEnvironmentSetup: true # environment setup was performed in the first deployment
+    - template: /eng/common/TestResources/deploy-test-resources.yml
+      parameters:
+        ServiceConnection: azure-sdk-tests-public
+        PersistOidcToken: true
+        TestResourcesDirectory: $(Build.SourcesDirectory)/$(TestResourcesPath)
+        AdditionalParameters: "@{ UseHttpTransport = true }"
+        SkipEnvironmentSetup: true # environment setup was performed in the first deployment
 
   - task: AzurePowershell@5
     displayName: "Run tests (http) - az pwsh"

--- a/eng/pipelines/templates/jobs/live-test.yml
+++ b/eng/pipelines/templates/jobs/live-test.yml
@@ -69,7 +69,7 @@ jobs:
 
   # Only perform a second deployment of test resources if the live tests are not self-contained.
   # Self-contained live tests do not require a fresh set of test resources to be deployed.
-  - ${{ if ne(variables['HasSelfContainedLiveTests'], 'true') }}:
+  - ${{ if ne($(HasSelfContainedLiveTests), 'true') }}:
     - template: /eng/common/TestResources/remove-test-resources.yml
       parameters:
         ServiceConnection: azure-sdk-tests-public

--- a/eng/pipelines/templates/jobs/live-test.yml
+++ b/eng/pipelines/templates/jobs/live-test.yml
@@ -17,6 +17,8 @@ jobs:
     matrix: $[ ${{ parameters.Matrix }} ]
   steps:
   - checkout: self
+    fetchDepth: 1
+    fetchTags: false
 
   - template: /eng/pipelines/templates/steps/install-dotnet.yml
 
@@ -81,7 +83,7 @@ jobs:
 
   # Only perform a second deployment of test resources if the live tests are not self-contained.
   # Self-contained live tests do not require a fresh set of test resources to be deployed.
-  - ${{ if ne(variables['SelfContainedLiveTests'], true) }}:
+  - ${{ if ne(variables['hasSelfContainedLiveTests'], 'true') }}:
     - template: /eng/common/TestResources/remove-test-resources.yml
       parameters:
         ServiceConnection: azure-sdk-tests-public

--- a/eng/scripts/Get-ProjectProperties.ps1
+++ b/eng/scripts/Get-ProjectProperties.ps1
@@ -67,7 +67,8 @@ $propertyList = @(
     'AzureSupportedClouds',
 
     'HasLiveTests',
-    'HasUnitTests'
+    'HasUnitTests',
+    'SelfContainedLiveTests'
 )
 
 $projectFile = $projectFiles | Select-Object -First 1

--- a/eng/scripts/New-BuildInfo.ps1
+++ b/eng/scripts/New-BuildInfo.ps1
@@ -332,6 +332,9 @@ function Get-PathsToTest {
         $hasRecordedTests = $hasLiveTests -and (Get-ChildItem $rootedTestResourcesPath -Filter 'assets.json' -Recurse).Count -gt 0
         $hasUnitTests = $hasTestsProject -and $testProjectDetails.HasUnitTests
 
+
+        $hasTestsProject -and [bool]::TryParse($testProjectDetails.SelfContainedLiveTests, [ref]$result) -and $result
+
         $sourcePath = Join-Path $using:RepoRoot $path "src"
 
         $sourceProject = Get-ChildItem $sourcePath -Filter '*.csproj' | Select-Object -First 1
@@ -352,14 +355,15 @@ function Get-PathsToTest {
         }
 
         return @{
-            _error               = $false
-            path                 = $path
-            hasTestResources     = $hasTestResources
-            testResourcesPath    = $hasTestResources ? $testResourcesPath : $null
-            hasLiveTests         = $hasLiveTests
-            hasUnitTests         = $hasUnitTests
-            hasRecordedTests     = $hasRecordedTests
-            azureSupportedClouds = $resolvedClouds
+            _error                      = $false
+            path                        = $path
+            hasTestResources            = $hasTestResources
+            testResourcesPath           = $hasTestResources ? $testResourcesPath : $null
+            hasLiveTests                = $hasLiveTests
+            hasUnitTests                = $hasUnitTests
+            hasSelfContainedLiveTests   = $hasSelfContainedLiveTests
+            hasRecordedTests            = $hasRecordedTests
+            azureSupportedClouds        = $resolvedClouds
         }
     }
 
@@ -394,6 +398,7 @@ function Get-TestMatrix {
 
             $entry.testResourcesPath = $path.TestResourcesPath
             $entry.hasTestResources = $path.HasTestResources
+            $entry.hasSelfContainedLiveTests = $path.SelfContainedLiveTests
 
             if ($ServerName) {
                 $entry.serverName = $ServerName

--- a/eng/scripts/New-BuildInfo.ps1
+++ b/eng/scripts/New-BuildInfo.ps1
@@ -403,7 +403,7 @@ function Get-TestMatrix {
 
             $entry.testResourcesPath = $path.TestResourcesPath
             $entry.hasTestResources = $path.HasTestResources
-            $entry.hasSelfContainedLiveTests = $path.SelfContainedLiveTests
+            $entry.hasSelfContainedLiveTests = $path.hasSelfContainedLiveTests
 
             if ($ServerName) {
                 $entry.serverName = $ServerName

--- a/eng/scripts/New-BuildInfo.ps1
+++ b/eng/scripts/New-BuildInfo.ps1
@@ -338,9 +338,7 @@ function Get-PathsToTest {
         $hasUnitTests = $hasTestsProject -and [bool]::TryParse($testProjectDetails.HasUnitTests, [ref]$result) -and $result
         $hasLiveTests = $hasTestsProject -and [bool]::TryParse($testProjectDetails.HasLiveTests, [ref]$result) -and $result
         $hasRecordedTests = $hasLiveTests -and (Get-ChildItem $rootedTestResourcesPath -Filter 'assets.json' -Recurse).Count -gt 0
-
-
-        $hasTestsProject -and [bool]::TryParse($testProjectDetails.SelfContainedLiveTests, [ref]$result) -and $result
+        $hasSelfContainedLiveTests = $hasTestsProject -and [bool]::TryParse($testProjectDetails.SelfContainedLiveTests, [ref]$result) -and $result
 
         $sourcePath = Join-Path $using:RepoRoot $path "src"
 

--- a/tools/Azure.Mcp.Tools.Acr/tests/Azure.Mcp.Tools.Acr.Tests/Azure.Mcp.Tools.Acr.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.Acr/tests/Azure.Mcp.Tools.Acr.Tests/Azure.Mcp.Tools.Acr.Tests.csproj
@@ -7,6 +7,7 @@
     <IsPackable>false</IsPackable>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.Tests/Azure.Mcp.Tools.Aks.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.Aks/tests/Azure.Mcp.Tools.Aks.Tests/Azure.Mcp.Tools.Aks.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/Azure.Mcp.Tools.Authorization.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/Azure.Mcp.Tools.Authorization.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.AzureIsv/tests/Azure.Mcp.Tools.AzureIsv.Tests/Azure.Mcp.Tools.AzureIsv.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.AzureIsv/tests/Azure.Mcp.Tools.AzureIsv.Tests/Azure.Mcp.Tools.AzureIsv.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.Tests/Azure.Mcp.Tools.Deploy.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.Deploy/tests/Azure.Mcp.Tools.Deploy.Tests/Azure.Mcp.Tools.Deploy.Tests.csproj
@@ -4,6 +4,7 @@
     <IsTestProject>true</IsTestProject>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NSubstitute" />

--- a/tools/Azure.Mcp.Tools.DeviceRegistry/tests/Azure.Mcp.Tools.DeviceRegistry.Tests/Azure.Mcp.Tools.DeviceRegistry.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.DeviceRegistry/tests/Azure.Mcp.Tools.DeviceRegistry.Tests/Azure.Mcp.Tools.DeviceRegistry.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.Tests/Azure.Mcp.Tools.EventGrid.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.EventGrid/tests/Azure.Mcp.Tools.EventGrid.Tests/Azure.Mcp.Tools.EventGrid.Tests.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.FunctionApp/tests/Azure.Mcp.Tools.FunctionApp.Tests/Azure.Mcp.Tools.FunctionApp.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.FunctionApp/tests/Azure.Mcp.Tools.FunctionApp.Tests/Azure.Mcp.Tools.FunctionApp.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.Tests/Azure.Mcp.Tools.Functions.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.Functions/tests/Azure.Mcp.Tools.Functions.Tests/Azure.Mcp.Tools.Functions.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.Grafana/tests/Azure.Mcp.Tools.Grafana.Tests/Azure.Mcp.Tools.Grafana.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.Grafana/tests/Azure.Mcp.Tools.Grafana.Tests/Azure.Mcp.Tools.Grafana.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.IoTHub/tests/Azure.Mcp.Tools.IoTHub.Tests/Azure.Mcp.Tools.IoTHub.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.IoTHub/tests/Azure.Mcp.Tools.IoTHub.Tests/Azure.Mcp.Tools.IoTHub.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/Azure.Mcp.Tools.Kusto.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/Azure.Mcp.Tools.Kusto.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NSubstitute" />

--- a/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.Tests/Azure.Mcp.Tools.Marketplace.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.Marketplace/tests/Azure.Mcp.Tools.Marketplace.Tests/Azure.Mcp.Tools.Marketplace.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.Pricing/tests/Azure.Mcp.Tools.Pricing.Tests/Azure.Mcp.Tools.Pricing.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.Pricing/tests/Azure.Mcp.Tools.Pricing.Tests/Azure.Mcp.Tools.Pricing.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NSubstitute" />

--- a/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.Tests/Azure.Mcp.Tools.Quota.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.Quota/tests/Azure.Mcp.Tools.Quota.Tests/Azure.Mcp.Tools.Quota.Tests.csproj
@@ -4,6 +4,7 @@
     <IsTestProject>true</IsTestProject>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NSubstitute" />

--- a/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/Azure.Mcp.Tools.Search.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.Search/tests/Azure.Mcp.Tools.Search.Tests/Azure.Mcp.Tools.Search.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.Tests/Azure.Mcp.Tools.ServiceBus.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.Tests/Azure.Mcp.Tools.ServiceBus.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.SignalR/tests/Azure.Mcp.Tools.SignalR.Tests/Azure.Mcp.Tools.SignalR.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.SignalR/tests/Azure.Mcp.Tools.SignalR.Tests/Azure.Mcp.Tools.SignalR.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.Tests/Azure.Mcp.Tools.Speech.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.Tests/Azure.Mcp.Tools.Speech.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.Tests/Azure.Mcp.Tools.VirtualDesktop.Tests.csproj
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.Tests/Azure.Mcp.Tools.VirtualDesktop.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <HasLiveTests>true</HasLiveTests>
     <HasUnitTests>true</HasUnitTests>
+    <SelfContainedLiveTests>true</SelfContainedLiveTests>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)servers\Azure.Mcp.Server\src\Azure.Mcp.Server.csproj" />


### PR DESCRIPTION
## What does this PR do?

Add property `SelfContainedLiveTests` to some test CSPROJs to indicate that the tests contained in the project are self-contained, meaning that they do not mutate state in a way which is irreversible. This then allows those test projects to skip a second round of resource deployment when testing against Azure services.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
