### PR TITLE
Refresh Cosmos recorded test assets

### DIFF
--- a/servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.Tests/Infrastructure/ConsolidatedModeTests.cs
+++ b/servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.Tests/Infrastructure/ConsolidatedModeTests.cs
@@ -474,7 +474,7 @@ public class ConsolidatedModeTests
 
     private static async Task<string?> ReadJsonRpcResponseAsync(StreamReader reader)
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         try
         {
             return await reader.ReadLineAsync(cts.Token);

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
@@ -122,9 +122,6 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
                 break;
         }
 
-        // Validate the client by performing a lightweight operation
-        await ValidateCosmosClientAsync(cosmosClient, cancellationToken);
-
         return cosmosClient;
     }
 
@@ -137,12 +134,6 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
             AzureCloudConfiguration.AzureCloud.AzureChinaCloud => $"https://{accountName}.documents.azure.cn:443/",
             _ => $"https://{accountName}.documents.azure.com:443/"
         };
-    }
-
-    private async Task ValidateCosmosClientAsync(CosmosClient client, CancellationToken cancellationToken = default)
-    {
-        // Perform a lightweight operation to validate the client
-        await client.ReadAccountAsync().WaitAsync(cancellationToken);
     }
 
     private async Task<CosmosClient> GetCosmosClientAsync(

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosServiceTests.cs
@@ -76,7 +76,7 @@ public class CosmosServiceTests : IAsyncDisposable
     [Fact]
     public async Task ListDatabases_CredentialAuthFails_DoesNotFallBackToKeyAuth()
     {
-        // Arrange: HTTP handler returns 401 so credential-based CosmosClient validation fails
+        // Arrange: HTTP handler returns 401 so the credential-based database operation fails
         var handler = new MockHttpHandler(HttpStatusCode.Unauthorized);
         _azureService.GetClient().Returns(new HttpClient(handler));
 
@@ -98,7 +98,7 @@ public class CosmosServiceTests : IAsyncDisposable
     [Fact]
     public async Task ListDatabases_CredentialAuthFailsWith403_DoesNotFallBackToKeyAuth()
     {
-        // Arrange: HTTP handler returns 403 so credential-based CosmosClient validation fails
+        // Arrange: HTTP handler returns 403 so the credential-based database operation fails
         var handler = new MockHttpHandler(HttpStatusCode.Forbidden);
         _azureService.GetClient().Returns(new HttpClient(handler));
 
@@ -128,7 +128,7 @@ public class CosmosServiceTests : IAsyncDisposable
         _cacheService.GetAsync<List<string>>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
             .Returns(default(List<string>));
 
-        // Act: client creation fails, but cache lookup has already happened
+        // Act: the database operation fails, but the client cache lookup has already happened
         await Assert.ThrowsAnyAsync<Exception>(() =>
             _service.ListDatabases("myaccount", "sub123", AuthMethod.Credential, cancellationToken: TestContext.Current.CancellationToken));
 
@@ -156,7 +156,7 @@ public class CosmosServiceTests : IAsyncDisposable
         _cacheService.GetAsync<List<string>>(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
             .Returns(default(List<string>));
 
-        // Act: client creation fails after the cache miss, but cache lookup has already happened
+        // Act: key authentication setup fails after the cache miss, but cache lookup has already happened
         await Assert.ThrowsAnyAsync<Exception>(() =>
             _service.ListDatabases("myaccount", "sub123", AuthMethod.Key, cancellationToken: TestContext.Current.CancellationToken));
 

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/assets.json
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/assets.json
@@ -2,5 +2,5 @@
     "AssetsRepo": "Azure/azure-sdk-assets",
     "AssetsRepoPrefixPath": "",
     "TagPrefix": "Azure.Mcp.Tools.Cosmos.Tests",
-    "Tag": "Azure.Mcp.Tools.Cosmos.Tests_04ac7b75fd"
+    "Tag": "Azure.Mcp.Tools.Cosmos.Tests_241ef3d966"
 }


### PR DESCRIPTION
This pull request primarily refactors the Cosmos client creation flow in `CosmosService` by removing the explicit validation step, and updates related test comments for clarity. It also increases the timeout for reading JSON-RPC responses in a test and updates a test asset tag.

**Cosmos client creation and validation:**
* Removed the `ValidateCosmosClientAsync` method and the call to it in `CreateCosmosClientWithAuth`, so the client is no longer validated with a lightweight operation immediately after creation. This simplifies the client initialization process. [[1]](diffhunk://#diff-f5a7588bcbd525c1ad00e5babb727dd5f1594fffae77a98c3ba50b7180ebefe0L125-L127) [[2]](diffhunk://#diff-f5a7588bcbd525c1ad00e5babb727dd5f1594fffae77a98c3ba50b7180ebefe0L142-L147)

**Test updates and clarifications:**
* Updated comments in several tests in `CosmosServiceTests.cs` to clarify that failures occur during database operations, not during client validation or creation. [[1]](diffhunk://#diff-c6f2c82821ac42751d52793b508a323942d635e2b93daad432dd8258e6829465L79-R79) [[2]](diffhunk://#diff-c6f2c82821ac42751d52793b508a323942d635e2b93daad432dd8258e6829465L101-R101) [[3]](diffhunk://#diff-c6f2c82821ac42751d52793b508a323942d635e2b93daad432dd8258e6829465L131-R131) [[4]](diffhunk://#diff-c6f2c82821ac42751d52793b508a323942d635e2b93daad432dd8258e6829465L159-R159)
* Increased the timeout for reading a JSON-RPC response from 10 to 30 seconds in `ConsolidatedMode_Should_Interop_With_Legacy_Initialize_Handsha` to reduce test flakiness.

**Test asset update:**
* Updated the test asset tag in `assets.json` to a new value.This pull request makes a minor update to the test assets configuration by changing the `Tag` value in the `assets.json` file. This typically reflects a new version or state of the assets used for testing.

* Updated the `Tag` field in `assets.json` to `Azure.Mcp.Tools.Cosmos.Tests_241ef3d966` to reference the latest asset version.

https://github.com/microsoft/mcp/issues/3315