### PR TITLE
[Part 5] Remove RetryPolicyOptions from tools

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/remove-retry-policy-options-part5.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/remove-retry-policy-options-part5.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: Breaking Changes
+    description: Removed custom retry policy options from Function App, Grafana, Insights, IoT Hub, Key Vault, and Kusto tools.

--- a/tools/Azure.Mcp.Tools.FunctionApp/src/Commands/FunctionApp/FunctionAppGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/src/Commands/FunctionApp/FunctionAppGetCommand.cs
@@ -53,7 +53,6 @@ public sealed class FunctionAppGetCommand(ILogger<FunctionAppGetCommand> logger,
                 options.FunctionApp,
                 options.ResourceGroup,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(functionApps ?? []), FunctionAppJsonContext.Default.FunctionAppGetCommandResult);

--- a/tools/Azure.Mcp.Tools.FunctionApp/src/Options/FunctionApp/FunctionAppGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/src/Options/FunctionApp/FunctionAppGetOptions.cs
@@ -19,7 +19,4 @@ public sealed class FunctionAppGetOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.FunctionApp/src/Services/FunctionAppService.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/src/Services/FunctionAppService.cs
@@ -5,7 +5,6 @@ using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.FunctionApp.Models;
 using Azure.ResourceManager.AppService;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Caching;
 
 namespace Azure.Mcp.Tools.FunctionApp.Services;
@@ -25,12 +24,11 @@ public sealed class FunctionAppService(IAzureService azureService, ICacheService
         string? functionAppName,
         string? resourceGroup,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
 
-        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var functionApps = new List<FunctionAppInfo>();
         if (string.IsNullOrEmpty(functionAppName))
         {

--- a/tools/Azure.Mcp.Tools.FunctionApp/src/Services/IFunctionAppService.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/src/Services/IFunctionAppService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.FunctionApp.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.FunctionApp.Services;
 
@@ -13,6 +12,5 @@ public interface IFunctionAppService
         string? functionAppName,
         string? resourceGroup,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.FunctionApp/tests/Azure.Mcp.Tools.FunctionApp.Tests/FunctionApp/FunctionAppGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FunctionApp/tests/Azure.Mcp.Tools.FunctionApp.Tests/FunctionApp/FunctionAppGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.FunctionApp.Commands;
 using Azure.Mcp.Tools.FunctionApp.Commands.FunctionApp;
 using Azure.Mcp.Tools.FunctionApp.Models;
 using Azure.Mcp.Tools.FunctionApp.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -35,7 +34,6 @@ public sealed class FunctionAppGetCommandTests : SubscriptionCommandUnitTestsBas
                 Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
                 Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(testFunctionApps);
         }
@@ -70,7 +68,6 @@ public sealed class FunctionAppGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedFunctionApps);
 
@@ -84,7 +81,6 @@ public sealed class FunctionAppGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
 
         var result = ValidateAndDeserializeResponse(response, FunctionAppJsonContext.Default.FunctionAppGetCommandResult);
@@ -108,7 +104,6 @@ public sealed class FunctionAppGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -130,7 +125,6 @@ public sealed class FunctionAppGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -164,7 +158,6 @@ public sealed class FunctionAppGetCommandTests : SubscriptionCommandUnitTestsBas
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns([new("app1", "rg1", "eastus", "plan1", "Running", "app1.azurewebsites.net", null)]);
         }
@@ -183,7 +176,6 @@ public sealed class FunctionAppGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([expected]);
 
@@ -203,7 +195,6 @@ public sealed class FunctionAppGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns((List<FunctionAppInfo>?)null);
 

--- a/tools/Azure.Mcp.Tools.Grafana/src/Commands/Workspace/WorkspaceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/src/Commands/Workspace/WorkspaceListCommand.cs
@@ -43,7 +43,6 @@ public sealed class WorkspaceListCommand(IGrafanaService grafanaService, ILogger
                 options.Subscription!,
                 options.ResourceGroup,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(workspaces?.Results ?? [], workspaces?.AreResultsTruncated ?? false), GrafanaJsonContext.Default.WorkspaceListCommandResult);

--- a/tools/Azure.Mcp.Tools.Grafana/src/Options/Workspace/WorkspaceListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/src/Options/Workspace/WorkspaceListOptions.cs
@@ -16,7 +16,4 @@ public sealed class WorkspaceListOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Grafana/src/Services/GrafanaService.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/src/Services/GrafanaService.cs
@@ -8,7 +8,6 @@ using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.Grafana.Models;
 using Azure.Mcp.Tools.Grafana.Services.Models;
 using Microsoft.Mcp.Core.Models.Identity;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Grafana.Services;
 
@@ -19,7 +18,6 @@ public class GrafanaService(IAzureService azureService)
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
@@ -28,7 +26,7 @@ public class GrafanaService(IAzureService azureService)
             "Microsoft.Dashboard/grafana",
             resourceGroup: resourceGroup,
             subscription,
-            retryPolicy,
+            null,
             ConvertToWorkspaceModel,
             tenant: tenant,
             cancellationToken: cancellationToken);

--- a/tools/Azure.Mcp.Tools.Grafana/src/Services/IGrafanaService.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/src/Services/IGrafanaService.cs
@@ -3,7 +3,6 @@
 
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.Grafana.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Grafana.Services;
 
@@ -14,13 +13,11 @@ public interface IGrafanaService
     /// </summary>
     /// <param name="subscription">The subscription ID or name</param>
     /// <param name="tenant">Optional tenant ID for cross-tenant operations</param>
-    /// <param name="retryPolicy">Optional retry policy configuration</param>
     /// <returns>List of Grafana workspace details</returns>
     /// <exception cref="Exception">When the service request fails</exception>
     Task<ResourceQueryResults<GrafanaWorkspace>> ListWorkspacesAsync(
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Grafana/tests/Azure.Mcp.Tools.Grafana.Tests/WorkspaceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Grafana/tests/Azure.Mcp.Tools.Grafana.Tests/WorkspaceListCommandTests.cs
@@ -8,7 +8,6 @@ using Azure.Mcp.Tools.Grafana.Commands;
 using Azure.Mcp.Tools.Grafana.Commands.Workspace;
 using Azure.Mcp.Tools.Grafana.Models;
 using Azure.Mcp.Tools.Grafana.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -62,7 +61,7 @@ public sealed class WorkspaceListCommandTests : SubscriptionCommandUnitTestsBase
             )
         ], false);
 
-        Service.ListWorkspacesAsync("sub123", Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspacesAsync("sub123", Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(expectedWorkspaces);
 
         // Act
@@ -80,7 +79,7 @@ public sealed class WorkspaceListCommandTests : SubscriptionCommandUnitTestsBase
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoWorkspacesExist()
     {
         // Arrange
-        Service.ListWorkspacesAsync("sub123", Arg.Any<string?>(), null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspacesAsync("sub123", Arg.Any<string?>(), null, Arg.Any<CancellationToken>())
             .Returns(new ResourceQueryResults<GrafanaWorkspace>([], false));
 
         // Act
@@ -113,7 +112,7 @@ public sealed class WorkspaceListCommandTests : SubscriptionCommandUnitTestsBase
             )
         ], false);
 
-        Service.ListWorkspacesAsync("sub123", Arg.Any<string?>(), "tenant456", Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspacesAsync("sub123", Arg.Any<string?>(), "tenant456", Arg.Any<CancellationToken>())
             .Returns(expectedWorkspaces);
 
         // Act
@@ -131,7 +130,7 @@ public sealed class WorkspaceListCommandTests : SubscriptionCommandUnitTestsBase
         var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
         var subscriptionId = "sub123";
 
-        Service.ListWorkspacesAsync(subscriptionId, Arg.Any<string?>(), null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspacesAsync(subscriptionId, Arg.Any<string?>(), null, Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -148,7 +147,7 @@ public sealed class WorkspaceListCommandTests : SubscriptionCommandUnitTestsBase
     {
         // Arrange
         const string resourceGroup = "test-rg";
-        Service.ListWorkspacesAsync(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ListWorkspacesAsync(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new ResourceQueryResults<GrafanaWorkspace>([], false));
 
         // Act
@@ -156,6 +155,6 @@ public sealed class WorkspaceListCommandTests : SubscriptionCommandUnitTestsBase
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await Service.Received(1).ListWorkspacesAsync(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListWorkspacesAsync(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Insights/src/Commands/InsightsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Insights/src/Commands/InsightsGetCommand.cs
@@ -182,8 +182,8 @@ public sealed partial class InsightsGetCommand(
             IProgress<string> progress = new Progress<string>(msg => _ = NotifyProgressAsync(context, msg, cancellationToken));
 
             var aggregation = scope == InsightsOptionDefinitions.ScopeTenant
-                ? await _insightsService.AggregateTenantAsync(options.Tenant, options.RetryPolicy, cancellationToken, progress, options.NoCache)
-                : await _insightsService.AggregateSubscriptionAsync(options.Subscription!, options.Tenant, options.RetryPolicy, cancellationToken, progress, options.NoCache);
+                ? await _insightsService.AggregateTenantAsync(options.Tenant, cancellationToken, progress, options.NoCache)
+                : await _insightsService.AggregateSubscriptionAsync(options.Subscription!, options.Tenant, cancellationToken, progress, options.NoCache);
 
             // Return empty list if no resources are found
             if (aggregation.ResourceTypes.Count == 0)

--- a/tools/Azure.Mcp.Tools.Insights/src/Options/InsightsGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Insights/src/Options/InsightsGetOptions.cs
@@ -22,7 +22,4 @@ public class InsightsGetOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Insights/src/Services/IInsightsService.cs
+++ b/tools/Azure.Mcp.Tools.Insights/src/Services/IInsightsService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.Insights.Services.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Insights.Services;
 
@@ -20,7 +19,6 @@ public interface IInsightsService
     Task<SubscriptionAggregation> AggregateSubscriptionAsync(
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken,
         IProgress<string>? progress = null,
         bool noCache = false);
@@ -33,7 +31,6 @@ public interface IInsightsService
     /// <param name="noCache">Fetch new ARG data if true, else use cached data.</param>
     Task<SubscriptionAggregation> AggregateTenantAsync(
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken,
         IProgress<string>? progress = null,
         bool noCache = false);

--- a/tools/Azure.Mcp.Tools.Insights/src/Services/InsightsService.cs
+++ b/tools/Azure.Mcp.Tools.Insights/src/Services/InsightsService.cs
@@ -9,7 +9,6 @@ using Azure.ResourceManager.ResourceGraph;
 using Azure.ResourceManager.ResourceGraph.Models;
 using Azure.ResourceManager.Resources;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Caching;
 
 namespace Azure.Mcp.Tools.Insights.Services;
@@ -49,14 +48,13 @@ public sealed class InsightsService(IAzureService azureService, ICacheService ca
     public async Task<SubscriptionAggregation> AggregateSubscriptionAsync(
         string subscription,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken,
         IProgress<string>? progress = null,
         bool noCache = false)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
 
-        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
 
         // Cache ARG data by subscription ID
         var cacheKey = $"sub:{subscriptionResource.Data.SubscriptionId}";
@@ -102,12 +100,11 @@ public sealed class InsightsService(IAzureService azureService, ICacheService ca
 
     public async Task<SubscriptionAggregation> AggregateTenantAsync(
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken,
         IProgress<string>? progress = null,
         bool noCache = false)
     {
-        var subscriptions = await AzureService.GetSubscriptions(tenant, retryPolicy, cancellationToken);
+        var subscriptions = await AzureService.GetSubscriptions(tenant, cancellationToken: cancellationToken);
         if (subscriptions.Count == 0)
         {
             throw new InvalidOperationException("No accessible subscriptions were found in the tenant.");

--- a/tools/Azure.Mcp.Tools.Insights/tests/Azure.Mcp.Tools.Insights.Tests/InsightsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Insights/tests/Azure.Mcp.Tools.Insights.Tests/InsightsGetCommandTests.cs
@@ -10,7 +10,6 @@ using Azure.Mcp.Tools.Insights.Services.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Command;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -53,7 +52,7 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
     public async Task ExecuteAsync_WithSubscription_CallsAggregateSubscription()
     {
         var aggregation = CreatePopulatedAggregation();
-        Service.AggregateSubscriptionAsync(default!, default, default, TestContext.Current.CancellationToken)
+        Service.AggregateSubscriptionAsync(default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs(aggregation);
         _samplingService.SampleTextAsync(default!, default!, default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs("[]");
@@ -64,7 +63,6 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
         await Service.Received(1).AggregateSubscriptionAsync(
             "sub1",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>(),
             Arg.Any<IProgress<string>?>(),
             Arg.Any<bool>());
@@ -79,7 +77,7 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
     [Fact]
     public async Task ExecuteAsync_WithoutSubscription_CallsAggregateTenant()
     {
-        Service.AggregateTenantAsync(default, default, TestContext.Current.CancellationToken)
+        Service.AggregateTenantAsync(default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs(CreatePopulatedAggregation());
         _samplingService.SampleTextAsync(default!, default!, default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs("[]");
@@ -89,18 +87,17 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         await Service.Received(1).AggregateTenantAsync(
             "tenant-1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>(),
             Arg.Any<IProgress<string>?>(),
             Arg.Any<bool>());
         await Service.DidNotReceiveWithAnyArgs().AggregateSubscriptionAsync(
-            default!, default, default, TestContext.Current.CancellationToken);
+            default!, default, TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task ExecuteAsync_SamplingReturnsInsights_ReturnsResultsList()
     {
-        Service.AggregateSubscriptionAsync(default!, default, default, TestContext.Current.CancellationToken)
+        Service.AggregateSubscriptionAsync(default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs(CreatePopulatedAggregation());
         _samplingService.SampleTextAsync(default!, default!, default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs("""
@@ -124,7 +121,7 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
     [Fact]
     public async Task ExecuteAsync_AggregateThrows_ReturnsErrorInResponse()
     {
-        Service.AggregateSubscriptionAsync(default!, default, default, TestContext.Current.CancellationToken)
+        Service.AggregateSubscriptionAsync(default!, default, TestContext.Current.CancellationToken)
             .ThrowsAsyncForAnyArgs(new InvalidOperationException("boom"));
 
         var response = await ExecuteWithSamplingAsync("--subscription", "sub1");
@@ -136,7 +133,7 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
     [Fact]
     public async Task ExecuteAsync_QuotedSubscription_StripsQuotes()
     {
-        Service.AggregateSubscriptionAsync(default!, default, default, TestContext.Current.CancellationToken)
+        Service.AggregateSubscriptionAsync(default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs(CreatePopulatedAggregation());
         _samplingService.SampleTextAsync(default!, default!, default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs("[]");
@@ -147,7 +144,6 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
         await Service.Received(1).AggregateSubscriptionAsync(
             "sub1",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>(),
             Arg.Any<IProgress<string>?>(),
             Arg.Any<bool>());
@@ -164,9 +160,9 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("scope", response.Message, StringComparison.OrdinalIgnoreCase);
         await Service.DidNotReceiveWithAnyArgs().AggregateSubscriptionAsync(
-            default!, default, default, TestContext.Current.CancellationToken);
+            default!, default, TestContext.Current.CancellationToken);
         await Service.DidNotReceiveWithAnyArgs().AggregateTenantAsync(
-            default, default, TestContext.Current.CancellationToken);
+            default, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -177,7 +173,7 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("subscription", response.Message, StringComparison.OrdinalIgnoreCase);
         await Service.DidNotReceiveWithAnyArgs().AggregateTenantAsync(
-            default, default, TestContext.Current.CancellationToken);
+            default, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -190,14 +186,14 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("default subscription", response.Message, StringComparison.OrdinalIgnoreCase);
         await Service.DidNotReceiveWithAnyArgs().AggregateSubscriptionAsync(
-            default!, default, default, TestContext.Current.CancellationToken);
+            default!, default, TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task ExecuteAsync_UsesDefaultSubscription_WhenNotProvided()
     {
         _azureService.GetDefaultSubscriptionId().Returns("default-sub");
-        Service.AggregateSubscriptionAsync(default!, default, default, TestContext.Current.CancellationToken)
+        Service.AggregateSubscriptionAsync(default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs(CreatePopulatedAggregation());
         _samplingService.SampleTextAsync(default!, default!, default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs("[]");
@@ -208,7 +204,6 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
         await Service.Received(1).AggregateSubscriptionAsync(
             "default-sub",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>(),
             Arg.Any<IProgress<string>?>(),
             Arg.Any<bool>());
@@ -219,7 +214,7 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
     [InlineData(false)]
     public async Task ExecuteAsync_NoCacheFlag_PropagatesToService(bool noCache)
     {
-        Service.AggregateSubscriptionAsync(default!, default, default, TestContext.Current.CancellationToken)
+        Service.AggregateSubscriptionAsync(default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs(CreatePopulatedAggregation());
         _samplingService.SampleTextAsync(default!, default!, default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs("[]");
@@ -233,7 +228,6 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
         await Service.Received(1).AggregateSubscriptionAsync(
             "sub1",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>(),
             Arg.Any<IProgress<string>?>(),
             noCache);
@@ -249,7 +243,7 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("query", response.Message, StringComparison.OrdinalIgnoreCase);
         await Service.DidNotReceiveWithAnyArgs().AggregateSubscriptionAsync(
-            default!, default, default, TestContext.Current.CancellationToken);
+            default!, default, TestContext.Current.CancellationToken);
     }
 
     [Theory]
@@ -258,7 +252,7 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
     [InlineData("  trim me  ", "trim me")]
     public async Task ExecuteAsync_SanitizesQueryBeforeSampling(string rawQuery, string expected)
     {
-        Service.AggregateSubscriptionAsync(default!, default, default, TestContext.Current.CancellationToken)
+        Service.AggregateSubscriptionAsync(default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs(CreatePopulatedAggregation());
         _samplingService.SampleTextAsync(default!, default!, default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs("[]");
@@ -277,7 +271,7 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
     [Fact]
     public async Task ExecuteAsync_WhitespaceOnlyQuery_OmittedFromPayload()
     {
-        Service.AggregateSubscriptionAsync(default!, default, default, TestContext.Current.CancellationToken)
+        Service.AggregateSubscriptionAsync(default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs(CreatePopulatedAggregation());
         _samplingService.SampleTextAsync(default!, default!, default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs("[]");
@@ -296,7 +290,7 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
     [Fact]
     public async Task ExecuteAsync_SamplingReturnsSensitiveContent_DropsThoseInsights()
     {
-        Service.AggregateSubscriptionAsync(default!, default, default, TestContext.Current.CancellationToken)
+        Service.AggregateSubscriptionAsync(default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs(CreatePopulatedAggregation());
         _samplingService.SampleTextAsync(default!, default!, default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs("""
@@ -317,7 +311,7 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
     [Fact]
     public async Task ExecuteAsync_NoResourcesInScope_ReturnsEmptyWithoutSampling()
     {
-        Service.AggregateSubscriptionAsync(default!, default, default, TestContext.Current.CancellationToken)
+        Service.AggregateSubscriptionAsync(default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs(CreateEmptyAggregation());
 
         var response = await ExecuteWithSamplingAsync("--subscription", "sub1");
@@ -337,7 +331,7 @@ public class InsightsGetCommandTests : CommandUnitTestsBase<InsightsGetCommand, 
     [InlineData("""{ "message": "no insights here" }""")]               // valid JSON but not an insights array
     public async Task ExecuteAsync_SamplingReturnsUnparseable_ReturnsBadGatewayWithoutStackTrace(string sampled)
     {
-        Service.AggregateSubscriptionAsync(default!, default, default, TestContext.Current.CancellationToken)
+        Service.AggregateSubscriptionAsync(default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs(CreatePopulatedAggregation());
         _samplingService.SampleTextAsync(default!, default!, default!, default, TestContext.Current.CancellationToken)
             .ReturnsForAnyArgs(sampled);

--- a/tools/Azure.Mcp.Tools.IoTHub/src/Commands/Device/IoTHubDeviceListCommand.cs
+++ b/tools/Azure.Mcp.Tools.IoTHub/src/Commands/Device/IoTHubDeviceListCommand.cs
@@ -73,8 +73,7 @@ public sealed class IoTHubDeviceListCommand(
                 options.Subscription!,
                 options.Tenant,
                 maxCount,
-                options.RetryPolicy,
-                cancellationToken);
+                cancellationToken: cancellationToken);
 
             context.Response.Results = ResponseResult.Create(result, IoTHubJsonContext.Default.DeviceListResult);
 

--- a/tools/Azure.Mcp.Tools.IoTHub/src/Commands/IoTHub/IoTHubGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.IoTHub/src/Commands/IoTHub/IoTHubGetCommand.cs
@@ -57,8 +57,7 @@ public sealed class IoTHubGetCommand(
                 options.ResourceGroup,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy,
-                cancellationToken);
+                cancellationToken: cancellationToken);
 
             context.Response.Results = ResponseResult.Create(
                 new IoTHubGetCommandResult(iotHub, AreResultsTruncated: false),

--- a/tools/Azure.Mcp.Tools.IoTHub/src/Options/Device/IoTHubDeviceListOptions.cs
+++ b/tools/Azure.Mcp.Tools.IoTHub/src/Options/Device/IoTHubDeviceListOptions.cs
@@ -22,7 +22,4 @@ public sealed class IoTHubDeviceListOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.IoTHub/src/Options/IoTHub/IoTHubGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.IoTHub/src/Options/IoTHub/IoTHubGetOptions.cs
@@ -19,7 +19,4 @@ public sealed class IoTHubGetOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.IoTHub/src/Services/IIoTHubDeviceService.cs
+++ b/tools/Azure.Mcp.Tools.IoTHub/src/Services/IIoTHubDeviceService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.IoTHub.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.IoTHub.Services;
 
@@ -14,6 +13,5 @@ public interface IIoTHubDeviceService
         string subscription,
         string? tenant = null,
         int? maxCount = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.IoTHub/src/Services/IIoTHubHostnameResolver.cs
+++ b/tools/Azure.Mcp.Tools.IoTHub/src/Services/IIoTHubHostnameResolver.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Mcp.Core.Options;
-
 namespace Azure.Mcp.Tools.IoTHub.Services;
 
 /// <summary>
@@ -16,6 +14,5 @@ public interface IIoTHubHostnameResolver
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.IoTHub/src/Services/IIoTHubService.cs
+++ b/tools/Azure.Mcp.Tools.IoTHub/src/Services/IIoTHubService.cs
@@ -3,7 +3,6 @@
 
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.IoTHub.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.IoTHub.Services;
 
@@ -14,6 +13,5 @@ public interface IIoTHubService
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.IoTHub/src/Services/IoTHubClientOptions.cs
+++ b/tools/Azure.Mcp.Tools.IoTHub/src/Services/IoTHubClientOptions.cs
@@ -6,6 +6,6 @@ using Azure.Core;
 namespace Azure.Mcp.Tools.IoTHub.Services;
 
 /// <summary>
-/// Client options for IoT Hub device registry data-plane calls with Azure Core retry support.
+/// Client options for IoT Hub device registry data-plane calls.
 /// </summary>
 public class IoTHubClientOptions : ClientOptions;

--- a/tools/Azure.Mcp.Tools.IoTHub/src/Services/IoTHubDeviceService.cs
+++ b/tools/Azure.Mcp.Tools.IoTHub/src/Services/IoTHubDeviceService.cs
@@ -8,7 +8,6 @@ using Azure.Core.Pipeline;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.IoTHub.Commands;
 using Azure.Mcp.Tools.IoTHub.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.IoTHub.Services;
 
@@ -56,7 +55,6 @@ public class IoTHubDeviceService(
         string subscription,
         string? tenant = null,
         int? maxCount = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -66,7 +64,12 @@ public class IoTHubDeviceService(
 
         return await ExecuteWithTimeoutAsync(async ct =>
         {
-            var hostname = await _hostnameResolver.GetHostnameAsync(hubName, resourceGroup, subscription, tenant, retryPolicy, ct);
+            var hostname = await _hostnameResolver.GetHostnameAsync(
+                hubName,
+                resourceGroup,
+                subscription,
+                tenant,
+                cancellationToken: ct);
 
             // The registry API has no continuation token, so fetch one more than the requested max
             // (top = maxCount + 1). If the hub returns the extra device we know more devices exist
@@ -75,10 +78,8 @@ public class IoTHubDeviceService(
             var maxCountParam = maxCount.HasValue ? $"&top={maxCount.Value + 1}" : string.Empty;
             var requestUri = $"https://{hostname}/devices?api-version={RegistryApiVersion}{maxCountParam}";
 
-            // Send the request through an Azure.Core pipeline so the caller's RetryPolicyOptions
-            // governs transient-failure retries (408/429/5xx and network errors).
             using var httpClient = _httpClientFactory.CreateClient();
-            var clientOptions = ConfigureRetryPolicy(AddDefaultPolicies(new IoTHubClientOptions()), retryPolicy);
+            var clientOptions = AddDefaultPolicies(new IoTHubClientOptions());
             clientOptions.Transport = new HttpClientTransport(httpClient);
             var pipeline = HttpPipelineBuilder.Build(clientOptions);
 

--- a/tools/Azure.Mcp.Tools.IoTHub/src/Services/IoTHubHostnameResolver.cs
+++ b/tools/Azure.Mcp.Tools.IoTHub/src/Services/IoTHubHostnameResolver.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Caching;
 
 namespace Azure.Mcp.Tools.IoTHub.Services;
@@ -24,7 +23,6 @@ public class IoTHubHostnameResolver(
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         var cacheKey = $"{subscription}/{resourceGroup}/{hubName}";
@@ -34,7 +32,12 @@ public class IoTHubHostnameResolver(
             return cached;
         }
 
-        var hub = await _ioTHubService.GetIoTHub(hubName, resourceGroup, subscription, tenant: tenant, retryPolicy: retryPolicy, cancellationToken: cancellationToken);
+        var hub = await _ioTHubService.GetIoTHub(
+            hubName,
+            resourceGroup,
+            subscription,
+            tenant: tenant,
+            cancellationToken: cancellationToken);
         var hostname = hub.HostName ?? throw new InvalidOperationException("IoT Hub hostname is null");
 
         await _cacheService.SetAsync(HostnameCacheGroup, cacheKey, hostname, s_cacheDuration, cancellationToken);

--- a/tools/Azure.Mcp.Tools.IoTHub/src/Services/IoTHubService.cs
+++ b/tools/Azure.Mcp.Tools.IoTHub/src/Services/IoTHubService.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.IoTHub.Commands;
 using Azure.Mcp.Tools.IoTHub.Models;
 using Azure.ResourceManager.Resources;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.IoTHub.Services;
 
@@ -21,7 +20,6 @@ public class IoTHubService(IAzureService azureService, ILogger<IoTHubService> lo
         string resourceGroup,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -31,8 +29,13 @@ public class IoTHubService(IAzureService azureService, ILogger<IoTHubService> lo
 
         try
         {
-            var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
-            var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+            var subscriptionResource = await AzureService.GetSubscription(
+                subscription,
+                tenant,
+                cancellationToken: cancellationToken);
+            var armClient = await CreateArmClientAsync(
+                tenant,
+                cancellationToken: cancellationToken);
             var iotHubResourceId = new ResourceIdentifier(
                 $"/subscriptions/{subscriptionResource.Data.SubscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Devices/IotHubs/{hubName}");
             var hub = await armClient.GetGenericResource(iotHubResourceId).GetAsync(cancellationToken);

--- a/tools/Azure.Mcp.Tools.IoTHub/tests/Azure.Mcp.Tools.IoTHub.Tests/Device/IoTHubDeviceListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.IoTHub/tests/Azure.Mcp.Tools.IoTHub.Tests/Device/IoTHubDeviceListCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.IoTHub.Commands;
 using Azure.Mcp.Tools.IoTHub.Commands.Device;
 using Azure.Mcp.Tools.IoTHub.Models;
 using Azure.Mcp.Tools.IoTHub.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -41,7 +40,6 @@ public class IoTHubDeviceListCommandTests : SubscriptionCommandUnitTestsBase<IoT
             "sub-id",
             "tenant-id",
             100,
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new DeviceListResult(devices, false));
 
@@ -84,7 +82,6 @@ public class IoTHubDeviceListCommandTests : SubscriptionCommandUnitTestsBase<IoT
             "sub-id",
             "tenant-id",
             100,
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new DeviceListResult(new List<DeviceIdentity> { CreateDevice("device1") }, true));
 
@@ -127,7 +124,6 @@ public class IoTHubDeviceListCommandTests : SubscriptionCommandUnitTestsBase<IoT
             "sub-id",
             "tenant-id",
             100,
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new DeviceListResult(devices, false));
 
@@ -164,7 +160,6 @@ public class IoTHubDeviceListCommandTests : SubscriptionCommandUnitTestsBase<IoT
             "sub-id",
             "tenant-id",
             100,
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 

--- a/tools/Azure.Mcp.Tools.IoTHub/tests/Azure.Mcp.Tools.IoTHub.Tests/IoTHub/IoTHubGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.IoTHub/tests/Azure.Mcp.Tools.IoTHub.Tests/IoTHub/IoTHubGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.IoTHub.Commands;
 using Azure.Mcp.Tools.IoTHub.Commands.IoTHub;
 using Azure.Mcp.Tools.IoTHub.Models;
 using Azure.Mcp.Tools.IoTHub.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -38,7 +37,6 @@ public class IoTHubGetCommandTests : SubscriptionCommandUnitTestsBase<IoTHubGetC
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new IoTHubDescription(
                     Id: "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Devices/IotHubs/hub1",
@@ -93,7 +91,6 @@ public class IoTHubGetCommandTests : SubscriptionCommandUnitTestsBase<IoTHubGetC
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new IoTHubDescription(
                 Id: "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Devices/IotHubs/hub1",
@@ -122,7 +119,6 @@ public class IoTHubGetCommandTests : SubscriptionCommandUnitTestsBase<IoTHubGetC
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -141,7 +137,6 @@ public class IoTHubGetCommandTests : SubscriptionCommandUnitTestsBase<IoTHubGetC
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Resource not found"));
 

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Admin/AdminSettingsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Admin/AdminSettingsGetCommand.cs
@@ -32,7 +32,7 @@ public sealed class AdminSettingsGetCommand(ILogger<AdminSettingsGetCommand> log
     {
         try
         {
-            var settingsResult = await _keyVaultService.GetVaultSettings(options.Vault, options.Subscription!, options.Tenant, options.RetryPolicy, cancellationToken);
+            var settingsResult = await _keyVaultService.GetVaultSettings(options.Vault, options.Subscription!, options.Tenant, cancellationToken);
 
             // Convert settings to a dictionary of strings for easier serialization in case the service adds new settings in the future.
             Dictionary<string, string> settings = new(StringComparer.OrdinalIgnoreCase);

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateCreateCommand.cs
@@ -38,7 +38,6 @@ public sealed class CertificateCreateCommand(ILogger<CertificateCreateCommand> l
                 options.Certificate,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(CertificateDetails.FromCertificate(certificate), KeyVaultJsonContext.Default.CertificateDetails);

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateGetCommand.cs
@@ -40,7 +40,6 @@ public sealed class CertificateGetCommand(ILogger<CertificateGetCommand> logger,
                     options.Vault,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(certificates ?? [], null), KeyVaultJsonContext.Default.CertificateGetCommandResult);
@@ -53,7 +52,6 @@ public sealed class CertificateGetCommand(ILogger<CertificateGetCommand> logger,
                     options.Certificate,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(null, CertificateDetails.FromCertificate(certificate)), KeyVaultJsonContext.Default.CertificateGetCommandResult);

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateImportCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateImportCommand.cs
@@ -40,7 +40,6 @@ public sealed class CertificateImportCommand(ILogger<CertificateImportCommand> l
                 options.Password,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(CertificateDetails.FromCertificate(certificate), KeyVaultJsonContext.Default.CertificateDetails);

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Key/KeyCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Key/KeyCreateCommand.cs
@@ -39,7 +39,6 @@ public sealed class KeyCreateCommand(ILogger<KeyCreateCommand> logger, IKeyVault
                 options.KeyType,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(KeyDetails.FromKey(key), KeyVaultJsonContext.Default.KeyDetails);

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Key/KeyGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Key/KeyGetCommand.cs
@@ -41,7 +41,6 @@ public sealed class KeyGetCommand(ILogger<KeyGetCommand> logger, IKeyVaultServic
                     options.IncludeManaged,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(keys ?? [], null), KeyVaultJsonContext.Default.KeyGetCommandResult);
@@ -54,7 +53,6 @@ public sealed class KeyGetCommand(ILogger<KeyGetCommand> logger, IKeyVaultServic
                     options.Key,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(null, KeyDetails.FromKey(key)), KeyVaultJsonContext.Default.KeyGetCommandResult);

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Secret/SecretCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Secret/SecretCreateCommand.cs
@@ -39,7 +39,6 @@ public sealed class SecretCreateCommand(ILogger<SecretCreateCommand> logger, IKe
                 options.Value!,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(SecretDetails.FromSecret(secret), KeyVaultJsonContext.Default.SecretDetails);

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Secret/SecretGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Secret/SecretGetCommand.cs
@@ -40,7 +40,6 @@ public sealed class SecretGetCommand(ILogger<SecretGetCommand> logger, IKeyVault
                     options.Vault,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(Secrets: secrets ?? [], Secret: null), KeyVaultJsonContext.Default.SecretGetCommandResult);
@@ -53,7 +52,6 @@ public sealed class SecretGetCommand(ILogger<SecretGetCommand> logger, IKeyVault
                     options.Secret,
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(null, SecretDetails.FromSecret(secret)), KeyVaultJsonContext.Default.SecretGetCommandResult);

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Options/BaseKeyVaultOptions.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Options/BaseKeyVaultOptions.cs
@@ -16,7 +16,4 @@ public class BaseKeyVaultOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Services/IKeyVaultService.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Services/IKeyVaultService.cs
@@ -5,7 +5,6 @@ using Azure.Security.KeyVault.Administration;
 using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Secrets;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.KeyVault.Services;
 
@@ -18,7 +17,6 @@ public interface IKeyVaultService
     /// <param name="certificateName">The name of the certificate to create</param>
     /// <param name="subscriptionId">The subscription ID or name</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations</param>
-    /// <param name="retryPolicy">Optional retry policy for the operation</param>
     /// <param name="cancellationToken">A cancellation token</param>
     /// <returns>The created certificate</returns>
     Task<KeyVaultCertificateWithPolicy> CreateCertificate(
@@ -26,7 +24,6 @@ public interface IKeyVaultService
         string certificateName,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -37,7 +34,6 @@ public interface IKeyVaultService
     /// <param name="keyType">The type of key to create (e.g., RSA, EC, OCT)</param>
     /// <param name="subscriptionId">The subscription ID or name</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations</param>
-    /// <param name="retryPolicy">Optional retry policy for the operation</param>
     /// <returns>The created key</returns>
     Task<KeyVaultKey> CreateKey(
         string vaultName,
@@ -45,7 +41,6 @@ public interface IKeyVaultService
         string keyType,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -56,7 +51,6 @@ public interface IKeyVaultService
     /// <param name="secretValue">The value of the secret</param>
     /// <param name="subscriptionId">The subscription ID or name</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations</param>
-    /// <param name="retryPolicy">Optional retry policy for the operation</param>
     /// <returns>The created secret</returns>
     Task<KeyVaultSecret> CreateSecret(
         string vaultName,
@@ -64,7 +58,6 @@ public interface IKeyVaultService
         string secretValue,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -74,14 +67,12 @@ public interface IKeyVaultService
     /// <param name="certificateName">The name of the certificate to retrieve</param>
     /// <param name="subscriptionId">The subscription ID or name</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations</param>
-    /// <param name="retryPolicy">Optional retry policy for the operation</param>
     /// <returns>The certificate</returns>
     Task<KeyVaultCertificateWithPolicy> GetCertificate(
         string vaultName,
         string certificateName,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -91,14 +82,12 @@ public interface IKeyVaultService
     /// <param name="keyName">The name of the key to retrieve</param>
     /// <param name="subscriptionId">The subscription ID or name</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations</param>
-    /// <param name="retryPolicy">Optional retry policy for the operation</param>
     /// <returns>The key</returns>
     Task<KeyVaultKey> GetKey(
         string vaultName,
         string keyName,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -108,14 +97,12 @@ public interface IKeyVaultService
     /// <param name="secretName">The name of the secret to retrieve</param>
     /// <param name="subscriptionId">The subscription ID or name</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations</param>
-    /// <param name="retryPolicy">Optional retry policy for the operation</param>
     /// <returns>The secret value</returns>
     Task<KeyVaultSecret> GetSecret(
         string vaultName,
         string secretName,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -124,13 +111,11 @@ public interface IKeyVaultService
     /// <param name="vaultName">Name of the Key Vault.</param>
     /// <param name="subscriptionId">Subscription ID containing the Key Vault.</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations.</param>
-    /// <param name="retryPolicy">Optional retry policy for the operation.</param>
     /// <returns>List of certificate names in the vault.</returns>
     Task<List<string>> ListCertificates(
         string vaultName,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -139,14 +124,12 @@ public interface IKeyVaultService
     /// <param name="vaultName">Name of the Key Vault.</param>
     /// <param name="subscriptionId">Subscription ID containing the Key Vault.</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations.</param>
-    /// <param name="retryPolicy">Optional retry policy for the operation.</param>
     /// <returns>List of key names in the vault.</returns>
     Task<List<string>> ListKeys(
         string vaultName,
         bool includeManagedKeys,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -155,13 +138,11 @@ public interface IKeyVaultService
     /// <param name="vaultName">Name of the Key Vault.</param>
     /// <param name="subscriptionId">Subscription ID containing the Key Vault.</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations.</param>
-    /// <param name="retryPolicy">Optional retry policy for the operation.</param>
     /// <returns>List of secret names in the vault.</returns>
     Task<List<string>> ListSecrets(
         string vaultName,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -173,7 +154,6 @@ public interface IKeyVaultService
     /// <param name="password">Optional password if the certificate is a protected PFX.</param>
     /// <param name="subscriptionId">The subscription ID or name.</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations.</param>
-    /// <param name="retryPolicy">Optional retry policy for the operation.</param>
     /// <returns>The imported certificate.</returns>
     Task<KeyVaultCertificateWithPolicy> ImportCertificate(
         string vaultName,
@@ -182,7 +162,6 @@ public interface IKeyVaultService
         string? password,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -191,12 +170,10 @@ public interface IKeyVaultService
     /// <param name="vaultName">The name of the Key Vault.</param>
     /// <param name="subscription">The subscription ID or name.</param>
     /// <param name="tenant">Optional tenant ID for cross-tenant operations.</param>
-    /// <param name="retryPolicy">Optional retry policy for the operation.</param>
     /// <returns>Structured vault settings.</returns>
     Task<GetSettingsResult> GetVaultSettings(
         string vaultName,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Services/KeyVaultService.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Services/KeyVaultService.cs
@@ -6,7 +6,6 @@ using Azure.Security.KeyVault.Administration;
 using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Secrets;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Azure.Authentication;
 
 namespace Azure.Mcp.Tools.KeyVault.Services;
@@ -19,13 +18,12 @@ public sealed class KeyVaultService(IAzureService azureService)
         bool includeManagedKeys,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId, cancellationToken);
-        var client = CreateKeyClient(vaultName, credential, retryPolicy);
+        var client = CreateKeyClient(vaultName, credential);
         var keys = new List<string>();
 
         await foreach (var key in client.GetPropertiesOfKeysAsync(cancellationToken).Where(x => includeManagedKeys || !x.Managed))
@@ -41,13 +39,12 @@ public sealed class KeyVaultService(IAzureService azureService)
         string keyName,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(keyName), keyName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId, cancellationToken);
-        var client = CreateKeyClient(vaultName, credential, retryPolicy);
+        var client = CreateKeyClient(vaultName, credential);
 
         return await client.GetKeyAsync(keyName, cancellationToken: cancellationToken);
     }
@@ -58,14 +55,13 @@ public sealed class KeyVaultService(IAzureService azureService)
         string keyType,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(keyName), keyName), (nameof(keyType), keyType), (nameof(subscriptionId), subscriptionId));
 
         var type = new KeyType(keyType);
         var credential = await GetCredential(tenantId, cancellationToken);
-        var client = CreateKeyClient(vaultName, credential, retryPolicy);
+        var client = CreateKeyClient(vaultName, credential);
 
         return await client.CreateKeyAsync(keyName, type, cancellationToken: cancellationToken);
     }
@@ -74,13 +70,12 @@ public sealed class KeyVaultService(IAzureService azureService)
         string vaultName,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId, cancellationToken);
-        var client = CreateSecretClient(vaultName, credential, retryPolicy);
+        var client = CreateSecretClient(vaultName, credential);
         var secrets = new List<string>();
 
         await foreach (var secret in client.GetPropertiesOfSecretsAsync(cancellationToken))
@@ -97,13 +92,12 @@ public sealed class KeyVaultService(IAzureService azureService)
         string secretValue,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(secretName), secretName), (nameof(secretValue), secretValue), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId, cancellationToken);
-        var client = CreateSecretClient(vaultName, credential, retryPolicy);
+        var client = CreateSecretClient(vaultName, credential);
 
         return await client.SetSecretAsync(secretName, secretValue, cancellationToken);
     }
@@ -113,13 +107,12 @@ public sealed class KeyVaultService(IAzureService azureService)
         string secretName,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(secretName), secretName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId, cancellationToken);
-        var client = CreateSecretClient(vaultName, credential, retryPolicy);
+        var client = CreateSecretClient(vaultName, credential);
 
         return await client.GetSecretAsync(secretName, cancellationToken: cancellationToken);
     }
@@ -128,13 +121,12 @@ public sealed class KeyVaultService(IAzureService azureService)
         string vaultName,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId, cancellationToken);
-        var client = CreateCertificateClient(vaultName, credential, retryPolicy);
+        var client = CreateCertificateClient(vaultName, credential);
         var certificates = new List<string>();
 
         await foreach (var certificate in client.GetPropertiesOfCertificatesAsync(cancellationToken: cancellationToken))
@@ -150,13 +142,12 @@ public sealed class KeyVaultService(IAzureService azureService)
         string certificateName,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(certificateName), certificateName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId, cancellationToken);
-        var client = CreateCertificateClient(vaultName, credential, retryPolicy);
+        var client = CreateCertificateClient(vaultName, credential);
 
         return await client.GetCertificateAsync(certificateName, cancellationToken);
     }
@@ -166,13 +157,12 @@ public sealed class KeyVaultService(IAzureService azureService)
         string certificateName,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(certificateName), certificateName), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId, cancellationToken);
-        var client = CreateCertificateClient(vaultName, credential, retryPolicy);
+        var client = CreateCertificateClient(vaultName, credential);
 
         var certificateOperation = await client.StartCreateCertificateAsync(certificateName, CertificatePolicy.Default, cancellationToken: cancellationToken);
         await WaitForLroCompletionAsync(certificateOperation, cancellationToken);
@@ -186,13 +176,12 @@ public sealed class KeyVaultService(IAzureService azureService)
         string? password,
         string subscriptionId,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(certificateName), certificateName), (nameof(certificateData), certificateData), (nameof(subscriptionId), subscriptionId));
 
         var credential = await GetCredential(tenantId, cancellationToken);
-        var client = CreateCertificateClient(vaultName, credential, retryPolicy);
+        var client = CreateCertificateClient(vaultName, credential);
 
         // certificateData expected as base64 PFX bytes or raw PEM text.
         byte[] bytes;
@@ -294,35 +283,35 @@ public sealed class KeyVaultService(IAzureService azureService)
     }
 
     // Create clients with injected HttpClient, this will enable record/playback during testing.
-    private KeyClient CreateKeyClient(string vaultName, Azure.Core.TokenCredential credential, RetryPolicyOptions? retry)
+    private KeyClient CreateKeyClient(string vaultName, Azure.Core.TokenCredential credential)
     {
         var vaultUri = new Uri(BuildVaultUri(vaultName));
         var httpClient = AzureService.GetClient();
         httpClient.BaseAddress = vaultUri;
         var options = new KeyClientOptions();
-        options = ConfigureRetryPolicy(AddDefaultPolicies(options), retry);
+        options = AddDefaultPolicies(options);
         options.Transport = new Azure.Core.Pipeline.HttpClientTransport(httpClient);
         return new(vaultUri, credential, options);
     }
 
-    private SecretClient CreateSecretClient(string vaultName, Azure.Core.TokenCredential credential, RetryPolicyOptions? retry)
+    private SecretClient CreateSecretClient(string vaultName, Azure.Core.TokenCredential credential)
     {
         var vaultUri = new Uri(BuildVaultUri(vaultName));
         var httpClient = AzureService.GetClient();
         httpClient.BaseAddress = vaultUri;
         var options = new SecretClientOptions();
-        options = ConfigureRetryPolicy(AddDefaultPolicies(options), retry);
+        options = AddDefaultPolicies(options);
         options.Transport = new Azure.Core.Pipeline.HttpClientTransport(httpClient);
         return new(vaultUri, credential, options);
     }
 
-    private CertificateClient CreateCertificateClient(string vaultName, Azure.Core.TokenCredential credential, RetryPolicyOptions? retry)
+    private CertificateClient CreateCertificateClient(string vaultName, Azure.Core.TokenCredential credential)
     {
         var vaultUri = new Uri(BuildVaultUri(vaultName));
         var httpClient = AzureService.GetClient();
         httpClient.BaseAddress = vaultUri;
         var options = new CertificateClientOptions();
-        options = ConfigureRetryPolicy(AddDefaultPolicies(options), retry);
+        options = AddDefaultPolicies(options);
         options.Transport = new Azure.Core.Pipeline.HttpClientTransport(httpClient);
         return new(vaultUri, credential, options);
     }
@@ -331,24 +320,23 @@ public sealed class KeyVaultService(IAzureService azureService)
         string vaultName,
         string subscription,
         string? tenantId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(subscription), subscription));
         var credential = await GetCredential(tenantId, cancellationToken);
         var hsmUri = new Uri(GetHsmUri(vaultName));
 
-        var hsmClient = CreateSettingsClient(hsmUri, credential, retryPolicy);
+        var hsmClient = CreateSettingsClient(hsmUri, credential);
         var hsmResponse = await hsmClient.GetSettingsAsync(cancellationToken);
         return hsmResponse.Value;
     }
 
-    private KeyVaultSettingsClient CreateSettingsClient(Uri hsmUri, Azure.Core.TokenCredential credential, RetryPolicyOptions? retry)
+    private KeyVaultSettingsClient CreateSettingsClient(Uri hsmUri, Azure.Core.TokenCredential credential)
     {
         var httpClient = AzureService.GetClient();
         httpClient.BaseAddress = hsmUri;
         var options = new KeyVaultAdministrationClientOptions();
-        options = ConfigureRetryPolicy(AddDefaultPolicies(options), retry);
+        options = AddDefaultPolicies(options);
         options.Transport = new Azure.Core.Pipeline.HttpClientTransport(httpClient);
         return new(hsmUri, credential, options);
     }

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Admin/AdminSettingsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Admin/AdminSettingsGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Admin;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Administration;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -27,7 +26,6 @@ public class AdminSettingsGetCommandTests : SubscriptionCommandUnitTestsBase<Adm
             Arg.Is(KnownVaultName),
             Arg.Is(KnownSubscriptionId),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns((GetSettingsResult)null!);
 
@@ -46,7 +44,6 @@ public class AdminSettingsGetCommandTests : SubscriptionCommandUnitTestsBase<Adm
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
@@ -70,7 +67,6 @@ public class AdminSettingsGetCommandTests : SubscriptionCommandUnitTestsBase<Adm
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns((GetSettingsResult)null!);
         }

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Certificate/CertificateCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Certificate/CertificateCreateCommandTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Certificate;
 using Azure.Mcp.Tools.KeyVault.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -31,7 +30,6 @@ public class CertificateCreateCommandTests : SubscriptionCommandUnitTestsBase<Ce
             Arg.Is(_knownCertificateName),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
@@ -47,7 +45,6 @@ public class CertificateCreateCommandTests : SubscriptionCommandUnitTestsBase<Ce
             _knownCertificateName,
             _knownSubscriptionId,
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
 
         // Should handle the exception
@@ -79,7 +76,6 @@ public class CertificateCreateCommandTests : SubscriptionCommandUnitTestsBase<Ce
             Arg.Is(_knownCertificateName),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Certificate/CertificateGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Certificate/CertificateGetCommandTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Certificate;
 using Azure.Mcp.Tools.KeyVault.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -31,7 +30,6 @@ public class CertificateGetCommandTests : SubscriptionCommandUnitTestsBase<Certi
             Arg.Is(_knownCertificateName),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
@@ -47,7 +45,6 @@ public class CertificateGetCommandTests : SubscriptionCommandUnitTestsBase<Certi
             Arg.Is(_knownCertificateName),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
 
         // Should handle the exception
@@ -65,7 +62,6 @@ public class CertificateGetCommandTests : SubscriptionCommandUnitTestsBase<Certi
             Arg.Is(_knownCertificateName),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
@@ -91,7 +87,6 @@ public class CertificateGetCommandTests : SubscriptionCommandUnitTestsBase<Certi
             Arg.Is(_knownVaultName),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedCertificates);
 
@@ -119,7 +114,6 @@ public class CertificateGetCommandTests : SubscriptionCommandUnitTestsBase<Certi
             Arg.Is(_knownVaultName),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Certificate/CertificateImportCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Certificate/CertificateImportCommandTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Certificate;
 using Azure.Mcp.Tools.KeyVault.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -32,7 +31,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             null,
             _knownSubscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error")); // force exception to avoid building return object
 
@@ -51,7 +49,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             null,
             _knownSubscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status); // due to forced exception
     }
@@ -98,7 +95,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expected));
 
@@ -125,7 +121,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             null,
             _knownSubscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -144,7 +139,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             null,
             _knownSubscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
     }
@@ -161,7 +155,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             password,
             _knownSubscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -179,7 +172,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             password,
             _knownSubscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
     }
@@ -199,7 +191,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
                 null,
                 _knownSubscription,
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .ThrowsAsync(new Exception("Test error"));
 
@@ -218,7 +209,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
                 null,
                 _knownSubscription,
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>());
             Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         }
@@ -246,7 +236,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             null,
             _knownSubscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException(errorMessage));
 
@@ -274,7 +263,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             password,
             _knownSubscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(mismatchMessage));
 

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Key/KeyCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Key/KeyCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Key;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Keys;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,6 @@ public class KeyCreateCommandTests : SubscriptionCommandUnitTestsBase<KeyCreateC
             Arg.Is(_knownKeyType.ToString()),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(_knownKeyVaultKey);
 
@@ -92,7 +90,6 @@ public class KeyCreateCommandTests : SubscriptionCommandUnitTestsBase<KeyCreateC
             Arg.Is(_knownKeyType.ToString()),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Key/KeyGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Key/KeyGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Key;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Keys;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -46,7 +45,6 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
             Arg.Is(_knownKeyName),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(_knownKeyVaultKey);
 
@@ -76,7 +74,6 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
             Arg.Is(_knownKeyName),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
@@ -103,7 +100,6 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
             Arg.Is(false),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedKeys);
 
@@ -132,7 +128,6 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
             Arg.Is(true),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedKeys);
 
@@ -162,7 +157,6 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
             Arg.Any<bool>(),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
@@ -190,7 +184,6 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
             Arg.Is(false),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedKeys);
 

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Secret/SecretCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Secret/SecretCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Secret;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Secrets;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -32,7 +31,6 @@ public class SecretCreateCommandTests : SubscriptionCommandUnitTestsBase<SecretC
             Arg.Is(_knownSecretValue),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(_knownKeyVaultSecret);
 
@@ -77,7 +75,6 @@ public class SecretCreateCommandTests : SubscriptionCommandUnitTestsBase<SecretC
             Arg.Is(_knownSecretValue),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Secret/SecretGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Secret/SecretGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Secret;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Secrets;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -31,7 +30,6 @@ public class SecretGetCommandTests : SubscriptionCommandUnitTestsBase<SecretGetC
             Arg.Is(_knownSecretName),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(_knownKeyVaultSecret);
 
@@ -61,7 +59,6 @@ public class SecretGetCommandTests : SubscriptionCommandUnitTestsBase<SecretGetC
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
@@ -87,7 +84,6 @@ public class SecretGetCommandTests : SubscriptionCommandUnitTestsBase<SecretGetC
             Arg.Is(_knownVaultName),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedSecrets);
 
@@ -115,7 +111,6 @@ public class SecretGetCommandTests : SubscriptionCommandUnitTestsBase<SecretGetC
             Arg.Is(_knownVaultName),
             Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterGetCommand.cs
@@ -38,7 +38,6 @@ public sealed class ClusterGetCommand(
                 options.Subscription!,
                 options.Cluster,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = cluster is null ?

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/ClusterListCommand.cs
@@ -36,7 +36,6 @@ public sealed class ClusterListCommand(
                 options.Subscription!,
                 options.ResourceGroup,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new ClusterListCommandResult(clusterNames?.Results ?? [], clusterNames?.AreResultsTruncated ?? false), KustoJsonContext.Default.ClusterListCommandResult);

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/DatabaseListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/DatabaseListCommand.cs
@@ -38,7 +38,6 @@ public sealed class DatabaseListCommand(
                 databasesNames = await kustoService.ListDatabasesAsync(
                     options.ClusterUri!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
             else
@@ -47,7 +46,6 @@ public sealed class DatabaseListCommand(
                     options.Subscription!,
                     options.Cluster!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
 

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/QueryCommand.cs
@@ -41,7 +41,6 @@ public sealed class QueryCommand(
                     options.Database,
                     options.Query,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
             else
@@ -52,7 +51,6 @@ public sealed class QueryCommand(
                     options.Database,
                     options.Query,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
 

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/SampleCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/SampleCommand.cs
@@ -46,7 +46,6 @@ public sealed class SampleCommand(
                     options.Database,
                     query,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
             else
@@ -57,7 +56,6 @@ public sealed class SampleCommand(
                     options.Database,
                     query,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
 

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/TableListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/TableListCommand.cs
@@ -39,7 +39,6 @@ public sealed class TableListCommand(
                     options.ClusterUri!,
                     options.Database,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
             else
@@ -49,7 +48,6 @@ public sealed class TableListCommand(
                     options.Cluster!,
                     options.Database,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
 

--- a/tools/Azure.Mcp.Tools.Kusto/src/Commands/TableSchemaCommand.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Commands/TableSchemaCommand.cs
@@ -40,7 +40,6 @@ public sealed class TableSchemaCommand(
                     options.Database,
                     options.Table,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
             else
@@ -51,7 +50,6 @@ public sealed class TableSchemaCommand(
                     options.Database,
                     options.Table,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
 

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/ClusterGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/ClusterGetOptions.cs
@@ -16,7 +16,4 @@ public sealed class ClusterGetOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/ClusterListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/ClusterListOptions.cs
@@ -16,7 +16,4 @@ public sealed class ClusterListOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/DatabaseListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/DatabaseListOptions.cs
@@ -19,7 +19,4 @@ public sealed class DatabaseListOptions : ISubscriptionOption, IClusterOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/QueryOptions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/QueryOptions.cs
@@ -25,7 +25,4 @@ public sealed class QueryOptions : ISubscriptionOption, IDatabaseOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/SampleOptions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/SampleOptions.cs
@@ -28,7 +28,4 @@ public sealed class SampleOptions : ISubscriptionOption, ITableOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/TableListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/TableListOptions.cs
@@ -22,7 +22,4 @@ public sealed class TableListOptions : ISubscriptionOption, IDatabaseOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Options/TableSchemaOptions.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Options/TableSchemaOptions.cs
@@ -25,7 +25,4 @@ public sealed class TableSchemaOptions : ISubscriptionOption, ITableOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Services/IKustoService.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Services/IKustoService.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.Kusto.Models;
 using Microsoft.Mcp.Core.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Kusto.Services;
 
@@ -15,27 +14,23 @@ public interface IKustoService
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<KustoClusterModel> GetClusterAsync(
         string subscription,
         string clusterName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<string>> ListDatabasesAsync(
         string clusterUri,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<string>> ListDatabasesAsync(
         string subscription,
         string clusterName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<JsonElement>> QueryItemsAsync(
@@ -43,7 +38,6 @@ public interface IKustoService
         string databaseName,
         string query,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<JsonElement>> QueryItemsAsync(
@@ -52,14 +46,12 @@ public interface IKustoService
         string databaseName,
         string query,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<string>> ListTablesAsync(
         string clusterUri,
         string databaseName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<string>> ListTablesAsync(
@@ -67,7 +59,6 @@ public interface IKustoService
         string clusterName,
         string databaseName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<string> GetTableSchemaAsync(
@@ -75,7 +66,6 @@ public interface IKustoService
         string databaseName,
         string tableName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<string> GetTableSchemaAsync(
@@ -84,6 +74,5 @@ public interface IKustoService
         string databaseName,
         string tableName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoService.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/src/Services/KustoService.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.Kusto.Models;
 using Azure.Mcp.Tools.Kusto.Validation;
 using Microsoft.Mcp.Core.Helpers;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Caching;
 using Microsoft.Mcp.Core.Validation;
 
@@ -58,16 +57,15 @@ public sealed class KustoService(IAzureService azureService, ICacheService cache
         string subscriptionId,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscriptionId), subscriptionId));
 
         var clusters = await ExecuteResourceQueryAsync(
             "Microsoft.Kusto/clusters",
-            resourceGroup: resourceGroup,
+            resourceGroup,
             subscriptionId,
-            retryPolicy,
+            null,
             item => ConvertToClusterModel(item).ClusterName,
             tenant: tenant,
             cancellationToken: cancellationToken);
@@ -79,17 +77,16 @@ public sealed class KustoService(IAzureService azureService, ICacheService cache
         string subscriptionId,
         string clusterName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscriptionId), subscriptionId));
 
         var cluster = await ExecuteSingleResourceQueryAsync(
             "Microsoft.Kusto/clusters",
-            resourceGroup: null, // all resource groups
-            subscription: subscriptionId,
-            retryPolicy: retryPolicy,
-            converter: ConvertToClusterModel,
+            null, // all resource groups
+            subscriptionId,
+            null,
+            ConvertToClusterModel,
             additionalFilter: $"name =~ '{EscapeKqlString(clusterName)}'",
             tenant: tenant,
             cancellationToken: cancellationToken);
@@ -105,21 +102,19 @@ public sealed class KustoService(IAzureService azureService, ICacheService cache
         string subscriptionId,
         string clusterName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
             (nameof(subscriptionId), subscriptionId),
             (nameof(clusterName), clusterName));
 
-        string clusterUri = await GetClusterUriAsync(subscriptionId, clusterName, tenant, retryPolicy);
-        return await ListDatabasesAsync(clusterUri, tenant, retryPolicy, cancellationToken);
+        string clusterUri = await GetClusterUriAsync(subscriptionId, clusterName, tenant);
+        return await ListDatabasesAsync(clusterUri, tenant, cancellationToken);
     }
 
     public async Task<List<string>> ListDatabasesAsync(
         string clusterUri,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(clusterUri), clusterUri));
@@ -137,7 +132,6 @@ public sealed class KustoService(IAzureService azureService, ICacheService cache
         string clusterName,
         string databaseName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -145,15 +139,14 @@ public sealed class KustoService(IAzureService azureService, ICacheService cache
             (nameof(clusterName), clusterName),
             (nameof(databaseName), databaseName));
 
-        string clusterUri = await GetClusterUriAsync(subscriptionId, clusterName, tenant, retryPolicy);
-        return await ListTablesAsync(clusterUri, databaseName, tenant, retryPolicy, cancellationToken);
+        string clusterUri = await GetClusterUriAsync(subscriptionId, clusterName, tenant);
+        return await ListTablesAsync(clusterUri, databaseName, tenant, cancellationToken);
     }
 
     public async Task<List<string>> ListTablesAsync(
         string clusterUri,
         string databaseName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(clusterUri), clusterUri), (nameof(databaseName), databaseName));
@@ -172,11 +165,10 @@ public sealed class KustoService(IAzureService azureService, ICacheService cache
         string databaseName,
         string tableName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        string clusterUri = await GetClusterUriAsync(subscriptionId, clusterName, tenant, retryPolicy);
-        return await GetTableSchemaAsync(clusterUri, databaseName, tableName, tenant, retryPolicy, cancellationToken);
+        string clusterUri = await GetClusterUriAsync(subscriptionId, clusterName, tenant);
+        return await GetTableSchemaAsync(clusterUri, databaseName, tableName, tenant, cancellationToken);
     }
 
     public async Task<string> GetTableSchemaAsync(
@@ -184,7 +176,6 @@ public sealed class KustoService(IAzureService azureService, ICacheService cache
         string databaseName,
         string tableName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -214,7 +205,6 @@ public sealed class KustoService(IAzureService azureService, ICacheService cache
         string databaseName,
         string query,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -223,8 +213,8 @@ public sealed class KustoService(IAzureService azureService, ICacheService cache
             (nameof(databaseName), databaseName),
             (nameof(query), query));
 
-        string clusterUri = await GetClusterUriAsync(subscriptionId, clusterName, tenant, retryPolicy);
-        return await QueryItemsAsync(clusterUri, databaseName, query, tenant, retryPolicy, cancellationToken);
+        string clusterUri = await GetClusterUriAsync(subscriptionId, clusterName, tenant);
+        return await QueryItemsAsync(clusterUri, databaseName, query, tenant, cancellationToken);
     }
 
     public async Task<List<JsonElement>> QueryItemsAsync(
@@ -232,7 +222,6 @@ public sealed class KustoService(IAzureService azureService, ICacheService cache
         string databaseName,
         string query,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -353,10 +342,9 @@ public sealed class KustoService(IAzureService azureService, ICacheService cache
     private async Task<string> GetClusterUriAsync(
         string subscriptionId,
         string clusterName,
-        string? tenant,
-        RetryPolicyOptions? retryPolicy)
+        string? tenant)
     {
-        var cluster = await GetClusterAsync(subscriptionId, clusterName, tenant, retryPolicy);
+        var cluster = await GetClusterAsync(subscriptionId, clusterName, tenant);
         var value = cluster?.ClusterUri;
 
         if (string.IsNullOrEmpty(value))

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/ClusterGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/ClusterGetCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Kusto.Commands;
 using Azure.Mcp.Tools.Kusto.Models;
 using Azure.Mcp.Tools.Kusto.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -39,7 +38,7 @@ public sealed class ClusterGetCommandTests : SubscriptionCommandUnitTestsBase<Cl
         );
 
         Service.GetClusterAsync(
-            "sub123", "clusterA", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            "sub123", "clusterA", Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(expectedCluster);
 
         var response = await ExecuteCommandAsync("--subscription sub123 --cluster clusterA");
@@ -54,7 +53,7 @@ public sealed class ClusterGetCommandTests : SubscriptionCommandUnitTestsBase<Cl
     public async Task ExecuteAsync_Returns404_WhenClusterDoesNotExist()
     {
         Service.GetClusterAsync(
-            "sub123", "clusterA", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            "sub123", "clusterA", Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new KeyNotFoundException("Kusto cluster 'clusterA' not found for subscription 'sub123'."));
 
         var response = await ExecuteCommandAsync("--subscription sub123 --cluster clusterA");
@@ -68,7 +67,7 @@ public sealed class ClusterGetCommandTests : SubscriptionCommandUnitTestsBase<Cl
     {
         var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
         Service.GetClusterAsync(
-            "sub123", "clusterA", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            "sub123", "clusterA", Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         var response = await ExecuteCommandAsync("--subscription sub123 --cluster clusterA");

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/ClusterListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/ClusterListCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Kusto.Commands;
 using Azure.Mcp.Tools.Kusto.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -21,7 +20,7 @@ public sealed class ClusterListCommandTests : SubscriptionCommandUnitTestsBase<C
         // Arrange
         var expectedClusters = new ResourceQueryResults<string>(["clusterA", "clusterB"], false);
         Service.ListClustersAsync(
-            "sub123", Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            "sub123", Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(expectedClusters);
 
         // Act
@@ -37,7 +36,7 @@ public sealed class ClusterListCommandTests : SubscriptionCommandUnitTestsBase<C
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoClustersExist()
     {
         // Arrange
-        Service.ListClustersAsync("sub123", Arg.Any<string?>(), null, null, Arg.Any<CancellationToken>())
+        Service.ListClustersAsync("sub123", Arg.Any<string?>(), null, Arg.Any<CancellationToken>())
             .Returns(new ResourceQueryResults<string>([], false));
 
         // Act
@@ -57,7 +56,7 @@ public sealed class ClusterListCommandTests : SubscriptionCommandUnitTestsBase<C
         var subscriptionId = "sub123";
 
         // Arrange
-        Service.ListClustersAsync(subscriptionId, Arg.Any<string?>(), null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListClustersAsync(subscriptionId, Arg.Any<string?>(), null, Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -74,7 +73,7 @@ public sealed class ClusterListCommandTests : SubscriptionCommandUnitTestsBase<C
     {
         // Arrange
         const string resourceGroup = "test-rg";
-        Service.ListClustersAsync(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ListClustersAsync(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new ResourceQueryResults<string>([], false));
 
         // Act
@@ -82,6 +81,6 @@ public sealed class ClusterListCommandTests : SubscriptionCommandUnitTestsBase<C
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await Service.Received(1).ListClustersAsync(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListClustersAsync(Arg.Any<string>(), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/DatabaseListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/DatabaseListCommandTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Kusto.Commands;
 using Azure.Mcp.Tools.Kusto.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -30,13 +29,13 @@ public sealed class DatabaseListCommandTests : SubscriptionCommandUnitTestsBase<
         {
             Service.ListDatabasesAsync(
                 "https://mycluster.kusto.windows.net",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(expectedDatabases);
         }
         else
         {
             Service.ListDatabasesAsync(
-                "sub1", "mycluster", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                "sub1", "mycluster", Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(expectedDatabases);
         }
 
@@ -57,13 +56,13 @@ public sealed class DatabaseListCommandTests : SubscriptionCommandUnitTestsBase<
         {
             Service.ListDatabasesAsync(
                 "https://mycluster.kusto.windows.net",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns([]);
         }
         else
         {
             Service.ListDatabasesAsync(
-                "sub1", "mycluster", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                "sub1", "mycluster", Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns([]);
         }
 
@@ -85,13 +84,13 @@ public sealed class DatabaseListCommandTests : SubscriptionCommandUnitTestsBase<
         {
             Service.ListDatabasesAsync(
                 "https://mycluster.kusto.windows.net",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync(new Exception("Test error"));
         }
         else
         {
             Service.ListDatabasesAsync(
-                "sub1", "mycluster", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                "sub1", "mycluster", Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync(new Exception("Test error"));
         }
 

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/QueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/QueryCommandTests.cs
@@ -6,7 +6,6 @@ using System.Text.Json;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Kusto.Commands;
 using Azure.Mcp.Tools.Kusto.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -33,14 +32,14 @@ public sealed class QueryCommandTests : SubscriptionCommandUnitTestsBase<QueryCo
                 "https://mycluster.kusto.windows.net",
                 "db1",
                 "StormEvents | take 1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(expectedJson);
         }
         else
         {
             Service.QueryItemsAsync(
                 "sub1", "mycluster", "db1", "StormEvents | take 1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(expectedJson);
         }
 
@@ -67,14 +66,14 @@ public sealed class QueryCommandTests : SubscriptionCommandUnitTestsBase<QueryCo
                 "https://mycluster.kusto.windows.net",
                 "db1",
                 "StormEvents | take 1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns([]);
         }
         else
         {
             Service.QueryItemsAsync(
                 "sub1", "mycluster", "db1", "StormEvents | take 1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns([]);
         }
 
@@ -95,14 +94,14 @@ public sealed class QueryCommandTests : SubscriptionCommandUnitTestsBase<QueryCo
                 "https://mycluster.kusto.windows.net",
                 "db1",
                 "StormEvents | take 1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync(new Exception("Test error"));
         }
         else
         {
             Service.QueryItemsAsync(
                 "sub1", "mycluster", "db1", "StormEvents | take 1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync(new Exception("Test error"));
         }
 

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/SampleCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/SampleCommandTests.cs
@@ -6,7 +6,6 @@ using System.Text.Json;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Kusto.Commands;
 using Azure.Mcp.Tools.Kusto.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using Xunit;
 
@@ -32,14 +31,14 @@ public sealed class SampleCommandTests : SubscriptionCommandUnitTestsBase<Sample
                 "https://mycluster.kusto.windows.net",
                 "db1",
                 "['table1'] | sample 10",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(expectedJson);
         }
         else
         {
             Service.QueryItemsAsync(
                 "sub1", "mycluster", "db1", "['table1'] | sample 10",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(expectedJson);
         }
 
@@ -66,14 +65,14 @@ public sealed class SampleCommandTests : SubscriptionCommandUnitTestsBase<Sample
                 "https://mycluster.kusto.windows.net",
                 "db1",
                 "['table1'] | sample 10",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns([]);
         }
         else
         {
             Service.QueryItemsAsync(
                 "sub1", "mycluster", "db1", "['table1'] | sample 10",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns([]);
         }
 
@@ -95,14 +94,14 @@ public sealed class SampleCommandTests : SubscriptionCommandUnitTestsBase<Sample
     //             "https://mycluster.kusto.windows.net",
     //             "db1",
     //             "table1 | sample 10",
-    //             Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+    //             Arg.Any<string>())
     //             .Returns(Task.FromException<List<JsonElement>>(new Exception("Test error")));
     //     }
     //     else
     //     {
     //         _kusto.QueryItems(
     //             "sub1", "mycluster", "db1", "table1 | sample 10",
-    //             Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+    //             Arg.Any<string>())
     //             .Returns(Task.FromException<List<JsonElement>>(new Exception("Test error")));
     //     }
     //     var command = new SampleCommand(_logger, _kusto);

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/TableListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/TableListCommandTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Kusto.Commands;
 using Azure.Mcp.Tools.Kusto.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -30,14 +29,14 @@ public sealed class TableListCommandTests : SubscriptionCommandUnitTestsBase<Tab
             Service.ListTablesAsync(
                 "https://mycluster.kusto.windows.net",
                 "db1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(expectedTables);
         }
         else
         {
             Service.ListTablesAsync(
                 "sub1", "mycluster", "db1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(expectedTables);
         }
 
@@ -57,14 +56,14 @@ public sealed class TableListCommandTests : SubscriptionCommandUnitTestsBase<Tab
             Service.ListTablesAsync(
                 "https://mycluster.kusto.windows.net",
                 "db1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns([]);
         }
         else
         {
             Service.ListTablesAsync(
                 "sub1", "mycluster", "db1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns([]);
         }
 
@@ -84,14 +83,14 @@ public sealed class TableListCommandTests : SubscriptionCommandUnitTestsBase<Tab
             Service.ListTablesAsync(
                 "https://mycluster.kusto.windows.net",
                 "db1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync(new Exception("Test error"));
         }
         else
         {
             Service.ListTablesAsync(
                 "sub1", "mycluster", "db1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync(new Exception("Test error"));
         }
 

--- a/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/TableSchemaCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Kusto/tests/Azure.Mcp.Tools.Kusto.Tests/TableSchemaCommandTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Kusto.Commands;
 using Azure.Mcp.Tools.Kusto.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -32,14 +31,14 @@ public sealed class TableSchemaCommandTests : SubscriptionCommandUnitTestsBase<T
                 "https://mycluster.kusto.windows.net",
                 "db1",
                 "table1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(expectedSchema);
         }
         else
         {
             Service.GetTableSchemaAsync(
                 "sub1", "mycluster", "db1", "table1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(expectedSchema);
         }
 
@@ -64,14 +63,14 @@ public sealed class TableSchemaCommandTests : SubscriptionCommandUnitTestsBase<T
                 "https://mycluster.kusto.windows.net",
                 "db1",
                 "table1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync(new Exception("Test error"));
         }
         else
         {
             Service.GetTableSchemaAsync(
                 "sub1", "mycluster", "db1", "table1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync(new Exception("Test error"));
         }
 
@@ -94,14 +93,14 @@ public sealed class TableSchemaCommandTests : SubscriptionCommandUnitTestsBase<T
                 "https://mycluster.kusto.windows.net",
                 "db1",
                 "table1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync(new Exception("Test error"));
         }
         else
         {
             Service.GetTableSchemaAsync(
                 "sub1", "mycluster", "db1", "table1",
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync(new Exception("Test error"));
         }
 


### PR DESCRIPTION
## What does this PR do?

Removed custom retry policy options from Function App, Grafana, Insights, IoT Hub, Key Vault, and Kusto tools.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
