### PR TITLE
docs: refresh Azure MCP global option descriptions

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -9,14 +9,14 @@ The following options are available for most commands:
 
 | Option | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `--subscription` | No | Environment variable `AZURE_SUBSCRIPTION_ID` | The Azure subscription GUID identifier or display name. If not specified, the Azure CLI profile default subscription or `AZURE_SUBSCRIPTION_ID` environment variable will be used. |
+| `--subscription` | No | Azure CLI profile default; otherwise `AZURE_SUBSCRIPTION_ID` | The Azure subscription GUID identifier or display name. If not specified, the Azure CLI profile default subscription or `AZURE_SUBSCRIPTION_ID` environment variable will be used. |
 | `--tenant` | No | - | The Microsoft Entra ID tenant GUID identifier or display name. |
 | `--auth-method` | No | 'credential' | Authentication method ('credential', 'key', 'connectionString') |
 | `--retry-max-retries` | No | 3 | Maximum number of retry attempts. |
 | `--retry-delay` | No | 2 | Initial delay in seconds. For exponential backoff, this value is used as the base. |
-| `--retry-max-delay` | No | 10 | Maximum delay between retries (seconds) |
+| `--retry-max-delay` | No | 10 | Maximum delay in seconds, regardless of the retry strategy. |
 | `--retry-mode` | No | 'exponential' | Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts. |
-| `--retry-network-timeout` | No | 100 | Network operation timeout (seconds) |
+| `--retry-network-timeout` | No | 100 | Network operation timeout in seconds. |
 | `--learn` | No | false | Discover available sub-commands and their parameters without executing any Azure operation. Use on a command group to list commands in that group, or on a specific command to see its options. |
 
 ### Discovery with `--learn`

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -9,13 +9,13 @@ The following options are available for most commands:
 
 | Option | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `--subscription` | No | Environment variable `AZURE_SUBSCRIPTION_ID` | Azure subscription ID for target resources |
-| `--tenant-id` | No | - | Azure tenant ID for authentication |
+| `--subscription` | No | Environment variable `AZURE_SUBSCRIPTION_ID` | The Azure subscription GUID identifier or display name. If not specified, the Azure CLI profile default subscription or `AZURE_SUBSCRIPTION_ID` environment variable will be used. |
+| `--tenant` | No | - | The Microsoft Entra ID tenant GUID identifier or display name. |
 | `--auth-method` | No | 'credential' | Authentication method ('credential', 'key', 'connectionString') |
-| `--retry-max-retries` | No | 3 | Maximum retry attempts for failed operations |
-| `--retry-delay` | No | 2 | Delay between retry attempts (seconds) |
+| `--retry-max-retries` | No | 3 | Maximum number of retry attempts. |
+| `--retry-delay` | No | 2 | Initial delay in seconds. For exponential backoff, this value is used as the base. |
 | `--retry-max-delay` | No | 10 | Maximum delay between retries (seconds) |
-| `--retry-mode` | No | 'exponential' | Retry strategy ('fixed' or 'exponential') |
+| `--retry-mode` | No | 'exponential' | Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts. |
 | `--retry-network-timeout` | No | 100 | Network operation timeout (seconds) |
 | `--learn` | No | false | Discover available sub-commands and their parameters without executing any Azure operation. Use on a command group to list commands in that group, or on a specific command to see its options. |
 


### PR DESCRIPTION
## What does this PR do?

Refreshes the Azure MCP global options table so it matches the current shared option descriptions:

- documents that `--subscription` accepts a GUID or display name and explains its fallback behavior
- corrects the global tenant option from `--tenant-id` to `--tenant`
- synchronizes the retry count, initial delay, and retry mode descriptions with `RetryPolicyOptions`

This is a documentation-only change; it does not change command behavior or tool metadata.

## GitHub issue number?

Fixes https://github.com/microsoft/mcp/issues/3224

## Validation

- `git diff --check`
- `npx --yes cspell@^10.0.0 lint --config .vscode/cspell.json servers/Azure.Mcp.Server/docs/azmcp-commands.md`

The PowerShell metadata script was not run because no generated tool metadata or tool implementation changed.

## Pre-merge checklist

- [x] Read the contribution guidelines
- [x] PR title clearly describes the change
- [x] Commit history is clean with a single descriptive commit
- [x] Reviewed the source option descriptions for accuracy
- [x] Spelling check passes
- [x] Tests are not applicable to this documentation-only change
- [x] A changelog entry is not required for this documentation-only correction

