### PR TITLE
Simplify Fabric and OneLake endpoint configuration to production

### DIFF
--- a/tools/Fabric.Mcp.Tools.Core/src/Models/CoreModels.cs
+++ b/tools/Fabric.Mcp.Tools.Core/src/Models/CoreModels.cs
@@ -134,21 +134,12 @@ public class CatalogWorkspace
 /// </summary>
 public static class FabricEndpoints
 {
-    private static readonly FabricEnvironmentEndpoints Endpoints = new()
-    {
-        FabricApiBaseUrl = "https://api.fabric.microsoft.com/v1",
-        FabricScope = "https://api.fabric.microsoft.com/.default"
-    };
+    public const string FabricApiBaseUrl = "https://api.fabric.microsoft.com/v1";
+    public const string FabricScope = "https://api.fabric.microsoft.com/.default";
 
-    public static string GetFabricApiBaseUrl() => Endpoints.FabricApiBaseUrl;
+    public static readonly string[] FabricScopes = [FabricScope];
 
-    public static string GetFabricScope() => Endpoints.FabricScope;
+    public static string GetFabricApiBaseUrl() => FabricApiBaseUrl;
 
-    public static readonly string[] FabricScopes = ["https://api.fabric.microsoft.com/.default"];
-}
-
-public class FabricEnvironmentEndpoints
-{
-    public string FabricApiBaseUrl { get; set; } = string.Empty;
-    public string FabricScope { get; set; } = string.Empty;
+    public static string GetFabricScope() => FabricScope;
 }

--- a/tools/Fabric.Mcp.Tools.Core/src/Models/CoreModels.cs
+++ b/tools/Fabric.Mcp.Tools.Core/src/Models/CoreModels.cs
@@ -134,48 +134,17 @@ public class CatalogWorkspace
 /// </summary>
 public static class FabricEndpoints
 {
-    private static readonly Dictionary<string, FabricEnvironmentEndpoints> EnvironmentEndpoints = new()
+    private static readonly FabricEnvironmentEndpoints Endpoints = new()
     {
-        ["PROD"] = new FabricEnvironmentEndpoints
-        {
-            FabricApiBaseUrl = "https://api.fabric.microsoft.com/v1",
-            FabricScope = "https://api.fabric.microsoft.com/.default"
-        },
-        ["DAILY"] = new FabricEnvironmentEndpoints
-        {
-            FabricApiBaseUrl = "https://dailyapi.fabric.microsoft.com/v1",
-            FabricScope = "https://api.fabric.microsoft.com/.default"
-        },
-        ["DXT"] = new FabricEnvironmentEndpoints
-        {
-            FabricApiBaseUrl = "https://dxt-api.fabric.microsoft.com/v1",
-            FabricScope = "https://api.fabric.microsoft.com/.default"
-        },
-        ["MSIT"] = new FabricEnvironmentEndpoints
-        {
-            FabricApiBaseUrl = "https://msit-api.fabric.microsoft.com/v1",
-            FabricScope = "https://api.fabric.microsoft.com/.default"
-        }
+        FabricApiBaseUrl = "https://api.fabric.microsoft.com/v1",
+        FabricScope = "https://api.fabric.microsoft.com/.default"
     };
 
-    private static string CurrentEnvironment =>
-        Environment.GetEnvironmentVariable("FABRIC_ENVIRONMENT")?.ToUpperInvariant() ?? "PROD";
+    public static string GetFabricApiBaseUrl() => Endpoints.FabricApiBaseUrl;
 
-    public static string GetFabricApiBaseUrl() => GetEndpoints(CurrentEnvironment).FabricApiBaseUrl;
-
-    public static string GetFabricScope() => GetEndpoints(CurrentEnvironment).FabricScope;
+    public static string GetFabricScope() => Endpoints.FabricScope;
 
     public static readonly string[] FabricScopes = ["https://api.fabric.microsoft.com/.default"];
-
-    public static FabricEnvironmentEndpoints GetEndpoints(string environment)
-    {
-        var env = environment.ToUpperInvariant();
-        return EnvironmentEndpoints.TryGetValue(env, out var endpoints)
-            ? endpoints
-            : EnvironmentEndpoints["PROD"];
-    }
-
-    public static IEnumerable<string> GetAvailableEnvironments() => EnvironmentEndpoints.Keys;
 }
 
 public class FabricEnvironmentEndpoints

--- a/tools/Fabric.Mcp.Tools.OneLake/README.md
+++ b/tools/Fabric.Mcp.Tools.OneLake/README.md
@@ -86,15 +86,9 @@ Configure your MCP client to use OneLake tools:
 }
 ```
 
-### Environment Verification
+### Endpoint Verification
 
-You can verify which environment you're targeting by checking the endpoints in the logs or by listing workspaces and comparing the results with what you expect in each environment.
-
-**Important Notes:**
-- Each environment may have different workspaces and items available
-- Authentication requirements may vary between environments
-- Daily and DXT environments are primarily for testing and development
-- Production environment should be used for production workloads
+You can verify which endpoints you're targeting by checking the URLs in the logs or by listing workspaces and comparing the results with what you expect.
 
 ### Workspace and Item Identifiers
 

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Models/OneLakeJsonContext.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Models/OneLakeJsonContext.cs
@@ -27,7 +27,6 @@ namespace Fabric.Mcp.Tools.OneLake.Models;
 [JsonSerializable(typeof(ItemsResponse))]
 [JsonSerializable(typeof(LakehousesResponse))]
 [JsonSerializable(typeof(OneLakeEndpoint))]
-[JsonSerializable(typeof(OneLakeEnvironmentEndpoints))]
 [JsonSerializable(typeof(OneLakeWorkspaceListCommand.OneLakeWorkspaceListCommandResult))]
 [JsonSerializable(typeof(OneLakeItemListCommand.OneLakeItemListCommandResult))]
 [JsonSerializable(typeof(OneLakeItemListDfsCommand.OneLakeItemListDfsCommandResult))]

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Models/OneLakeModels.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Models/OneLakeModels.cs
@@ -313,86 +313,32 @@ public static class OneLakeEndpoints
     public const string FabricApiBaseUrl = "https://api.fabric.microsoft.com/v1";
     public const string StorageScope = "https://storage.azure.com/.default";
 
-    // Environment-aware Fabric API base URL
-    public static string GetFabricApiBaseUrl() => GetEndpoints(CurrentEnvironment).FabricApiBaseUrl;
+    public static string GetFabricApiBaseUrl() => Endpoints.FabricApiBaseUrl;
 
-    // Environment-aware Fabric authentication scope
-    public static string GetFabricScope() => GetEndpoints(CurrentEnvironment).FabricScope;
+    public static string GetFabricScope() => Endpoints.FabricScope;
 
     public static readonly string[] FabricScopes =
     [
         "https://api.fabric.microsoft.com/.default"
     ];
 
-    // Environment-specific endpoints
-    private static readonly Dictionary<string, OneLakeEnvironmentEndpoints> EnvironmentEndpoints = new()
+    private static readonly OneLakeEnvironmentEndpoints Endpoints = new()
     {
-        ["PROD"] = new OneLakeEnvironmentEndpoints
-        {
-            OneLakeDataPlaneBaseUrl = "https://api.onelake.fabric.microsoft.com",
-            OneLakeDataPlaneDfsBaseUrl = "https://onelake.dfs.fabric.microsoft.com",
-            OneLakeDataPlaneBlobBaseUrl = "https://onelake.blob.fabric.microsoft.com",
-            OneLakeTableApiBaseUrl = "https://onelake.table.fabric.microsoft.com",
-            FabricApiBaseUrl = "https://api.fabric.microsoft.com/v1",
-            FabricScope = "https://api.fabric.microsoft.com/.default"
-        },
-        ["DAILY"] = new OneLakeEnvironmentEndpoints
-        {
-            OneLakeDataPlaneBaseUrl = "https://daily-api.onelake.fabric.microsoft.com",
-            OneLakeDataPlaneDfsBaseUrl = "https://daily-onelake.dfs.fabric.microsoft.com",
-            OneLakeDataPlaneBlobBaseUrl = "https://daily-onelake.blob.fabric.microsoft.com",
-            OneLakeTableApiBaseUrl = "https://daily-onelake.table.fabric.microsoft.com",
-            FabricApiBaseUrl = "https://dailyapi.fabric.microsoft.com/v1",
-            FabricScope = "https://api.fabric.microsoft.com/.default"
-        },
-        ["DXT"] = new OneLakeEnvironmentEndpoints
-        {
-            OneLakeDataPlaneBaseUrl = "https://dxt-api.onelake.fabric.microsoft.com",
-            OneLakeDataPlaneDfsBaseUrl = "https://dxt-onelake.dfs.fabric.microsoft.com",
-            OneLakeDataPlaneBlobBaseUrl = "https://dxt-onelake.blob.fabric.microsoft.com",
-            OneLakeTableApiBaseUrl = "https://dxt-onelake.table.fabric.microsoft.com",
-            FabricApiBaseUrl = "https://dxt-api.fabric.microsoft.com/v1",
-            FabricScope = "https://api.fabric.microsoft.com/.default"
-        },
-        ["MSIT"] = new OneLakeEnvironmentEndpoints
-        {
-            OneLakeDataPlaneBaseUrl = "https://msit-api.onelake.fabric.microsoft.com",
-            OneLakeDataPlaneDfsBaseUrl = "https://msit-onelake.dfs.fabric.microsoft.com",
-            OneLakeDataPlaneBlobBaseUrl = "https://msit-onelake.blob.fabric.microsoft.com",
-            OneLakeTableApiBaseUrl = "https://msit-onelake.table.fabric.microsoft.com",
-            FabricApiBaseUrl = "https://msit-api.fabric.microsoft.com/v1",
-            FabricScope = "https://api.fabric.microsoft.com/.default"
-        }
+        OneLakeDataPlaneBaseUrl = "https://api.onelake.fabric.microsoft.com",
+        OneLakeDataPlaneDfsBaseUrl = "https://onelake.dfs.fabric.microsoft.com",
+        OneLakeDataPlaneBlobBaseUrl = "https://onelake.blob.fabric.microsoft.com",
+        OneLakeTableApiBaseUrl = "https://onelake.table.fabric.microsoft.com",
+        FabricApiBaseUrl = "https://api.fabric.microsoft.com/v1",
+        FabricScope = "https://api.fabric.microsoft.com/.default"
     };
 
-    // Get current environment from environment variable or default to PROD
-    private static string CurrentEnvironment =>
-        Environment.GetEnvironmentVariable("ONELAKE_ENVIRONMENT")?.ToUpperInvariant() ?? "PROD";
+    public static string OneLakeDataPlaneBaseUrl => Endpoints.OneLakeDataPlaneBaseUrl;
 
-    // Public properties that return environment-specific URLs
-    public static string OneLakeDataPlaneBaseUrl =>
-        EnvironmentEndpoints[CurrentEnvironment].OneLakeDataPlaneBaseUrl;
+    public static string OneLakeDataPlaneDfsBaseUrl => Endpoints.OneLakeDataPlaneDfsBaseUrl;
 
-    public static string OneLakeDataPlaneDfsBaseUrl =>
-        EnvironmentEndpoints[CurrentEnvironment].OneLakeDataPlaneDfsBaseUrl;
+    public static string OneLakeDataPlaneBlobBaseUrl => Endpoints.OneLakeDataPlaneBlobBaseUrl;
 
-    public static string OneLakeDataPlaneBlobBaseUrl =>
-        EnvironmentEndpoints[CurrentEnvironment].OneLakeDataPlaneBlobBaseUrl;
-
-    public static string OneLakeTableApiBaseUrl =>
-        EnvironmentEndpoints[CurrentEnvironment].OneLakeTableApiBaseUrl;
-
-    // Method to get endpoints for a specific environment
-    public static OneLakeEnvironmentEndpoints GetEndpoints(string environment)
-    {
-        var env = environment.ToUpperInvariant();
-        return EnvironmentEndpoints.TryGetValue(env, out var endpoints)
-            ? endpoints
-            : EnvironmentEndpoints["PROD"];
-    }
-
-    // Method to list available environments
-    public static IEnumerable<string> GetAvailableEnvironments() => EnvironmentEndpoints.Keys;
+    public static string OneLakeTableApiBaseUrl => Endpoints.OneLakeTableApiBaseUrl;
 }
 
 public sealed class OneLakeEnvironmentEndpoints

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Models/OneLakeModels.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Models/OneLakeModels.cs
@@ -311,42 +311,17 @@ public sealed class FileSystemItem
 public static class OneLakeEndpoints
 {
     public const string FabricApiBaseUrl = "https://api.fabric.microsoft.com/v1";
+    public const string FabricScope = "https://api.fabric.microsoft.com/.default";
     public const string StorageScope = "https://storage.azure.com/.default";
 
-    public static string GetFabricApiBaseUrl() => Endpoints.FabricApiBaseUrl;
+    public const string OneLakeDataPlaneBaseUrl = "https://api.onelake.fabric.microsoft.com";
+    public const string OneLakeDataPlaneDfsBaseUrl = "https://onelake.dfs.fabric.microsoft.com";
+    public const string OneLakeDataPlaneBlobBaseUrl = "https://onelake.blob.fabric.microsoft.com";
+    public const string OneLakeTableApiBaseUrl = "https://onelake.table.fabric.microsoft.com";
 
-    public static string GetFabricScope() => Endpoints.FabricScope;
+    public static readonly string[] FabricScopes = [FabricScope];
 
-    public static readonly string[] FabricScopes =
-    [
-        "https://api.fabric.microsoft.com/.default"
-    ];
+    public static string GetFabricApiBaseUrl() => FabricApiBaseUrl;
 
-    private static readonly OneLakeEnvironmentEndpoints Endpoints = new()
-    {
-        OneLakeDataPlaneBaseUrl = "https://api.onelake.fabric.microsoft.com",
-        OneLakeDataPlaneDfsBaseUrl = "https://onelake.dfs.fabric.microsoft.com",
-        OneLakeDataPlaneBlobBaseUrl = "https://onelake.blob.fabric.microsoft.com",
-        OneLakeTableApiBaseUrl = "https://onelake.table.fabric.microsoft.com",
-        FabricApiBaseUrl = "https://api.fabric.microsoft.com/v1",
-        FabricScope = "https://api.fabric.microsoft.com/.default"
-    };
-
-    public static string OneLakeDataPlaneBaseUrl => Endpoints.OneLakeDataPlaneBaseUrl;
-
-    public static string OneLakeDataPlaneDfsBaseUrl => Endpoints.OneLakeDataPlaneDfsBaseUrl;
-
-    public static string OneLakeDataPlaneBlobBaseUrl => Endpoints.OneLakeDataPlaneBlobBaseUrl;
-
-    public static string OneLakeTableApiBaseUrl => Endpoints.OneLakeTableApiBaseUrl;
-}
-
-public sealed class OneLakeEnvironmentEndpoints
-{
-    public string OneLakeDataPlaneBaseUrl { get; set; } = string.Empty;
-    public string OneLakeDataPlaneDfsBaseUrl { get; set; } = string.Empty;
-    public string OneLakeDataPlaneBlobBaseUrl { get; set; } = string.Empty;
-    public string OneLakeTableApiBaseUrl { get; set; } = string.Empty;
-    public string FabricApiBaseUrl { get; set; } = string.Empty;
-    public string FabricScope { get; set; } = string.Empty;
+    public static string GetFabricScope() => FabricScope;
 }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Services/OneLakeServiceLroTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Services/OneLakeServiceLroTests.cs
@@ -19,9 +19,9 @@ public class OneLakeServiceLroTests
     private const string WorkspaceId = "ws-lro-test";
     private const string ItemId = "item-lro-test";
     private const string OperationId = "op-lro-12345";
-    private const string OperationUrl = $"https://dailyapi.fabric.microsoft.com/v1/operations/{OperationId}";
-    private const string ResultUrl = $"https://dailyapi.fabric.microsoft.com/v1/operations/{OperationId}/result";
-    private const string ShortcutsUrl = $"https://dailyapi.fabric.microsoft.com/v1/workspaces/{WorkspaceId}/items/{ItemId}/shortcuts/bulkCreate";
+    private const string OperationUrl = $"https://api.fabric.microsoft.com/v1/operations/{OperationId}";
+    private const string ResultUrl = $"https://api.fabric.microsoft.com/v1/operations/{OperationId}/result";
+    private const string ShortcutsUrl = $"https://api.fabric.microsoft.com/v1/workspaces/{WorkspaceId}/items/{ItemId}/shortcuts/bulkCreate";
 
     private static OneLakeService CreateService(Func<HttpRequestMessage, HttpResponseMessage> handler)
     {

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Services/OneLakeServiceLroTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Services/OneLakeServiceLroTests.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using Fabric.Mcp.Tools.OneLake.Models;
 using Fabric.Mcp.Tools.OneLake.Services;
 using Fabric.Mcp.Tools.OneLake.Tests.TestSupport;
 using Xunit;
@@ -19,9 +20,9 @@ public class OneLakeServiceLroTests
     private const string WorkspaceId = "ws-lro-test";
     private const string ItemId = "item-lro-test";
     private const string OperationId = "op-lro-12345";
-    private const string OperationUrl = $"https://api.fabric.microsoft.com/v1/operations/{OperationId}";
-    private const string ResultUrl = $"https://api.fabric.microsoft.com/v1/operations/{OperationId}/result";
-    private const string ShortcutsUrl = $"https://api.fabric.microsoft.com/v1/workspaces/{WorkspaceId}/items/{ItemId}/shortcuts/bulkCreate";
+    private const string OperationUrl = $"{OneLakeEndpoints.FabricApiBaseUrl}/operations/{OperationId}";
+    private const string ResultUrl = $"{OneLakeEndpoints.FabricApiBaseUrl}/operations/{OperationId}/result";
+    private const string ShortcutsUrl = $"{OneLakeEndpoints.FabricApiBaseUrl}/workspaces/{WorkspaceId}/items/{ItemId}/shortcuts/bulkCreate";
 
     private static OneLakeService CreateService(Func<HttpRequestMessage, HttpResponseMessage> handler)
     {


### PR DESCRIPTION
## Description

The `core` and `onelake` toolsets resolved their Fabric API endpoints through a lookup table keyed off an environment variable. Only the production endpoints are usable by consumers of this server, so the indirection added configuration surface without adding value.

This replaces the lookup with a single set of production endpoint constants and drops the now-unused environment lookup helpers (`GetEndpoints`, `GetAvailableEnvironments`, and the environment variable reads). Test URLs and README notes are updated to match.

## Changes

- `tools/Fabric.Mcp.Tools.Core/src/Models/CoreModels.cs` — `FabricEndpoints` now exposes a single production endpoint set.
- `tools/Fabric.Mcp.Tools.OneLake/src/Models/OneLakeModels.cs` — same for `OneLakeEndpoints` (data plane, DFS, blob, table, and Fabric API URLs).
- `tools/Fabric.Mcp.Tools.OneLake/tests/.../OneLakeServiceLroTests.cs` — test URLs use the public API host.
- `tools/Fabric.Mcp.Tools.OneLake/README.md` — removed stale endpoint-selection notes.

No tool names, parameters, or response shapes change, so `consolidated-tools.json`, `e2eTestPrompts.md`, and `azmcp-commands.md` are unaffected.

## Validation

- `dotnet build` succeeds for both toolsets.
- `dotnet test tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests` — 348 passed, 0 failed.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
