### PR TITLE
docs: remove stale Build-Local UsePaths guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@
 
 ## Engineering System
 
-- Use `./eng/scripts/Build-Local.ps1 -UsePaths -VerifyNpx` to verify changes to powershell, c# project files and npm packages
+- Use `./eng/scripts/Build-Local.ps1 -VerifyNpx` to verify changes to powershell, c# project files and npm packages
 - Don't run local builds to check pipeline YAML files (e.g., files in `eng/pipelines/` with `.yml` extension)
 
 ## Pull Request Guidelines

--- a/.github/skills/add-azure-mcp-tools/SKILL.md
+++ b/.github/skills/add-azure-mcp-tools/SKILL.md
@@ -951,7 +951,7 @@ dotnet test tools/Azure.Mcp.Tools.{Toolset}/tests
 .\eng\common\spelling\Invoke-Cspell.ps1
 
 # 5. Full verification
-./eng/scripts/Build-Local.ps1 -UsePaths -VerifyNpx
+./eng/scripts/Build-Local.ps1 -VerifyNpx
 
 # 6. AOT/Native build (required for AOT-compatible toolsets)
 ./eng/scripts/Build-Local.ps1 -BuildNative

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -146,6 +146,7 @@
         "ssword",
         "storageaccount",
         "targetdir",
+        "testcontainer",
         "testdb",
         "testproxy",
         "testrg",

--- a/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-add-tool/SKILL.md
+++ b/tools/Azure.Mcp.Tools.AzureBackup/skills/azurebackup-add-tool/SKILL.md
@@ -265,7 +265,7 @@ If new Azure Backup-specific technical terms are flagged, add them to `tools/Azu
 #### 5f. Full Build Verification
 
 ```powershell
-./eng/scripts/Build-Local.ps1 -UsePaths -VerifyNpx
+./eng/scripts/Build-Local.ps1 -VerifyNpx
 ```
 
 #### 5g. AOT/Native Build Verification


### PR DESCRIPTION
## Description

## Related Issue

### Resolves 

## Additional Context

## Testing

- [x] 🧪 **Tested this change with all relevant test suites and ensured all pass.**

## Checklist

- [x] 📖 **Reviewed CONTRIBUTING.md and followed all contribution guidelines.**
- [x] ✅ **Included tests covering all new and changed functionality.**
- [x] 📝 **Updated documentation where needed (or N/A).**
- [x] 📓 **Added/updated changelog entry if user-facing behavior changed.**
- [x] 🔍 **Ran spelling checks and corrected any errors.**

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.