### PR TITLE
Updates to Vally handling

### DIFF
--- a/.github/workflows/vally-eval.yml
+++ b/.github/workflows/vally-eval.yml
@@ -67,7 +67,7 @@ jobs:
             Write-Host "Run type: manual run"
           }
 
-          ./eng/scripts/New-BuildInfo.ps1 -ServerName Azure.Mcp.Server
+          ./eng/scripts/New-BuildInfo.ps1 -ServerName Azure.Mcp.Server -CommonCodeBuildsAll $false
 
       - name: Build server code
         shell: pwsh

--- a/.vally.yaml
+++ b/.vally.yaml
@@ -1,4 +1,5 @@
 paths:
+  skills: []
   evals: ["tools/Azure.Mcp.Tools.*/tests/", ".work/vally/evals/*/"]
   results: ".work/vally/vally-results/"
 
@@ -10,6 +11,8 @@ environments:
         command: ".work/build/Azure.Mcp.Server/linux-x64/azmcp"
         args: ["server", "start"]
         timeout: "2m"
+        env:
+          AZURE_MCP_COLLECT_TELEMETRY: 'false'
   windows:
     mcpServers:
       azmcp:
@@ -17,6 +20,8 @@ environments:
         command: ".work/build/Azure.Mcp.Server/windows-x64/azmcp"
         args: ["server", "start"]
         timeout: "2m"
+        env:
+          AZURE_MCP_COLLECT_TELEMETRY: 'false'
 
 suites:
   basic:

--- a/eng/scripts/New-BuildInfo.ps1
+++ b/eng/scripts/New-BuildInfo.ps1
@@ -9,7 +9,8 @@ param(
     [string] $ServerName,
     [switch] $IncludeNative,
     [switch] $TestPipeline,
-    [switch] $CI
+    [switch] $CI,
+    [bool] $CommonCodeBuildsAll = $true
 )
 
 . "$PSScriptRoot/../common/scripts/common.ps1"
@@ -262,9 +263,9 @@ function Get-PathsToTest {
         # If we're in a pull request, use the set of changed files to narrow down the set of paths to test.
         $changedFiles = Get-ChangedFiles
         # Track whether engineering, the Core libraries, or shared build changed. If so, build everything.
-        $coreChanged = ($changedFiles | Where-Object { $_ -match '^core/(Azure|Fabric|Microsoft).Mcp.Core/src/' }).Count -gt 0
-        $engChanged = ($changedFiles | Where-Object { $_ -match '^eng/' }).Count -gt 0
-        $sharedBuildChanged = ($changedFiles | Where-Object { $_ -match '^Directory.(Build|Packages).props' }).Count -gt 0
+        $coreChanged = $CommonCodeBuildsAll -and ($changedFiles | Where-Object { $_ -match '^core/(Azure|Fabric|Microsoft).Mcp.Core/src/' }).Count -gt 0
+        $engChanged = $CommonCodeBuildsAll -and  ($changedFiles | Where-Object { $_ -match '^eng/' }).Count -gt 0
+        $sharedBuildChanged = $CommonCodeBuildsAll -and  ($changedFiles | Where-Object { $_ -match '^Directory.(Build|Packages).props' }).Count -gt 0
         if ($coreChanged -or $engChanged -or $sharedBuildChanged) {
             Write-Host "Core, engineering, or shared build changes detected. Building everything." -ForegroundColor Yellow
             $pathsToTest = @()

--- a/eng/scripts/New-BuildInfo.ps1
+++ b/eng/scripts/New-BuildInfo.ps1
@@ -262,7 +262,7 @@ function Get-PathsToTest {
 
         # If we're in a pull request, use the set of changed files to narrow down the set of paths to test.
         $changedFiles = Get-ChangedFiles
-        # Track whether engineering, the Core libraries, or shared build changed. If so, build everything.
+        # When common code builds all, track whether engineering, the Core libraries, or shared build changed. If so, build everything.
         $coreChanged = $CommonCodeBuildsAll -and ($changedFiles | Where-Object { $_ -match '^core/(Azure|Fabric|Microsoft).Mcp.Core/src/' }).Count -gt 0
         $engChanged = $CommonCodeBuildsAll -and  ($changedFiles | Where-Object { $_ -match '^eng/' }).Count -gt 0
         $sharedBuildChanged = $CommonCodeBuildsAll -and  ($changedFiles | Where-Object { $_ -match '^Directory.(Build|Packages).props' }).Count -gt 0

--- a/tools/Azure.Mcp.Tools.EventGrid/src/EventGridSetup.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/src/EventGridSetup.cs
@@ -17,6 +17,7 @@ public class EventGridSetup : IAreaSetup
 
     public string Title => "Azure Event Grid";
 
+    // Test changes
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddSingleton<IEventGridService, EventGridService>();

--- a/tools/Azure.Mcp.Tools.EventGrid/src/EventGridSetup.cs
+++ b/tools/Azure.Mcp.Tools.EventGrid/src/EventGridSetup.cs
@@ -17,7 +17,6 @@ public class EventGridSetup : IAreaSetup
 
     public string Title => "Azure Event Grid";
 
-    // Test changes
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddSingleton<IEventGridService, EventGridService>();


### PR DESCRIPTION
## What does this PR do?

Disables Skills and MCP telemetry capture when running Vally evals. Updates `New-BuildInfo.ps1` with a new flag that allows scoping to tool source code changes so all evaluations aren't ran when changing common code.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
