### PR TITLE
[Part 3] Remove RetryPolicyOptions from tools

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/remove-retry-policy-options-part3.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/remove-retry-policy-options-part3.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: Breaking Changes
+    description: Removed custom retry policy options from Communication, Compute, Container Apps, and Cosmos tools.

--- a/tools/Azure.Mcp.Tools.Communication/src/Commands/Email/EmailSendCommand.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Commands/Email/EmailSendCommand.cs
@@ -75,7 +75,6 @@ public sealed class EmailSendCommand(ILogger<EmailSendCommand> logger, ICommunic
                 options.Bcc,
                 options.ReplyTo,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(result), CommunicationJsonContext.Default.EmailSendCommandResult);

--- a/tools/Azure.Mcp.Tools.Communication/src/Commands/Sms/SmsSendCommand.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Commands/Sms/SmsSendCommand.cs
@@ -43,7 +43,6 @@ public sealed class SmsSendCommand(ILogger<SmsSendCommand> logger, ICommunicatio
                 options.EnableDeliveryReport,
                 options.Tag,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             // Set results

--- a/tools/Azure.Mcp.Tools.Communication/src/Options/BaseCommunicationOptions.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Options/BaseCommunicationOptions.cs
@@ -16,7 +16,4 @@ public class BaseCommunicationOptions
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Communication/src/Services/CommunicationService.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Services/CommunicationService.cs
@@ -8,7 +8,6 @@ using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.Communication.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Helpers;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Communication.Services;
 
@@ -25,7 +24,6 @@ public class CommunicationService(IAzureService azureService, ILogger<Communicat
         bool enableDeliveryReport = false,
         string? tag = null,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         // Validate required parameters using base class method
@@ -48,7 +46,7 @@ public class CommunicationService(IAzureService azureService, ILogger<Communicat
             // Create SMS client using Azure credential from base class and endpoint
             var credential = await GetCredential(tenantId, cancellationToken);
 
-            var smsClientOptions = ConfigureRetryPolicy(AddDefaultPolicies(new SmsClientOptions()), retryPolicy);
+            var smsClientOptions = AddDefaultPolicies(new SmsClientOptions());
             smsClientOptions.Transport = new HttpClientTransport(AzureService.GetClient());
 
             var smsClient = new SmsClient(new Uri(endpoint), credential, smsClientOptions);
@@ -103,7 +101,6 @@ public class CommunicationService(IAzureService azureService, ILogger<Communicat
         string[]? bcc = null,
         string[]? replyTo = null,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         // Validate required parameters using base class method
@@ -132,7 +129,7 @@ public class CommunicationService(IAzureService azureService, ILogger<Communicat
             // Create email client with credential from base class
             var credential = await GetCredential(tenantId, cancellationToken);
 
-            var emailClientOptions = ConfigureRetryPolicy(AddDefaultPolicies(new EmailClientOptions()), retryPolicy);
+            var emailClientOptions = AddDefaultPolicies(new EmailClientOptions());
             emailClientOptions.Transport = new HttpClientTransport(AzureService.GetClient());
 
             var emailClient = new EmailClient(new(endpoint), credential, emailClientOptions);

--- a/tools/Azure.Mcp.Tools.Communication/src/Services/ICommunicationService.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Services/ICommunicationService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.Communication.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Communication.Services;
 
@@ -16,7 +15,6 @@ public interface ICommunicationService
         bool enableDeliveryReport = false,
         string? tag = null,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -32,7 +30,6 @@ public interface ICommunicationService
     /// <param name="cc">Optional CC recipient email addresses.</param>
     /// <param name="bcc">Optional BCC recipient email addresses.</param>
     /// <param name="replyTo">Optional reply-to addresses.</param>
-    /// <param name="retryPolicy">Optional retry policy options.</param>
     /// <returns>The result of the email send operation.</returns>
     Task<EmailSendResult> SendEmailAsync(
         string endpoint,
@@ -46,6 +43,5 @@ public interface ICommunicationService
         string[]? bcc = null,
         string[]? replyTo = null,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/Email/EmailSendCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/Email/EmailSendCommandTests.cs
@@ -6,7 +6,6 @@ using System.Text.Json;
 using Azure.Mcp.Tools.Communication.Commands.Email;
 using Azure.Mcp.Tools.Communication.Models;
 using Azure.Mcp.Tools.Communication.Services;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -65,7 +64,6 @@ public class EmailSendCommandTests : CommandUnitTestsBase<EmailSendCommand, ICom
                 Arg.Any<string[]>(),
                 Arg.Any<string[]>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(expectedResult);
         }
@@ -122,7 +120,6 @@ public class EmailSendCommandTests : CommandUnitTestsBase<EmailSendCommand, ICom
             Arg.Any<string[]>(),
             Arg.Any<string[]>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -141,7 +138,6 @@ public class EmailSendCommandTests : CommandUnitTestsBase<EmailSendCommand, ICom
             "Test Subject",
             "Test Message",
             false,
-            null,
             null,
             null,
             null,
@@ -183,7 +179,6 @@ public class EmailSendCommandTests : CommandUnitTestsBase<EmailSendCommand, ICom
             Arg.Any<string[]>(),
             Arg.Any<string[]>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(expectedException);
 

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/Services/CommunicationServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/Services/CommunicationServiceTests.cs
@@ -36,7 +36,7 @@ public class CommunicationServiceTests
         // Act & Assert
         // Updated to use Assert.ThrowsAsync for async methods
         var exception = await Assert.ThrowsAsync<ArgumentException>(
-            () => _service.SendEmailAsync(endpoint, sender, senderName, to, subject, message, false, null, null, null, null, null, TestContext.Current.CancellationToken));
+            () => _service.SendEmailAsync(endpoint, sender, senderName, to, subject, message, false, null, null, null, null, TestContext.Current.CancellationToken));
 
         Assert.Contains("endpoint", exception.Message, StringComparison.OrdinalIgnoreCase);
     }

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/Sms/SmsSendCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/Sms/SmsSendCommandTests.cs
@@ -3,7 +3,6 @@
 
 using Azure.Mcp.Tools.Communication.Commands.Sms;
 using Azure.Mcp.Tools.Communication.Services;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -43,7 +42,7 @@ public class SmsSendCommandTests : CommandUnitTestsBase<SmsSendCommand, ICommuni
             new(MessageId: "msg1", To: to.First(), Successful: true, HttpStatusCode: 202, ErrorMessage: null)
         };
         Service.SendSmsAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(results);
 
         var args = new List<string>
@@ -70,7 +69,7 @@ public class SmsSendCommandTests : CommandUnitTestsBase<SmsSendCommand, ICommuni
     public async Task ExecuteAsync_ServiceThrowsException_HandlesError()
     {
         Service.SendSmsAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string[]>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("fail"));
 
         // Act

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskCreateCommand.cs
@@ -94,7 +94,6 @@ public sealed class DiskCreateCommand(ILogger<DiskCreateCommand> logger, IComput
                 options.UploadSizeBytes,
                 options.SecurityType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(disk), ComputeJsonContext.Default.DiskCreateCommandResult);

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskDeleteCommand.cs
@@ -44,7 +44,6 @@ public sealed class DiskDeleteCommand(ILogger<DiskDeleteCommand> logger, IComput
                 options.ResourceGroup,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskGetCommand.cs
@@ -50,7 +50,6 @@ public sealed class DiskGetCommand(ILogger<DiskGetCommand> logger, IComputeServi
                     options.ResourceGroup!,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new([disk]), ComputeJsonContext.Default.DiskGetCommandResult);
@@ -65,7 +64,6 @@ public sealed class DiskGetCommand(ILogger<DiskGetCommand> logger, IComputeServi
                     options.Subscription!,
                     options.ResourceGroup,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 // Apply wildcard filtering if disk name pattern is provided

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Disk/DiskUpdateCommand.cs
@@ -70,7 +70,6 @@ public sealed class DiskUpdateCommand(ILogger<DiskUpdateCommand> logger, IComput
                     options.Subscription!,
                     null,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 var matchingDisks = disks
@@ -120,7 +119,6 @@ public sealed class DiskUpdateCommand(ILogger<DiskUpdateCommand> logger, IComput
                 options.DiskAccess,
                 options.Tier,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(disk), ComputeJsonContext.Default.DiskUpdateCommandResult);

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmCreateCommand.cs
@@ -100,7 +100,6 @@ public sealed class VmCreateCommand(ILogger<VmCreateCommand> logger, IComputeSer
                 options.OsDiskSizeGb,
                 options.OsDiskType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(result), ComputeJsonContext.Default.VmCreateCommandResult);

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmDeleteCommand.cs
@@ -50,7 +50,6 @@ public sealed class VmDeleteCommand(ILogger<VmDeleteCommand> logger, IComputeSer
                 options.Subscription!,
                 options.ForceDeletion ? true : null,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             var message = deleted

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmGetCommand.cs
@@ -62,7 +62,6 @@ public sealed class VmGetCommand(ILogger<VmGetCommand> logger, IComputeService c
                         options.ResourceGroup!,
                         options.Subscription!,
                         options.Tenant,
-                        options.RetryPolicy,
                         cancellationToken);
 
                     context.Response.Results = ResponseResult.Create(
@@ -76,7 +75,6 @@ public sealed class VmGetCommand(ILogger<VmGetCommand> logger, IComputeService c
                         options.ResourceGroup!,
                         options.Subscription!,
                         options.Tenant,
-                        options.RetryPolicy,
                         cancellationToken);
 
                     context.Response.Results = ResponseResult.Create(new(vm, null, null), ComputeJsonContext.Default.VmGetResult);
@@ -89,7 +87,6 @@ public sealed class VmGetCommand(ILogger<VmGetCommand> logger, IComputeService c
                     options.ResourceGroup!,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(null, null, vms), ComputeJsonContext.Default.VmGetResult);

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmPowerStateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmPowerStateCommand.cs
@@ -75,7 +75,6 @@ public sealed class VmPowerStateCommand(ILogger<VmPowerStateCommand> logger, ICo
                 options.NoWait,
                 options.SkipShutdown,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vm/VmUpdateCommand.cs
@@ -70,7 +70,6 @@ public sealed class VmUpdateCommand(ILogger<VmUpdateCommand> logger, IComputeSer
                 options.BootDiagnostics,
                 options.UserData,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(result), ComputeJsonContext.Default.VmUpdateCommandResult);

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssCreateCommand.cs
@@ -100,7 +100,6 @@ public sealed class VmssCreateCommand(ILogger<VmssCreateCommand> logger, IComput
                 options.OsDiskSizeGb,
                 options.OsDiskType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(result), ComputeJsonContext.Default.VmssCreateCommandResult);

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssDeleteCommand.cs
@@ -48,7 +48,6 @@ public sealed class VmssDeleteCommand(ILogger<VmssDeleteCommand> logger, IComput
                 options.Subscription!,
                 options.ForceDeletion ? true : null,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             var message = deleted

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssGetCommand.cs
@@ -61,7 +61,6 @@ public sealed class VmssGetCommand(ILogger<VmssGetCommand> logger, IComputeServi
                     options.ResourceGroup!,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(null, vmInstance, null), ComputeJsonContext.Default.VmssGetResult);
@@ -74,7 +73,6 @@ public sealed class VmssGetCommand(ILogger<VmssGetCommand> logger, IComputeServi
                     options.ResourceGroup!,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(vmss, null, null), ComputeJsonContext.Default.VmssGetResult);
@@ -86,7 +84,6 @@ public sealed class VmssGetCommand(ILogger<VmssGetCommand> logger, IComputeServi
                     options.ResourceGroup,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(null, null, vmssList ?? []), ComputeJsonContext.Default.VmssGetResult);

--- a/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Commands/Vmss/VmssUpdateCommand.cs
@@ -72,7 +72,6 @@ public sealed class VmssUpdateCommand(ILogger<VmssUpdateCommand> logger, IComput
                 options.ScaleInPolicy,
                 options.Tags,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(result), ComputeJsonContext.Default.VmssUpdateCommandResult);

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/Disk/DiskCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/Disk/DiskCreateOptions.cs
@@ -158,6 +158,4 @@ public sealed class DiskCreateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/Disk/DiskDeleteOptions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/Disk/DiskDeleteOptions.cs
@@ -26,6 +26,4 @@ public sealed class DiskDeleteOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/Disk/DiskGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/Disk/DiskGetOptions.cs
@@ -26,6 +26,4 @@ public sealed class DiskGetOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/Disk/DiskUpdateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/Disk/DiskUpdateOptions.cs
@@ -98,6 +98,4 @@ public sealed class DiskUpdateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/Vm/VmCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/Vm/VmCreateOptions.cs
@@ -68,6 +68,4 @@ public sealed class VmCreateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/Vm/VmDeleteOptions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/Vm/VmDeleteOptions.cs
@@ -23,6 +23,4 @@ public sealed class VmDeleteOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/Vm/VmGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/Vm/VmGetOptions.cs
@@ -23,6 +23,4 @@ public sealed class VmGetOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/Vm/VmPowerStateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/Vm/VmPowerStateOptions.cs
@@ -29,6 +29,4 @@ public sealed class VmPowerStateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/Vm/VmUpdateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/Vm/VmUpdateOptions.cs
@@ -35,6 +35,4 @@ public sealed class VmUpdateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/Vmss/VmssCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/Vmss/VmssCreateOptions.cs
@@ -62,6 +62,4 @@ public sealed class VmssCreateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/Vmss/VmssDeleteOptions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/Vmss/VmssDeleteOptions.cs
@@ -23,6 +23,4 @@ public sealed class VmssDeleteOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/Vmss/VmssGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/Vmss/VmssGetOptions.cs
@@ -23,6 +23,4 @@ public sealed class VmssGetOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Options/Vmss/VmssUpdateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Options/Vmss/VmssUpdateOptions.cs
@@ -41,6 +41,4 @@ public sealed class VmssUpdateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Compute/src/Services/ComputeService.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Services/ComputeService.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Mcp.Core.Areas.Server;
 using Microsoft.Mcp.Core.Helpers;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Compute.Services;
 
@@ -84,10 +83,9 @@ public class ComputeService(
         int? osDiskSizeGb = null,
         string? osDiskType = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -512,10 +510,9 @@ public class ComputeService(
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -532,10 +529,9 @@ public class ComputeService(
         string? resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -565,10 +561,9 @@ public class ComputeService(
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -588,10 +583,9 @@ public class ComputeService(
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -613,10 +607,9 @@ public class ComputeService(
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -633,10 +626,9 @@ public class ComputeService(
         string? resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -666,10 +658,9 @@ public class ComputeService(
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -694,10 +685,9 @@ public class ComputeService(
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -733,10 +723,9 @@ public class ComputeService(
         int? osDiskSizeGb = null,
         string? osDiskType = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -903,10 +892,9 @@ public class ComputeService(
         string? scaleInPolicy = null,
         string? tags = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -1019,10 +1007,9 @@ public class ComputeService(
         string? bootDiagnostics = null,
         string? userData = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -1134,10 +1121,9 @@ public class ComputeService(
         string subscription,
         bool? forceDeletion = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -1169,10 +1155,9 @@ public class ComputeService(
         bool noWait = false,
         bool skipShutdown = false,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -1228,10 +1213,9 @@ public class ComputeService(
         string subscription,
         bool? forceDeletion = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
 
@@ -1452,10 +1436,9 @@ public class ComputeService(
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroups().GetAsync(resourceGroup, cancellationToken);
@@ -1468,12 +1451,11 @@ public class ComputeService(
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         try
         {
-            var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+            var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
             var subscriptionResource = armClient.GetSubscriptionResource(
                 SubscriptionResource.CreateResourceIdentifier(subscription));
             var disks = new List<DiskInfo>();
@@ -1566,10 +1548,9 @@ public class ComputeService(
         long? uploadSizeBytes = null,
         string? securityType = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
         var rgResource = await subscriptionResource.GetResourceGroups().GetAsync(resourceGroup, cancellationToken);
@@ -1699,10 +1680,9 @@ public class ComputeService(
         string? diskAccessId = null,
         string? tier = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(
             SubscriptionResource.CreateResourceIdentifier(subscription));
         var rgResource = await subscriptionResource.GetResourceGroups().GetAsync(resourceGroup, cancellationToken);
@@ -1835,12 +1815,11 @@ public class ComputeService(
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         try
         {
-            var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+            var armClient = await CreateArmClientAsync(tenant, cancellationToken: cancellationToken);
             var subscriptionResource = armClient.GetSubscriptionResource(
                 SubscriptionResource.CreateResourceIdentifier(subscription));
             var resourceGroupResource = await subscriptionResource.GetResourceGroups().GetAsync(resourceGroup, cancellationToken);

--- a/tools/Azure.Mcp.Tools.Compute/src/Services/IComputeService.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Services/IComputeService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.Compute.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Compute.Services;
 
@@ -14,14 +13,12 @@ public interface IComputeService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<VmInfo>> ListVmsAsync(
         string? resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<VmInstanceView> GetVmInstanceViewAsync(
@@ -29,7 +26,6 @@ public interface IComputeService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<(VmInfo VmInfo, VmInstanceView InstanceView)> GetVmWithInstanceViewAsync(
@@ -37,7 +33,6 @@ public interface IComputeService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<VmCreateResult> CreateVmAsync(
@@ -61,7 +56,6 @@ public interface IComputeService
         int? osDiskSizeGb = null,
         string? osDiskType = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     // Virtual Machine Scale Set operations
@@ -70,14 +64,12 @@ public interface IComputeService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<VmssInfo>> ListVmssAsync(
         string? resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<VmssVmInfo>> ListVmssVmsAsync(
@@ -85,7 +77,6 @@ public interface IComputeService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<VmssVmInfo> GetVmssVmAsync(
@@ -94,7 +85,6 @@ public interface IComputeService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<VmssCreateResult> CreateVmssAsync(
@@ -116,7 +106,6 @@ public interface IComputeService
         int? osDiskSizeGb = null,
         string? osDiskType = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<VmssUpdateResult> UpdateVmssAsync(
@@ -131,7 +120,6 @@ public interface IComputeService
         string? scaleInPolicy = null,
         string? tags = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<VmUpdateResult> UpdateVmAsync(
@@ -144,7 +132,6 @@ public interface IComputeService
         string? bootDiagnostics = null,
         string? userData = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     // Delete operations
@@ -154,7 +141,6 @@ public interface IComputeService
         string subscription,
         bool? forceDeletion = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     // Power state operations
@@ -166,7 +152,6 @@ public interface IComputeService
         bool noWait = false,
         bool skipShutdown = false,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<bool> DeleteVmssAsync(
@@ -175,7 +160,6 @@ public interface IComputeService
         string subscription,
         bool? forceDeletion = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     // Disk operations
@@ -184,14 +168,12 @@ public interface IComputeService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<DiskInfo>> ListDisksAsync(
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<DiskInfo> CreateDiskAsync(
@@ -221,7 +203,6 @@ public interface IComputeService
         long? uploadSizeBytes = null,
         string? securityType = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<DiskInfo> UpdateDiskAsync(
@@ -241,7 +222,6 @@ public interface IComputeService
         string? diskAccessId = null,
         string? tier = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<bool> DeleteDiskAsync(
@@ -249,6 +229,5 @@ public interface IComputeService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Disk/DiskCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Disk/DiskCreateCommandTests.cs
@@ -10,7 +10,6 @@ using Azure.Mcp.Tools.Compute.Models;
 using Azure.Mcp.Tools.Compute.Services;
 using Azure.ResourceManager;
 using Microsoft.Mcp.Core.Helpers;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -94,7 +93,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -170,7 +168,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -244,7 +241,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -314,7 +310,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -378,7 +373,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Service unavailable"));
 
@@ -479,7 +473,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -545,7 +538,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -617,7 +609,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -668,7 +659,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -722,7 +712,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -808,7 +797,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             uploadSizeBytes,
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -891,7 +879,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             uploadSizeBytes,
             "TrustedLaunch",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -961,7 +948,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -1028,7 +1014,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -1073,7 +1058,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -1181,7 +1165,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new SecurityException("Endpoint must use HTTPS protocol. Got: http"));
 
@@ -1231,7 +1214,6 @@ public class DiskCreateCommandTests : SubscriptionCommandUnitTestsBase<DiskCreat
             Arg.Any<long?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new SecurityException("Endpoint host 'evil-server.com' is not a valid storage-blob domain for Azure Public Cloud."));
 

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Disk/DiskDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Disk/DiskDeleteCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Disk;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -41,7 +40,6 @@ public class DiskDeleteCommandTests : SubscriptionCommandUnitTestsBase<DiskDelet
             resourceGroup,
             subscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -71,7 +69,6 @@ public class DiskDeleteCommandTests : SubscriptionCommandUnitTestsBase<DiskDelet
             resourceGroup,
             subscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(false);
 
@@ -101,7 +98,6 @@ public class DiskDeleteCommandTests : SubscriptionCommandUnitTestsBase<DiskDelet
             resourceGroup,
             subscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -157,7 +153,6 @@ public class DiskDeleteCommandTests : SubscriptionCommandUnitTestsBase<DiskDelet
             resourceGroup,
             subscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException("Conflict"));
 
@@ -192,7 +187,6 @@ public class DiskDeleteCommandTests : SubscriptionCommandUnitTestsBase<DiskDelet
             resourceGroup,
             subscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Disk/DiskGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Disk/DiskGetCommandTests.cs
@@ -5,7 +5,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Disk;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using Xunit;
 
@@ -59,7 +58,6 @@ public class DiskGetCommandTests : SubscriptionCommandUnitTestsBase<DiskGetComma
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisks);
 
@@ -100,7 +98,6 @@ public class DiskGetCommandTests : SubscriptionCommandUnitTestsBase<DiskGetComma
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisks);
 
@@ -141,7 +138,6 @@ public class DiskGetCommandTests : SubscriptionCommandUnitTestsBase<DiskGetComma
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -183,7 +179,6 @@ public class DiskGetCommandTests : SubscriptionCommandUnitTestsBase<DiskGetComma
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -246,7 +241,6 @@ public class DiskGetCommandTests : SubscriptionCommandUnitTestsBase<DiskGetComma
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisks);
 
@@ -306,7 +300,6 @@ public class DiskGetCommandTests : SubscriptionCommandUnitTestsBase<DiskGetComma
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisks);
 
@@ -359,7 +352,6 @@ public class DiskGetCommandTests : SubscriptionCommandUnitTestsBase<DiskGetComma
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisks);
 

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Disk/DiskUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Disk/DiskUpdateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Disk;
 using Azure.Mcp.Tools.Compute.Models;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -80,7 +79,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -136,7 +134,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -191,7 +188,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -251,7 +247,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -296,7 +291,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(existingDisks);
 
@@ -327,7 +321,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(updatedDisk);
 
@@ -352,7 +345,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -388,7 +380,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Service unavailable"));
 
@@ -426,7 +417,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundEx);
 
@@ -507,7 +497,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -539,7 +528,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -584,7 +572,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             diskAccess,
             tier,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -619,7 +606,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             diskAccess,
             tier,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -660,7 +646,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDisk);
 
@@ -717,7 +702,6 @@ public class DiskUpdateCommandTests : SubscriptionCommandUnitTestsBase<DiskUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Vm;
 using Azure.Mcp.Tools.Compute.Models;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -81,7 +80,6 @@ public class VmCreateCommandTests : SubscriptionCommandUnitTestsBase<VmCreateCom
                 Arg.Any<int?>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(createResult);
         }
@@ -139,7 +137,6 @@ public class VmCreateCommandTests : SubscriptionCommandUnitTestsBase<VmCreateCom
             Arg.Any<int?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -205,7 +202,6 @@ public class VmCreateCommandTests : SubscriptionCommandUnitTestsBase<VmCreateCom
             Arg.Any<int?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(conflictException);
 
@@ -251,7 +247,6 @@ public class VmCreateCommandTests : SubscriptionCommandUnitTestsBase<VmCreateCom
             Arg.Any<int?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(forbiddenException);
 
@@ -307,7 +302,6 @@ public class VmCreateCommandTests : SubscriptionCommandUnitTestsBase<VmCreateCom
             Arg.Any<int?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmDeleteCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Vm;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -44,7 +43,6 @@ public class VmDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmDeleteCom
                 Arg.Any<string>(),
                 Arg.Any<bool?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(true);
         }
@@ -72,7 +70,6 @@ public class VmDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmDeleteCom
             Arg.Is(_knownSubscription),
             Arg.Any<bool?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -99,7 +96,6 @@ public class VmDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmDeleteCom
             Arg.Is(_knownSubscription),
             Arg.Is<bool?>(true),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -119,7 +115,6 @@ public class VmDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmDeleteCom
             _knownSubscription,
             true,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -133,7 +128,6 @@ public class VmDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmDeleteCom
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(false);
 
@@ -163,7 +157,6 @@ public class VmDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmDeleteCom
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(forbiddenException);
 
@@ -190,7 +183,6 @@ public class VmDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmDeleteCom
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(conflictException);
 
@@ -215,7 +207,6 @@ public class VmDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmDeleteCom
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Vm;
 using Azure.Mcp.Tools.Compute.Models;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -75,7 +74,6 @@ public class VmGetCommandTests : SubscriptionCommandUnitTestsBase<VmGetCommand, 
                     Arg.Any<string>(),
                     Arg.Any<string>(),
                     Arg.Any<string?>(),
-                    Arg.Any<RetryPolicyOptions?>(),
                     Arg.Any<CancellationToken>())
                     .Returns((vmInfo, instanceView));
             }
@@ -86,7 +84,6 @@ public class VmGetCommandTests : SubscriptionCommandUnitTestsBase<VmGetCommand, 
                     Arg.Any<string>(),
                     Arg.Any<string>(),
                     Arg.Any<string?>(),
-                    Arg.Any<RetryPolicyOptions?>(),
                     Arg.Any<CancellationToken>())
                     .Returns(vmInfo);
             }
@@ -96,7 +93,6 @@ public class VmGetCommandTests : SubscriptionCommandUnitTestsBase<VmGetCommand, 
                     Arg.Any<string?>(),
                     Arg.Any<string>(),
                     Arg.Any<string?>(),
-                    Arg.Any<RetryPolicyOptions?>(),
                     Arg.Any<CancellationToken>())
                     .Returns(vmList);
             }
@@ -158,7 +154,6 @@ public class VmGetCommandTests : SubscriptionCommandUnitTestsBase<VmGetCommand, 
             Arg.Is<string?>(x => x == null),
             Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedVms);
 
@@ -196,7 +191,6 @@ public class VmGetCommandTests : SubscriptionCommandUnitTestsBase<VmGetCommand, 
             Arg.Is(_knownResourceGroup),
             Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedVms);
 
@@ -221,7 +215,6 @@ public class VmGetCommandTests : SubscriptionCommandUnitTestsBase<VmGetCommand, 
             Arg.Any<string?>(),
             Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -255,7 +248,6 @@ public class VmGetCommandTests : SubscriptionCommandUnitTestsBase<VmGetCommand, 
             Arg.Is(_knownResourceGroup),
             Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedVm);
 
@@ -312,7 +304,6 @@ public class VmGetCommandTests : SubscriptionCommandUnitTestsBase<VmGetCommand, 
             Arg.Is(_knownResourceGroup),
             Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns((vmInfo, instanceView));
 
@@ -355,7 +346,6 @@ public class VmGetCommandTests : SubscriptionCommandUnitTestsBase<VmGetCommand, 
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(vmInfo);
 
@@ -382,7 +372,6 @@ public class VmGetCommandTests : SubscriptionCommandUnitTestsBase<VmGetCommand, 
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
@@ -407,7 +396,6 @@ public class VmGetCommandTests : SubscriptionCommandUnitTestsBase<VmGetCommand, 
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(forbiddenException);
 
@@ -430,7 +418,6 @@ public class VmGetCommandTests : SubscriptionCommandUnitTestsBase<VmGetCommand, 
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(exception);
 

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmPowerStateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmPowerStateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Vm;
 using Azure.Mcp.Tools.Compute.Models;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -54,7 +53,6 @@ public class VmPowerStateCommandTests : SubscriptionCommandUnitTestsBase<VmPower
                 Arg.Any<bool>(),
                 Arg.Any<bool>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new VmPowerStateResult("test-vm", null, "test-rg", "start", "Operation completed.", true));
         }
@@ -93,7 +91,6 @@ public class VmPowerStateCommandTests : SubscriptionCommandUnitTestsBase<VmPower
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -125,7 +122,6 @@ public class VmPowerStateCommandTests : SubscriptionCommandUnitTestsBase<VmPower
             Arg.Is(true),
             Arg.Any<bool>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -149,7 +145,6 @@ public class VmPowerStateCommandTests : SubscriptionCommandUnitTestsBase<VmPower
             true,
             Arg.Any<bool>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -169,7 +164,6 @@ public class VmPowerStateCommandTests : SubscriptionCommandUnitTestsBase<VmPower
             Arg.Any<bool>(),
             Arg.Is(true),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -192,7 +186,6 @@ public class VmPowerStateCommandTests : SubscriptionCommandUnitTestsBase<VmPower
             Arg.Any<bool>(),
             true,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -210,7 +203,6 @@ public class VmPowerStateCommandTests : SubscriptionCommandUnitTestsBase<VmPower
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
@@ -240,7 +232,6 @@ public class VmPowerStateCommandTests : SubscriptionCommandUnitTestsBase<VmPower
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(forbiddenException);
 
@@ -270,7 +261,6 @@ public class VmPowerStateCommandTests : SubscriptionCommandUnitTestsBase<VmPower
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(conflictException);
 
@@ -301,7 +291,6 @@ public class VmPowerStateCommandTests : SubscriptionCommandUnitTestsBase<VmPower
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vm/VmUpdateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Vm;
 using Azure.Mcp.Tools.Compute.Models;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -64,7 +63,6 @@ public class VmUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmUpdateCom
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(updateResult);
         }
@@ -110,7 +108,6 @@ public class VmUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmUpdateCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -155,7 +152,6 @@ public class VmUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmUpdateCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -188,7 +184,6 @@ public class VmUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmUpdateCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
@@ -220,7 +215,6 @@ public class VmUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmUpdateCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(conflictException);
 
@@ -262,7 +256,6 @@ public class VmUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmUpdateCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -319,7 +312,6 @@ public class VmUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmUpdateCom
             Arg.Any<string?>(),
             Arg.Is(base64UserData),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -342,7 +334,6 @@ public class VmUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmUpdateCom
             Arg.Any<string?>(),
             base64UserData,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -372,7 +363,6 @@ public class VmUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmUpdateCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -395,7 +385,6 @@ public class VmUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmUpdateCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -424,7 +413,6 @@ public class VmUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmUpdateCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -445,7 +433,6 @@ public class VmUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmUpdateCom
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Vmss;
 using Azure.Mcp.Tools.Compute.Models;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -79,7 +78,6 @@ public class VmssCreateCommandTests : SubscriptionCommandUnitTestsBase<VmssCreat
                 Arg.Any<int?>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(createResult);
         }
@@ -135,7 +133,6 @@ public class VmssCreateCommandTests : SubscriptionCommandUnitTestsBase<VmssCreat
             Arg.Is(40),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -201,7 +198,6 @@ public class VmssCreateCommandTests : SubscriptionCommandUnitTestsBase<VmssCreat
             Arg.Any<int?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(conflictException);
 
@@ -255,7 +251,6 @@ public class VmssCreateCommandTests : SubscriptionCommandUnitTestsBase<VmssCreat
             Arg.Any<int?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssDeleteCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Vmss;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -44,7 +43,6 @@ public class VmssDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmssDelet
                 Arg.Any<string>(),
                 Arg.Any<bool?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(true);
         }
@@ -73,7 +71,6 @@ public class VmssDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmssDelet
             Arg.Is(_knownSubscription),
             Arg.Any<bool?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -100,7 +97,6 @@ public class VmssDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmssDelet
             Arg.Is(_knownSubscription),
             Arg.Is<bool?>(true),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -120,7 +116,6 @@ public class VmssDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmssDelet
             _knownSubscription,
             true,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -134,7 +129,6 @@ public class VmssDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmssDelet
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(false);
 
@@ -164,7 +158,6 @@ public class VmssDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmssDelet
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(forbiddenException);
 
@@ -191,7 +184,6 @@ public class VmssDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmssDelet
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(conflictException);
 
@@ -216,7 +208,6 @@ public class VmssDeleteCommandTests : SubscriptionCommandUnitTestsBase<VmssDelet
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Vmss;
 using Azure.Mcp.Tools.Compute.Models;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -87,7 +86,6 @@ public class VmssGetCommandTests : SubscriptionCommandUnitTestsBase<VmssGetComma
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(vmssList);
 
@@ -96,7 +94,6 @@ public class VmssGetCommandTests : SubscriptionCommandUnitTestsBase<VmssGetComma
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(vmssInfo);
 
@@ -106,7 +103,6 @@ public class VmssGetCommandTests : SubscriptionCommandUnitTestsBase<VmssGetComma
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(vmssVmInfo);
 
@@ -164,7 +160,6 @@ public class VmssGetCommandTests : SubscriptionCommandUnitTestsBase<VmssGetComma
             Arg.Is((string?)null),
             Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(vmssList);
 
@@ -203,7 +198,6 @@ public class VmssGetCommandTests : SubscriptionCommandUnitTestsBase<VmssGetComma
             Arg.Is(_knownResourceGroup),
             Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(vmssList);
 
@@ -228,7 +222,6 @@ public class VmssGetCommandTests : SubscriptionCommandUnitTestsBase<VmssGetComma
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new List<VmssInfo>());
 
@@ -263,7 +256,6 @@ public class VmssGetCommandTests : SubscriptionCommandUnitTestsBase<VmssGetComma
             Arg.Is(_knownResourceGroup),
             Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(vmssInfo);
 
@@ -304,7 +296,6 @@ public class VmssGetCommandTests : SubscriptionCommandUnitTestsBase<VmssGetComma
             Arg.Is(_knownResourceGroup),
             Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(vmssVmInfo);
 
@@ -345,7 +336,6 @@ public class VmssGetCommandTests : SubscriptionCommandUnitTestsBase<VmssGetComma
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(vmssInfo);
 
@@ -372,7 +362,6 @@ public class VmssGetCommandTests : SubscriptionCommandUnitTestsBase<VmssGetComma
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
@@ -399,7 +388,6 @@ public class VmssGetCommandTests : SubscriptionCommandUnitTestsBase<VmssGetComma
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
@@ -425,7 +413,6 @@ public class VmssGetCommandTests : SubscriptionCommandUnitTestsBase<VmssGetComma
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(forbiddenException);
 
@@ -448,7 +435,6 @@ public class VmssGetCommandTests : SubscriptionCommandUnitTestsBase<VmssGetComma
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(exception);
 

--- a/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Compute/tests/Azure.Mcp.Tools.Compute.Tests/Vmss/VmssUpdateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Compute.Commands;
 using Azure.Mcp.Tools.Compute.Commands.Vmss;
 using Azure.Mcp.Tools.Compute.Models;
 using Azure.Mcp.Tools.Compute.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -67,7 +66,6 @@ public class VmssUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmssUpdat
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(updateResult);
         }
@@ -114,7 +112,6 @@ public class VmssUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmssUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -159,7 +156,6 @@ public class VmssUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmssUpdat
             Arg.Any<string?>(),
             Arg.Is(string.Empty),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -182,7 +178,6 @@ public class VmssUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmssUpdat
             Arg.Any<string?>(),
             string.Empty,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -213,7 +208,6 @@ public class VmssUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmssUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -248,7 +242,6 @@ public class VmssUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmssUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
@@ -282,7 +275,6 @@ public class VmssUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmssUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(quotaException);
 
@@ -325,7 +317,6 @@ public class VmssUpdateCommandTests : SubscriptionCommandUnitTestsBase<VmssUpdat
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 

--- a/tools/Azure.Mcp.Tools.ContainerApps/src/Commands/ContainerApp/ContainerAppListCommand.cs
+++ b/tools/Azure.Mcp.Tools.ContainerApps/src/Commands/ContainerApp/ContainerAppListCommand.cs
@@ -40,7 +40,6 @@ public sealed class ContainerAppListCommand(ILogger<ContainerAppListCommand> log
                 options.Subscription!,
                 options.ResourceGroup,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(containerApps?.Results ?? [], containerApps?.AreResultsTruncated ?? false), ContainerAppsJsonContext.Default.ContainerAppListCommandResult);

--- a/tools/Azure.Mcp.Tools.ContainerApps/src/Options/ContainerApp/ContainerAppListOptions.cs
+++ b/tools/Azure.Mcp.Tools.ContainerApps/src/Options/ContainerApp/ContainerAppListOptions.cs
@@ -16,7 +16,4 @@ public sealed class ContainerAppListOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.ContainerApps/src/Services/ContainerAppsService.cs
+++ b/tools/Azure.Mcp.Tools.ContainerApps/src/Services/ContainerAppsService.cs
@@ -4,7 +4,6 @@
 using System.Text.Json;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.ContainerApps.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.ContainerApps.Services;
 
@@ -15,7 +14,6 @@ public sealed class ContainerAppsService(IAzureService azureService)
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
@@ -24,7 +22,7 @@ public sealed class ContainerAppsService(IAzureService azureService)
             "Microsoft.App/containerApps",
             resourceGroup,
             subscription,
-            retryPolicy,
+            null,
             ConvertToContainerAppInfoModel,
             tenant: tenant,
             cancellationToken: cancellationToken);

--- a/tools/Azure.Mcp.Tools.ContainerApps/src/Services/IContainerAppsService.cs
+++ b/tools/Azure.Mcp.Tools.ContainerApps/src/Services/IContainerAppsService.cs
@@ -3,7 +3,6 @@
 
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.ContainerApps.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.ContainerApps.Services;
 
@@ -13,6 +12,5 @@ public interface IContainerAppsService
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.ContainerApps/tests/Azure.Mcp.Tools.ContainerApps.Tests/ContainerApp/ContainerAppListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ContainerApps/tests/Azure.Mcp.Tools.ContainerApps.Tests/ContainerApp/ContainerAppListCommandTests.cs
@@ -8,7 +8,6 @@ using Azure.Mcp.Tools.ContainerApps.Commands;
 using Azure.Mcp.Tools.ContainerApps.Commands.ContainerApp;
 using Azure.Mcp.Tools.ContainerApps.Models;
 using Azure.Mcp.Tools.ContainerApps.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -35,7 +34,7 @@ public class ContainerAppListCommandTests : SubscriptionCommandUnitTestsBase<Con
         // Arrange
         if (shouldSucceed)
         {
-            Service.ListContainerApps(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Service.ListContainerApps(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(new ResourceQueryResults<ContainerAppInfo>(
                 [
                     new("app1", "eastus", "rg1", "/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.App/managedEnvironments/env1", "Succeeded"),
@@ -62,7 +61,7 @@ public class ContainerAppListCommandTests : SubscriptionCommandUnitTestsBase<Con
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        Service.ListContainerApps(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListContainerApps(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -79,7 +78,7 @@ public class ContainerAppListCommandTests : SubscriptionCommandUnitTestsBase<Con
     {
         // Arrange
         var expectedApps = new ResourceQueryResults<ContainerAppInfo>([new("app1", null, null, null, null)], false);
-        Service.ListContainerApps("sub", "rg", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListContainerApps("sub", "rg", Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(expectedApps);
 
         // Act
@@ -88,14 +87,14 @@ public class ContainerAppListCommandTests : SubscriptionCommandUnitTestsBase<Con
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
-        await Service.Received(1).ListContainerApps("sub", "rg", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListContainerApps("sub", "rg", Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ExecuteAsync_EmptyList_ReturnsEmptyResults()
     {
         // Arrange
-        Service.ListContainerApps("sub", null, Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListContainerApps("sub", null, Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new ResourceQueryResults<ContainerAppInfo>([], false));
 
         // Act
@@ -111,7 +110,7 @@ public class ContainerAppListCommandTests : SubscriptionCommandUnitTestsBase<Con
     {
         // Arrange
         var expectedApps = new ResourceQueryResults<ContainerAppInfo>([new("app1", null, null, null, null)], false);
-        Service.ListContainerApps("sub", Arg.Any<string>(), "my-tenant", Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListContainerApps("sub", Arg.Any<string>(), "my-tenant", Arg.Any<CancellationToken>())
             .Returns(expectedApps);
 
         // Act
@@ -119,7 +118,7 @@ public class ContainerAppListCommandTests : SubscriptionCommandUnitTestsBase<Con
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await Service.Received(1).ListContainerApps("sub", Arg.Any<string>(), "my-tenant", Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListContainerApps("sub", Arg.Any<string>(), "my-tenant", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -127,7 +126,7 @@ public class ContainerAppListCommandTests : SubscriptionCommandUnitTestsBase<Con
     {
         // Arrange
         var containerApp = new ContainerAppInfo("myapp", "eastus", "myrg", "/subscriptions/sub/resourceGroups/myrg/providers/Microsoft.App/managedEnvironments/myenv", "Succeeded");
-        Service.ListContainerApps("sub", null, Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListContainerApps("sub", null, Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new ResourceQueryResults<ContainerAppInfo>([containerApp], false));
 
         // Act

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/Container/ContainerSchemaInferCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/Container/ContainerSchemaInferCommand.cs
@@ -50,7 +50,6 @@ public sealed class ContainerSchemaInferCommand(ILogger<ContainerSchemaInferComm
                 options.Subscription!,
                 options.AuthMethod ?? AuthMethod.Credential,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CosmosListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/CosmosListCommand.cs
@@ -53,7 +53,6 @@ public sealed class CosmosListCommand(ILogger<CosmosListCommand> logger, ICosmos
                     options.AuthMethod ?? AuthMethod.Credential,
                     options.Tenant,
                     options.ResourceGroup,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(
@@ -69,7 +68,6 @@ public sealed class CosmosListCommand(ILogger<CosmosListCommand> logger, ICosmos
                     options.AuthMethod ?? AuthMethod.Credential,
                     options.Tenant,
                     options.ResourceGroup,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(
@@ -83,7 +81,6 @@ public sealed class CosmosListCommand(ILogger<CosmosListCommand> logger, ICosmos
                     options.Subscription!,
                     options.ResourceGroup,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/Item/ItemGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/Item/ItemGetCommand.cs
@@ -42,7 +42,6 @@ public sealed class ItemGetCommand(ILogger<ItemGetCommand> logger, ICosmosServic
                 options.Subscription!,
                 options.AuthMethod ?? AuthMethod.Credential,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/Item/ItemListRecentCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/Item/ItemListRecentCommand.cs
@@ -51,7 +51,6 @@ public sealed class ItemListRecentCommand(ILogger<ItemListRecentCommand> logger,
                 options.Subscription!,
                 options.AuthMethod ?? AuthMethod.Credential,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/Item/ItemTextSearchCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/Item/ItemTextSearchCommand.cs
@@ -85,7 +85,6 @@ public sealed class ItemTextSearchCommand(ILogger<ItemTextSearchCommand> logger,
                 options.Subscription!,
                 options.AuthMethod ?? AuthMethod.Credential,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/Item/ItemVectorSearchCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/Item/ItemVectorSearchCommand.cs
@@ -132,7 +132,6 @@ public sealed class ItemVectorSearchCommand(ILogger<ItemVectorSearchCommand> log
                 options.Subscription!,
                 options.AuthMethod ?? AuthMethod.Credential,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ItemQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Commands/ItemQueryCommand.cs
@@ -59,7 +59,6 @@ public sealed class ItemQueryCommand(ILogger<ItemQueryCommand> logger, ICosmosSe
                 options.Subscription!,
                 options.AuthMethod ?? AuthMethod.Credential,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(items ?? []), CosmosJsonContext.Default.ItemQueryCommandResult);

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Options/Container/ContainerSchemaInferOptions.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Options/Container/ContainerSchemaInferOptions.cs
@@ -27,9 +27,6 @@ public sealed class ContainerSchemaInferOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
-
     [Option(Description = OptionDescriptions.AuthMethod)]
     public AuthMethod? AuthMethod { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Options/CosmosListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Options/CosmosListOptions.cs
@@ -24,9 +24,6 @@ public sealed class CosmosListOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
-
     [Option(Description = OptionDescriptions.AuthMethod)]
     public AuthMethod? AuthMethod { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Options/Item/ItemGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Options/Item/ItemGetOptions.cs
@@ -30,9 +30,6 @@ public sealed class ItemGetOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
-
     [Option(Description = OptionDescriptions.AuthMethod)]
     public AuthMethod? AuthMethod { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Options/Item/ItemListRecentOptions.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Options/Item/ItemListRecentOptions.cs
@@ -27,9 +27,6 @@ public sealed class ItemListRecentOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
-
     [Option(Description = OptionDescriptions.AuthMethod)]
     public AuthMethod? AuthMethod { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Options/Item/ItemTextSearchOptions.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Options/Item/ItemTextSearchOptions.cs
@@ -36,9 +36,6 @@ public sealed class ItemTextSearchOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
-
     [Option(Description = OptionDescriptions.AuthMethod)]
     public AuthMethod? AuthMethod { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Options/Item/ItemVectorSearchOptions.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Options/Item/ItemVectorSearchOptions.cs
@@ -45,9 +45,6 @@ public sealed class ItemVectorSearchOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
-
     [Option(Description = OptionDescriptions.AuthMethod)]
     public AuthMethod? AuthMethod { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Options/ItemQueryOptions.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Options/ItemQueryOptions.cs
@@ -27,9 +27,6 @@ public sealed class ItemQueryOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
-
     [Option(Description = OptionDescriptions.AuthMethod)]
     public AuthMethod? AuthMethod { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Services/CosmosService.cs
@@ -12,7 +12,6 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Azure;
 using Microsoft.Mcp.Core.Services.Azure.Authentication;
 using Microsoft.Mcp.Core.Services.Caching;
@@ -37,12 +36,11 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
         string accountName,
         string? tenant = null,
         string? resourceGroup = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription), (nameof(accountName), accountName));
 
-        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
 
         // Fast path: when the resource group is known, look the account up directly
         // instead of enumerating every Cosmos DB account in the subscription.
@@ -88,7 +86,6 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
         AuthMethod authMethod,
         string? tenant = null,
         string? resourceGroup = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         // Enable bulk execution and distributed tracing telemetry features once they are supported by the Microsoft.Azure.Cosmos.Aot package.
@@ -97,21 +94,13 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
         var clientOptions = new CosmosClientOptions();
         clientOptions.CustomHandlers.Add(new UserPolicyRequestHandler(UserAgent));
 
-        if (retryPolicy != null)
-        {
-            if (retryPolicy.MaxRetries is { } maxRetries)
-                clientOptions.MaxRetryAttemptsOnRateLimitedRequests = maxRetries;
-            if (retryPolicy.MaxDelaySeconds is { } maxDelaySeconds)
-                clientOptions.MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(maxDelaySeconds);
-        }
-
         clientOptions.HttpClientFactory = () => AzureService.GetClient();
 
         CosmosClient cosmosClient;
         switch (authMethod)
         {
             case AuthMethod.Key:
-                var cosmosAccount = await GetCosmosAccountAsync(subscription, accountName, tenant, resourceGroup, retryPolicy, cancellationToken);
+                var cosmosAccount = await GetCosmosAccountAsync(subscription, accountName, tenant, resourceGroup, cancellationToken);
                 var keys = await cosmosAccount.GetKeysAsync(cancellationToken);
                 cosmosClient = new(GetCosmosBaseUri(accountName), keys.Value.PrimaryMasterKey, clientOptions);
                 break;
@@ -151,7 +140,6 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
         string? resourceGroup = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(accountName), accountName), (nameof(subscription), subscription));
@@ -167,18 +155,17 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
             authMethod,
             tenant,
             resourceGroup,
-            retryPolicy,
             cancellationToken);
 
         await _cacheService.SetAsync(CacheGroup, key, cosmosClient, s_cacheDurationClients, cancellationToken);
         return cosmosClient;
     }
 
-    public async Task<List<string>> GetCosmosAccounts(string subscription, string? resourceGroup = null, string? tenant = null, RetryPolicyOptions? retryPolicy = null, CancellationToken cancellationToken = default)
+    public async Task<List<string>> GetCosmosAccounts(string subscription, string? resourceGroup = null, string? tenant = null, CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
 
-        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var accounts = new List<string>();
 
         if (!string.IsNullOrEmpty(resourceGroup))
@@ -224,7 +211,6 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
         string? resourceGroup = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(accountName), accountName), (nameof(subscription), subscription));
@@ -237,7 +223,7 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
             return cachedDatabases;
         }
 
-        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, resourceGroup, retryPolicy, cancellationToken);
+        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, resourceGroup, cancellationToken);
         var databases = new List<string>();
 
         var iterator = client.GetDatabaseQueryStreamIterator();
@@ -271,7 +257,6 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
         string? resourceGroup = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(accountName), accountName), (nameof(databaseName), databaseName), (nameof(subscription), subscription));
@@ -284,7 +269,7 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
             return cachedContainers;
         }
 
-        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, resourceGroup, retryPolicy, cancellationToken);
+        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, resourceGroup, cancellationToken);
         var containers = new List<string>();
 
         var database = client.GetDatabase(databaseName);
@@ -320,12 +305,11 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(accountName), accountName), (nameof(databaseName), databaseName), (nameof(containerName), containerName), (nameof(subscription), subscription));
 
-        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, null, retryPolicy, cancellationToken);
+        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, cancellationToken: cancellationToken);
 
         var container = client.GetContainer(databaseName, containerName);
         var baseQuery = string.IsNullOrEmpty(query) ? "SELECT * FROM c" : query;
@@ -364,7 +348,6 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -373,7 +356,7 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
             (nameof(containerName), containerName),
             (nameof(subscription), subscription));
 
-        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, null, retryPolicy, cancellationToken);
+        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, cancellationToken: cancellationToken);
         var container = client.GetContainer(databaseName, containerName);
 
         var queryDef = new QueryDefinition("SELECT TOP @sampleSize * FROM c")
@@ -448,7 +431,6 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -457,7 +439,7 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
             (nameof(containerName), containerName),
             (nameof(subscription), subscription));
 
-        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, null, retryPolicy, cancellationToken);
+        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, cancellationToken: cancellationToken);
         var container = client.GetContainer(databaseName, containerName);
 
         var queryDef = new QueryDefinition("SELECT TOP @topN * FROM c ORDER BY c._ts DESC")
@@ -500,7 +482,6 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -510,7 +491,7 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
             (nameof(id), id),
             (nameof(subscription), subscription));
 
-        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, null, retryPolicy, cancellationToken);
+        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, cancellationToken: cancellationToken);
         var container = client.GetContainer(databaseName, containerName);
 
         // TODO: When Microsoft.Azure.Cosmos.Aot covers ReadItemStreamAsync + CosmosException, restore the
@@ -558,7 +539,6 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -569,7 +549,7 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
             (nameof(searchPhrase), searchPhrase),
             (nameof(subscription), subscription));
 
-        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, null, retryPolicy, cancellationToken);
+        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, cancellationToken: cancellationToken);
         var container = client.GetContainer(databaseName, containerName);
 
         var selectClause = propertiesToSelect is { Count: > 0 }
@@ -621,7 +601,6 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -631,7 +610,7 @@ public sealed class CosmosService(IAzureService azureService, ICacheService cach
             (nameof(vectorProperty), vectorProperty),
             (nameof(subscription), subscription));
 
-        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, null, retryPolicy, cancellationToken);
+        var client = await GetCosmosClientAsync(accountName, subscription, authMethod, tenant, cancellationToken: cancellationToken);
         var container = client.GetContainer(databaseName, containerName);
 
         // Inline the embedding as a JSON array literal. The Cosmos AOT serializer

--- a/tools/Azure.Mcp.Tools.Cosmos/src/Services/ICosmosService.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/src/Services/ICosmosService.cs
@@ -4,7 +4,6 @@
 using System.Text.Json;
 using Azure.Mcp.Tools.Cosmos.Models;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Cosmos.Services;
 
@@ -14,7 +13,6 @@ public interface ICosmosService : IAsyncDisposable
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<string>> ListDatabases(
@@ -23,7 +21,6 @@ public interface ICosmosService : IAsyncDisposable
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
         string? resourceGroup = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<string>> ListContainers(
@@ -33,7 +30,6 @@ public interface ICosmosService : IAsyncDisposable
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
         string? resourceGroup = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<JsonElement>> QueryItems(
@@ -44,7 +40,6 @@ public interface ICosmosService : IAsyncDisposable
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<ContainerSchema> GetApproximateSchema(
@@ -55,7 +50,6 @@ public interface ICosmosService : IAsyncDisposable
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<JsonElement>> GetRecentItems(
@@ -66,7 +60,6 @@ public interface ICosmosService : IAsyncDisposable
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<JsonElement?> GetItem(
@@ -78,7 +71,6 @@ public interface ICosmosService : IAsyncDisposable
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<JsonElement>> TextSearch(
@@ -92,7 +84,6 @@ public interface ICosmosService : IAsyncDisposable
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<JsonElement>> VectorSearch(
@@ -106,7 +97,6 @@ public interface ICosmosService : IAsyncDisposable
         string subscription,
         AuthMethod authMethod = AuthMethod.Credential,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<float[]> GenerateEmbedding(

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/Container/ContainerSchemaInferCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/Container/ContainerSchemaInferCommandTests.cs
@@ -8,7 +8,6 @@ using Azure.Mcp.Tools.Cosmos.Commands.Container;
 using Azure.Mcp.Tools.Cosmos.Models;
 using Azure.Mcp.Tools.Cosmos.Services;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -45,7 +44,6 @@ public class ContainerSchemaInferCommandTests : SubscriptionCommandUnitTestsBase
             Arg.Is("sub"),
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(schema);
 
@@ -83,7 +81,7 @@ public class ContainerSchemaInferCommandTests : SubscriptionCommandUnitTestsBase
         Service.GetApproximateSchema(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
             Arg.Any<string>(), Arg.Any<AuthMethod>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("boom"));
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosListCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Cosmos.Commands;
 using Azure.Mcp.Tools.Cosmos.Services;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -44,7 +43,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Is("sub123"),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedAccounts);
 
@@ -70,7 +68,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedDatabases);
 
@@ -97,7 +94,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedContainers);
 
@@ -123,7 +119,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Is("sub123"),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -148,7 +143,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -174,7 +168,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -224,7 +217,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Is("sub123"),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -246,7 +238,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
@@ -271,7 +262,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
@@ -296,7 +286,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new KeyNotFoundException("Cosmos DB account 'missingaccount' not found in subscription 'sub123'."));
 
@@ -321,7 +310,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
             Arg.Is("rg1"),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedDatabases);
 
@@ -341,7 +329,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
             "rg1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -354,7 +341,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Is("sub123"),
             Arg.Is("rg1"),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedAccounts);
 
@@ -371,7 +357,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             "sub123",
             "rg1",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -383,7 +368,6 @@ public class CosmosListCommandTests : SubscriptionCommandUnitTestsBase<CosmosLis
             Arg.Is("sub123"),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("Service Unavailable", null, HttpStatusCode.ServiceUnavailable));
 

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/CosmosServiceTests.cs
@@ -11,7 +11,6 @@ using Azure.ResourceManager.Resources;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Azure.Authentication;
 using Microsoft.Mcp.Core.Services.Caching;
 using NSubstitute;
@@ -92,7 +91,7 @@ public class CosmosServiceTests : IAsyncDisposable
         // Verify no fallback to key auth: GetSubscription is only called for key-based auth
         // (to look up the account and retrieve master keys)
         await _azureService.DidNotReceive()
-            .GetSubscription(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            .GetSubscription(Arg.Any<string>(), Arg.Any<string?>(), null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -113,7 +112,7 @@ public class CosmosServiceTests : IAsyncDisposable
 
         // Verify no fallback to key auth
         await _azureService.DidNotReceive()
-            .GetSubscription(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            .GetSubscription(Arg.Any<string>(), Arg.Any<string?>(), null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -216,7 +215,7 @@ public class CosmosServiceTests : IAsyncDisposable
     {
         // Arrange: the resource group lookup returns a 404, which should surface as a not-found.
         var subscriptionResource = Substitute.For<SubscriptionResource>();
-        _azureService.GetSubscription("sub123", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        _azureService.GetSubscription("sub123", Arg.Any<string?>(), null, Arg.Any<CancellationToken>())
             .Returns(subscriptionResource);
         subscriptionResource.GetResourceGroupAsync("missing-rg", Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Resource group not found"));
@@ -238,7 +237,7 @@ public class CosmosServiceTests : IAsyncDisposable
             .Returns(default(List<string>));
 
         var subscriptionResource = Substitute.For<SubscriptionResource>();
-        _azureService.GetSubscription("sub123", Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        _azureService.GetSubscription("sub123", Arg.Any<string?>(), null, Arg.Any<CancellationToken>())
             .Returns(subscriptionResource);
         subscriptionResource.GetResourceGroupAsync("missing-rg", Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, "Resource group not found"));

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/Item/ItemGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/Item/ItemGetCommandTests.cs
@@ -8,7 +8,6 @@ using Azure.Mcp.Tools.Cosmos.Commands;
 using Azure.Mcp.Tools.Cosmos.Commands.Item;
 using Azure.Mcp.Tools.Cosmos.Services;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using Xunit;
 
@@ -28,7 +27,7 @@ public class ItemGetCommandTests : SubscriptionCommandUnitTestsBase<ItemGetComma
             Arg.Is("acct"), Arg.Is("db"), Arg.Is("c"), Arg.Is("abc"),
             Arg.Is("pk1"),
             Arg.Is("sub"), Arg.Any<AuthMethod>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>())
             .Returns(item);
 
         var response = await ExecuteCommandAsync(
@@ -51,7 +50,7 @@ public class ItemGetCommandTests : SubscriptionCommandUnitTestsBase<ItemGetComma
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string>(), Arg.Any<AuthMethod>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>())
             .Returns((JsonElement?)null);
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/Item/ItemListRecentCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/Item/ItemListRecentCommandTests.cs
@@ -8,7 +8,6 @@ using Azure.Mcp.Tools.Cosmos.Commands;
 using Azure.Mcp.Tools.Cosmos.Commands.Item;
 using Azure.Mcp.Tools.Cosmos.Services;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using Xunit;
 
@@ -31,7 +30,7 @@ public class ItemListRecentCommandTests : SubscriptionCommandUnitTestsBase<ItemL
         Service.GetRecentItems(
             Arg.Is("acct"), Arg.Is("db"), Arg.Is("c"), Arg.Is(2),
             Arg.Is("sub"), Arg.Any<AuthMethod>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>())
             .Returns(items);
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/Item/ItemQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/Item/ItemQueryCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Cosmos.Commands;
 using Azure.Mcp.Tools.Cosmos.Services;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -35,7 +34,6 @@ public class ItemQueryCommandTests : SubscriptionCommandUnitTestsBase<ItemQueryC
             Arg.Is("sub123"),
             Arg.Any<AuthMethod>(),
             null,
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedItems);
 
@@ -71,7 +69,6 @@ public class ItemQueryCommandTests : SubscriptionCommandUnitTestsBase<ItemQueryC
             Arg.Is("sub123"),
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedItems);
 
@@ -99,7 +96,6 @@ public class ItemQueryCommandTests : SubscriptionCommandUnitTestsBase<ItemQueryC
             Arg.Is("sub123"),
             Arg.Is(AuthMethod.Credential),
             Arg.Is((string?)null),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -130,7 +126,6 @@ public class ItemQueryCommandTests : SubscriptionCommandUnitTestsBase<ItemQueryC
             Arg.Is("sub123"),
             Arg.Any<AuthMethod>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/Item/ItemTextSearchCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/Item/ItemTextSearchCommandTests.cs
@@ -8,7 +8,6 @@ using Azure.Mcp.Tools.Cosmos.Commands;
 using Azure.Mcp.Tools.Cosmos.Commands.Item;
 using Azure.Mcp.Tools.Cosmos.Services;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using Xunit;
 
@@ -33,7 +32,7 @@ public class ItemTextSearchCommandTests : SubscriptionCommandUnitTestsBase<ItemT
             Arg.Any<IReadOnlyList<string>?>(),
             Arg.Is(5), Arg.Is("sub"),
             Arg.Any<AuthMethod>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>())
             .Returns(items);
 
         var response = await ExecuteCommandAsync(

--- a/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/Item/ItemVectorSearchCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Cosmos/tests/Azure.Mcp.Tools.Cosmos.Tests/Item/ItemVectorSearchCommandTests.cs
@@ -9,7 +9,6 @@ using Azure.Mcp.Tools.Cosmos.Commands.Item;
 using Azure.Mcp.Tools.Cosmos.Models;
 using Azure.Mcp.Tools.Cosmos.Services;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using Xunit;
 
@@ -42,7 +41,7 @@ public class ItemVectorSearchCommandTests : SubscriptionCommandUnitTestsBase<Ite
             Arg.Is<IReadOnlyList<float>>(v => v.Count == 2 && v[0] == 0.5f),
             Arg.Is(3),
             Arg.Is("sub"), Arg.Any<AuthMethod>(), Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>())
             .Returns(items);
 
         var response = await ExecuteCommandAsync(


### PR DESCRIPTION
## What does this PR do?

Removed custom retry policy options from Communication, Compute, Container Apps, and Cosmos tools.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
