### PR TITLE
Don't update ServerRuntimeConfiguration to include a namespace

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
@@ -71,6 +71,8 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
         Assert.NotNull(result);
         Assert.NotNull(result.Tools);
         Assert.NotEmpty(result.Tools);
+        // We're using a real command factory, so we expect a significant number of tools to be loaded
+        Assert.True(result.Tools.Count > 50, "Expected more than 50 tools to be loaded from the command factory");
 
         // Verify hierarchical structure
         foreach (var tool in result.Tools)

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
@@ -56,14 +56,6 @@ public static partial class ServiceCollectionExtensions
             Cloud = serverStartOptions.Cloud
         };
 
-        if (serverStartOptions.Mode == ModeTypes.NamespaceProxy)
-        {
-            if (serverRuntimeConfiguration.Namespace == null || serverRuntimeConfiguration.Namespace.Length == 0)
-            {
-                serverRuntimeConfiguration.Namespace = ["extension"];
-            }
-        }
-
         services.AddSingleton(serverRuntimeConfiguration);
         services.AddSingleton(Options.Create(serverRuntimeConfiguration));
 
@@ -143,9 +135,18 @@ public static partial class ServiceCollectionExtensions
 
                 // Always add utility commands (subscription, group) in namespace mode
                 // so they are available regardless of which namespaces are loaded
-                var utilityServerRuntimeConfiguration = new ServerRuntimeConfiguration
+                var additionalIncludedTools = new List<string>(DiscoveryConstants.UtilityNamespaces);
+
+                // Append extension commands when no other namespaces are specified.
+                // Extension commands aren't included in the NamespaceToolLoader.
+                if (serverStartOptions.Namespace == null || serverStartOptions.Namespace.Length == 0)
                 {
-                    Namespace = DiscoveryConstants.UtilityNamespaces,
+                    additionalIncludedTools.Add("extension");
+                }
+
+                var additionalToolsServerRuntimeConfiguration = new ServerRuntimeConfiguration
+                {
+                    Namespace = [.. additionalIncludedTools],
                     ReadOnly = serverRuntimeConfiguration.ReadOnly,
                     DangerouslyDisableElicitation = serverRuntimeConfiguration.DangerouslyDisableElicitation,
                     Tool = serverRuntimeConfiguration.Tool,
@@ -156,15 +157,9 @@ public static partial class ServiceCollectionExtensions
 
                 toolLoaders.Add(new CommandFactoryToolLoader(
                     sp.GetRequiredService<ICommandFactory>(),
-                    Options.Create(utilityServerRuntimeConfiguration),
+                    Options.Create(additionalToolsServerRuntimeConfiguration),
                     loggerFactory.CreateLogger<CommandFactoryToolLoader>()
                 ));
-
-                // Append extension commands when no other namespaces are specified.
-                if (utilityServerRuntimeConfiguration.Namespace?.SequenceEqual(["extension"]) == true)
-                {
-                    toolLoaders.Add(sp.GetRequiredService<CommandFactoryToolLoader>());
-                }
 
                 return new CompositeToolLoader(toolLoaders, loggerFactory.CreateLogger<CompositeToolLoader>());
             });


### PR DESCRIPTION
## What does this PR do?

Fixes a bug introduced in the migration away from dependency injecting `ServerStartOptions` and `ToolLoaderOptions` to using `ServerRuntimeConfiguration`. In `ServiceCollectionExtensions` logic was incorrectly mapped to update `ServerRuntimeConfiguration.Namespace` to `["extension"]` when `ServerStartOptions.Namespace` was null or empty. This behavior was incorrect and results in namespaces from being excluded when they shouldn't.

This is fixed by removing that modification to `ServerRuntimeConfiguration` and making the logic when binding `Namespace` mode clearer when adding in the additional utility namespaces to also include `extension` namespace if no namespaces were filter.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
