### PR TITLE
docs: add coding-agent to Azure best practices options

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3107,9 +3107,10 @@ azmcp get azure bestpractices get --resource <resource> --action <action>
 #   general        - General Azure best practices
 #   azurefunctions - Azure Functions specific best practices
 #   static-web-app - Azure Static Web Apps specific best practices
+#   coding-agent   - Coding Agent configuration best practices
 #
 # Action options:
-#   all             - Best practices for both code generation and deployment (only for static-web-app)
+#   all             - Best practices for both code generation and deployment (only for static-web-app and coding-agent)
 #   code-generation - Best practices for code generation (for general and azurefunctions)
 #   deployment      - Best practices for deployment (for general and azurefunctions)
 


### PR DESCRIPTION
## What does this PR do?

Updates the Azure MCP Best Practices command reference to:

- list `coding-agent` as a supported resource
- clarify that `coding-agent`, like `static-web-app`, supports only the `all` action

The issue also identified missing end-to-end prompt coverage. That gap has already been resolved by later work: `e2eTestPrompts.md` currently includes the prompt “configure azure mcp in coding agent for my repo”. This PR therefore changes only the command reference and avoids adding duplicate prompt coverage.

This is a documentation-only change; it does not change command behavior or tool metadata.

## GitHub issue number?

Fixes https://github.com/microsoft/mcp/issues/3044

## Validation

- confirmed `BestPracticesOptions.cs` lists `coding-agent` and restricts it to the `all` action
- confirmed the existing coding-agent end-to-end prompt remains present
- `git diff --check`
- `npx --yes cspell@^10.0.0 lint --config .vscode/cspell.json servers/Azure.Mcp.Server/docs/azmcp-commands.md`

The PowerShell metadata script was not run because no generated tool metadata or tool implementation changed.

## Pre-merge checklist

- [x] Read the contribution guidelines
- [x] PR title clearly describes the change
- [x] Commit history is clean with a single descriptive commit
- [x] Reviewed the source option descriptions and existing E2E prompt for accuracy
- [x] Spelling check passes
- [x] Tests are not applicable to this documentation-only change
- [x] A changelog entry is not required for this documentation-only correction

