### PR TITLE
[Part 2] Remove RetryPolicyOptions from tools

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/remove-retry-policy-options-part2.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/remove-retry-policy-options-part2.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: Breaking Changes
+    description: Removed custom retry policy options from Authorization, Azure Backup, and Azure Migrate tools.

--- a/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
@@ -40,7 +40,6 @@ public sealed class RoleAssignmentListCommand(ILogger<RoleAssignmentListCommand>
                 options.Subscription!,
                 options.Scope,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(assignments?.Results ?? [], assignments?.AreResultsTruncated ?? false), AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);

--- a/tools/Azure.Mcp.Tools.Authorization/src/Options/RoleAssignmentListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Options/RoleAssignmentListOptions.cs
@@ -16,7 +16,4 @@ public sealed class RoleAssignmentListOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Authorization/src/Services/AuthorizationService.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Services/AuthorizationService.cs
@@ -6,7 +6,6 @@ using Azure.Core;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.Authorization.Models;
 using Azure.Mcp.Tools.Authorization.Services.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Authorization.Services;
 
@@ -17,7 +16,6 @@ public class AuthorizationService(IAzureService azureService)
         string subscription,
         string scope,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(scope), scope));
@@ -27,7 +25,7 @@ public class AuthorizationService(IAzureService azureService)
             "Microsoft.Authorization/roleAssignments",
             null, // all resource groups
             subscription,
-            retryPolicy,
+            null,
             ConvertToRoleAssignmentModel,
             "authorizationresources",
             additionalFilter: $"id contains '{EscapeKqlString(scope)}'",

--- a/tools/Azure.Mcp.Tools.Authorization/src/Services/IAuthorizationService.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Services/IAuthorizationService.cs
@@ -3,7 +3,6 @@
 
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.Authorization.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Authorization.Services;
 
@@ -15,13 +14,11 @@ public interface IAuthorizationService
     /// <param name="subscription">The subscription ID to query.</param>
     /// <param name="scope">The scope that the resource will apply against.</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations.</param>
-    /// <param name="retryPolicy">Optional retry policy for the operation.</param>
     /// <param name="cancellationToken">Optional cancellation token for the operation.</param>
     /// <returns>List of role assignments in the format "Role Definition ID: Principal ID"</returns>
     Task<ResourceQueryResults<RoleAssignment>> ListRoleAssignmentsAsync(
         string subscription,
         string scope,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/RoleAssignmentListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/RoleAssignmentListCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Authorization.Commands;
 using Azure.Mcp.Tools.Authorization.Models;
 using Azure.Mcp.Tools.Authorization.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -53,7 +52,6 @@ public class RoleAssignmentListCommandTests : SubscriptionCommandUnitTestsBase<R
             Arg.Is(subscriptionId),
             Arg.Is(scope),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedRoleAssignments);
 
@@ -72,7 +70,7 @@ public class RoleAssignmentListCommandTests : SubscriptionCommandUnitTestsBase<R
         // Arrange
         var subscriptionId = "00000000-0000-0000-0000-000000000001";
         var scope = $"/subscriptions/{subscriptionId}/resourceGroups/rg1";
-        Service.ListRoleAssignmentsAsync(subscriptionId, scope, null, null, TestContext.Current.CancellationToken)
+        Service.ListRoleAssignmentsAsync(subscriptionId, scope, null, TestContext.Current.CancellationToken)
             .Returns(new ResourceQueryResults<RoleAssignment>([], false));
 
         // Act
@@ -92,7 +90,7 @@ public class RoleAssignmentListCommandTests : SubscriptionCommandUnitTestsBase<R
         var subscriptionId = "00000000-0000-0000-0000-000000000001";
         var scope = $"/subscriptions/{subscriptionId}/resourceGroups/rg1";
 
-        Service.ListRoleAssignmentsAsync(subscriptionId, scope, null, null, TestContext.Current.CancellationToken)
+        Service.ListRoleAssignmentsAsync(subscriptionId, scope, null, TestContext.Current.CancellationToken)
             .ThrowsAsync(new Exception(expectedError));
 
         // Act

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Backup/BackupStatusCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Backup/BackupStatusCommand.cs
@@ -47,7 +47,6 @@ public sealed class BackupStatusCommand(ILogger<BackupStatusCommand> logger, IAz
                 options.Subscription!,
                 options.Location,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/DisasterRecovery/DisasterRecoveryEnableCrrCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/DisasterRecovery/DisasterRecoveryEnableCrrCommand.cs
@@ -42,7 +42,6 @@ public sealed class DisasterRecoveryEnableCrrCommand(ILogger<DisasterRecoveryEna
                 options.Subscription!,
                 options.VaultType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceFindUnprotectedCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceFindUnprotectedCommand.cs
@@ -67,7 +67,6 @@ public sealed class GovernanceFindUnprotectedCommand(ILogger<GovernanceFindUnpro
                 options.ResourceGroup,
                 options.TagFilter,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceImmutabilityCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceImmutabilityCommand.cs
@@ -59,7 +59,6 @@ public sealed class GovernanceImmutabilityCommand(ILogger<GovernanceImmutability
                 options.ImmutabilityState!,
                 options.VaultType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceSoftDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Governance/GovernanceSoftDeleteCommand.cs
@@ -67,7 +67,6 @@ public sealed class GovernanceSoftDeleteCommand(ILogger<GovernanceSoftDeleteComm
                 options.VaultType,
                 options.SoftDeleteRetentionDays,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Job/JobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Job/JobGetCommand.cs
@@ -54,7 +54,6 @@ public sealed class JobGetCommand(ILogger<JobGetCommand> logger, IAzureBackupSer
                     options.Job,
                     options.VaultType,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(
@@ -69,7 +68,6 @@ public sealed class JobGetCommand(ILogger<JobGetCommand> logger, IAzureBackupSer
                     options.Subscription!,
                     options.VaultType,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyCreateCommand.cs
@@ -101,7 +101,6 @@ public sealed class PolicyCreateCommand(ILogger<PolicyCreateCommand> logger, IAz
                 options.Subscription!,
                 options.VaultType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyGetCommand.cs
@@ -54,7 +54,6 @@ public sealed class PolicyGetCommand(ILogger<PolicyGetCommand> logger, IAzureBac
                     options.Policy,
                     options.VaultType,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(
@@ -69,7 +68,6 @@ public sealed class PolicyGetCommand(ILogger<PolicyGetCommand> logger, IAzureBac
                     options.Subscription!,
                     options.VaultType,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Policy/PolicyUpdateCommand.cs
@@ -45,7 +45,6 @@ public sealed class PolicyUpdateCommand(ILogger<PolicyUpdateCommand> logger, IAz
                 options.ScheduleTime,
                 options.DailyRetentionDays,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectableItem/ProtectableItemListCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectableItem/ProtectableItemListCommand.cs
@@ -66,7 +66,6 @@ public sealed class ProtectableItemListCommand(ILogger<ProtectableItemListComman
                 options.Container,
                 options.VaultType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemGetCommand.cs
@@ -57,7 +57,6 @@ public sealed class ProtectedItemGetCommand(ILogger<ProtectedItemGetCommand> log
                     options.VaultType,
                     options.Container,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(
@@ -72,7 +71,6 @@ public sealed class ProtectedItemGetCommand(ILogger<ProtectedItemGetCommand> log
                     options.Subscription!,
                     options.VaultType,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemProtectCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemProtectCommand.cs
@@ -110,7 +110,6 @@ public sealed class ProtectedItemProtectCommand(ILogger<ProtectedItemProtectComm
                 options.AksIncludeClusterScopeResources ? "true" : null,
                 options.AksSnapshotResourceGroup,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemUndeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ProtectedItem/ProtectedItemUndeleteCommand.cs
@@ -51,7 +51,6 @@ public sealed class ProtectedItemUndeleteCommand(ILogger<ProtectedItemUndeleteCo
                 options.VaultType,
                 options.Container,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/RecoveryPoint/RecoveryPointGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/RecoveryPoint/RecoveryPointGetCommand.cs
@@ -56,7 +56,6 @@ public sealed class RecoveryPointGetCommand(ILogger<RecoveryPointGetCommand> log
                     options.VaultType,
                     options.Container,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(
@@ -73,7 +72,6 @@ public sealed class RecoveryPointGetCommand(ILogger<RecoveryPointGetCommand> log
                     options.VaultType,
                     options.Container,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ResourceGuard/ResourceGuardCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ResourceGuard/ResourceGuardCreateCommand.cs
@@ -55,7 +55,6 @@ public sealed class ResourceGuardCreateCommand(ILogger<ResourceGuardCreateComman
                 excluded,
                 tags,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ResourceGuard/ResourceGuardDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ResourceGuard/ResourceGuardDeleteCommand.cs
@@ -47,7 +47,6 @@ public sealed class ResourceGuardDeleteCommand(ILogger<ResourceGuardDeleteComman
                 options.ResourceGroup,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ResourceGuard/ResourceGuardGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/ResourceGuard/ResourceGuardGetCommand.cs
@@ -61,7 +61,6 @@ public sealed class ResourceGuardGetCommand(ILogger<ResourceGuardGetCommand> log
                     options.ResourceGroup!,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
                 guards = [guard];
             }
@@ -71,7 +70,6 @@ public sealed class ResourceGuardGetCommand(ILogger<ResourceGuardGetCommand> log
                     options.Subscription!,
                     options.ResourceGroup,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityConfigureEncryptionCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityConfigureEncryptionCommand.cs
@@ -99,7 +99,6 @@ public sealed class SecurityConfigureEncryptionCommand(ILogger<SecurityConfigure
                 options.UserAssignedIdentityId,
                 options.VaultType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityDisableMuaCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityDisableMuaCommand.cs
@@ -48,7 +48,6 @@ public sealed class SecurityDisableMuaCommand(ILogger<SecurityDisableMuaCommand>
                 options.Subscription!,
                 options.VaultType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityEnableMuaCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Security/SecurityEnableMuaCommand.cs
@@ -65,7 +65,6 @@ public sealed class SecurityEnableMuaCommand(ILogger<SecurityEnableMuaCommand> l
                 options.ResourceGuardId!,
                 options.VaultType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/PrivateEndpoint/PrivateEndpointApproveRejectCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/PrivateEndpoint/PrivateEndpointApproveRejectCommand.cs
@@ -55,7 +55,6 @@ public sealed class PrivateEndpointApproveRejectCommand(
                 options.Description,
                 options.VaultType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/PrivateEndpoint/PrivateEndpointCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/PrivateEndpoint/PrivateEndpointCreateCommand.cs
@@ -58,7 +58,6 @@ public sealed class PrivateEndpointCreateCommand(
                 options.AutoApprove ?? false,
                 options.VaultType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/PrivateEndpoint/PrivateEndpointDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/PrivateEndpoint/PrivateEndpointDeleteCommand.cs
@@ -51,7 +51,6 @@ public sealed class PrivateEndpointDeleteCommand(
                 options.PrivateEndpointName,
                 options.VaultType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/PrivateEndpoint/PrivateEndpointGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/PrivateEndpoint/PrivateEndpointGetCommand.cs
@@ -48,7 +48,7 @@ public sealed class PrivateEndpointGetCommand(
             {
                 var list = await _azureBackupService.ListPrivateEndpointsAsync(
                     options.Vault, options.ResourceGroup, options.Subscription!,
-                    options.VaultType, options.Tenant, options.RetryPolicy, cancellationToken);
+                    options.VaultType, options.Tenant, cancellationToken);
                 context.Response.Results = ResponseResult.Create(
                     new(Connections: list),
                     AzureBackupJsonContext.Default.PrivateEndpointGetCommandResult);
@@ -58,7 +58,7 @@ public sealed class PrivateEndpointGetCommand(
                 var single = await _azureBackupService.GetPrivateEndpointAsync(
                     options.Vault, options.ResourceGroup, options.Subscription!,
                     options.PrivateEndpointName!,
-                    options.VaultType, options.Tenant, options.RetryPolicy, cancellationToken);
+                    options.VaultType, options.Tenant, cancellationToken);
                 context.Response.Results = ResponseResult.Create(
                     new(Connections: [single]),
                     AzureBackupJsonContext.Default.PrivateEndpointGetCommandResult);

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultCreateCommand.cs
@@ -72,7 +72,6 @@ public sealed class VaultCreateCommand(ILogger<VaultCreateCommand> logger, IAzur
                 options.Sku,
                 options.StorageType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultGetCommand.cs
@@ -91,7 +91,6 @@ public sealed class VaultGetCommand(ILogger<VaultGetCommand> logger, IAzureBacku
                     options.Subscription!,
                     options.VaultType,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken,
                     expand);
 
@@ -106,7 +105,6 @@ public sealed class VaultGetCommand(ILogger<VaultGetCommand> logger, IAzureBacku
                     options.ResourceGroup,
                     options.VaultType,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken,
                     expand);
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Commands/Vault/VaultUpdateCommand.cs
@@ -84,7 +84,6 @@ public sealed class VaultUpdateCommand(ILogger<VaultUpdateCommand> logger, IAzur
                 options.IdentityType,
                 options.Tags,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Options/Backup/BackupStatusOptions.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Options/Backup/BackupStatusOptions.cs
@@ -19,7 +19,4 @@ public sealed class BackupStatusOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Options/BaseAzureBackupOptions.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Options/BaseAzureBackupOptions.cs
@@ -22,7 +22,4 @@ public class BaseAzureBackupOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.ResourceGroup)]
     public required string ResourceGroup { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Options/Governance/GovernanceFindUnprotectedOptions.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Options/Governance/GovernanceFindUnprotectedOptions.cs
@@ -22,7 +22,4 @@ public sealed class GovernanceFindUnprotectedOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.ResourceGroup)]
     public string? ResourceGroup { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Options/ResourceGuard/ResourceGuardCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Options/ResourceGuard/ResourceGuardCreateOptions.cs
@@ -28,7 +28,4 @@ public sealed class ResourceGuardCreateOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.ResourceGroup)]
     public required string ResourceGroup { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Options/ResourceGuard/ResourceGuardDeleteOptions.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Options/ResourceGuard/ResourceGuardDeleteOptions.cs
@@ -19,7 +19,4 @@ public sealed class ResourceGuardDeleteOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.ResourceGroup)]
     public required string ResourceGroup { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Options/ResourceGuard/ResourceGuardGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Options/ResourceGuard/ResourceGuardGetOptions.cs
@@ -19,7 +19,4 @@ public sealed class ResourceGuardGetOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.ResourceGroup)]
     public string? ResourceGroup { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Options/Vault/VaultGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Options/Vault/VaultGetOptions.cs
@@ -25,7 +25,4 @@ public sealed class VaultGetOptions : ISubscriptionOption
 
     [Option(Description = AzureBackupOptionDefinitions.VaultExpand)]
     public string? Expand { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs
@@ -12,7 +12,6 @@ using Azure.ResourceManager.RecoveryServicesBackup.Models;
 using Azure.ResourceManager.Resources;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Helpers;
-using Microsoft.Mcp.Core.Options;
 
 using SdkBackupStatusResult = Azure.ResourceManager.RecoveryServicesBackup.Models.BackupStatusResult;
 
@@ -29,14 +28,14 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
     /// This preserves the documented contract that <c>--subscription</c> accepts both IDs and names.
     /// </summary>
     private async Task<string> ResolveSubscriptionIdAsync(
-        string subscription, string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string subscription, string? tenant, CancellationToken cancellationToken)
     {
         if (Guid.TryParse(subscription, out _))
         {
             return subscription;
         }
 
-        var resource = await AzureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var resource = await AzureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         return resource.Data.SubscriptionId;
     }
 
@@ -98,44 +97,44 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
     public async Task<VaultCreateResult> CreateVaultAsync(
         string vaultName, string resourceGroup, string subscription, string vaultType,
         string location, string? sku, string? storageType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         // Perform validations that don't require a network call first so invalid input
         // fails fast without going through ResolveSubscriptionIdAsync (which may call ARM).
         VaultTypeResolver.ValidateVaultType(vaultType);
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
 
         return VaultTypeResolver.IsRsv(vaultType)
-            ? await rsvOps.CreateVaultAsync(vaultName, resourceGroup, subscription, location, sku, storageType, tenant, retryPolicy, cancellationToken)
-            : await dppOps.CreateVaultAsync(vaultName, resourceGroup, subscription, location, sku, storageType, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.CreateVaultAsync(vaultName, resourceGroup, subscription, location, sku, storageType, tenant, cancellationToken)
+            : await dppOps.CreateVaultAsync(vaultName, resourceGroup, subscription, location, sku, storageType, tenant, cancellationToken);
     }
 
     public async Task<BackupVaultInfo> GetVaultAsync(
         string vaultName, string resourceGroup, string subscription,
         string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken,
+        CancellationToken cancellationToken,
         VaultExpand expand = VaultExpand.None)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
         if (VaultTypeResolver.IsVaultTypeSpecified(vaultType))
         {
             return VaultTypeResolver.IsRsv(vaultType)
-                ? await rsvOps.GetVaultAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken, expand)
-                : await dppOps.GetVaultAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken, expand);
+                ? await rsvOps.GetVaultAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken, expand)
+                : await dppOps.GetVaultAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken, expand);
         }
 
         return await AutoDetectAndExecuteAsync(
-            () => rsvOps.GetVaultAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken, expand),
-            () => dppOps.GetVaultAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken, expand),
+            () => rsvOps.GetVaultAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken, expand),
+            () => dppOps.GetVaultAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken, expand),
             vaultName);
     }
 
     public async Task<List<BackupVaultInfo>> ListVaultsAsync(
         string subscription, string? resourceGroup, string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken,
+        CancellationToken cancellationToken,
         VaultExpand expand = VaultExpand.None)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
         List<BackupVaultInfo> FilterByResourceGroup(List<BackupVaultInfo> vaults) =>
             string.IsNullOrEmpty(resourceGroup)
                 ? vaults
@@ -143,16 +142,16 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
 
         if (VaultTypeResolver.IsRsv(vaultType))
         {
-            return FilterByResourceGroup(await rsvOps.ListVaultsAsync(subscription, tenant, retryPolicy, cancellationToken, expand));
+            return FilterByResourceGroup(await rsvOps.ListVaultsAsync(subscription, tenant, cancellationToken, expand));
         }
 
         if (VaultTypeResolver.IsDpp(vaultType))
         {
-            return FilterByResourceGroup(await dppOps.ListVaultsAsync(subscription, tenant, retryPolicy, cancellationToken, expand));
+            return FilterByResourceGroup(await dppOps.ListVaultsAsync(subscription, tenant, cancellationToken, expand));
         }
 
-        var rsvTask = rsvOps.ListVaultsAsync(subscription, tenant, retryPolicy, cancellationToken, expand);
-        var dppTask = dppOps.ListVaultsAsync(subscription, tenant, retryPolicy, cancellationToken, expand);
+        var rsvTask = rsvOps.ListVaultsAsync(subscription, tenant, cancellationToken, expand);
+        var dppTask = dppOps.ListVaultsAsync(subscription, tenant, cancellationToken, expand);
 
         try
         {
@@ -203,132 +202,132 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
         string? aksLabelSelectors, string? aksIncludeClusterScopeResources,
         string? aksSnapshotResourceGroup,
         string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
 
         return VaultTypeResolver.IsRsv(resolvedType)
-            ? await rsvOps.ProtectItemAsync(vaultName, resourceGroup, subscription, datasourceId, policyName, containerName, datasourceType, tenant, retryPolicy, cancellationToken)
-            : await dppOps.ProtectItemAsync(vaultName, resourceGroup, subscription, datasourceId, policyName, datasourceType, aksIncludedNamespaces, aksExcludedNamespaces, aksLabelSelectors, aksIncludeClusterScopeResources, aksSnapshotResourceGroup, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.ProtectItemAsync(vaultName, resourceGroup, subscription, datasourceId, policyName, containerName, datasourceType, tenant, cancellationToken)
+            : await dppOps.ProtectItemAsync(vaultName, resourceGroup, subscription, datasourceId, policyName, datasourceType, aksIncludedNamespaces, aksExcludedNamespaces, aksLabelSelectors, aksIncludeClusterScopeResources, aksSnapshotResourceGroup, tenant, cancellationToken);
     }
 
     public async Task<ProtectedItemInfo> GetProtectedItemAsync(
         string vaultName, string resourceGroup, string subscription,
         string protectedItemName, string? vaultType, string? containerName,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
 
         return VaultTypeResolver.IsRsv(resolvedType)
-            ? await rsvOps.GetProtectedItemAsync(vaultName, resourceGroup, subscription, protectedItemName, containerName, tenant, retryPolicy, cancellationToken)
-            : await dppOps.GetProtectedItemAsync(vaultName, resourceGroup, subscription, protectedItemName, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.GetProtectedItemAsync(vaultName, resourceGroup, subscription, protectedItemName, containerName, tenant, cancellationToken)
+            : await dppOps.GetProtectedItemAsync(vaultName, resourceGroup, subscription, protectedItemName, tenant, cancellationToken);
     }
 
     public async Task<List<ProtectedItemInfo>> ListProtectedItemsAsync(
         string vaultName, string resourceGroup, string subscription,
         string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
 
         return VaultTypeResolver.IsRsv(resolvedType)
-            ? await rsvOps.ListProtectedItemsAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken)
-            : await dppOps.ListProtectedItemsAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.ListProtectedItemsAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken)
+            : await dppOps.ListProtectedItemsAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken);
     }
 
     public async Task<OperationResult> UndeleteProtectedItemAsync(
         string vaultName, string resourceGroup, string subscription,
         string datasourceId, string? vaultType, string? containerName,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
 
         return VaultTypeResolver.IsRsv(resolvedType)
-            ? await rsvOps.UndeleteProtectedItemAsync(vaultName, resourceGroup, subscription, datasourceId, containerName, tenant, retryPolicy, cancellationToken)
-            : await dppOps.UndeleteProtectedItemAsync(vaultName, resourceGroup, subscription, datasourceId, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.UndeleteProtectedItemAsync(vaultName, resourceGroup, subscription, datasourceId, containerName, tenant, cancellationToken)
+            : await dppOps.UndeleteProtectedItemAsync(vaultName, resourceGroup, subscription, datasourceId, tenant, cancellationToken);
     }
 
     public async Task<BackupPolicyInfo> GetPolicyAsync(
         string vaultName, string resourceGroup, string subscription,
         string policyName, string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
 
         return VaultTypeResolver.IsRsv(resolvedType)
-            ? await rsvOps.GetPolicyAsync(vaultName, resourceGroup, subscription, policyName, tenant, retryPolicy, cancellationToken)
-            : await dppOps.GetPolicyAsync(vaultName, resourceGroup, subscription, policyName, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.GetPolicyAsync(vaultName, resourceGroup, subscription, policyName, tenant, cancellationToken)
+            : await dppOps.GetPolicyAsync(vaultName, resourceGroup, subscription, policyName, tenant, cancellationToken);
     }
 
     public async Task<List<BackupPolicyInfo>> ListPoliciesAsync(
         string vaultName, string resourceGroup, string subscription,
         string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
 
         return VaultTypeResolver.IsRsv(resolvedType)
-            ? await rsvOps.ListPoliciesAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken)
-            : await dppOps.ListPoliciesAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.ListPoliciesAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken)
+            : await dppOps.ListPoliciesAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken);
     }
 
     public async Task<BackupJobInfo> GetJobAsync(
         string vaultName, string resourceGroup, string subscription,
         string jobId, string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
 
         return VaultTypeResolver.IsRsv(resolvedType)
-            ? await rsvOps.GetJobAsync(vaultName, resourceGroup, subscription, jobId, tenant, retryPolicy, cancellationToken)
-            : await dppOps.GetJobAsync(vaultName, resourceGroup, subscription, jobId, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.GetJobAsync(vaultName, resourceGroup, subscription, jobId, tenant, cancellationToken)
+            : await dppOps.GetJobAsync(vaultName, resourceGroup, subscription, jobId, tenant, cancellationToken);
     }
 
     public async Task<List<BackupJobInfo>> ListJobsAsync(
         string vaultName, string resourceGroup, string subscription,
         string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
 
         return VaultTypeResolver.IsRsv(resolvedType)
-            ? await rsvOps.ListJobsAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken)
-            : await dppOps.ListJobsAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.ListJobsAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken)
+            : await dppOps.ListJobsAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken);
     }
 
     public async Task<RecoveryPointInfo> GetRecoveryPointAsync(
         string vaultName, string resourceGroup, string subscription,
         string protectedItemName, string recoveryPointId, string? vaultType,
         string? containerName, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
 
         return VaultTypeResolver.IsRsv(resolvedType)
-            ? await rsvOps.GetRecoveryPointAsync(vaultName, resourceGroup, subscription, protectedItemName, recoveryPointId, containerName, tenant, retryPolicy, cancellationToken)
-            : await dppOps.GetRecoveryPointAsync(vaultName, resourceGroup, subscription, protectedItemName, recoveryPointId, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.GetRecoveryPointAsync(vaultName, resourceGroup, subscription, protectedItemName, recoveryPointId, containerName, tenant, cancellationToken)
+            : await dppOps.GetRecoveryPointAsync(vaultName, resourceGroup, subscription, protectedItemName, recoveryPointId, tenant, cancellationToken);
     }
 
     public async Task<List<RecoveryPointInfo>> ListRecoveryPointsAsync(
         string vaultName, string resourceGroup, string subscription,
         string protectedItemName, string? vaultType, string? containerName,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolvedType = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
 
         return VaultTypeResolver.IsRsv(resolvedType)
-            ? await rsvOps.ListRecoveryPointsAsync(vaultName, resourceGroup, subscription, protectedItemName, containerName, tenant, retryPolicy, cancellationToken)
-            : await dppOps.ListRecoveryPointsAsync(vaultName, resourceGroup, subscription, protectedItemName, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.ListRecoveryPointsAsync(vaultName, resourceGroup, subscription, protectedItemName, containerName, tenant, cancellationToken)
+            : await dppOps.ListRecoveryPointsAsync(vaultName, resourceGroup, subscription, protectedItemName, tenant, cancellationToken);
     }
 
 
@@ -337,50 +336,50 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
         string? vaultType, string? redundancy, string? softDelete,
         string? softDeleteRetentionDays, string? immutabilityState,
         string? identityType, string? tags, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
         return VaultTypeResolver.IsRsv(resolved)
-            ? await rsvOps.UpdateVaultAsync(vaultName, resourceGroup, subscription, redundancy, softDelete, softDeleteRetentionDays, immutabilityState, identityType, tags, tenant, retryPolicy, cancellationToken)
-            : await dppOps.UpdateVaultAsync(vaultName, resourceGroup, subscription, redundancy, softDelete, softDeleteRetentionDays, immutabilityState, identityType, tags, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.UpdateVaultAsync(vaultName, resourceGroup, subscription, redundancy, softDelete, softDeleteRetentionDays, immutabilityState, identityType, tags, tenant, cancellationToken)
+            : await dppOps.UpdateVaultAsync(vaultName, resourceGroup, subscription, redundancy, softDelete, softDeleteRetentionDays, immutabilityState, identityType, tags, tenant, cancellationToken);
     }
 
     public async Task<OperationResult> CreatePolicyAsync(
         Policy.PolicyCreateRequest request,
         string vaultName, string resourceGroup, string subscription,
         string? vaultType,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
         return VaultTypeResolver.IsRsv(resolved)
-            ? await rsvOps.CreatePolicyAsync(request, vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken)
-            : await dppOps.CreatePolicyAsync(request, vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.CreatePolicyAsync(request, vaultName, resourceGroup, subscription, tenant, cancellationToken)
+            : await dppOps.CreatePolicyAsync(request, vaultName, resourceGroup, subscription, tenant, cancellationToken);
     }
 
     public async Task<OperationResult> UpdatePolicyAsync(
         string vaultName, string resourceGroup, string subscription,
         string policyName, string? vaultType,
         string? scheduleTime, string? dailyRetentionDays,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
         if (!VaultTypeResolver.IsRsv(resolved))
         {
             throw new ArgumentException("Update is only supported for RSV (Recovery Services vault) policies. DPP policies do not support update.");
         }
 
-        return await rsvOps.UpdatePolicyAsync(vaultName, resourceGroup, subscription, policyName, scheduleTime, dailyRetentionDays, tenant, retryPolicy, cancellationToken);
+        return await rsvOps.UpdatePolicyAsync(vaultName, resourceGroup, subscription, policyName, scheduleTime, dailyRetentionDays, tenant, cancellationToken);
     }
 
     public async Task<List<ProtectableItemInfo>> ListProtectableItemsAsync(
         string vaultName, string resourceGroup, string subscription,
         string? workloadType, string? containerName, string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
         if (VaultTypeResolver.IsDpp(vaultType))
         {
             throw new ArgumentException("Protectable item discovery is only supported for Recovery Services (RSV) vaults. DPP datasources are protected by their ARM resource ID directly.");
@@ -389,7 +388,7 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
         // Auto-detect vault type when not explicitly specified to avoid routing DPP vaults to RSV
         if (!VaultTypeResolver.IsVaultTypeSpecified(vaultType))
         {
-            var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+            var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
             if (VaultTypeResolver.IsDpp(resolved))
             {
                 throw new ArgumentException(
@@ -398,14 +397,14 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
             }
         }
 
-        return await rsvOps.ListProtectableItemsAsync(vaultName, resourceGroup, subscription, workloadType, containerName, tenant, retryPolicy, cancellationToken);
+        return await rsvOps.ListProtectableItemsAsync(vaultName, resourceGroup, subscription, workloadType, containerName, tenant, cancellationToken);
     }
 
     public async Task<Models.BackupStatusResult> GetBackupStatusAsync(
         string datasourceId, string subscription, string location,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
         ResourceIdentifier resourceId;
         try
         {
@@ -435,7 +434,7 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
         if (datasourceType != null)
         {
             // RSV-supported resource types use the BackupStatus API
-            var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+            var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
             var subId = SubscriptionResource.CreateResourceIdentifier(subscription);
             var subResource = armClient.GetSubscriptionResource(subId);
 
@@ -459,7 +458,7 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
         }
 
         // DPP-only resource types (disks, blobs, AKS, etc.) - search across DPP vaults
-        return await GetDppBackupStatusAsync(datasourceId, subscription, tenant, retryPolicy, cancellationToken);
+        return await GetDppBackupStatusAsync(datasourceId, subscription, tenant, cancellationToken);
     }
 
     /// <summary>
@@ -468,15 +467,15 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
     /// </summary>
     private async Task<Models.BackupStatusResult> GetDppBackupStatusAsync(
         string datasourceId, string subscription, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        var dppVaults = await dppOps.ListVaultsAsync(subscription, tenant, retryPolicy, cancellationToken);
+        var dppVaults = await dppOps.ListVaultsAsync(subscription, tenant, cancellationToken);
 
         foreach (var vault in dppVaults.Where(v => v.Name is not null && v.ResourceGroup is not null))
         {
             try
             {
-                var items = await dppOps.ListProtectedItemsAsync(vault.Name!, vault.ResourceGroup!, subscription, tenant, retryPolicy, cancellationToken);
+                var items = await dppOps.ListProtectedItemsAsync(vault.Name!, vault.ResourceGroup!, subscription, tenant, cancellationToken);
                 var match = items.FirstOrDefault(i =>
                     string.Equals(i.DatasourceId, datasourceId, StringComparison.OrdinalIgnoreCase));
                 if (match != null)
@@ -529,12 +528,12 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
     public async Task<List<UnprotectedResourceInfo>> FindUnprotectedResourcesAsync(
         string subscription, string? resourceTypeFilter, string? resourceGroup,
         string? tagFilter, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
         // Step 1: List all vaults (RSV + DPP) in the subscription (parallelized)
-        var rsvVaultsTask = rsvOps.ListVaultsAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var dppVaultsTask = dppOps.ListVaultsAsync(subscription, tenant, retryPolicy, cancellationToken);
+        var rsvVaultsTask = rsvOps.ListVaultsAsync(subscription, tenant, cancellationToken);
+        var dppVaultsTask = dppOps.ListVaultsAsync(subscription, tenant, cancellationToken);
 
         try
         {
@@ -580,7 +579,7 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
                 try
                 {
                     return await rsvOps.ListProtectedItemsAsync(
-                        v.Name!, v.ResourceGroup!, subscription, tenant, retryPolicy, cancellationToken);
+                        v.Name!, v.ResourceGroup!, subscription, tenant, cancellationToken);
                 }
                 catch (OperationCanceledException)
                 {
@@ -612,7 +611,7 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
                 try
                 {
                     return await dppOps.ListProtectedItemsAsync(
-                        v.Name!, v.ResourceGroup!, subscription, tenant, retryPolicy, cancellationToken);
+                        v.Name!, v.ResourceGroup!, subscription, tenant, cancellationToken);
                 }
                 catch (OperationCanceledException)
                 {
@@ -638,7 +637,7 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
         }
 
         // Step 3: List all resources of protectable types in the subscription
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subId = SubscriptionResource.CreateResourceIdentifier(subscription);
         var subResource = armClient.GetSubscriptionResource(subId);
 
@@ -722,7 +721,7 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
                 try
                 {
                     return (Vault: v, Items: await rsvOps.ListDiscoveredProtectableItemsAsync(
-                        v.Name!, v.ResourceGroup!, subscription, tenant, retryPolicy, cancellationToken));
+                        v.Name!, v.ResourceGroup!, subscription, tenant, cancellationToken));
                 }
                 catch (OperationCanceledException)
                 {
@@ -785,16 +784,16 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
     public async Task<OperationResult> ConfigureImmutabilityAsync(
         string vaultName, string resourceGroup, string subscription,
         string immutabilityState, string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
         ArgumentException.ThrowIfNullOrWhiteSpace(immutabilityState, nameof(immutabilityState));
 
         var normalizedState = NormalizeImmutabilityState(immutabilityState);
-        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
         return VaultTypeResolver.IsRsv(resolved)
-            ? await rsvOps.ConfigureImmutabilityAsync(vaultName, resourceGroup, subscription, normalizedState, tenant, retryPolicy, cancellationToken)
-            : await dppOps.ConfigureImmutabilityAsync(vaultName, resourceGroup, subscription, normalizedState, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.ConfigureImmutabilityAsync(vaultName, resourceGroup, subscription, normalizedState, tenant, cancellationToken)
+            : await dppOps.ConfigureImmutabilityAsync(vaultName, resourceGroup, subscription, normalizedState, tenant, cancellationToken);
     }
 
     /// <summary>
@@ -817,51 +816,51 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
     public async Task<OperationResult> ConfigureSoftDeleteAsync(
         string vaultName, string resourceGroup, string subscription,
         string softDeleteState, string? vaultType, string? softDeleteRetentionDays,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
         return VaultTypeResolver.IsRsv(resolved)
-            ? await rsvOps.ConfigureSoftDeleteAsync(vaultName, resourceGroup, subscription, softDeleteState, softDeleteRetentionDays, tenant, retryPolicy, cancellationToken)
-            : await dppOps.ConfigureSoftDeleteAsync(vaultName, resourceGroup, subscription, softDeleteState, softDeleteRetentionDays, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.ConfigureSoftDeleteAsync(vaultName, resourceGroup, subscription, softDeleteState, softDeleteRetentionDays, tenant, cancellationToken)
+            : await dppOps.ConfigureSoftDeleteAsync(vaultName, resourceGroup, subscription, softDeleteState, softDeleteRetentionDays, tenant, cancellationToken);
     }
 
     public async Task<OperationResult> ConfigureCrossRegionRestoreAsync(
         string vaultName, string resourceGroup, string subscription,
         string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
         if (VaultTypeResolver.IsRsv(resolved))
         {
-            return await rsvOps.ConfigureCrossRegionRestoreAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+            return await rsvOps.ConfigureCrossRegionRestoreAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken);
         }
-        return await dppOps.ConfigureCrossRegionRestoreAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+        return await dppOps.ConfigureCrossRegionRestoreAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken);
     }
 
     public async Task<OperationResult> ConfigureMultiUserAuthorizationAsync(
         string vaultName, string resourceGroup, string subscription,
         string resourceGuardId, string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
         return VaultTypeResolver.IsRsv(resolved)
-            ? await rsvOps.ConfigureMultiUserAuthorizationAsync(vaultName, resourceGroup, subscription, resourceGuardId, tenant, retryPolicy, cancellationToken)
-            : await dppOps.ConfigureMultiUserAuthorizationAsync(vaultName, resourceGroup, subscription, resourceGuardId, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.ConfigureMultiUserAuthorizationAsync(vaultName, resourceGroup, subscription, resourceGuardId, tenant, cancellationToken)
+            : await dppOps.ConfigureMultiUserAuthorizationAsync(vaultName, resourceGroup, subscription, resourceGuardId, tenant, cancellationToken);
     }
 
     public async Task<OperationResult> DisableMultiUserAuthorizationAsync(
         string vaultName, string resourceGroup, string subscription,
         string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
         return VaultTypeResolver.IsRsv(resolved)
-            ? await rsvOps.DisableMultiUserAuthorizationAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken)
-            : await dppOps.DisableMultiUserAuthorizationAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.DisableMultiUserAuthorizationAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken)
+            : await dppOps.DisableMultiUserAuthorizationAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken);
     }
 
     public async Task<OperationResult> ConfigureEncryptionAsync(
@@ -869,12 +868,12 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
         string keyVaultUri, string keyName, string identityType,
         string? keyVersion, string? userAssignedIdentityId,
         string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken);
+        var resolved = await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken);
         return VaultTypeResolver.IsRsv(resolved)
-            ? await rsvOps.ConfigureEncryptionAsync(vaultName, resourceGroup, subscription, keyVaultUri, keyName, identityType, keyVersion, userAssignedIdentityId, tenant, retryPolicy, cancellationToken)
-            : await dppOps.ConfigureEncryptionAsync(vaultName, resourceGroup, subscription, keyVaultUri, keyName, identityType, keyVersion, userAssignedIdentityId, tenant, retryPolicy, cancellationToken);
+            ? await rsvOps.ConfigureEncryptionAsync(vaultName, resourceGroup, subscription, keyVaultUri, keyName, identityType, keyVersion, userAssignedIdentityId, tenant, cancellationToken)
+            : await dppOps.ConfigureEncryptionAsync(vaultName, resourceGroup, subscription, keyVaultUri, keyName, identityType, keyVersion, userAssignedIdentityId, tenant, cancellationToken);
     }
 
     // ---------------------------------------------------------------------
@@ -926,7 +925,7 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
     public async Task<ResourceGuardInfo> CreateResourceGuardAsync(
         string resourceGuardName, string resourceGroup, string subscription, string location,
         IReadOnlyList<string>? excludedOperations, IReadOnlyDictionary<string, string>? tags,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(resourceGuardName), resourceGuardName),
@@ -948,8 +947,8 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
             }
         }
 
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
         var rgResource = armClient.GetResourceGroupResource(rgId);
         var collection = rgResource.GetResourceGuards();
@@ -979,15 +978,15 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
 
     public async Task<ResourceGuardInfo> GetResourceGuardAsync(
         string resourceGuardName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(resourceGuardName), resourceGuardName),
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var id = ResourceGuardResource.CreateResourceIdentifier(subscription, resourceGroup, resourceGuardName);
         var resource = armClient.GetResourceGuardResource(id);
         var response = await resource.GetAsync(cancellationToken);
@@ -996,12 +995,12 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
 
     public async Task<List<ResourceGuardInfo>> ListResourceGuardsAsync(
         string subscription, string? resourceGroup, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
 
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
 
         var results = new List<ResourceGuardInfo>();
         if (!string.IsNullOrEmpty(resourceGroup))
@@ -1028,15 +1027,15 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
 
     public async Task<OperationResult> DeleteResourceGuardAsync(
         string resourceGuardName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(resourceGuardName), resourceGuardName),
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var id = ResourceGuardResource.CreateResourceIdentifier(subscription, resourceGroup, resourceGuardName);
         var resource = armClient.GetResourceGuardResource(id);
         var operation = await resource.DeleteAsync(WaitUntil.Started, cancellationToken);
@@ -1053,65 +1052,65 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
         string privateEndpointName, string vnetSubnetId, string groupId,
         string? location, bool autoApprove,
         string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        EnsurePrivateEndpointVaultType(await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken));
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        EnsurePrivateEndpointVaultType(await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken));
         return await rsvOps.CreatePrivateEndpointAsync(
             vaultName, resourceGroup, subscription, privateEndpointName, vnetSubnetId,
             string.IsNullOrWhiteSpace(groupId) ? "AzureBackup" : groupId,
-            location, autoApprove, tenant, retryPolicy, cancellationToken);
+            location, autoApprove, tenant, cancellationToken);
     }
 
     public async Task<PrivateEndpointConnectionInfo> GetPrivateEndpointAsync(
         string vaultName, string resourceGroup, string subscription,
         string privateEndpointConnectionName, string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        EnsurePrivateEndpointVaultType(await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken));
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        EnsurePrivateEndpointVaultType(await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken));
         return await rsvOps.GetPrivateEndpointAsync(
             vaultName, resourceGroup, subscription, privateEndpointConnectionName,
-            tenant, retryPolicy, cancellationToken);
+            tenant, cancellationToken);
     }
 
     public async Task<List<PrivateEndpointConnectionInfo>> ListPrivateEndpointsAsync(
         string vaultName, string resourceGroup, string subscription,
         string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        EnsurePrivateEndpointVaultType(await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken));
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        EnsurePrivateEndpointVaultType(await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken));
         return await rsvOps.ListPrivateEndpointsAsync(
-            vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+            vaultName, resourceGroup, subscription, tenant, cancellationToken);
     }
 
     public async Task<OperationResult> DeletePrivateEndpointAsync(
         string vaultName, string resourceGroup, string subscription,
         string privateEndpointConnectionName, string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        EnsurePrivateEndpointVaultType(await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken));
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        EnsurePrivateEndpointVaultType(await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken));
         return await rsvOps.DeletePrivateEndpointAsync(
             vaultName, resourceGroup, subscription, privateEndpointConnectionName,
-            tenant, retryPolicy, cancellationToken);
+            tenant, cancellationToken);
     }
 
     public async Task<PrivateEndpointConnectionInfo> SetPrivateEndpointConnectionStateAsync(
         string vaultName, string resourceGroup, string subscription,
         string privateEndpointConnectionName, PrivateEndpointConnectionAction action,
         string? description, string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, retryPolicy, cancellationToken);
-        EnsurePrivateEndpointVaultType(await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, retryPolicy, cancellationToken));
+        subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
+        EnsurePrivateEndpointVaultType(await ResolveVaultTypeAsync(vaultName, resourceGroup, subscription, vaultType, tenant, cancellationToken));
         var targetStatus = action == PrivateEndpointConnectionAction.Approve
             ? PrivateEndpointConnectionStatus.Approved
             : PrivateEndpointConnectionStatus.Rejected;
         return await rsvOps.SetPrivateEndpointConnectionStateAsync(
             vaultName, resourceGroup, subscription, privateEndpointConnectionName,
-            targetStatus, description, tenant, retryPolicy, cancellationToken);
+            targetStatus, description, tenant, cancellationToken);
     }
 
     private static void EnsurePrivateEndpointVaultType(string resolvedVaultType)
@@ -1127,7 +1126,7 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
     private async Task<string> ResolveVaultTypeAsync(
         string vaultName, string resourceGroup, string subscription,
         string? vaultType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         if (VaultTypeResolver.IsVaultTypeSpecified(vaultType))
         {
@@ -1136,7 +1135,7 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
 
         try
         {
-            await rsvOps.GetVaultAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+            await rsvOps.GetVaultAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken);
             return VaultTypeResolver.Rsv;
         }
         catch (RequestFailedException ex) when (ex.Status is 401 or 403)
@@ -1150,7 +1149,7 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
 
         try
         {
-            await dppOps.GetVaultAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+            await dppOps.GetVaultAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken);
             return VaultTypeResolver.Dpp;
         }
         catch (RequestFailedException ex) when (ex.Status is 401 or 403)

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs
@@ -8,7 +8,6 @@ using Azure.ResourceManager;
 using Azure.ResourceManager.DataProtectionBackup;
 using Azure.ResourceManager.DataProtectionBackup.Models;
 using Azure.ResourceManager.Resources;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.AzureBackup.Services;
 
@@ -35,7 +34,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
     public async Task<VaultCreateResult> CreateVaultAsync(
         string vaultName, string resourceGroup, string subscription, string location,
         string? sku, string? storageType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -43,7 +42,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(subscription), subscription),
             (nameof(location), location));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
         var rgResource = armClient.GetResourceGroupResource(rgId);
         var collection = rgResource.GetDataProtectionBackupVaults();
@@ -87,7 +86,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
 
     public async Task<BackupVaultInfo> GetVaultAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken,
+        string? tenant, CancellationToken cancellationToken,
         VaultExpand expand = VaultExpand.None)
     {
         ValidateRequiredParameters(
@@ -95,7 +94,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
         var vault = await vaultResource.GetAsync(cancellationToken);
@@ -109,12 +108,12 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
 
     public async Task<List<BackupVaultInfo>> ListVaultsAsync(
         string subscription, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken,
+        CancellationToken cancellationToken,
         VaultExpand expand = VaultExpand.None)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subId = SubscriptionResource.CreateResourceIdentifier(subscription);
         var subResource = armClient.GetSubscriptionResource(subId);
 
@@ -152,7 +151,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
         string? aksIncludedNamespaces, string? aksExcludedNamespaces,
         string? aksLabelSelectors, string? aksIncludeClusterScopeResources,
         string? aksSnapshotResourceGroup,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -161,7 +160,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(datasourceId), datasourceId),
             (nameof(policyName), policyName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
         var vaultData = await vaultResource.GetAsync(cancellationToken);
@@ -357,7 +356,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
     public async Task<ProtectedItemInfo> GetProtectedItemAsync(
         string vaultName, string resourceGroup, string subscription,
         string protectedItemName, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -365,7 +364,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(subscription), subscription),
             (nameof(protectedItemName), protectedItemName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
 
         // First try direct lookup by exact instance name
         try
@@ -381,7 +380,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
         }
 
         // Fall back to listing all items and searching by friendly name
-        var items = await ListProtectedItemsAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+        var items = await ListProtectedItemsAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken);
         var found = items.FirstOrDefault(i =>
             (!string.IsNullOrEmpty(i.Name) && i.Name.Equals(protectedItemName, StringComparison.OrdinalIgnoreCase)) ||
             MatchesDppFriendlyName(i, protectedItemName));
@@ -411,14 +410,14 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
 
     public async Task<List<ProtectedItemInfo>> ListProtectedItemsAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
         var collection = vaultResource.GetDataProtectionBackupInstances();
@@ -435,7 +434,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
     public async Task<BackupPolicyInfo> GetPolicyAsync(
         string vaultName, string resourceGroup, string subscription,
         string policyName, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -443,7 +442,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(subscription), subscription),
             (nameof(policyName), policyName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var policyId = DataProtectionBackupPolicyResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName, policyName);
         var policyResource = armClient.GetDataProtectionBackupPolicyResource(policyId);
 
@@ -458,7 +457,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             // retention/duration fields (XmlConvert.ToTimeSpan limitation in
             // DataProtectionBackupAbsoluteDeleteSetting). Fall back to listing all
             // policies and matching by name to work around this SDK limitation.
-            var policies = await ListPoliciesAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+            var policies = await ListPoliciesAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken);
             return policies.FirstOrDefault(p => p.Name == policyName)
                 ?? throw new KeyNotFoundException(
                     $"Policy '{policyName}' not found in vault '{vaultName}'. " +
@@ -468,14 +467,14 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
 
     public async Task<List<BackupPolicyInfo>> ListPoliciesAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
         var collection = vaultResource.GetDataProtectionBackupPolicies();
@@ -525,7 +524,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
     public async Task<OperationResult> UndeleteProtectedItemAsync(
         string vaultName, string resourceGroup, string subscription,
         string datasourceId, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -533,7 +532,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(subscription), subscription),
             (nameof(datasourceId), datasourceId));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
 
@@ -571,7 +570,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
     public async Task<BackupJobInfo> GetJobAsync(
         string vaultName, string resourceGroup, string subscription,
         string jobId, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -579,7 +578,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(subscription), subscription),
             (nameof(jobId), jobId));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var jobResourceId = DataProtectionBackupJobResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName, jobId);
         var jobResource = armClient.GetDataProtectionBackupJobResource(jobResourceId);
 
@@ -598,7 +597,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             // exist beyond the point where the enumerator broke. Re-throw FormatException
             // (not KeyNotFoundException) to preserve SDK-parse-failure semantics.
             // Tracked in azure-sdk-for-net#59306.
-            var jobs = await ListJobsAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+            var jobs = await ListJobsAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken);
             return jobs.FirstOrDefault(j => j.Name == jobId)
                 ?? throw new FormatException($"Job '{jobId}' exists but the Azure SDK cannot parse its duration field (XmlConvert.ToTimeSpan limitation).");
         }
@@ -606,14 +605,14 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
 
     public async Task<List<BackupJobInfo>> ListJobsAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
         var collection = vaultResource.GetDataProtectionBackupJobs();
@@ -661,7 +660,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
     public async Task<RecoveryPointInfo> GetRecoveryPointAsync(
         string vaultName, string resourceGroup, string subscription,
         string protectedItemName, string recoveryPointId, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -670,7 +669,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(protectedItemName), protectedItemName),
             (nameof(recoveryPointId), recoveryPointId));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var rpId = DataProtectionBackupRecoveryPointResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName, protectedItemName, recoveryPointId);
         var rpResource = armClient.GetDataProtectionBackupRecoveryPointResource(rpId);
         var rp = await rpResource.GetAsync(cancellationToken);
@@ -681,7 +680,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
     public async Task<List<RecoveryPointInfo>> ListRecoveryPointsAsync(
         string vaultName, string resourceGroup, string subscription,
         string protectedItemName, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -689,7 +688,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(subscription), subscription),
             (nameof(protectedItemName), protectedItemName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var instanceId = DataProtectionBackupInstanceResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName, protectedItemName);
         var instanceResource = armClient.GetDataProtectionBackupInstanceResource(instanceId);
         var collection = instanceResource.GetDataProtectionBackupRecoveryPoints();
@@ -708,7 +707,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
         string vaultName, string resourceGroup, string subscription,
         string? redundancy, string? softDelete, string? softDeleteRetentionDays,
         string? immutabilityState, string? identityType, string? tags,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -722,7 +721,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
                 "Set --storage-type during vault creation instead.");
         }
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
         var vault = await vaultResource.GetAsync(cancellationToken);
@@ -789,7 +788,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
     public async Task<OperationResult> CreatePolicyAsync(
         Policy.PolicyCreateRequest request,
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -803,7 +802,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(policyName), policyName),
             (nameof(workloadType), workloadType));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
         var collection = vaultResource.GetDataProtectionBackupPolicies();
@@ -829,14 +828,14 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
 
     public async Task<OperationResult> ConfigureCrossRegionRestoreAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
 
@@ -879,7 +878,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
 
     public async Task<OperationResult> ConfigureImmutabilityAsync(
         string vaultName, string resourceGroup, string subscription,
-        string immutabilityState, string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string immutabilityState, string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -887,7 +886,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(subscription), subscription),
             (nameof(immutabilityState), immutabilityState));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
 
@@ -910,7 +909,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
     public async Task<OperationResult> ConfigureSoftDeleteAsync(
         string vaultName, string resourceGroup, string subscription,
         string softDeleteState, string? softDeleteRetentionDays,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -918,7 +917,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(subscription), subscription),
             (nameof(softDeleteState), softDeleteState));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
 
@@ -950,7 +949,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
 
     public async Task<OperationResult> ConfigureMultiUserAuthorizationAsync(
         string vaultName, string resourceGroup, string subscription,
-        string resourceGuardId, string? tenant, RetryPolicyOptions? retryPolicy,
+        string resourceGuardId, string? tenant,
         CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
@@ -959,7 +958,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(subscription), subscription),
             (nameof(resourceGuardId), resourceGuardId));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
         var proxyCollection = vaultResource.GetResourceGuardProxyBaseResources();
@@ -984,7 +983,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
 
     public async Task<OperationResult> DisableMultiUserAuthorizationAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy,
+        string? tenant,
         CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
@@ -992,7 +991,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
 
@@ -1007,7 +1006,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
         string vaultName, string resourceGroup, string subscription,
         string keyVaultUri, string keyName, string identityType,
         string? keyVersion, string? userAssignedIdentityId,
-        string? tenant, RetryPolicyOptions? retryPolicy,
+        string? tenant,
         CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
@@ -1039,7 +1038,7 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
             ? $"{kvUri}/keys/{keyName}"
             : $"{kvUri}/keys/{keyName}/{keyVersion}";
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IAzureBackupService.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IAzureBackupService.cs
@@ -2,65 +2,64 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.AzureBackup.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.AzureBackup.Services;
 
 public interface IAzureBackupService
 {
     // Vault operations
-    Task<VaultCreateResult> CreateVaultAsync(string vaultName, string resourceGroup, string subscription, string vaultType, string location, string? sku = null, string? storageType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<BackupVaultInfo> GetVaultAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default, VaultExpand expand = VaultExpand.None);
-    Task<List<BackupVaultInfo>> ListVaultsAsync(string subscription, string? resourceGroup = null, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default, VaultExpand expand = VaultExpand.None);
-    Task<OperationResult> UpdateVaultAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? redundancy = null, string? softDelete = null, string? softDeleteRetentionDays = null, string? immutabilityState = null, string? identityType = null, string? tags = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<VaultCreateResult> CreateVaultAsync(string vaultName, string resourceGroup, string subscription, string vaultType, string location, string? sku = null, string? storageType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<BackupVaultInfo> GetVaultAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default, VaultExpand expand = VaultExpand.None);
+    Task<List<BackupVaultInfo>> ListVaultsAsync(string subscription, string? resourceGroup = null, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default, VaultExpand expand = VaultExpand.None);
+    Task<OperationResult> UpdateVaultAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? redundancy = null, string? softDelete = null, string? softDeleteRetentionDays = null, string? immutabilityState = null, string? identityType = null, string? tags = null, string? tenant = null, CancellationToken cancellationToken = default);
 
     // Policy operations
-    Task<BackupPolicyInfo> GetPolicyAsync(string vaultName, string resourceGroup, string subscription, string policyName, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<List<BackupPolicyInfo>> ListPoliciesAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<OperationResult> CreatePolicyAsync(Policy.PolicyCreateRequest request, string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<OperationResult> UpdatePolicyAsync(string vaultName, string resourceGroup, string subscription, string policyName, string? vaultType = null, string? scheduleTime = null, string? dailyRetentionDays = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<BackupPolicyInfo> GetPolicyAsync(string vaultName, string resourceGroup, string subscription, string policyName, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<List<BackupPolicyInfo>> ListPoliciesAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> CreatePolicyAsync(Policy.PolicyCreateRequest request, string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> UpdatePolicyAsync(string vaultName, string resourceGroup, string subscription, string policyName, string? vaultType = null, string? scheduleTime = null, string? dailyRetentionDays = null, string? tenant = null, CancellationToken cancellationToken = default);
 
     // Protection operations
-    Task<ProtectResult> ProtectItemAsync(string vaultName, string resourceGroup, string subscription, string datasourceId, string policyName, string? vaultType = null, string? containerName = null, string? datasourceType = null, string? aksIncludedNamespaces = null, string? aksExcludedNamespaces = null, string? aksLabelSelectors = null, string? aksIncludeClusterScopeResources = null, string? aksSnapshotResourceGroup = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<ProtectedItemInfo> GetProtectedItemAsync(string vaultName, string resourceGroup, string subscription, string protectedItemName, string? vaultType = null, string? containerName = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<List<ProtectedItemInfo>> ListProtectedItemsAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<List<ProtectableItemInfo>> ListProtectableItemsAsync(string vaultName, string resourceGroup, string subscription, string? workloadType = null, string? containerName = null, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<OperationResult> UndeleteProtectedItemAsync(string vaultName, string resourceGroup, string subscription, string datasourceId, string? vaultType = null, string? containerName = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<ProtectResult> ProtectItemAsync(string vaultName, string resourceGroup, string subscription, string datasourceId, string policyName, string? vaultType = null, string? containerName = null, string? datasourceType = null, string? aksIncludedNamespaces = null, string? aksExcludedNamespaces = null, string? aksLabelSelectors = null, string? aksIncludeClusterScopeResources = null, string? aksSnapshotResourceGroup = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<ProtectedItemInfo> GetProtectedItemAsync(string vaultName, string resourceGroup, string subscription, string protectedItemName, string? vaultType = null, string? containerName = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<List<ProtectedItemInfo>> ListProtectedItemsAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<List<ProtectableItemInfo>> ListProtectableItemsAsync(string vaultName, string resourceGroup, string subscription, string? workloadType = null, string? containerName = null, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> UndeleteProtectedItemAsync(string vaultName, string resourceGroup, string subscription, string datasourceId, string? vaultType = null, string? containerName = null, string? tenant = null, CancellationToken cancellationToken = default);
 
     // Job operations
-    Task<BackupJobInfo> GetJobAsync(string vaultName, string resourceGroup, string subscription, string jobId, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<List<BackupJobInfo>> ListJobsAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<BackupJobInfo> GetJobAsync(string vaultName, string resourceGroup, string subscription, string jobId, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<List<BackupJobInfo>> ListJobsAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
 
     // Recovery point operations
-    Task<RecoveryPointInfo> GetRecoveryPointAsync(string vaultName, string resourceGroup, string subscription, string protectedItemName, string recoveryPointId, string? vaultType = null, string? containerName = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<List<RecoveryPointInfo>> ListRecoveryPointsAsync(string vaultName, string resourceGroup, string subscription, string protectedItemName, string? vaultType = null, string? containerName = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<RecoveryPointInfo> GetRecoveryPointAsync(string vaultName, string resourceGroup, string subscription, string protectedItemName, string recoveryPointId, string? vaultType = null, string? containerName = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<List<RecoveryPointInfo>> ListRecoveryPointsAsync(string vaultName, string resourceGroup, string subscription, string protectedItemName, string? vaultType = null, string? containerName = null, string? tenant = null, CancellationToken cancellationToken = default);
 
     // Backup status
-    Task<BackupStatusResult> GetBackupStatusAsync(string datasourceId, string subscription, string location, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<BackupStatusResult> GetBackupStatusAsync(string datasourceId, string subscription, string location, string? tenant = null, CancellationToken cancellationToken = default);
 
     // Governance
-    Task<List<UnprotectedResourceInfo>> FindUnprotectedResourcesAsync(string subscription, string? resourceTypeFilter = null, string? resourceGroup = null, string? tagFilter = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<OperationResult> ConfigureImmutabilityAsync(string vaultName, string resourceGroup, string subscription, string immutabilityState, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<OperationResult> ConfigureSoftDeleteAsync(string vaultName, string resourceGroup, string subscription, string softDeleteState, string? vaultType = null, string? softDeleteRetentionDays = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<List<UnprotectedResourceInfo>> FindUnprotectedResourcesAsync(string subscription, string? resourceTypeFilter = null, string? resourceGroup = null, string? tagFilter = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> ConfigureImmutabilityAsync(string vaultName, string resourceGroup, string subscription, string immutabilityState, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> ConfigureSoftDeleteAsync(string vaultName, string resourceGroup, string subscription, string softDeleteState, string? vaultType = null, string? softDeleteRetentionDays = null, string? tenant = null, CancellationToken cancellationToken = default);
 
     // DR
-    Task<OperationResult> ConfigureCrossRegionRestoreAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> ConfigureCrossRegionRestoreAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
 
     // Security
-    Task<OperationResult> ConfigureMultiUserAuthorizationAsync(string vaultName, string resourceGroup, string subscription, string resourceGuardId, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<OperationResult> DisableMultiUserAuthorizationAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<OperationResult> ConfigureEncryptionAsync(string vaultName, string resourceGroup, string subscription, string keyVaultUri, string keyName, string identityType, string? keyVersion = null, string? userAssignedIdentityId = null, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> ConfigureMultiUserAuthorizationAsync(string vaultName, string resourceGroup, string subscription, string resourceGuardId, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> DisableMultiUserAuthorizationAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> ConfigureEncryptionAsync(string vaultName, string resourceGroup, string subscription, string keyVaultUri, string keyName, string identityType, string? keyVersion = null, string? userAssignedIdentityId = null, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
 
     // Resource Guard (Microsoft.DataProtection/resourceGuards) — protects RSV and DPP vaults via MUA.
-    Task<ResourceGuardInfo> CreateResourceGuardAsync(string resourceGuardName, string resourceGroup, string subscription, string location, IReadOnlyList<string>? excludedOperations = null, IReadOnlyDictionary<string, string>? tags = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<ResourceGuardInfo> GetResourceGuardAsync(string resourceGuardName, string resourceGroup, string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<List<ResourceGuardInfo>> ListResourceGuardsAsync(string subscription, string? resourceGroup = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<OperationResult> DeleteResourceGuardAsync(string resourceGuardName, string resourceGroup, string subscription, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<ResourceGuardInfo> CreateResourceGuardAsync(string resourceGuardName, string resourceGroup, string subscription, string location, IReadOnlyList<string>? excludedOperations = null, IReadOnlyDictionary<string, string>? tags = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<ResourceGuardInfo> GetResourceGuardAsync(string resourceGuardName, string resourceGroup, string subscription, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<List<ResourceGuardInfo>> ListResourceGuardsAsync(string subscription, string? resourceGroup = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> DeleteResourceGuardAsync(string resourceGuardName, string resourceGroup, string subscription, string? tenant = null, CancellationToken cancellationToken = default);
 
     // Private endpoint operations (RSV only; DPP returns NotSupportedException)
-    Task<PrivateEndpointConnectionInfo> CreatePrivateEndpointAsync(string vaultName, string resourceGroup, string subscription, string privateEndpointName, string vnetSubnetId, string groupId, string? location = null, bool autoApprove = false, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<PrivateEndpointConnectionInfo> GetPrivateEndpointAsync(string vaultName, string resourceGroup, string subscription, string privateEndpointConnectionName, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<List<PrivateEndpointConnectionInfo>> ListPrivateEndpointsAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<OperationResult> DeletePrivateEndpointAsync(string vaultName, string resourceGroup, string subscription, string privateEndpointConnectionName, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
-    Task<PrivateEndpointConnectionInfo> SetPrivateEndpointConnectionStateAsync(string vaultName, string resourceGroup, string subscription, string privateEndpointConnectionName, PrivateEndpointConnectionAction action, string? description = null, string? vaultType = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default);
+    Task<PrivateEndpointConnectionInfo> CreatePrivateEndpointAsync(string vaultName, string resourceGroup, string subscription, string privateEndpointName, string vnetSubnetId, string groupId, string? location = null, bool autoApprove = false, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<PrivateEndpointConnectionInfo> GetPrivateEndpointAsync(string vaultName, string resourceGroup, string subscription, string privateEndpointConnectionName, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<List<PrivateEndpointConnectionInfo>> ListPrivateEndpointsAsync(string vaultName, string resourceGroup, string subscription, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<OperationResult> DeletePrivateEndpointAsync(string vaultName, string resourceGroup, string subscription, string privateEndpointConnectionName, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
+    Task<PrivateEndpointConnectionInfo> SetPrivateEndpointConnectionStateAsync(string vaultName, string resourceGroup, string subscription, string privateEndpointConnectionName, PrivateEndpointConnectionAction action, string? description = null, string? vaultType = null, string? tenant = null, CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IDppBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IDppBackupOperations.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.AzureBackup.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.AzureBackup.Services;
 
@@ -16,7 +15,6 @@ public interface IDppBackupOperations
         string? sku,
         string? storageType,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<BackupVaultInfo> GetVaultAsync(
@@ -24,14 +22,12 @@ public interface IDppBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken,
         VaultExpand expand = VaultExpand.None);
 
     Task<List<BackupVaultInfo>> ListVaultsAsync(
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken,
         VaultExpand expand = VaultExpand.None);
 
@@ -46,7 +42,6 @@ public interface IDppBackupOperations
         string? identityType,
         string? tags,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<BackupPolicyInfo> GetPolicyAsync(
@@ -55,7 +50,6 @@ public interface IDppBackupOperations
         string subscription,
         string policyName,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<List<BackupPolicyInfo>> ListPoliciesAsync(
@@ -63,7 +57,6 @@ public interface IDppBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> CreatePolicyAsync(
@@ -72,7 +65,6 @@ public interface IDppBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<ProtectResult> ProtectItemAsync(
@@ -88,7 +80,6 @@ public interface IDppBackupOperations
         string? aksIncludeClusterScopeResources,
         string? aksSnapshotResourceGroup,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<ProtectedItemInfo> GetProtectedItemAsync(
@@ -97,7 +88,6 @@ public interface IDppBackupOperations
         string subscription,
         string protectedItemName,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<List<ProtectedItemInfo>> ListProtectedItemsAsync(
@@ -105,7 +95,6 @@ public interface IDppBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> UndeleteProtectedItemAsync(
@@ -114,7 +103,6 @@ public interface IDppBackupOperations
         string subscription,
         string datasourceId,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<BackupJobInfo> GetJobAsync(
@@ -123,7 +111,6 @@ public interface IDppBackupOperations
         string subscription,
         string jobId,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<List<BackupJobInfo>> ListJobsAsync(
@@ -131,7 +118,6 @@ public interface IDppBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<RecoveryPointInfo> GetRecoveryPointAsync(
@@ -141,7 +127,6 @@ public interface IDppBackupOperations
         string protectedItemName,
         string recoveryPointId,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<List<RecoveryPointInfo>> ListRecoveryPointsAsync(
@@ -150,7 +135,6 @@ public interface IDppBackupOperations
         string subscription,
         string protectedItemName,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> ConfigureImmutabilityAsync(
@@ -159,7 +143,6 @@ public interface IDppBackupOperations
         string subscription,
         string immutabilityState,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> ConfigureSoftDeleteAsync(
@@ -169,7 +152,6 @@ public interface IDppBackupOperations
         string softDeleteState,
         string? softDeleteRetentionDays,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> ConfigureCrossRegionRestoreAsync(
@@ -177,7 +159,6 @@ public interface IDppBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> ConfigureMultiUserAuthorizationAsync(
@@ -186,7 +167,6 @@ public interface IDppBackupOperations
         string subscription,
         string resourceGuardId,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> DisableMultiUserAuthorizationAsync(
@@ -194,7 +174,6 @@ public interface IDppBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> ConfigureEncryptionAsync(
@@ -207,6 +186,5 @@ public interface IDppBackupOperations
         string? keyVersion,
         string? userAssignedIdentityId,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IRsvBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/IRsvBackupOperations.cs
@@ -3,7 +3,6 @@
 
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.ResourceManager.RecoveryServicesBackup.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.AzureBackup.Services;
 
@@ -17,7 +16,6 @@ public interface IRsvBackupOperations
         string? sku,
         string? storageType,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<BackupVaultInfo> GetVaultAsync(
@@ -25,14 +23,12 @@ public interface IRsvBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken,
         VaultExpand expand = VaultExpand.None);
 
     Task<List<BackupVaultInfo>> ListVaultsAsync(
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken,
         VaultExpand expand = VaultExpand.None);
 
@@ -47,7 +43,6 @@ public interface IRsvBackupOperations
         string? identityType,
         string? tags,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<BackupPolicyInfo> GetPolicyAsync(
@@ -56,7 +51,6 @@ public interface IRsvBackupOperations
         string subscription,
         string policyName,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<List<BackupPolicyInfo>> ListPoliciesAsync(
@@ -64,7 +58,6 @@ public interface IRsvBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> CreatePolicyAsync(
@@ -73,7 +66,6 @@ public interface IRsvBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> UpdatePolicyAsync(
@@ -84,7 +76,6 @@ public interface IRsvBackupOperations
         string? scheduleTime,
         string? dailyRetentionDays,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<ProtectResult> ProtectItemAsync(
@@ -96,7 +87,6 @@ public interface IRsvBackupOperations
         string? containerName,
         string? datasourceType,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<ProtectedItemInfo> GetProtectedItemAsync(
@@ -106,7 +96,6 @@ public interface IRsvBackupOperations
         string protectedItemName,
         string? containerName,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<List<ProtectedItemInfo>> ListProtectedItemsAsync(
@@ -114,7 +103,6 @@ public interface IRsvBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<List<ProtectableItemInfo>> ListProtectableItemsAsync(
@@ -124,7 +112,6 @@ public interface IRsvBackupOperations
         string? workloadType,
         string? containerName,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> UndeleteProtectedItemAsync(
@@ -134,7 +121,6 @@ public interface IRsvBackupOperations
         string datasourceId,
         string? containerName,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<BackupJobInfo> GetJobAsync(
@@ -143,7 +129,6 @@ public interface IRsvBackupOperations
         string subscription,
         string jobId,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<List<BackupJobInfo>> ListJobsAsync(
@@ -151,7 +136,6 @@ public interface IRsvBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<RecoveryPointInfo> GetRecoveryPointAsync(
@@ -162,7 +146,6 @@ public interface IRsvBackupOperations
         string recoveryPointId,
         string? containerName,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<List<RecoveryPointInfo>> ListRecoveryPointsAsync(
@@ -172,7 +155,6 @@ public interface IRsvBackupOperations
         string protectedItemName,
         string? containerName,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> ConfigureImmutabilityAsync(
@@ -181,7 +163,6 @@ public interface IRsvBackupOperations
         string subscription,
         string immutabilityState,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> ConfigureSoftDeleteAsync(
@@ -191,7 +172,6 @@ public interface IRsvBackupOperations
         string softDeleteState,
         string? softDeleteRetentionDays,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> ConfigureCrossRegionRestoreAsync(
@@ -199,7 +179,6 @@ public interface IRsvBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> ConfigureMultiUserAuthorizationAsync(
@@ -208,7 +187,6 @@ public interface IRsvBackupOperations
         string subscription,
         string resourceGuardId,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> DisableMultiUserAuthorizationAsync(
@@ -216,7 +194,6 @@ public interface IRsvBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<List<ProtectableItemInfo>> ListDiscoveredProtectableItemsAsync(
@@ -224,7 +201,6 @@ public interface IRsvBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> ConfigureEncryptionAsync(
@@ -237,7 +213,6 @@ public interface IRsvBackupOperations
         string? keyVersion,
         string? userAssignedIdentityId,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     // Private endpoint operations
@@ -251,7 +226,6 @@ public interface IRsvBackupOperations
         string? location,
         bool autoApprove,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<List<PrivateEndpointConnectionInfo>> ListPrivateEndpointsAsync(
@@ -259,7 +233,6 @@ public interface IRsvBackupOperations
         string resourceGroup,
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<PrivateEndpointConnectionInfo> GetPrivateEndpointAsync(
@@ -268,7 +241,6 @@ public interface IRsvBackupOperations
         string subscription,
         string privateEndpointConnectionName,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<OperationResult> DeletePrivateEndpointAsync(
@@ -277,7 +249,6 @@ public interface IRsvBackupOperations
         string subscription,
         string privateEndpointConnectionName,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 
     Task<PrivateEndpointConnectionInfo> SetPrivateEndpointConnectionStateAsync(
@@ -288,6 +259,5 @@ public interface IRsvBackupOperations
         PrivateEndpointConnectionStatus targetStatus,
         string? description,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken);
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.PrivateEndpoint.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.PrivateEndpoint.cs
@@ -11,7 +11,6 @@ using Azure.ResourceManager.RecoveryServices.Models;
 using Azure.ResourceManager.RecoveryServicesBackup;
 using Azure.ResourceManager.RecoveryServicesBackup.Models;
 using Azure.ResourceManager.Resources;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.AzureBackup.Services;
 
@@ -27,7 +26,7 @@ public sealed partial class RsvBackupOperations
         string vaultName, string resourceGroup, string subscription,
         string privateEndpointName, string vnetSubnetId, string groupId,
         string? location, bool autoApprove,
-        string? tenant, RetryPolicyOptions? retryPolicy,
+        string? tenant,
         CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
@@ -41,7 +40,7 @@ public sealed partial class RsvBackupOperations
         ValidateGroupId(groupId);
         var subnetResourceId = ParseSubnetId(vnetSubnetId);
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = RecoveryServicesVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetRecoveryServicesVaultResource(vaultId);
         var vault = await vaultResource.GetAsync(cancellationToken);
@@ -88,7 +87,7 @@ public sealed partial class RsvBackupOperations
                 vaultName, resourceGroup, subscription, ExtractPecName(pec.Id!),
                 PrivateEndpointConnectionStatus.Approved,
                 description: "Auto-approved by Azure MCP tool",
-                tenant, retryPolicy, cancellationToken);
+                tenant, cancellationToken);
         }
 
         return MapToPrivateEndpointConnectionInfo(pec);
@@ -96,7 +95,7 @@ public sealed partial class RsvBackupOperations
 
     public async Task<List<PrivateEndpointConnectionInfo>> ListPrivateEndpointsAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy,
+        string? tenant,
         CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
@@ -104,7 +103,7 @@ public sealed partial class RsvBackupOperations
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = RecoveryServicesVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetRecoveryServicesVaultResource(vaultId);
         var vault = await vaultResource.GetAsync(cancellationToken);
@@ -121,7 +120,7 @@ public sealed partial class RsvBackupOperations
     public async Task<PrivateEndpointConnectionInfo> GetPrivateEndpointAsync(
         string vaultName, string resourceGroup, string subscription,
         string privateEndpointConnectionName,
-        string? tenant, RetryPolicyOptions? retryPolicy,
+        string? tenant,
         CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
@@ -130,7 +129,7 @@ public sealed partial class RsvBackupOperations
             (nameof(subscription), subscription),
             (nameof(privateEndpointConnectionName), privateEndpointConnectionName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var pecResource = GetBackupPrivateEndpointConnectionResource(
             armClient, subscription, resourceGroup, vaultName, privateEndpointConnectionName);
 
@@ -141,7 +140,7 @@ public sealed partial class RsvBackupOperations
     public async Task<OperationResult> DeletePrivateEndpointAsync(
         string vaultName, string resourceGroup, string subscription,
         string privateEndpointConnectionName,
-        string? tenant, RetryPolicyOptions? retryPolicy,
+        string? tenant,
         CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
@@ -150,7 +149,7 @@ public sealed partial class RsvBackupOperations
             (nameof(subscription), subscription),
             (nameof(privateEndpointConnectionName), privateEndpointConnectionName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var pecResource = GetBackupPrivateEndpointConnectionResource(
             armClient, subscription, resourceGroup, vaultName, privateEndpointConnectionName);
 
@@ -166,7 +165,7 @@ public sealed partial class RsvBackupOperations
     public async Task<PrivateEndpointConnectionInfo> SetPrivateEndpointConnectionStateAsync(
         string vaultName, string resourceGroup, string subscription,
         string privateEndpointConnectionName, PrivateEndpointConnectionStatus targetStatus,
-        string? description, string? tenant, RetryPolicyOptions? retryPolicy,
+        string? description, string? tenant,
         CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
@@ -175,7 +174,7 @@ public sealed partial class RsvBackupOperations
             (nameof(subscription), subscription),
             (nameof(privateEndpointConnectionName), privateEndpointConnectionName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var pecResource = GetBackupPrivateEndpointConnectionResource(
             armClient, subscription, resourceGroup, vaultName, privateEndpointConnectionName);
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.cs
@@ -10,7 +10,6 @@ using Azure.ResourceManager.RecoveryServices.Models;
 using Azure.ResourceManager.RecoveryServicesBackup;
 using Azure.ResourceManager.RecoveryServicesBackup.Models;
 using Azure.ResourceManager.Resources;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.AzureBackup.Services;
 
@@ -22,7 +21,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
     public async Task<VaultCreateResult> CreateVaultAsync(
         string vaultName, string resourceGroup, string subscription, string location,
         string? sku, string? storageType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -30,7 +29,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             (nameof(subscription), subscription),
             (nameof(location), location));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
         var rgResource = armClient.GetResourceGroupResource(rgId);
         var collection = rgResource.GetRecoveryServicesVaults();
@@ -58,7 +57,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
 
     public async Task<BackupVaultInfo> GetVaultAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken,
+        string? tenant, CancellationToken cancellationToken,
         VaultExpand expand = VaultExpand.None)
     {
         ValidateRequiredParameters(
@@ -66,7 +65,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = RecoveryServicesVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetRecoveryServicesVaultResource(vaultId);
         var vault = await vaultResource.GetAsync(cancellationToken);
@@ -80,12 +79,12 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
 
     public async Task<List<BackupVaultInfo>> ListVaultsAsync(
         string subscription, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken,
+        CancellationToken cancellationToken,
         VaultExpand expand = VaultExpand.None)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subId = SubscriptionResource.CreateResourceIdentifier(subscription);
         var subResource = armClient.GetSubscriptionResource(subId);
 
@@ -124,7 +123,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
         string vaultName, string resourceGroup, string subscription,
         string datasourceId, string policyName, string? containerName,
         string? datasourceType, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -133,7 +132,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             (nameof(datasourceId), datasourceId),
             (nameof(policyName), policyName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
 
         var vaultId = RecoveryServicesVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetRecoveryServicesVaultResource(vaultId);
@@ -262,7 +261,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
     public async Task<ProtectedItemInfo> GetProtectedItemAsync(
         string vaultName, string resourceGroup, string subscription,
         string protectedItemName, string? containerName, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -270,12 +269,12 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             (nameof(subscription), subscription),
             (nameof(protectedItemName), protectedItemName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
 
         if (string.IsNullOrEmpty(containerName))
         {
             // Search by both internal RSV name and friendly/datasource name
-            var items = await ListProtectedItemsAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+            var items = await ListProtectedItemsAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken);
             var found = items.FirstOrDefault(i =>
                 (!string.IsNullOrEmpty(i.Name) && i.Name.Equals(protectedItemName, StringComparison.OrdinalIgnoreCase)) ||
                 MatchesFriendlyName(i, protectedItemName));
@@ -327,14 +326,14 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
 
     public async Task<List<ProtectedItemInfo>> ListProtectedItemsAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
         var rgResource = armClient.GetResourceGroupResource(rgId);
 
@@ -350,7 +349,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
     public async Task<BackupPolicyInfo> GetPolicyAsync(
         string vaultName, string resourceGroup, string subscription,
         string policyName, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -358,7 +357,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             (nameof(subscription), subscription),
             (nameof(policyName), policyName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var policyId = BackupProtectionPolicyResource.CreateResourceIdentifier(
             subscription, resourceGroup, vaultName, policyName);
         var policyResource = armClient.GetBackupProtectionPolicyResource(policyId);
@@ -369,14 +368,14 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
 
     public async Task<List<BackupPolicyInfo>> ListPoliciesAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
         var rgResource = armClient.GetResourceGroupResource(rgId);
 
@@ -392,7 +391,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
     public async Task<BackupJobInfo> GetJobAsync(
         string vaultName, string resourceGroup, string subscription,
         string jobId, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -400,7 +399,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             (nameof(subscription), subscription),
             (nameof(jobId), jobId));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var jobResourceId = BackupJobResource.CreateResourceIdentifier(
             subscription, resourceGroup, vaultName, jobId);
         var jobResource = armClient.GetBackupJobResource(jobResourceId);
@@ -411,14 +410,14 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
 
     public async Task<List<BackupJobInfo>> ListJobsAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
         var rgResource = armClient.GetResourceGroupResource(rgId);
 
@@ -434,7 +433,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
     public async Task<RecoveryPointInfo> GetRecoveryPointAsync(
         string vaultName, string resourceGroup, string subscription,
         string protectedItemName, string recoveryPointId, string? containerName,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -447,12 +446,12 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
         {
             // Auto-discover container from protected items list
             var resolvedItem = await ResolveProtectedItemContainerAsync(
-                vaultName, resourceGroup, subscription, protectedItemName, tenant, retryPolicy, cancellationToken);
+                vaultName, resourceGroup, subscription, protectedItemName, tenant, cancellationToken);
             containerName = resolvedItem.ContainerName;
             protectedItemName = resolvedItem.Name;
         }
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var rpId = BackupRecoveryPointResource.CreateResourceIdentifier(
             subscription, resourceGroup, vaultName, FabricName, containerName!, protectedItemName, recoveryPointId);
         var rpResource = armClient.GetBackupRecoveryPointResource(rpId);
@@ -464,7 +463,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
     public async Task<List<RecoveryPointInfo>> ListRecoveryPointsAsync(
         string vaultName, string resourceGroup, string subscription,
         string protectedItemName, string? containerName,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -476,12 +475,12 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
         {
             // Auto-discover container from protected items list
             var resolvedItem = await ResolveProtectedItemContainerAsync(
-                vaultName, resourceGroup, subscription, protectedItemName, tenant, retryPolicy, cancellationToken);
+                vaultName, resourceGroup, subscription, protectedItemName, tenant, cancellationToken);
             containerName = resolvedItem.ContainerName;
             protectedItemName = resolvedItem.Name;
         }
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var itemId = BackupProtectedItemResource.CreateResourceIdentifier(
             subscription, resourceGroup, vaultName, FabricName, containerName!, protectedItemName);
         var itemResource = armClient.GetBackupProtectedItemResource(itemId);
@@ -504,9 +503,9 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
     private async Task<ProtectedItemInfo> ResolveProtectedItemContainerAsync(
         string vaultName, string resourceGroup, string subscription,
         string protectedItemName, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
-        var items = await ListProtectedItemsAsync(vaultName, resourceGroup, subscription, tenant, retryPolicy, cancellationToken);
+        var items = await ListProtectedItemsAsync(vaultName, resourceGroup, subscription, tenant, cancellationToken);
         var found = items.FirstOrDefault(i =>
             (!string.IsNullOrEmpty(i.Name) && i.Name.Equals(protectedItemName, StringComparison.OrdinalIgnoreCase)) ||
             MatchesFriendlyName(i, protectedItemName));
@@ -527,14 +526,14 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
         string vaultName, string resourceGroup, string subscription,
         string? redundancy, string? softDelete, string? softDeleteRetentionDays,
         string? immutabilityState, string? identityType, string? tags,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = RecoveryServicesVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetRecoveryServicesVaultResource(vaultId);
         var vault = await vaultResource.GetAsync(cancellationToken);
@@ -577,12 +576,12 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
         // since RSV vault patch only supports identity and tag updates.
         if (!string.IsNullOrEmpty(softDelete))
         {
-            await ConfigureSoftDeleteAsync(vaultName, resourceGroup, subscription, softDelete, softDeleteRetentionDays, tenant, retryPolicy, cancellationToken);
+            await ConfigureSoftDeleteAsync(vaultName, resourceGroup, subscription, softDelete, softDeleteRetentionDays, tenant, cancellationToken);
         }
 
         if (!string.IsNullOrEmpty(immutabilityState))
         {
-            await ConfigureImmutabilityAsync(vaultName, resourceGroup, subscription, immutabilityState, tenant, retryPolicy, cancellationToken);
+            await ConfigureImmutabilityAsync(vaultName, resourceGroup, subscription, immutabilityState, tenant, cancellationToken);
         }
 
         return new OperationResult("Succeeded", null, $"Vault '{vaultName}' updated successfully.");
@@ -609,7 +608,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
     public async Task<OperationResult> CreatePolicyAsync(
         Policy.PolicyCreateRequest request,
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -623,7 +622,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             (nameof(policyName), policyName),
             (nameof(workloadType), workloadType));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultResourceId = RecoveryServicesVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetRecoveryServicesVaultResource(vaultResourceId);
         var vault = await vaultResource.GetAsync(cancellationToken);
@@ -677,7 +676,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
         string vaultName, string resourceGroup, string subscription,
         string policyName,
         string? scheduleTime, string? dailyRetentionDays,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -685,7 +684,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             (nameof(subscription), subscription),
             (nameof(policyName), policyName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
         var rgResource = armClient.GetResourceGroupResource(rgId);
         var policyCollection = rgResource.GetBackupProtectionPolicies(vaultName);
@@ -845,7 +844,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
 
     public async Task<OperationResult> ConfigureImmutabilityAsync(
         string vaultName, string resourceGroup, string subscription,
-        string immutabilityState, string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string immutabilityState, string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -853,7 +852,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             (nameof(subscription), subscription),
             (nameof(immutabilityState), immutabilityState));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = RecoveryServicesVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetRecoveryServicesVaultResource(vaultId);
         var vault = await vaultResource.GetAsync(cancellationToken);
@@ -877,7 +876,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
     public async Task<OperationResult> ConfigureSoftDeleteAsync(
         string vaultName, string resourceGroup, string subscription,
         string softDeleteState, string? softDeleteRetentionDays,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -885,7 +884,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             (nameof(subscription), subscription),
             (nameof(softDeleteState), softDeleteState));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = RecoveryServicesVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetRecoveryServicesVaultResource(vaultId);
         var vault = await vaultResource.GetAsync(cancellationToken);
@@ -927,14 +926,14 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
 
     public async Task<OperationResult> ConfigureCrossRegionRestoreAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = RecoveryServicesVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetRecoveryServicesVaultResource(vaultId);
         var vault = await vaultResource.GetAsync(cancellationToken);
@@ -992,7 +991,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
 
     public async Task<OperationResult> ConfigureMultiUserAuthorizationAsync(
         string vaultName, string resourceGroup, string subscription,
-        string resourceGuardId, string? tenant, RetryPolicyOptions? retryPolicy,
+        string resourceGuardId, string? tenant,
         CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
@@ -1001,7 +1000,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             (nameof(subscription), subscription),
             (nameof(resourceGuardId), resourceGuardId));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
 
         var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
         var rgResource = armClient.GetResourceGroupResource(rgId);
@@ -1027,7 +1026,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
 
     public async Task<OperationResult> DisableMultiUserAuthorizationAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy,
+        string? tenant,
         CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
@@ -1035,7 +1034,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
 
         var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
         var rgResource = armClient.GetResourceGroupResource(rgId);
@@ -1052,7 +1051,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
         string vaultName, string resourceGroup, string subscription,
         string keyVaultUri, string keyName, string identityType,
         string? keyVersion, string? userAssignedIdentityId,
-        string? tenant, RetryPolicyOptions? retryPolicy,
+        string? tenant,
         CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
@@ -1082,7 +1081,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             ? $"{kvUri}/keys/{keyName}"
             : $"{kvUri}/keys/{keyName}/{keyVersion}";
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var vaultId = RecoveryServicesVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetRecoveryServicesVaultResource(vaultId);
         var vault = await vaultResource.GetAsync(cancellationToken);
@@ -1399,7 +1398,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
     public async Task<OperationResult> UndeleteProtectedItemAsync(
         string vaultName, string resourceGroup, string subscription,
         string datasourceId, string? containerName, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
@@ -1407,7 +1406,7 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
             (nameof(subscription), subscription),
             (nameof(datasourceId), datasourceId));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
 
         // Find the soft-deleted protected item by datasource ID
         var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
@@ -1678,14 +1677,14 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
     public async Task<List<ProtectableItemInfo>> ListProtectableItemsAsync(
         string vaultName, string resourceGroup, string subscription,
         string? workloadType, string? containerName, string? tenant,
-        RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
 
         var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
         var rgResource = armClient.GetResourceGroupResource(rgId);
@@ -1712,14 +1711,14 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
 
     public async Task<List<ProtectableItemInfo>> ListDiscoveredProtectableItemsAsync(
         string vaultName, string resourceGroup, string subscription,
-        string? tenant, RetryPolicyOptions? retryPolicy, CancellationToken cancellationToken)
+        string? tenant, CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
             (nameof(vaultName), vaultName),
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
 
         var rgId = ResourceGroupResource.CreateResourceIdentifier(subscription, resourceGroup);
         var rgResource = armClient.GetResourceGroupResource(rgId);

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Backup/BackupStatusCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Backup/BackupStatusCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Backup;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -44,7 +43,6 @@ public class BackupStatusCommandTests : SubscriptionCommandUnitTestsBase<BackupS
             Arg.Is("sub1"),
             Arg.Is("eastus"),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expected);
 
@@ -81,7 +79,6 @@ public class BackupStatusCommandTests : SubscriptionCommandUnitTestsBase<BackupS
             Arg.Is("sub1"),
             Arg.Is("eastus"),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expected);
 
@@ -108,7 +105,6 @@ public class BackupStatusCommandTests : SubscriptionCommandUnitTestsBase<BackupS
             Arg.Is("sub1"),
             Arg.Is("eastus"),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -132,7 +128,6 @@ public class BackupStatusCommandTests : SubscriptionCommandUnitTestsBase<BackupS
             Arg.Is("sub1"),
             Arg.Is("eastus"),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
@@ -156,7 +151,6 @@ public class BackupStatusCommandTests : SubscriptionCommandUnitTestsBase<BackupS
             Arg.Is("sub1"),
             Arg.Is("eastus"),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
@@ -185,7 +179,6 @@ public class BackupStatusCommandTests : SubscriptionCommandUnitTestsBase<BackupS
                 Arg.Is("sub1"),
                 Arg.Is("eastus"),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new BackupStatusResult("ds1", "Protected", "v1", "pol", null, null, null));
         }
@@ -223,7 +216,6 @@ public class BackupStatusCommandTests : SubscriptionCommandUnitTestsBase<BackupS
             Arg.Is("sub1"),
             Arg.Is("eastus"),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expected);
 
@@ -269,7 +261,6 @@ public class BackupStatusCommandTests : SubscriptionCommandUnitTestsBase<BackupS
             Arg.Is(expectedSubscription),
             Arg.Is(expectedLocation),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new BackupStatusResult(expectedDatasourceId, "Protected", null, null, null, null, null));
 
@@ -285,7 +276,6 @@ public class BackupStatusCommandTests : SubscriptionCommandUnitTestsBase<BackupS
             expectedSubscription,
             expectedLocation,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/DisasterRecovery/DisasterRecoveryEnableCrrCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/DisasterRecovery/DisasterRecoveryEnableCrrCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.DisasterRecovery;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -35,7 +34,6 @@ public class DisasterRecoveryEnableCrrCommandTests : SubscriptionCommandUnitTest
             Arg.Is("sub"),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, "Cross-region restore enabled"));
 
@@ -61,7 +59,6 @@ public class DisasterRecoveryEnableCrrCommandTests : SubscriptionCommandUnitTest
             Arg.Is("sub"),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -86,7 +83,6 @@ public class DisasterRecoveryEnableCrrCommandTests : SubscriptionCommandUnitTest
             Arg.Is("sub"),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
@@ -111,7 +107,6 @@ public class DisasterRecoveryEnableCrrCommandTests : SubscriptionCommandUnitTest
             Arg.Is("sub"),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(400, "CRR not supported"));
 
@@ -132,7 +127,7 @@ public class DisasterRecoveryEnableCrrCommandTests : SubscriptionCommandUnitTest
         // Arrange
         Service.ConfigureCrossRegionRestoreAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(409, "Already enabled"));
 
         // Act
@@ -171,7 +166,7 @@ public class DisasterRecoveryEnableCrrCommandTests : SubscriptionCommandUnitTest
     {
         Service.ConfigureCrossRegionRestoreAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(vaultType),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, null));
 
         var response = await ExecuteCommandAsync(
@@ -191,7 +186,7 @@ public class DisasterRecoveryEnableCrrCommandTests : SubscriptionCommandUnitTest
         {
             Service.ConfigureCrossRegionRestoreAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new OperationResult("Succeeded", null, null));
         }
 
@@ -228,7 +223,7 @@ public class DisasterRecoveryEnableCrrCommandTests : SubscriptionCommandUnitTest
         // Arrange
         Service.ConfigureCrossRegionRestoreAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, "Cross-region restore enabled"));
 
         // Act

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Governance/GovernanceFindUnprotectedCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Governance/GovernanceFindUnprotectedCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Governance;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -37,7 +36,7 @@ public class GovernanceFindUnprotectedCommandTests : SubscriptionCommandUnitTest
 
         Service.FindUnprotectedResourcesAsync(
             Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expectedResources);
 
         // Act
@@ -56,7 +55,7 @@ public class GovernanceFindUnprotectedCommandTests : SubscriptionCommandUnitTest
         // Arrange
         Service.FindUnprotectedResourcesAsync(
             Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act
@@ -74,7 +73,7 @@ public class GovernanceFindUnprotectedCommandTests : SubscriptionCommandUnitTest
         // Arrange
         Service.FindUnprotectedResourcesAsync(
             Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -93,7 +92,7 @@ public class GovernanceFindUnprotectedCommandTests : SubscriptionCommandUnitTest
         {
             Service.FindUnprotectedResourcesAsync(
                 Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns([]);
         }
 
@@ -136,7 +135,7 @@ public class GovernanceFindUnprotectedCommandTests : SubscriptionCommandUnitTest
         // Arrange
         Service.FindUnprotectedResourcesAsync(
             Arg.Is("sub123"), Arg.Any<string?>(), Arg.Is("myRG"), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act
@@ -146,7 +145,7 @@ public class GovernanceFindUnprotectedCommandTests : SubscriptionCommandUnitTest
         Assert.Equal(HttpStatusCode.OK, response.Status);
         await Service.Received(1).FindUnprotectedResourcesAsync(
             "sub123", Arg.Any<string?>(), "myRG",
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -161,7 +160,7 @@ public class GovernanceFindUnprotectedCommandTests : SubscriptionCommandUnitTest
 
         Service.FindUnprotectedResourcesAsync(
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expectedResources);
 
         // Act
@@ -192,7 +191,7 @@ public class GovernanceFindUnprotectedCommandTests : SubscriptionCommandUnitTest
 
         Service.FindUnprotectedResourcesAsync(
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expectedResources);
 
         // Act
@@ -234,7 +233,7 @@ public class GovernanceFindUnprotectedCommandTests : SubscriptionCommandUnitTest
 
         Service.FindUnprotectedResourcesAsync(
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expectedResources);
 
         // Act

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Governance/GovernanceImmutabilityCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Governance/GovernanceImmutabilityCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Governance;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -31,7 +30,7 @@ public class GovernanceImmutabilityCommandTests : SubscriptionCommandUnitTestsBa
         // Arrange
         Service.ConfigureImmutabilityAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("Enabled"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, "Immutability configured"));
 
         // Act
@@ -53,7 +52,7 @@ public class GovernanceImmutabilityCommandTests : SubscriptionCommandUnitTestsBa
         // Arrange
         Service.ConfigureImmutabilityAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("Enabled"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -78,7 +77,7 @@ public class GovernanceImmutabilityCommandTests : SubscriptionCommandUnitTestsBa
         {
             Service.ConfigureImmutabilityAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("Enabled"),
-                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new OperationResult("Succeeded", null, null));
         }
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Governance/GovernanceSoftDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Governance/GovernanceSoftDeleteCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Governance;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -29,7 +28,7 @@ public class GovernanceSoftDeleteCommandTests : SubscriptionCommandUnitTestsBase
         // Arrange
         Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("AlwaysOn"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, "Soft delete configured"));
 
         // Act
@@ -51,7 +50,7 @@ public class GovernanceSoftDeleteCommandTests : SubscriptionCommandUnitTestsBase
         // Arrange
         Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -76,7 +75,7 @@ public class GovernanceSoftDeleteCommandTests : SubscriptionCommandUnitTestsBase
         {
             Service.ConfigureSoftDeleteAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
-                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new OperationResult("Succeeded", null, null));
         }
 
@@ -100,7 +99,7 @@ public class GovernanceSoftDeleteCommandTests : SubscriptionCommandUnitTestsBase
         // Arrange
         Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
         // Act
@@ -121,7 +120,7 @@ public class GovernanceSoftDeleteCommandTests : SubscriptionCommandUnitTestsBase
         // Arrange
         Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(409, "Cannot change"));
 
         // Act
@@ -142,7 +141,7 @@ public class GovernanceSoftDeleteCommandTests : SubscriptionCommandUnitTestsBase
         // Arrange
         Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
         // Act
@@ -205,7 +204,7 @@ public class GovernanceSoftDeleteCommandTests : SubscriptionCommandUnitTestsBase
         // Arrange
         Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, null));
 
         // Act
@@ -226,7 +225,7 @@ public class GovernanceSoftDeleteCommandTests : SubscriptionCommandUnitTestsBase
         // Arrange
         Service.ConfigureSoftDeleteAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("On"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, "Soft delete set to 'On'"));
 
         // Act

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Job/JobGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Job/JobGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Job;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -43,7 +42,6 @@ public class JobGetCommandTests : SubscriptionCommandUnitTestsBase<JobGetCommand
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedJobs);
 
@@ -77,7 +75,6 @@ public class JobGetCommandTests : SubscriptionCommandUnitTestsBase<JobGetCommand
             Arg.Is(jobId),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedJob);
 
@@ -100,7 +97,7 @@ public class JobGetCommandTests : SubscriptionCommandUnitTestsBase<JobGetCommand
     {
         // Arrange
         Service.ListJobsAsync(
-            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act
@@ -120,7 +117,7 @@ public class JobGetCommandTests : SubscriptionCommandUnitTestsBase<JobGetCommand
     {
         // Arrange
         Service.ListJobsAsync(
-            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -139,7 +136,7 @@ public class JobGetCommandTests : SubscriptionCommandUnitTestsBase<JobGetCommand
     {
         // Arrange
         Service.GetJobAsync(
-            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("nonexistent"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("nonexistent"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Job not found"));
 
         // Act
@@ -163,11 +160,11 @@ public class JobGetCommandTests : SubscriptionCommandUnitTestsBase<JobGetCommand
         if (shouldSucceed)
         {
             Service.ListJobsAsync(
-                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns([]);
 
             Service.GetJobAsync(
-                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("j1"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("j1"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new BackupJobInfo("id", "j1", "rsv", "Backup", "Completed", null, null, "VM", "vm1"));
         }
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Policy/PolicyCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Policy/PolicyCreateCommandTests.cs
@@ -8,7 +8,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands.Policy;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
 using Azure.Mcp.Tools.AzureBackup.Services.Policy;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -35,7 +34,7 @@ public class PolicyCreateCommandTests : SubscriptionCommandUnitTestsBase<PolicyC
             Arg.Is<PolicyCreateRequest>(r => r.Policy == "myPolicy" && r.WorkloadType == "AzureIaasVM"),
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
             Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(expected));
         // Act
         var response = await ExecuteCommandAsync(
@@ -60,7 +59,7 @@ public class PolicyCreateCommandTests : SubscriptionCommandUnitTestsBase<PolicyC
             Arg.Is<PolicyCreateRequest>(r => r.Policy == "p" && r.WorkloadType == "AzureIaasVM"),
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
             Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
         // Act
         var response = await ExecuteCommandAsync(
@@ -87,7 +86,7 @@ public class PolicyCreateCommandTests : SubscriptionCommandUnitTestsBase<PolicyC
                 Arg.Is<PolicyCreateRequest>(r => r.Policy == "p" && r.WorkloadType == "VM"),
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
                 Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new OperationResult("Succeeded", null, null));
         }
 
@@ -204,7 +203,7 @@ public class PolicyCreateCommandTests : SubscriptionCommandUnitTestsBase<PolicyC
             Arg.Any<PolicyCreateRequest>(),
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(expected));
         // Act
         var response = await ExecuteCommandAsync(
@@ -230,7 +229,7 @@ public class PolicyCreateCommandTests : SubscriptionCommandUnitTestsBase<PolicyC
             Arg.Is<PolicyCreateRequest>(r => r.Policy == "p" && r.WorkloadType == "VM"),
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
             Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
         // Act
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Policy/PolicyGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Policy/PolicyGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Policy;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -43,7 +42,6 @@ public class PolicyGetCommandTests : SubscriptionCommandUnitTestsBase<PolicyGetC
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedPolicies);
 
@@ -76,7 +74,6 @@ public class PolicyGetCommandTests : SubscriptionCommandUnitTestsBase<PolicyGetC
             Arg.Is(policyName),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new BackupPolicyInfo("id1", policyName, "rsv", ["AzureIaasVM"], 5, null, null, null));
 
@@ -108,7 +105,6 @@ public class PolicyGetCommandTests : SubscriptionCommandUnitTestsBase<PolicyGetC
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -133,7 +129,7 @@ public class PolicyGetCommandTests : SubscriptionCommandUnitTestsBase<PolicyGetC
         var resourceGroup = "myRg";
 
         Service.ListPoliciesAsync(
-            Arg.Is(vault), Arg.Is(resourceGroup), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is(vault), Arg.Is(resourceGroup), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -157,7 +153,7 @@ public class PolicyGetCommandTests : SubscriptionCommandUnitTestsBase<PolicyGetC
         var policyName = "nonexistent";
 
         Service.GetPolicyAsync(
-            Arg.Is(vault), Arg.Is(resourceGroup), Arg.Is(subscription), Arg.Is(policyName), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is(vault), Arg.Is(resourceGroup), Arg.Is(subscription), Arg.Is(policyName), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Policy not found"));
 
         // Act
@@ -181,11 +177,11 @@ public class PolicyGetCommandTests : SubscriptionCommandUnitTestsBase<PolicyGetC
         if (shouldSucceed)
         {
             Service.ListPoliciesAsync(
-                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns([]);
 
             Service.GetPolicyAsync(
-                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub123"), Arg.Is("p"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub123"), Arg.Is("p"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new BackupPolicyInfo("id1", "p", "rsv", ["VM"], 1, null, null, null));
         }
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Policy/PolicyUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Policy/PolicyUpdateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Policy;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -35,7 +34,7 @@ public class PolicyUpdateCommandTests : SubscriptionCommandUnitTestsBase<PolicyU
         Service.UpdatePolicyAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("myPolicy"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expected);
 
         // Act
@@ -60,7 +59,7 @@ public class PolicyUpdateCommandTests : SubscriptionCommandUnitTestsBase<PolicyU
         Service.UpdatePolicyAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("p"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -85,7 +84,7 @@ public class PolicyUpdateCommandTests : SubscriptionCommandUnitTestsBase<PolicyU
             Service.UpdatePolicyAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("p"),
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new OperationResult("Succeeded", null, null));
         }
 
@@ -139,7 +138,7 @@ public class PolicyUpdateCommandTests : SubscriptionCommandUnitTestsBase<PolicyU
         Service.UpdatePolicyAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expected);
 
         // Act
@@ -164,7 +163,7 @@ public class PolicyUpdateCommandTests : SubscriptionCommandUnitTestsBase<PolicyU
         Service.UpdatePolicyAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("p"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
         // Act
@@ -186,7 +185,7 @@ public class PolicyUpdateCommandTests : SubscriptionCommandUnitTestsBase<PolicyU
         Service.UpdatePolicyAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("p"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not Found"));
 
         // Act
@@ -208,7 +207,7 @@ public class PolicyUpdateCommandTests : SubscriptionCommandUnitTestsBase<PolicyU
         Service.UpdatePolicyAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("p"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException("Update is only supported for RSV (Recovery Services vault) policies. DPP policies do not support update."));
 
         // Act
@@ -230,7 +229,7 @@ public class PolicyUpdateCommandTests : SubscriptionCommandUnitTestsBase<PolicyU
         Service.UpdatePolicyAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("p"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException("Unsupported policy type 'SomePolicy'."));
 
         // Act
@@ -252,7 +251,7 @@ public class PolicyUpdateCommandTests : SubscriptionCommandUnitTestsBase<PolicyU
         Service.UpdatePolicyAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("p"),
             Arg.Any<string?>(), Arg.Is("not-a-time"), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException("Invalid schedule time 'not-a-time'. Provide a valid time in UTC HH:mm format (e.g., '04:00')."));
 
         // Act
@@ -275,7 +274,7 @@ public class PolicyUpdateCommandTests : SubscriptionCommandUnitTestsBase<PolicyU
         Service.UpdatePolicyAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("p"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Is("-5"),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException("Invalid daily retention days '-5'. Provide a positive integer."));
 
         // Act
@@ -300,7 +299,7 @@ public class PolicyUpdateCommandTests : SubscriptionCommandUnitTestsBase<PolicyU
         Service.UpdatePolicyAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("p"),
             Arg.Any<string?>(), Arg.Is("04:00"), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expected);
 
         // Act
@@ -324,7 +323,7 @@ public class PolicyUpdateCommandTests : SubscriptionCommandUnitTestsBase<PolicyU
         Service.UpdatePolicyAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("p"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Is("60"),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expected);
 
         // Act

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ProtectableItem/ProtectableItemListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ProtectableItem/ProtectableItemListCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.ProtectableItem;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -36,7 +35,7 @@ public class ProtectableItemListCommandTests : SubscriptionCommandUnitTestsBase<
 
         Service.ListProtectableItemsAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expectedItems);
 
         // Act
@@ -57,7 +56,7 @@ public class ProtectableItemListCommandTests : SubscriptionCommandUnitTestsBase<
         // Arrange
         Service.ListProtectableItemsAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act
@@ -78,7 +77,7 @@ public class ProtectableItemListCommandTests : SubscriptionCommandUnitTestsBase<
         // Arrange
         Service.ListProtectableItemsAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -101,7 +100,7 @@ public class ProtectableItemListCommandTests : SubscriptionCommandUnitTestsBase<
         {
             Service.ListProtectableItemsAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns([]);
         }
 
@@ -163,7 +162,7 @@ public class ProtectableItemListCommandTests : SubscriptionCommandUnitTestsBase<
         // Arrange
         Service.ListProtectableItemsAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is<string?>(workloadType), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act
@@ -202,6 +201,6 @@ public class ProtectableItemListCommandTests : SubscriptionCommandUnitTestsBase<
         await Service.DidNotReceive().ListProtectableItemsAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ProtectedItem/ProtectedItemGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ProtectedItem/ProtectedItemGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.ProtectedItem;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -43,7 +42,6 @@ public class ProtectedItemGetCommandTests : SubscriptionCommandUnitTestsBase<Pro
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedItems);
 
@@ -78,7 +76,6 @@ public class ProtectedItemGetCommandTests : SubscriptionCommandUnitTestsBase<Pro
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedItem);
 
@@ -105,7 +102,7 @@ public class ProtectedItemGetCommandTests : SubscriptionCommandUnitTestsBase<Pro
         var resourceGroup = "myRg";
 
         Service.ListProtectedItemsAsync(
-            Arg.Is(vault), Arg.Is(resourceGroup), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is(vault), Arg.Is(resourceGroup), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act
@@ -125,7 +122,7 @@ public class ProtectedItemGetCommandTests : SubscriptionCommandUnitTestsBase<Pro
     {
         // Arrange
         Service.ListProtectedItemsAsync(
-            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -144,7 +141,7 @@ public class ProtectedItemGetCommandTests : SubscriptionCommandUnitTestsBase<Pro
     {
         // Arrange
         Service.GetProtectedItemAsync(
-            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("nonexistent"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("nonexistent"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Item not found"));
 
         // Act
@@ -168,11 +165,11 @@ public class ProtectedItemGetCommandTests : SubscriptionCommandUnitTestsBase<Pro
         if (shouldSucceed)
         {
             Service.ListProtectedItemsAsync(
-                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns([]);
 
             Service.GetProtectedItemAsync(
-                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item1"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item1"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult(new ProtectedItemInfo("id", "item1", "rsv", "Protected", "VM", "/sub/vm", "pol", null, null)));
         }
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ProtectedItem/ProtectedItemProtectCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ProtectedItem/ProtectedItemProtectCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.ProtectedItem;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -30,7 +29,7 @@ public class ProtectedItemProtectCommandTests : SubscriptionCommandUnitTestsBase
         // Arrange
         Service.ProtectItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("/subscriptions/.../vm1"), Arg.Is("DefaultPolicy"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new ProtectResult("Succeeded", "vm1-backup", "job123", "Protection enabled"));
 
         // Act
@@ -53,7 +52,7 @@ public class ProtectedItemProtectCommandTests : SubscriptionCommandUnitTestsBase
         // Arrange
         Service.ProtectItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("/subscriptions/.../vm1"), Arg.Is("DefaultPolicy"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -78,7 +77,7 @@ public class ProtectedItemProtectCommandTests : SubscriptionCommandUnitTestsBase
         {
             Service.ProtectItemAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"), Arg.Is("pol1"),
-                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new ProtectResult("Succeeded", "item1", "job1", null));
         }
 
@@ -102,7 +101,7 @@ public class ProtectedItemProtectCommandTests : SubscriptionCommandUnitTestsBase
         // Arrange
         Service.ProtectItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("/subscriptions/.../vm1"), Arg.Is("DefaultPolicy"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
         // Act
@@ -143,7 +142,7 @@ public class ProtectedItemProtectCommandTests : SubscriptionCommandUnitTestsBase
         // (read back from the backup instance) and leave JobId null.
         Service.ProtectItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("/subscriptions/.../disks/d1"), Arg.Is("policy-disk"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new ProtectResult(
                 Status: "Succeeded",
                 ProtectedItemName: "rg-mydisk-abcd1234",
@@ -174,7 +173,7 @@ public class ProtectedItemProtectCommandTests : SubscriptionCommandUnitTestsBase
         // carry Status="Failed" + ErrorMessage rather than a misleading "Accepted".
         Service.ProtectItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("/subscriptions/.../sa1"), Arg.Is("policy-blob"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new ProtectResult(
                 Status: "Failed",
                 ProtectedItemName: "rg-blob-xyz",
@@ -205,7 +204,7 @@ public class ProtectedItemProtectCommandTests : SubscriptionCommandUnitTestsBase
         // terminal status (Completed, CompletedWithWarnings, Failed) along with the job id.
         Service.ProtectItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("/subscriptions/.../vms/myvm"), Arg.Is("policy-vm"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new ProtectResult(
                 Status: "Completed",
                 ProtectedItemName: "vm;iaasvmcontainerv2;rg;myvm",
@@ -233,7 +232,7 @@ public class ProtectedItemProtectCommandTests : SubscriptionCommandUnitTestsBase
         // and ErrorMessage from the job rather than the previous "Accepted".
         Service.ProtectItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("/subscriptions/.../sa/fileServices/default/shares/share"), Arg.Is("policy-afs"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new ProtectResult(
                 Status: "Failed",
                 ProtectedItemName: "afsfileshare;sa;share",
@@ -263,7 +262,7 @@ public class ProtectedItemProtectCommandTests : SubscriptionCommandUnitTestsBase
         // should return InProgress with the job id so the caller can keep monitoring.
         Service.ProtectItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("/subscriptions/.../vms/slowvm"), Arg.Is("policy-vm"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new ProtectResult(
                 Status: "InProgress",
                 ProtectedItemName: "vm;iaasvmcontainerv2;rg;slowvm",
@@ -306,7 +305,7 @@ public class ProtectedItemProtectCommandTests : SubscriptionCommandUnitTestsBase
 
         await Service.DidNotReceive().ProtectItemAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -324,7 +323,7 @@ public class ProtectedItemProtectCommandTests : SubscriptionCommandUnitTestsBase
         // Arrange
         Service.ProtectItemAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new ProtectResult("Succeeded", "item1", "job1", null));
 
         // Act
@@ -362,7 +361,7 @@ public class ProtectedItemProtectCommandTests : SubscriptionCommandUnitTestsBase
 
         await Service.DidNotReceive().ProtectItemAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -387,6 +386,6 @@ public class ProtectedItemProtectCommandTests : SubscriptionCommandUnitTestsBase
 
         await Service.DidNotReceive().ProtectItemAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ProtectedItem/ProtectedItemUndeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ProtectedItem/ProtectedItemUndeleteCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.ProtectedItem;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -31,7 +30,7 @@ public class ProtectedItemUndeleteCommandTests : SubscriptionCommandUnitTestsBas
         Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
             Arg.Is("/subscriptions/00000000/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/my-vm"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Accepted", null, "Soft-deleted protected item restored"));
 
         // Act
@@ -53,7 +52,7 @@ public class ProtectedItemUndeleteCommandTests : SubscriptionCommandUnitTestsBas
         // Arrange
         Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Accepted", "job-456", "Item restored successfully"));
 
         // Act
@@ -77,7 +76,7 @@ public class ProtectedItemUndeleteCommandTests : SubscriptionCommandUnitTestsBas
         // Arrange
         Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -101,7 +100,7 @@ public class ProtectedItemUndeleteCommandTests : SubscriptionCommandUnitTestsBas
         {
             Service.UndeleteProtectedItemAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
-                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new OperationResult("Accepted", null, "Restored"));
         }
 
@@ -125,7 +124,7 @@ public class ProtectedItemUndeleteCommandTests : SubscriptionCommandUnitTestsBas
         // Arrange
         Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
         // Act
@@ -147,7 +146,7 @@ public class ProtectedItemUndeleteCommandTests : SubscriptionCommandUnitTestsBas
         // Arrange
         Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not Found"));
 
         // Act
@@ -168,7 +167,7 @@ public class ProtectedItemUndeleteCommandTests : SubscriptionCommandUnitTestsBas
         // Arrange
         Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(409, "Conflict"));
 
         // Act
@@ -189,7 +188,7 @@ public class ProtectedItemUndeleteCommandTests : SubscriptionCommandUnitTestsBas
         // Arrange
         Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new KeyNotFoundException("Item not found"));
 
         // Act
@@ -211,7 +210,7 @@ public class ProtectedItemUndeleteCommandTests : SubscriptionCommandUnitTestsBas
         Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
             Arg.Is("/subscriptions/00000000/resourceGroups/rg/providers/Microsoft.Compute/disks/my-disk"),
-            Arg.Is("dpp"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is("dpp"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Accepted", null, "Soft-deleted backup instance restored"));
 
         // Act
@@ -234,7 +233,7 @@ public class ProtectedItemUndeleteCommandTests : SubscriptionCommandUnitTestsBas
         // Arrange
         Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException("Invalid datasource ID format"));
 
         // Act
@@ -270,7 +269,7 @@ public class ProtectedItemUndeleteCommandTests : SubscriptionCommandUnitTestsBas
         Service.UndeleteProtectedItemAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("ds1"),
             Arg.Any<string?>(), Arg.Is("IaasVMContainer;iaasvmcontainerv2;rg;myvm"), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Accepted", null, "Restored"));
 
         // Act
@@ -286,6 +285,6 @@ public class ProtectedItemUndeleteCommandTests : SubscriptionCommandUnitTestsBas
         await Service.Received(1).UndeleteProtectedItemAsync(
             "v", "rg", "sub", "ds1",
             Arg.Any<string?>(), "IaasVMContainer;iaasvmcontainerv2;rg;myvm", Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/RecoveryPoint/RecoveryPointGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/RecoveryPoint/RecoveryPointGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.RecoveryPoint;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -46,7 +45,6 @@ public class RecoveryPointGetCommandTests : SubscriptionCommandUnitTestsBase<Rec
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedPoints);
 
@@ -83,7 +81,6 @@ public class RecoveryPointGetCommandTests : SubscriptionCommandUnitTestsBase<Rec
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new RecoveryPointInfo("rp1", rpId, "rsv", DateTimeOffset.UtcNow.AddDays(-1), "Full"));
 
@@ -107,7 +104,7 @@ public class RecoveryPointGetCommandTests : SubscriptionCommandUnitTestsBase<Rec
     {
         // Arrange
         Service.ListRecoveryPointsAsync(
-            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act
@@ -128,7 +125,7 @@ public class RecoveryPointGetCommandTests : SubscriptionCommandUnitTestsBase<Rec
     {
         // Arrange
         Service.ListRecoveryPointsAsync(
-            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -148,7 +145,7 @@ public class RecoveryPointGetCommandTests : SubscriptionCommandUnitTestsBase<Rec
     {
         // Arrange
         Service.GetRecoveryPointAsync(
-            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Is("nonexistent"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Is("nonexistent"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Recovery point not found"));
 
         // Act
@@ -173,11 +170,11 @@ public class RecoveryPointGetCommandTests : SubscriptionCommandUnitTestsBase<Rec
         if (shouldSucceed)
         {
             Service.ListRecoveryPointsAsync(
-                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns([]);
 
             Service.GetRecoveryPointAsync(
-                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Is("rp1"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("item"), Arg.Is("rp1"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new RecoveryPointInfo("rp1", "rp1", "rsv", DateTimeOffset.UtcNow, "Full"));
         }
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ResourceGuard/ResourceGuardCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ResourceGuard/ResourceGuardCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.ResourceGuard;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -39,7 +38,7 @@ public class ResourceGuardCreateCommandTests : SubscriptionCommandUnitTestsBase<
         Service.CreateResourceGuardAsync(
             Arg.Is("guard1"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("eastus2"),
             Arg.Any<IReadOnlyList<string>?>(), Arg.Any<IReadOnlyDictionary<string, string>?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(NewGuard());
 
         var response = await ExecuteCommandAsync(
@@ -60,7 +59,7 @@ public class ResourceGuardCreateCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Do<IReadOnlyList<string>?>(v => captured = v),
             Arg.Any<IReadOnlyDictionary<string, string>?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(NewGuard());
 
         var response = await ExecuteCommandAsync(
@@ -84,7 +83,7 @@ public class ResourceGuardCreateCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<IReadOnlyList<string>?>(),
             Arg.Do<IReadOnlyDictionary<string, string>?>(v => capturedTags = v),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(NewGuard());
 
         var response = await ExecuteCommandAsync(
@@ -139,7 +138,7 @@ public class ResourceGuardCreateCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<IReadOnlyList<string>?>(),
             Arg.Any<IReadOnlyDictionary<string, string>?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException("The following operations cannot be excluded from a Resource Guard because they are mandatory: disableSoftDelete."));
 
         var response = await ExecuteCommandAsync(
@@ -160,7 +159,7 @@ public class ResourceGuardCreateCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<IReadOnlyList<string>?>(),
             Arg.Any<IReadOnlyDictionary<string, string>?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(409, "Already exists"));
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ResourceGuard/ResourceGuardDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ResourceGuard/ResourceGuardDeleteCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.ResourceGuard;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -29,7 +28,7 @@ public class ResourceGuardDeleteCommandTests : SubscriptionCommandUnitTestsBase<
     {
         Service.DeleteResourceGuardAsync(
             Arg.Is("guard1"), Arg.Is("rg"), Arg.Is("sub"),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, null));
 
         var response = await ExecuteCommandAsync(
@@ -46,7 +45,7 @@ public class ResourceGuardDeleteCommandTests : SubscriptionCommandUnitTestsBase<
     {
         Service.DeleteResourceGuardAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
         var response = await ExecuteCommandAsync(
@@ -62,7 +61,7 @@ public class ResourceGuardDeleteCommandTests : SubscriptionCommandUnitTestsBase<
     {
         Service.DeleteResourceGuardAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(409, "In use"));
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ResourceGuard/ResourceGuardGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/ResourceGuard/ResourceGuardGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.ResourceGuard;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -38,7 +37,7 @@ public class ResourceGuardGetCommandTests : SubscriptionCommandUnitTestsBase<Res
     {
         Service.GetResourceGuardAsync(
             Arg.Is("guard1"), Arg.Is("rg"), Arg.Is("sub"),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(NewGuard());
 
         var response = await ExecuteCommandAsync(
@@ -56,7 +55,7 @@ public class ResourceGuardGetCommandTests : SubscriptionCommandUnitTestsBase<Res
     {
         Service.ListResourceGuardsAsync(
             Arg.Is("sub"), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new List<ResourceGuardInfo> { NewGuard("a"), NewGuard("b") });
 
         var response = await ExecuteCommandAsync(
@@ -82,7 +81,7 @@ public class ResourceGuardGetCommandTests : SubscriptionCommandUnitTestsBase<Res
     {
         Service.GetResourceGuardAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Security/SecurityConfigureEncryptionCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Security/SecurityConfigureEncryptionCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Security;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -40,7 +39,7 @@ public class SecurityConfigureEncryptionCommandTests : SubscriptionCommandUnitTe
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
             Arg.Is(TestKeyVaultUri), Arg.Is(TestKeyName), Arg.Is("SystemAssigned"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expected);
 
         // Act
@@ -68,7 +67,7 @@ public class SecurityConfigureEncryptionCommandTests : SubscriptionCommandUnitTe
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
             Arg.Is(TestKeyVaultUri), Arg.Is(TestKeyName), Arg.Is("UserAssigned"),
             Arg.Any<string?>(), Arg.Is(TestUserAssignedIdentityId), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expected);
 
         // Act
@@ -96,7 +95,7 @@ public class SecurityConfigureEncryptionCommandTests : SubscriptionCommandUnitTe
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
             Arg.Is(TestKeyVaultUri), Arg.Is(TestKeyName), Arg.Is("SystemAssigned"),
             Arg.Is(TestKeyVersion), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expected);
 
         // Act
@@ -121,7 +120,7 @@ public class SecurityConfigureEncryptionCommandTests : SubscriptionCommandUnitTe
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -146,7 +145,7 @@ public class SecurityConfigureEncryptionCommandTests : SubscriptionCommandUnitTe
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
         // Act
@@ -171,7 +170,7 @@ public class SecurityConfigureEncryptionCommandTests : SubscriptionCommandUnitTe
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
         // Act
@@ -196,7 +195,7 @@ public class SecurityConfigureEncryptionCommandTests : SubscriptionCommandUnitTe
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(400, "Bad request"));
 
         // Act
@@ -255,7 +254,7 @@ public class SecurityConfigureEncryptionCommandTests : SubscriptionCommandUnitTe
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Is(vaultType),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, null));
 
         var response = await ExecuteCommandAsync(
@@ -317,7 +316,7 @@ public class SecurityConfigureEncryptionCommandTests : SubscriptionCommandUnitTe
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expected);
 
         // Act
@@ -344,7 +343,7 @@ public class SecurityConfigureEncryptionCommandTests : SubscriptionCommandUnitTe
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, null));
 
         // Act
@@ -361,7 +360,7 @@ public class SecurityConfigureEncryptionCommandTests : SubscriptionCommandUnitTe
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
             Arg.Is(TestKeyVaultUri), Arg.Is(TestKeyName), Arg.Is("SystemAssigned"),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -375,7 +374,7 @@ public class SecurityConfigureEncryptionCommandTests : SubscriptionCommandUnitTe
                 Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
                 Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new OperationResult("Succeeded", null, null));
         }
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Security/SecurityDisableMuaCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Security/SecurityDisableMuaCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Security;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -31,7 +30,7 @@ public class SecurityDisableMuaCommandTests : SubscriptionCommandUnitTestsBase<S
         var expected = new OperationResult("Succeeded", null, "MUA disabled");
         Service.DisableMultiUserAuthorizationAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var response = await ExecuteCommandAsync(
@@ -44,7 +43,7 @@ public class SecurityDisableMuaCommandTests : SubscriptionCommandUnitTestsBase<S
 
         await Service.Received(1).DisableMultiUserAuthorizationAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -52,7 +51,7 @@ public class SecurityDisableMuaCommandTests : SubscriptionCommandUnitTestsBase<S
     {
         Service.DisableMultiUserAuthorizationAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
         var response = await ExecuteCommandAsync(
@@ -69,7 +68,7 @@ public class SecurityDisableMuaCommandTests : SubscriptionCommandUnitTestsBase<S
     {
         Service.DisableMultiUserAuthorizationAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Security/SecurityEnableMuaCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Security/SecurityEnableMuaCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Security;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -33,7 +32,7 @@ public class SecurityEnableMuaCommandTests : SubscriptionCommandUnitTestsBase<Se
         var expected = new OperationResult("Succeeded", null, "MUA enabled");
         Service.ConfigureMultiUserAuthorizationAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var response = await ExecuteCommandAsync(
@@ -62,10 +61,10 @@ public class SecurityEnableMuaCommandTests : SubscriptionCommandUnitTestsBase<Se
 
         await Service.DidNotReceive().DisableMultiUserAuthorizationAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
         await Service.DidNotReceive().ConfigureMultiUserAuthorizationAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -86,7 +85,7 @@ public class SecurityEnableMuaCommandTests : SubscriptionCommandUnitTestsBase<Se
     {
         Service.ConfigureMultiUserAuthorizationAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         var response = await ExecuteCommandAsync(
@@ -104,7 +103,7 @@ public class SecurityEnableMuaCommandTests : SubscriptionCommandUnitTestsBase<Se
     {
         Service.ConfigureMultiUserAuthorizationAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
         var response = await ExecuteCommandAsync(
@@ -122,7 +121,7 @@ public class SecurityEnableMuaCommandTests : SubscriptionCommandUnitTestsBase<Se
     {
         Service.ConfigureMultiUserAuthorizationAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
         var response = await ExecuteCommandAsync(
@@ -140,7 +139,7 @@ public class SecurityEnableMuaCommandTests : SubscriptionCommandUnitTestsBase<Se
     {
         Service.ConfigureMultiUserAuthorizationAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(400, "Region mismatch"));
 
         var response = await ExecuteCommandAsync(
@@ -158,7 +157,7 @@ public class SecurityEnableMuaCommandTests : SubscriptionCommandUnitTestsBase<Se
     {
         Service.ConfigureMultiUserAuthorizationAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(409, "Already configured"));
 
         var response = await ExecuteCommandAsync(
@@ -198,7 +197,7 @@ public class SecurityEnableMuaCommandTests : SubscriptionCommandUnitTestsBase<Se
     {
         Service.ConfigureMultiUserAuthorizationAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
-            Arg.Is(vaultType), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is(vaultType), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new OperationResult("Succeeded", null, null)));
 
         var response = await ExecuteCommandAsync(
@@ -220,7 +219,7 @@ public class SecurityEnableMuaCommandTests : SubscriptionCommandUnitTestsBase<Se
         {
             Service.ConfigureMultiUserAuthorizationAsync(
                 Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new OperationResult("Succeeded", null, null));
         }
 
@@ -255,7 +254,7 @@ public class SecurityEnableMuaCommandTests : SubscriptionCommandUnitTestsBase<Se
         var expected = new OperationResult("Succeeded", null, "MUA enabled with guard");
         Service.ConfigureMultiUserAuthorizationAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expected);
 
         var response = await ExecuteCommandAsync(
@@ -274,7 +273,7 @@ public class SecurityEnableMuaCommandTests : SubscriptionCommandUnitTestsBase<Se
     {
         Service.ConfigureMultiUserAuthorizationAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, null));
 
         await ExecuteCommandAsync(
@@ -285,10 +284,10 @@ public class SecurityEnableMuaCommandTests : SubscriptionCommandUnitTestsBase<Se
 
         await Service.Received(1).ConfigureMultiUserAuthorizationAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestResourceGuardId),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
 
         await Service.DidNotReceive().DisableMultiUserAuthorizationAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Services/AzureBackupServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Services/AzureBackupServiceTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
 using Azure.Mcp.Tools.AzureBackup.Services.Policy;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -37,16 +36,16 @@ public class AzureBackupServiceTests
     {
         // RSV returns 404 -> should try DPP
         var expectedVault = new BackupVaultInfo(null, "myVault", "DPP", "eastus", "rg", null, null, null, null, null, null, null, null, null);
-        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
-        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(expectedVault);
 
-        var result = await _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, null, CancellationToken.None);
+        var result = await _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Equal("DPP", result.VaultType);
-        await _rsvOps.Received(1).GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>());
-        await _dppOps.Received(1).GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>());
+        await _rsvOps.Received(1).GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>());
+        await _dppOps.Received(1).GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -54,12 +53,12 @@ public class AzureBackupServiceTests
     {
         // RSV returns 403 -> should try DPP (not propagate immediately)
         var expectedVault = new BackupVaultInfo(null, "myVault", "DPP", "eastus", "rg", null, null, null, null, null, null, null, null, null);
-        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
-        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(expectedVault);
 
-        var result = await _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, null, CancellationToken.None);
+        var result = await _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Equal("DPP", result.VaultType);
     }
@@ -69,12 +68,12 @@ public class AzureBackupServiceTests
     {
         // RSV returns 401 -> should try DPP
         var expectedVault = new BackupVaultInfo(null, "myVault", "DPP", "eastus", "rg", null, null, null, null, null, null, null, null, null);
-        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(401, "Unauthorized"));
-        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(expectedVault);
 
-        var result = await _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, null, CancellationToken.None);
+        var result = await _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Equal("DPP", result.VaultType);
     }
@@ -83,13 +82,13 @@ public class AzureBackupServiceTests
     public async Task GetVaultAsync_BothStacksFail_ThrowsKeyNotFoundException()
     {
         // Both RSV and DPP return 404
-        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
-        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
         var ex = await Assert.ThrowsAsync<KeyNotFoundException>(() =>
-            _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, null, CancellationToken.None));
+            _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
 
         Assert.Contains("myVault", ex.Message);
         Assert.Contains("--vault-type", ex.Message);
@@ -99,13 +98,13 @@ public class AzureBackupServiceTests
     public async Task GetVaultAsync_BothStacksForbidden_ThrowsUnauthorizedAccessException()
     {
         // Both RSV and DPP return 403 -> should throw UnauthorizedAccessException (not KeyNotFoundException)
-        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
-        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
 
         var ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
-            _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, null, CancellationToken.None));
+            _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
 
         Assert.Contains("Authorization failed", ex.Message);
         Assert.Contains("RBAC permissions", ex.Message);
@@ -115,13 +114,13 @@ public class AzureBackupServiceTests
     public async Task GetVaultAsync_BothStacksUnauthorized_ThrowsUnauthorizedAccessException()
     {
         // Both RSV and DPP return 401 -> should throw UnauthorizedAccessException
-        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(401, "Unauthorized"));
-        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(401, "Unauthorized"));
 
         var ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
-            _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, null, CancellationToken.None));
+            _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
 
         Assert.Contains("Authorization failed", ex.Message);
     }
@@ -130,39 +129,39 @@ public class AzureBackupServiceTests
     public async Task GetVaultAsync_RsvSucceeds_DoesNotCallDpp()
     {
         var expectedVault = new BackupVaultInfo(null, "myVault", "RSV", "eastus", "rg", null, null, null, null, null, null, null, null, null);
-        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(expectedVault);
 
-        var result = await _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, null, CancellationToken.None);
+        var result = await _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Equal("RSV", result.VaultType);
-        await _dppOps.DidNotReceive().GetVaultAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await _dppOps.DidNotReceive().GetVaultAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetVaultAsync_ExplicitRsvVaultType_CallsOnlyRsv()
     {
         var expectedVault = new BackupVaultInfo(null, "myVault", "RSV", "eastus", "rg", null, null, null, null, null, null, null, null, null);
-        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(expectedVault);
 
-        var result = await _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", "rsv", null, null, CancellationToken.None);
+        var result = await _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", vaultType: "rsv", tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Equal("RSV", result.VaultType);
-        await _dppOps.DidNotReceive().GetVaultAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await _dppOps.DidNotReceive().GetVaultAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetVaultAsync_ExplicitDppVaultType_CallsOnlyDpp()
     {
         var expectedVault = new BackupVaultInfo(null, "myVault", "DPP", "eastus", "rg", null, null, null, null, null, null, null, null, null);
-        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _dppOps.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(expectedVault);
 
-        var result = await _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", "dpp", null, null, CancellationToken.None);
+        var result = await _service.GetVaultAsync("myVault", "rg", "22222222-2222-2222-2222-222222222222", vaultType: "dpp", tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Equal("DPP", result.VaultType);
-        await _rsvOps.DidNotReceive().GetVaultAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await _rsvOps.DidNotReceive().GetVaultAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), cancellationToken: Arg.Any<CancellationToken>());
     }
 
     #endregion
@@ -180,10 +179,10 @@ public class AzureBackupServiceTests
         {
             new(null, "dppVault1", "DPP", "eastus", "rg", null, null, null, null, null, null, null, null, null)
         };
-        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>()).Returns(rsvVaults);
-        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>()).Returns(dppVaults);
+        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>()).Returns(rsvVaults);
+        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>()).Returns(dppVaults);
 
-        var result = await _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, null, null, CancellationToken.None);
+        var result = await _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Equal(2, result.Count);
         Assert.Contains(result, v => v.Name == "rsvVault1");
@@ -193,15 +192,15 @@ public class AzureBackupServiceTests
     [Fact]
     public async Task ListVaultsAsync_RsvFails_ReturnsDppOnly()
     {
-        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "Forbidden"));
         var dppVaults = new List<BackupVaultInfo>
         {
             new(null, "dppVault1", "DPP", "eastus", "rg", null, null, null, null, null, null, null, null, null)
         };
-        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>()).Returns(dppVaults);
+        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>()).Returns(dppVaults);
 
-        var result = await _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, null, null, CancellationToken.None);
+        var result = await _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Single(result);
         Assert.Equal("dppVault1", result[0].Name);
@@ -214,11 +213,11 @@ public class AzureBackupServiceTests
         {
             new(null, "rsvVault1", "RSV", "eastus", "rg", null, null, null, null, null, null, null, null, null)
         };
-        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>()).Returns(rsvVaults);
-        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>()).Returns(rsvVaults);
+        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(500, "Internal error"));
 
-        var result = await _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, null, null, CancellationToken.None);
+        var result = await _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Single(result);
         Assert.Equal("rsvVault1", result[0].Name);
@@ -232,13 +231,13 @@ public class AzureBackupServiceTests
         // RequestFailedException so the command-layer error mapper classifies the failure
         // as an Azure service error (with the original HTTP status code) rather than as
         // an MCP-side bug.
-        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "RSV error"));
-        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "DPP error"));
 
         var ex = await Assert.ThrowsAsync<RequestFailedException>(() =>
-            _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, null, null, CancellationToken.None));
+            _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
 
         Assert.Equal(403, ex.Status);
         Assert.Contains("RSV error", ex.Message);
@@ -252,13 +251,13 @@ public class AzureBackupServiceTests
         // NEW-5: when the RSV RequestFailedException carries a 0 status (e.g. transport-level
         // failure with no HTTP status), prefer the DPP status so the user still sees a
         // useful HTTP code.
-        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(0, "RSV transport error"));
-        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(503, "DPP throttled"));
 
         var ex = await Assert.ThrowsAsync<RequestFailedException>(() =>
-            _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, null, null, CancellationToken.None));
+            _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
 
         Assert.Equal(503, ex.Status);
     }
@@ -270,13 +269,13 @@ public class AzureBackupServiceTests
         // never see a mismatched (Status, ErrorCode) pair. Here RSV has Status=0 with
         // its own ErrorCode; the wrapper should take both fields from DPP (the source
         // of the non-zero Status).
-        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(0, "RSV transport error", "RsvOnlyCode", null));
-        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(503, "DPP throttled", "DppThrottled", null));
 
         var ex = await Assert.ThrowsAsync<RequestFailedException>(() =>
-            _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, null, null, CancellationToken.None));
+            _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
 
         Assert.Equal(503, ex.Status);
         Assert.Equal("DppThrottled", ex.ErrorCode);
@@ -288,13 +287,13 @@ public class AzureBackupServiceTests
         // NEW-1: when the two backend failures are not directly comparable, wrap them
         // in a single InvalidOperationException whose Message mentions both inner
         // exception messages so the caller still has actionable context.
-        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "RSV forbidden"));
-        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("DPP network issue"));
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, null, null, CancellationToken.None));
+            _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
 
         Assert.Contains("RSV forbidden", ex.Message);
         Assert.Contains("DPP network issue", ex.Message);
@@ -306,13 +305,13 @@ public class AzureBackupServiceTests
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new OperationCanceledException(cts.Token));
-        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new OperationCanceledException(cts.Token));
 
         await Assert.ThrowsAsync<OperationCanceledException>(() =>
-            _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, null, null, cts.Token));
+            _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", resourceGroup: null, vaultType: null, tenant: null, cancellationToken: cts.Token));
     }
 
     #endregion
@@ -323,7 +322,7 @@ public class AzureBackupServiceTests
     public async Task ListProtectableItemsAsync_DppVaultType_ThrowsArgumentException()
     {
         var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
-            _service.ListProtectableItemsAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", null, null, "dpp", null, null, CancellationToken.None));
+            _service.ListProtectableItemsAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", workloadType: null, containerName: null, vaultType: "dpp", tenant: null, cancellationToken: CancellationToken.None));
 
         Assert.Contains("RSV", ex.Message);
     }
@@ -332,10 +331,10 @@ public class AzureBackupServiceTests
     public async Task ListProtectableItemsAsync_RsvVaultType_DelegatesToRsv()
     {
         var expected = new List<ProtectableItemInfo> { new("item1", "SQL", null, null, null, null, null, null, null) };
-        _rsvOps.ListProtectableItemsAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", null, null, null, null, Arg.Any<CancellationToken>())
+        _rsvOps.ListProtectableItemsAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", workloadType: null, containerName: null, tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(expected);
 
-        var result = await _service.ListProtectableItemsAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", null, null, "rsv", null, null, CancellationToken.None);
+        var result = await _service.ListProtectableItemsAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", workloadType: null, containerName: null, vaultType: "rsv", tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Single(result);
     }
@@ -344,14 +343,14 @@ public class AzureBackupServiceTests
     public async Task ListProtectableItemsAsync_NoVaultType_DelegatesToRsv()
     {
         // When no vault type specified, service auto-detects by probing RSV first
-        _rsvOps.GetVaultAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.GetVaultAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(new BackupVaultInfo(null, "vault", "RSV", "eastus", "rg", null, null, null, null, null, null, null, null, null));
 
         var expected = new List<ProtectableItemInfo> { new("item1", "SQL", null, null, null, null, null, null, null) };
-        _rsvOps.ListProtectableItemsAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", null, null, null, null, Arg.Any<CancellationToken>())
+        _rsvOps.ListProtectableItemsAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", workloadType: null, containerName: null, tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(expected);
 
-        var result = await _service.ListProtectableItemsAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", null, null, null, null, null, CancellationToken.None);
+        var result = await _service.ListProtectableItemsAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", workloadType: null, containerName: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Single(result);
     }
@@ -360,13 +359,13 @@ public class AzureBackupServiceTests
     public async Task ListProtectableItemsAsync_NoVaultType_DppVault_ThrowsArgumentException()
     {
         // When no vault type specified and vault is DPP, service should throw helpful error
-        _rsvOps.GetVaultAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.GetVaultAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
-        _dppOps.GetVaultAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _dppOps.GetVaultAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(new BackupVaultInfo(null, "vault", "DPP", "eastus", "rg", null, null, null, null, null, null, null, null, null));
 
         var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
-            _service.ListProtectableItemsAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", null, null, null, null, null, CancellationToken.None));
+            _service.ListProtectableItemsAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", workloadType: null, containerName: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
 
         Assert.Contains("DPP", ex.Message);
         Assert.Contains("Protectable item discovery is only supported", ex.Message);
@@ -380,12 +379,12 @@ public class AzureBackupServiceTests
     public async Task CreatePolicyAsync_Succeeds()
     {
         var baseResult = new OperationResult("Succeeded", null, "Policy 'p' created in vault 'v'.");
-        _rsvOps.GetVaultAsync("v", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.GetVaultAsync("v", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(new BackupVaultInfo(null, "v", "RSV", "eastus", "rg", null, null, null, null, null, null, null, null, null));
         _rsvOps.CreatePolicyAsync(
             Arg.Is<PolicyCreateRequest>(r => r.Policy == "p" && r.WorkloadType == "VM" && r.DailyRetentionDays == "30"),
             "v", "rg", "22222222-2222-2222-2222-222222222222",
-            Arg.Any<string?>(), Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            tenant: Arg.Any<string?>(), cancellationToken: Arg.Any<CancellationToken>())
             .Returns(baseResult);
 
         var request = new PolicyCreateRequest
@@ -397,8 +396,8 @@ public class AzureBackupServiceTests
 
         var result = await _service.CreatePolicyAsync(
             request,
-            "v", "rg", "22222222-2222-2222-2222-222222222222", null,
-            null, null, CancellationToken.None);
+            "v", "rg", "22222222-2222-2222-2222-222222222222",
+            vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Equal("Succeeded", result.Status);
     }
@@ -453,15 +452,15 @@ public class AzureBackupServiceTests
     public async Task ConfigureImmutabilityAsync_NormalizesState(string inputState, string expectedNormalized)
     {
         // RSV vault probe succeeds
-        _rsvOps.GetVaultAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.GetVaultAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(new BackupVaultInfo(null, "vault", "RSV", null, "rg", null, null, null, null, null, null, null, null, null));
-        _rsvOps.ConfigureImmutabilityAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", expectedNormalized, null, null, Arg.Any<CancellationToken>())
+        _rsvOps.ConfigureImmutabilityAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", expectedNormalized, tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, "Done"));
 
-        var result = await _service.ConfigureImmutabilityAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", inputState, null, null, null, CancellationToken.None);
+        var result = await _service.ConfigureImmutabilityAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", inputState, vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Equal("Succeeded", result.Status);
-        await _rsvOps.Received(1).ConfigureImmutabilityAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", expectedNormalized, null, null, Arg.Any<CancellationToken>());
+        await _rsvOps.Received(1).ConfigureImmutabilityAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", expectedNormalized, tenant: null, cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -470,11 +469,11 @@ public class AzureBackupServiceTests
     public async Task ConfigureImmutabilityAsync_InvalidState_ThrowsArgumentException(string inputState)
     {
         // RSV vault probe succeeds
-        _rsvOps.GetVaultAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>())
+        _rsvOps.GetVaultAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .Returns(new BackupVaultInfo(null, "vault", "RSV", null, "rg", null, null, null, null, null, null, null, null, null));
 
         var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
-            _service.ConfigureImmutabilityAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", inputState, null, null, null, CancellationToken.None));
+            _service.ConfigureImmutabilityAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", inputState, vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
 
         Assert.Contains("Invalid immutability state", ex.Message);
     }
@@ -485,7 +484,7 @@ public class AzureBackupServiceTests
     public async Task ConfigureImmutabilityAsync_EmptyOrWhitespace_ThrowsArgumentException(string inputState)
     {
         var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
-            _service.ConfigureImmutabilityAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", inputState, null, null, null, CancellationToken.None));
+            _service.ConfigureImmutabilityAsync("vault", "rg", "22222222-2222-2222-2222-222222222222", inputState, vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
 
         Assert.Contains("immutabilityState", ex.Message);
     }
@@ -506,10 +505,10 @@ public class AzureBackupServiceTests
         {
             new(null, "vault3", "DPP", "eastus", "rg1", null, null, null, null, null, null, null, null, null)
         };
-        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>()).Returns(rsvVaults);
-        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>()).Returns(dppVaults);
+        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>()).Returns(rsvVaults);
+        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>()).Returns(dppVaults);
 
-        var result = await _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", "rg1", null, null, null, CancellationToken.None);
+        var result = await _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", resourceGroup: "rg1", vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Equal(2, result.Count);
         Assert.All(result, v => Assert.Equal("rg1", v.ResourceGroup, ignoreCase: true));
@@ -522,10 +521,10 @@ public class AzureBackupServiceTests
         {
             new(null, "vault1", "RSV", "eastus", "MyRG", null, null, null, null, null, null, null, null, null)
         };
-        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>()).Returns(rsvVaults);
-        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", null, null, Arg.Any<CancellationToken>()).Returns(new List<BackupVaultInfo>());
+        _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>()).Returns(rsvVaults);
+        _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>()).Returns(new List<BackupVaultInfo>());
 
-        var result = await _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", "myrg", null, null, null, CancellationToken.None);
+        var result = await _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", resourceGroup: "myrg", vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         Assert.Single(result);
         Assert.Equal("vault1", result[0].Name);
@@ -554,15 +553,15 @@ public class AzureBackupServiceTests
         subResource.Data.Returns(subData);
         _azureService.GetSubscription(name, null, null, Arg.Any<CancellationToken>()).Returns(subResource);
 
-        _rsvOps.ListVaultsAsync(resolvedId, null, null, Arg.Any<CancellationToken>()).Returns([]);
-        _dppOps.ListVaultsAsync(resolvedId, null, null, Arg.Any<CancellationToken>()).Returns([]);
+        _rsvOps.ListVaultsAsync(resolvedId, tenant: null, cancellationToken: Arg.Any<CancellationToken>()).Returns([]);
+        _dppOps.ListVaultsAsync(resolvedId, tenant: null, cancellationToken: Arg.Any<CancellationToken>()).Returns([]);
 
-        await _service.ListVaultsAsync(name, null, null, null, null, CancellationToken.None);
+        await _service.ListVaultsAsync(name, resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         // Ops must have been called with the resolved GUID, NOT the original name.
-        await _rsvOps.Received(1).ListVaultsAsync(resolvedId, null, null, Arg.Any<CancellationToken>());
-        await _dppOps.Received(1).ListVaultsAsync(resolvedId, null, null, Arg.Any<CancellationToken>());
-        await _rsvOps.DidNotReceive().ListVaultsAsync(name, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await _rsvOps.Received(1).ListVaultsAsync(resolvedId, tenant: null, cancellationToken: Arg.Any<CancellationToken>());
+        await _dppOps.Received(1).ListVaultsAsync(resolvedId, tenant: null, cancellationToken: Arg.Any<CancellationToken>());
+        await _rsvOps.DidNotReceive().ListVaultsAsync(name, Arg.Any<string?>(), cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -572,13 +571,13 @@ public class AzureBackupServiceTests
         // to IAzureService when the value already parses as a Guid.
         const string guid = "44444444-4444-4444-4444-444444444444";
 
-        _rsvOps.ListVaultsAsync(guid, null, null, Arg.Any<CancellationToken>()).Returns([]);
-        _dppOps.ListVaultsAsync(guid, null, null, Arg.Any<CancellationToken>()).Returns([]);
+        _rsvOps.ListVaultsAsync(guid, tenant: null, cancellationToken: Arg.Any<CancellationToken>()).Returns([]);
+        _dppOps.ListVaultsAsync(guid, tenant: null, cancellationToken: Arg.Any<CancellationToken>()).Returns([]);
 
-        await _service.ListVaultsAsync(guid, null, null, null, null, CancellationToken.None);
+        await _service.ListVaultsAsync(guid, resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         await _azureService.DidNotReceive().GetSubscription(
-            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string?>(), null, Arg.Any<CancellationToken>());
     }
 
     #endregion

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Vault/PrivateEndpoint/PrivateEndpointCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Vault/PrivateEndpoint/PrivateEndpointCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Vault.PrivateEndpoint;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,7 @@ public class PrivateEndpointCreateCommandTests : SubscriptionCommandUnitTestsBas
         Service.CreatePrivateEndpointAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is(TestPeName), Arg.Is(TestSubnetId),
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(expected);
 
         // Act
@@ -70,7 +69,7 @@ public class PrivateEndpointCreateCommandTests : SubscriptionCommandUnitTestsBas
         Service.CreatePrivateEndpointAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new NotSupportedException("Private Endpoints are not supported for Backup vaults (DPP). Only Recovery Services vaults (RSV) expose Private Endpoint Connections."));
 
         var response = await ExecuteCommandAsync(
@@ -91,7 +90,7 @@ public class PrivateEndpointCreateCommandTests : SubscriptionCommandUnitTestsBas
         Service.CreatePrivateEndpointAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "not found"));
 
         var response = await ExecuteCommandAsync(
@@ -110,7 +109,7 @@ public class PrivateEndpointCreateCommandTests : SubscriptionCommandUnitTestsBas
         Service.CreatePrivateEndpointAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "forbidden"));
 
         var response = await ExecuteCommandAsync(
@@ -130,7 +129,7 @@ public class PrivateEndpointCreateCommandTests : SubscriptionCommandUnitTestsBas
         Service.CreatePrivateEndpointAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(409, "conflict"));
 
         var response = await ExecuteCommandAsync(
@@ -149,7 +148,7 @@ public class PrivateEndpointCreateCommandTests : SubscriptionCommandUnitTestsBas
         Service.CreatePrivateEndpointAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("--group-id must be one of: AzureBackup, AzureBackup_secondary"));
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Vault/PrivateEndpoint/PrivateEndpointDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Vault/PrivateEndpoint/PrivateEndpointDeleteCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Vault.PrivateEndpoint;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -29,7 +28,7 @@ public class PrivateEndpointDeleteCommandTests : SubscriptionCommandUnitTestsBas
     {
         Service.DeletePrivateEndpointAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("pec-1"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, "Deleted"));
 
         var response = await ExecuteCommandAsync(
@@ -47,7 +46,7 @@ public class PrivateEndpointDeleteCommandTests : SubscriptionCommandUnitTestsBas
     {
         Service.DeletePrivateEndpointAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new NotSupportedException("Private Endpoints are not supported for Backup vaults (DPP)."));
 
         var response = await ExecuteCommandAsync(
@@ -65,7 +64,7 @@ public class PrivateEndpointDeleteCommandTests : SubscriptionCommandUnitTestsBas
     {
         Service.DeletePrivateEndpointAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "not found"));
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Vault/PrivateEndpoint/PrivateEndpointGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Vault/PrivateEndpoint/PrivateEndpointGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Vault.PrivateEndpoint;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -39,7 +38,7 @@ public class PrivateEndpointGetCommandTests : SubscriptionCommandUnitTestsBase<P
     {
         Service.GetPrivateEndpointAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("pec-1"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(SampleConnection());
 
         var response = await ExecuteCommandAsync(
@@ -58,7 +57,7 @@ public class PrivateEndpointGetCommandTests : SubscriptionCommandUnitTestsBase<P
     {
         Service.ListPrivateEndpointsAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns([SampleConnection("pec-1"), SampleConnection("pec-2")]);
 
         var response = await ExecuteCommandAsync(
@@ -75,7 +74,7 @@ public class PrivateEndpointGetCommandTests : SubscriptionCommandUnitTestsBase<P
     {
         Service.ListPrivateEndpointsAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new NotSupportedException("Private Endpoints are not supported for Backup vaults (DPP)."));
 
         var response = await ExecuteCommandAsync(
@@ -93,7 +92,7 @@ public class PrivateEndpointGetCommandTests : SubscriptionCommandUnitTestsBase<P
     {
         Service.GetPrivateEndpointAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "not found"));
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Vault/VaultCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Vault/VaultCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Vault;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -30,7 +29,7 @@ public class VaultCreateCommandTests : SubscriptionCommandUnitTestsBase<VaultCre
         // Arrange
         Service.CreateVaultAsync(
             Arg.Is("myVault"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("rsv"), Arg.Is("eastus"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new VaultCreateResult("id1", "myVault", "rsv", "eastus", "Succeeded"));
 
         // Act
@@ -53,7 +52,7 @@ public class VaultCreateCommandTests : SubscriptionCommandUnitTestsBase<VaultCre
         // Arrange
         Service.CreateVaultAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("rsv"), Arg.Is("eastus"),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -78,7 +77,7 @@ public class VaultCreateCommandTests : SubscriptionCommandUnitTestsBase<VaultCre
         {
             Service.CreateVaultAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Is("rsv"), Arg.Is("eastus"),
-                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new VaultCreateResult("id", "v", "rsv", "eastus", "Succeeded"));
         }
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Vault/VaultGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Vault/VaultGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Vault;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -40,7 +39,6 @@ public class VaultGetCommandTests : SubscriptionCommandUnitTestsBase<VaultGetCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedVaults);
 
@@ -70,7 +68,6 @@ public class VaultGetCommandTests : SubscriptionCommandUnitTestsBase<VaultGetCom
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedVault);
 
@@ -99,7 +96,6 @@ public class VaultGetCommandTests : SubscriptionCommandUnitTestsBase<VaultGetCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -123,7 +119,6 @@ public class VaultGetCommandTests : SubscriptionCommandUnitTestsBase<VaultGetCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -150,7 +145,6 @@ public class VaultGetCommandTests : SubscriptionCommandUnitTestsBase<VaultGetCom
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Vault not found"));
 
@@ -185,7 +179,7 @@ public class VaultGetCommandTests : SubscriptionCommandUnitTestsBase<VaultGetCom
     public async Task ExecuteAsync_AcceptsValidVaultType(string vaultType)
     {
         Service.ListVaultsAsync(
-            Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         var response = await ExecuteCommandAsync("--subscription", "sub123", "--vault-type", vaultType);
@@ -200,11 +194,11 @@ public class VaultGetCommandTests : SubscriptionCommandUnitTestsBase<VaultGetCom
         if (shouldSucceed)
         {
             Service.ListVaultsAsync(
-                Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns([]);
 
             Service.GetVaultAsync(
-                Arg.Is("myVault"), Arg.Is("myRg"), Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Is("myVault"), Arg.Is("myRg"), Arg.Is("sub123"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new BackupVaultInfo("id1", "myVault", "rsv", "eastus", "myRg", "Succeeded", "Standard", "GeoRedundant", null, null, null, null, null, null));
         }
 
@@ -266,7 +260,6 @@ public class VaultGetCommandTests : SubscriptionCommandUnitTestsBase<VaultGetCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>(),
             Arg.Is<VaultExpand>(e => e != VaultExpand.None))
             .Returns([]);
@@ -280,7 +273,6 @@ public class VaultGetCommandTests : SubscriptionCommandUnitTestsBase<VaultGetCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>(),
             Arg.Is<VaultExpand>(e => e != VaultExpand.None));
     }
@@ -294,7 +286,6 @@ public class VaultGetCommandTests : SubscriptionCommandUnitTestsBase<VaultGetCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>(),
             Arg.Is(VaultExpand.None))
             .Returns([]);
@@ -307,7 +298,6 @@ public class VaultGetCommandTests : SubscriptionCommandUnitTestsBase<VaultGetCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>(),
             Arg.Is(VaultExpand.None));
     }

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Vault/VaultUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Vault/VaultUpdateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.AzureBackup.Commands;
 using Azure.Mcp.Tools.AzureBackup.Commands.Vault;
 using Azure.Mcp.Tools.AzureBackup.Models;
 using Azure.Mcp.Tools.AzureBackup.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -31,7 +30,7 @@ public class VaultUpdateCommandTests : SubscriptionCommandUnitTestsBase<VaultUpd
         Service.UpdateVaultAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Is("SystemAssigned"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is("SystemAssigned"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, "Vault updated successfully"));
 
         // Act
@@ -54,7 +53,7 @@ public class VaultUpdateCommandTests : SubscriptionCommandUnitTestsBase<VaultUpd
         Service.UpdateVaultAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Is("SystemAssigned"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is("SystemAssigned"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -90,7 +89,7 @@ public class VaultUpdateCommandTests : SubscriptionCommandUnitTestsBase<VaultUpd
         Service.UpdateVaultAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Is("SystemAssigned"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is("SystemAssigned"), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Not found"));
 
         // Act
@@ -119,7 +118,7 @@ public class VaultUpdateCommandTests : SubscriptionCommandUnitTestsBase<VaultUpd
             Service.UpdateVaultAsync(
                 Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new OperationResult("Succeeded", null, null));
         }
 
@@ -167,7 +166,7 @@ public class VaultUpdateCommandTests : SubscriptionCommandUnitTestsBase<VaultUpd
         Service.UpdateVaultAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Is(identityType), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Is(identityType), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, null));
 
         // Act
@@ -210,7 +209,7 @@ public class VaultUpdateCommandTests : SubscriptionCommandUnitTestsBase<VaultUpd
         Service.UpdateVaultAsync(
             Arg.Is("v"), Arg.Is("rg"), Arg.Is("sub"), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new OperationResult("Succeeded", null, null));
 
         // Act

--- a/tools/Azure.Mcp.Tools.AzureMigrate/src/Commands/PlatformLandingZone/RequestCommand.cs
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/src/Commands/PlatformLandingZone/RequestCommand.cs
@@ -222,7 +222,6 @@ public sealed class RequestCommand(
             options.Location,
             options.Subscription!,
             options.Tenant,
-            options.RetryPolicy,
             cancellationToken);
 
         if (!result.HasData)

--- a/tools/Azure.Mcp.Tools.AzureMigrate/src/Helpers/AzureMigrateProjectHelper.cs
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/src/Helpers/AzureMigrateProjectHelper.cs
@@ -4,7 +4,6 @@
 using Azure.Core;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.AzureMigrate.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.AzureMigrate.Helpers;
 
@@ -26,7 +25,6 @@ public sealed class AzureMigrateProjectHelper(IAzureService azureService)
         string location,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -41,10 +39,9 @@ public sealed class AzureMigrateProjectHelper(IAzureService azureService)
                 MigrateProjectResourceType,
                 MigrateProjectApiVersion,
                 tenant,
-                retryPolicy,
-                cancellationToken);
+                cancellationToken: cancellationToken);
 
-            var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+            var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
             ResourceIdentifier projectId = new(
                 $"/subscriptions/{subscriptionResource.Data.SubscriptionId}/resourceGroups/{resourceGroup}/providers/{MigrateProjectResourceType}/{projectName}");
 

--- a/tools/Azure.Mcp.Tools.AzureMigrate/src/Options/PlatformLandingZone/RequestOptions.cs
+++ b/tools/Azure.Mcp.Tools.AzureMigrate/src/Options/PlatformLandingZone/RequestOptions.cs
@@ -106,10 +106,4 @@ public sealed class RequestOptions : ISubscriptionOption
     /// </summary>
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    /// <summary>
-    /// Gets or sets the retry policy options for HTTP requests.
-    /// </summary>
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }


### PR DESCRIPTION
## What does this PR do?

Removed custom retry policy options from Authorization, Azure Backup, and Azure Migrate tools.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
