### PR TITLE
docs: remove subscription from resilience get examples

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3771,20 +3771,17 @@ azmcp redis list --subscription <subscription>
 ```bash
 # Get a resilience goal template, or list all goal templates in a service group (omit --name)
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp resilience goal template get --subscription <subscription> \
-                                   --service-group <service-group> \
+azmcp resilience goal template get --service-group <service-group> \
                                    [--name <name>]
 
 # Get a resilience goal assignment, or list all goal assignments in a service group (omit --name)
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp resilience goal assignment get --subscription <subscription> \
-                                     --service-group <service-group> \
+azmcp resilience goal assignment get --service-group <service-group> \
                                      [--name <name>]
 
 # Get a resource (member) of a goal assignment, or list all resources of the assignment (omit --name)
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp resilience goal resource get --subscription <subscription> \
-                                   --service-group <service-group> \
+azmcp resilience goal resource get --service-group <service-group> \
                                    --goal-assignment <goal-assignment> \
                                    [--name <name>]
 
@@ -3818,8 +3815,7 @@ azmcp resilience usageplan enrollment create --subscription <subscription> \
 
 # Get a resilience recovery plan, or list all recovery plans in a service group (omit --name)
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp resilience recoveryplan get --subscription <subscription> \
-                                   --service-group <service-group> \
+azmcp resilience recoveryplan get --service-group <service-group> \
                                    [--name <name>]
 
 # Create or fully update a Zonal resilience recovery plan. Ask the customer to select an identity type; do not assume SystemAssigned or another default. Identity types can switch on update, but an existing user-assigned identity cannot be replaced with a different user-assigned identity. The plan description must be 5 to 50 characters and is required on create; it is preserved when omitted on update.
@@ -3856,22 +3852,19 @@ azmcp resilience recoveryplan checkreadiness --service-group <service-group> \
 
 # Get a resource (member) of a recovery plan, or list all resources of the plan (omit --name)
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp resilience recoveryplan resource get --subscription <subscription> \
-                                            --service-group <service-group> \
+azmcp resilience recoveryplan resource get --service-group <service-group> \
                                             --recovery-plan <recovery-plan> \
                                             [--name <name>]
 
 # Get a recovery job, or list all recovery jobs of a recovery plan (omit --name)
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp resilience recoveryjob get --subscription <subscription> \
-                                 --service-group <service-group> \
+azmcp resilience recoveryjob get --service-group <service-group> \
                                  --recovery-plan <recovery-plan> \
                                  [--name <name>]
 
 # Get a resource (target) of a recovery job, or list all resources of the job (omit --name)
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp resilience recoveryjob resource get --subscription <subscription> \
-                                          --service-group <service-group> \
+azmcp resilience recoveryjob resource get --service-group <service-group> \
                                           --recovery-plan <recovery-plan> \
                                           --recovery-job <recovery-job> \
                                           [--name <name>]


### PR DESCRIPTION
## What does this PR do?

Removes the stale `--subscription` argument from seven Azure Resilience Management get-command examples:

- goal template, assignment, and resource get
- recovery plan and recovery plan resource get
- recovery job and recovery job resource get

The corresponding option classes are tenant-scoped and no longer expose a subscription option. Subscription arguments remain documented for usage plan and usage plan enrollment commands, where they are still supported.

This is a documentation-only change; it does not change command behavior or tool metadata.

## GitHub issue number?

Fixes https://github.com/microsoft/mcp/issues/3072

## Validation

- reviewed all seven current option classes to confirm they do not expose `Subscription`
- verified usage plan and usage plan enrollment examples still include `--subscription`
- `git diff --check`
- `npx --yes cspell@^10.0.0 lint --config .vscode/cspell.json servers/Azure.Mcp.Server/docs/azmcp-commands.md`

The PowerShell metadata script was not run because no generated tool metadata or tool implementation changed.

## Pre-merge checklist

- [x] Read the contribution guidelines
- [x] PR title clearly describes the change
- [x] Commit history is clean with a single descriptive commit
- [x] Reviewed the source option classes for accuracy
- [x] Spelling check passes
- [x] Tests are not applicable to this documentation-only change
- [x] A changelog entry is not required for this documentation-only correction

