### PR TITLE
Prepare for Fabric MCP Server 1.4.0 release

### DIFF
--- a/servers/Fabric.Mcp.Server/CHANGELOG.md
+++ b/servers/Fabric.Mcp.Server/CHANGELOG.md
@@ -5,15 +5,25 @@ All notable changes to the Microsoft Fabric MCP Server will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.4.0 (Unreleased)
+## 1.4.0 (2026-08-27)
 
 ### Features Added
 
 ### Breaking Changes
 
+- Tool calls with unknown parameters are now explicitly rejected. [[#3282](https://github.com/microsoft/mcp/pull/3282)]
+- Renamed the `docs` toolset's `--workload-type` parameter to `--item-type`, aligning it with `core_create-item`'s existing `--item-type` and with official Fabric terminology. The accepted values are almost all Fabric item types (`notebook`, `lakehouse`, `dataPipeline`, `report`, ...); the description now also enumerates the four non-item API areas (`platform`, `admin`, `spark`, `realTimeIntelligence`). [[#3327](https://github.com/microsoft/mcp/pull/3327)]
+- Renamed the `docs_workloads` tool to `docs_list-item-types` and the `docs_workload-api-spec` tool to `docs_item-api-spec`. [[#3327](https://github.com/microsoft/mcp/pull/3327)]
+- The `docs_list-item-types` response property changed from `workloads` to `itemTypes`. [[#3327](https://github.com/microsoft/mcp/pull/3327)]
+- Renamed all `onelake` tools to use kebab-case, matching the `<namespace>_<tool-name>` convention already used by the `core`, `docs`, and `datafactory` namespaces. For example, `onelake_list_workspaces` is now `onelake_list-workspaces` and `onelake_create_shortcut_adls_gen2` is now `onelake_create-shortcut-adls-gen2`. The `onelake_confirm_delete` prompt is now `onelake_confirm-delete`. [[#3325](https://github.com/microsoft/mcp/pull/3325)]
+
 ### Bugs Fixed
 
+- Fixed `docs_item-api-spec` error messages referencing a non-existent `list_workloads` command; they now point to the `list-item-types` tool. [[#3327](https://github.com/microsoft/mcp/pull/3327)]
+
 ### Other Changes
+
+- Updated Fabric REST API specifications and item definition documentation. [[#3397](https://github.com/microsoft/mcp/pull/3397)]
 
 ## 1.3.0 (2026-08-10)
 

--- a/servers/Fabric.Mcp.Server/changelog-entries/1786656227003.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1786656227003.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Breaking Changes"
-    description: "Tool calls with unknown parameters are now explicitly rejected."

--- a/servers/Fabric.Mcp.Server/changelog-entries/1787000483954.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1787000483954.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Other Changes"
-    description: "Updated capture of ToolParameters for multi-step server modes."

--- a/servers/Fabric.Mcp.Server/changelog-entries/1787820133279.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1787820133279.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Other Changes"
-    description: "Updated Fabric REST API specifications and item definition documentation"

--- a/servers/Fabric.Mcp.Server/changelog-entries/docs-item-type-terminology.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/docs-item-type-terminology.yaml
@@ -1,9 +1,0 @@
-changes:
-  - section: "Breaking Changes"
-    description: "Renamed the `docs` toolset's `--workload-type` parameter to `--item-type`, aligning it with `core_create-item`'s existing `--item-type` and with official Fabric terminology. The accepted values are almost all Fabric item types (`notebook`, `lakehouse`, `dataPipeline`, `report`, ...); the description now also enumerates the four non-item API areas (`platform`, `admin`, `spark`, `realTimeIntelligence`)."
-  - section: "Breaking Changes"
-    description: "Renamed the `docs_workloads` tool to `docs_list-item-types` and the `docs_workload-api-spec` tool to `docs_item-api-spec`."
-  - section: "Breaking Changes"
-    description: "The `docs_list-item-types` response property changed from `workloads` to `itemTypes`."
-  - section: "Bugs Fixed"
-    description: "Fixed `docs_item-api-spec` error messages referencing a non-existent `list_workloads` command; they now point to the `list-item-types` tool."

--- a/servers/Fabric.Mcp.Server/changelog-entries/onelake-tool-name-kebab-case.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/onelake-tool-name-kebab-case.yaml
@@ -1,3 +1,0 @@
-changes:
-  - section: "Breaking Changes"
-    description: "Renamed all `onelake` tools to use kebab-case, matching the `<namespace>_<tool-name>` convention already used by the `core`, `docs`, and `datafactory` namespaces. For example, `onelake_list_workspaces` is now `onelake_list-workspaces` and `onelake_create_shortcut_adls_gen2` is now `onelake_create-shortcut-adls-gen2`. The `onelake_confirm_delete` prompt is now `onelake_confirm-delete`."

--- a/servers/Fabric.Mcp.Server/vscode/CHANGELOG.md
+++ b/servers/Fabric.Mcp.Server/vscode/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Release History
 
+## 1.4.0 (2026-08-27) (pre-release)
+
+### Changed
+
+- **Breaking:** Tool calls with unknown parameters are now explicitly rejected. [[#3282](https://github.com/microsoft/mcp/pull/3282)]
+- **Breaking:** Renamed the `docs` toolset's `--workload-type` parameter to `--item-type`, aligning it with `core_create-item`'s existing `--item-type` and with official Fabric terminology. The accepted values are almost all Fabric item types (`notebook`, `lakehouse`, `dataPipeline`, `report`, ...); the description now also enumerates the four non-item API areas (`platform`, `admin`, `spark`, `realTimeIntelligence`). [[#3327](https://github.com/microsoft/mcp/pull/3327)]
+- **Breaking:** Renamed the `docs_workloads` tool to `docs_list-item-types` and the `docs_workload-api-spec` tool to `docs_item-api-spec`. [[#3327](https://github.com/microsoft/mcp/pull/3327)]
+- **Breaking:** The `docs_list-item-types` response property changed from `workloads` to `itemTypes`. [[#3327](https://github.com/microsoft/mcp/pull/3327)]
+- **Breaking:** Renamed all `onelake` tools to use kebab-case, matching the `<namespace>_<tool-name>` convention already used by the `core`, `docs`, and `datafactory` namespaces. For example, `onelake_list_workspaces` is now `onelake_list-workspaces` and `onelake_create_shortcut_adls_gen2` is now `onelake_create-shortcut-adls-gen2`. The `onelake_confirm_delete` prompt is now `onelake_confirm-delete`. [[#3325](https://github.com/microsoft/mcp/pull/3325)]
+- Updated Fabric REST API specifications and item definition documentation. [[#3397](https://github.com/microsoft/mcp/pull/3397)]
+
+### Fixed
+
+- Fixed `docs_item-api-spec` error messages referencing a non-existent `list_workloads` command; they now point to the `list-item-types` tool. [[#3327](https://github.com/microsoft/mcp/pull/3327)]
+
 ## 1.3.0 (2026-08-10) (pre-release)
 
 ### Changed


### PR DESCRIPTION
Compile user-facing changelog entries into the 1.4.0 section, set the release date, and sync the VS Code extension changelog. The internal-only telemetry entry (ToolParameters capture in multi-step server modes, #3296) was consumed but omitted from the changelog per Fabric's user-facing documentation policy.