### PR TITLE
[Part 8] Remove RetryPolicyOptions from tools

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Subscription/SubscriptionCommandTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Subscription/SubscriptionCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Storage.Commands.Account;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using Xunit;
 
@@ -46,7 +45,6 @@ public class SubscriptionCommandTests : SubscriptionCommandUnitTestsBase<Account
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedAccounts);
 
@@ -62,7 +60,6 @@ public class SubscriptionCommandTests : SubscriptionCommandUnitTestsBase<Account
             subscription,
             Arg.Any<string?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -85,7 +82,6 @@ public class SubscriptionCommandTests : SubscriptionCommandUnitTestsBase<Account
             Arg.Is(expectedSubscription),
             Arg.Any<string?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedAccounts);
 
@@ -101,14 +97,12 @@ public class SubscriptionCommandTests : SubscriptionCommandUnitTestsBase<Account
             expectedSubscription,
             Arg.Any<string?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
         await Service.DidNotReceive().GetAccountDetails(
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
             ignoredSubscription,
             Arg.Any<string?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/servers/Azure.Mcp.Server/changelog-entries/remove-retry-policy-options-part8.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/remove-retry-policy-options-part8.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: Breaking Changes
+    description: Removed custom retry policy options from Service Fabric, SignalR, Speech, SQL, SRE Agent, Storage, and Storage Sync tools.

--- a/tools/Azure.Mcp.Tools.ServiceFabric/src/Commands/ManagedCluster/ManagedClusterNodeGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceFabric/src/Commands/ManagedCluster/ManagedClusterNodeGetCommand.cs
@@ -41,7 +41,6 @@ public sealed class ManagedClusterNodeGetCommand(ILogger<ManagedClusterNodeGetCo
                     options.Cluster,
                     options.Node,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new([node]), ServiceFabricJsonContext.Default.ManagedClusterNodeGetCommandResult);
@@ -53,7 +52,6 @@ public sealed class ManagedClusterNodeGetCommand(ILogger<ManagedClusterNodeGetCo
                     options.ResourceGroup,
                     options.Cluster,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(nodes ?? []), ServiceFabricJsonContext.Default.ManagedClusterNodeGetCommandResult);

--- a/tools/Azure.Mcp.Tools.ServiceFabric/src/Commands/ManagedCluster/ManagedClusterNodeTypeRestartCommand.cs
+++ b/tools/Azure.Mcp.Tools.ServiceFabric/src/Commands/ManagedCluster/ManagedClusterNodeTypeRestartCommand.cs
@@ -41,7 +41,6 @@ public sealed class ManagedClusterNodeTypeRestartCommand(ILogger<ManagedClusterN
                 options.Nodes,
                 options.UpdateType ?? Models.UpdateType.Default,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.ServiceFabric/src/Options/ManagedCluster/ManagedClusterNodeGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.ServiceFabric/src/Options/ManagedCluster/ManagedClusterNodeGetOptions.cs
@@ -22,7 +22,4 @@ public sealed class ManagedClusterNodeGetOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.ServiceFabric/src/Options/ManagedCluster/ManagedClusterNodeTypeRestartOptions.cs
+++ b/tools/Azure.Mcp.Tools.ServiceFabric/src/Options/ManagedCluster/ManagedClusterNodeTypeRestartOptions.cs
@@ -29,7 +29,4 @@ public sealed class ManagedClusterNodeTypeRestartOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.ServiceFabric/src/Services/IServiceFabricService.cs
+++ b/tools/Azure.Mcp.Tools.ServiceFabric/src/Services/IServiceFabricService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.ServiceFabric.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.ServiceFabric.Services;
 
@@ -13,7 +12,6 @@ public interface IServiceFabricService
         string resourceGroup,
         string clusterName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<ManagedClusterNode> GetManagedClusterNode(
@@ -22,7 +20,6 @@ public interface IServiceFabricService
         string clusterName,
         string nodeName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<RestartNodeResponse> RestartManagedClusterNodes(
@@ -33,6 +30,5 @@ public interface IServiceFabricService
         string[] nodes,
         UpdateType updateType = UpdateType.Default,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.ServiceFabric/src/Services/ServiceFabricService.cs
+++ b/tools/Azure.Mcp.Tools.ServiceFabric/src/Services/ServiceFabricService.cs
@@ -6,7 +6,6 @@ using System.Text.Json;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.ServiceFabric.Commands;
 using Azure.Mcp.Tools.ServiceFabric.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.ServiceFabric.Services;
 
@@ -23,7 +22,6 @@ public sealed class ServiceFabricService(IAzureService azureService)
         string resourceGroup,
         string clusterName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -31,7 +29,7 @@ public sealed class ServiceFabricService(IAzureService azureService)
             (nameof(resourceGroup), resourceGroup),
             (nameof(clusterName), clusterName));
 
-        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var subscriptionId = subscriptionResource.Id.SubscriptionId;
 
         var token = await GetArmAccessTokenAsync(tenant, cancellationToken);
@@ -69,7 +67,6 @@ public sealed class ServiceFabricService(IAzureService azureService)
         string clusterName,
         string nodeName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -78,7 +75,7 @@ public sealed class ServiceFabricService(IAzureService azureService)
             (nameof(clusterName), clusterName),
             (nameof(nodeName), nodeName));
 
-        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var subscriptionId = subscriptionResource.Id.SubscriptionId;
 
         var token = await GetArmAccessTokenAsync(tenant, cancellationToken);
@@ -104,7 +101,6 @@ public sealed class ServiceFabricService(IAzureService azureService)
         string[] nodes,
         UpdateType updateType = UpdateType.Default,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -119,7 +115,7 @@ public sealed class ServiceFabricService(IAzureService azureService)
             throw new ArgumentException("At least one node name must be specified.", nameof(nodes));
         }
 
-        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var subscriptionId = subscriptionResource.Id.SubscriptionId;
 
         var token = await GetArmAccessTokenAsync(tenant, cancellationToken);

--- a/tools/Azure.Mcp.Tools.ServiceFabric/tests/Azure.Mcp.Tools.ServiceFabric.Tests/ManagedCluster/ManagedClusterNodeGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ServiceFabric/tests/Azure.Mcp.Tools.ServiceFabric.Tests/ManagedCluster/ManagedClusterNodeGetCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.ServiceFabric.Commands;
 using Azure.Mcp.Tools.ServiceFabric.Commands.ManagedCluster;
 using Azure.Mcp.Tools.ServiceFabric.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -40,7 +39,6 @@ public class ManagedClusterNodeGetCommandTests : SubscriptionCommandUnitTestsBas
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns([]);
 
@@ -50,7 +48,6 @@ public class ManagedClusterNodeGetCommandTests : SubscriptionCommandUnitTestsBas
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new Models.ManagedClusterNode());
         }
@@ -112,7 +109,6 @@ public class ManagedClusterNodeGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedNodes);
 
@@ -128,7 +124,6 @@ public class ManagedClusterNodeGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
 
         var result = ValidateAndDeserializeResponse(response, ServiceFabricJsonContext.Default.ManagedClusterNodeGetCommandResult);
@@ -172,7 +167,6 @@ public class ManagedClusterNodeGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedNode);
 
@@ -187,7 +181,6 @@ public class ManagedClusterNodeGetCommandTests : SubscriptionCommandUnitTestsBas
         await Service.Received(1).GetManagedClusterNode(
             "sub1", "rg1", "cluster1", "primary_0",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
 
         await Service.DidNotReceive().ListManagedClusterNodes(
@@ -195,7 +188,6 @@ public class ManagedClusterNodeGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
 
         var result = ValidateAndDeserializeResponse(response, ServiceFabricJsonContext.Default.ManagedClusterNodeGetCommandResult);
@@ -214,7 +206,6 @@ public class ManagedClusterNodeGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -239,7 +230,6 @@ public class ManagedClusterNodeGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -265,7 +255,6 @@ public class ManagedClusterNodeGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("Not found", null, HttpStatusCode.NotFound));
 
@@ -290,7 +279,6 @@ public class ManagedClusterNodeGetCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 

--- a/tools/Azure.Mcp.Tools.ServiceFabric/tests/Azure.Mcp.Tools.ServiceFabric.Tests/ManagedCluster/ManagedClusterNodeTypeRestartCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.ServiceFabric/tests/Azure.Mcp.Tools.ServiceFabric.Tests/ManagedCluster/ManagedClusterNodeTypeRestartCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.ServiceFabric.Commands;
 using Azure.Mcp.Tools.ServiceFabric.Commands.ManagedCluster;
 using Azure.Mcp.Tools.ServiceFabric.Models;
 using Azure.Mcp.Tools.ServiceFabric.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,6 @@ public class ManagedClusterNodeTypeRestartCommandTests : SubscriptionCommandUnit
                 Arg.Any<string[]>(),
                 Arg.Any<UpdateType>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new RestartNodeResponse { StatusCode = 202 });
         }
@@ -87,7 +85,6 @@ public class ManagedClusterNodeTypeRestartCommandTests : SubscriptionCommandUnit
             Arg.Any<string[]>(),
             Arg.Any<UpdateType>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResponse);
 
@@ -109,7 +106,6 @@ public class ManagedClusterNodeTypeRestartCommandTests : SubscriptionCommandUnit
             Arg.Any<string[]>(),
             Arg.Any<UpdateType>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
 
         var result = ValidateAndDeserializeResponse(response, ServiceFabricJsonContext.Default.ManagedClusterNodeTypeRestartCommandResult);
@@ -131,7 +127,6 @@ public class ManagedClusterNodeTypeRestartCommandTests : SubscriptionCommandUnit
             Arg.Any<string[]>(),
             Arg.Is(UpdateType.ByUpgradeDomain),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(new RestartNodeResponse { StatusCode = 202 });
 
@@ -154,7 +149,6 @@ public class ManagedClusterNodeTypeRestartCommandTests : SubscriptionCommandUnit
             Arg.Any<string[]>(),
             Arg.Is(UpdateType.ByUpgradeDomain),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -170,7 +164,6 @@ public class ManagedClusterNodeTypeRestartCommandTests : SubscriptionCommandUnit
             Arg.Any<string[]>(),
             Arg.Any<UpdateType>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(new RestartNodeResponse { StatusCode = 202 });
 
@@ -200,7 +193,6 @@ public class ManagedClusterNodeTypeRestartCommandTests : SubscriptionCommandUnit
             Arg.Any<string[]>(),
             Arg.Any<UpdateType>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -230,7 +222,6 @@ public class ManagedClusterNodeTypeRestartCommandTests : SubscriptionCommandUnit
             Arg.Any<string[]>(),
             Arg.Any<UpdateType>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("Not found", null, HttpStatusCode.NotFound));
 
@@ -259,7 +250,6 @@ public class ManagedClusterNodeTypeRestartCommandTests : SubscriptionCommandUnit
             Arg.Any<string[]>(),
             Arg.Any<UpdateType>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(new RestartNodeResponse { StatusCode = 202 });
 
@@ -283,7 +273,6 @@ public class ManagedClusterNodeTypeRestartCommandTests : SubscriptionCommandUnit
             Arg.Is<string[]>(n => n.Length == 2 && n[0] == "Worker_0" && n[1] == "Worker_1"),
             Arg.Is(UpdateType.ByUpgradeDomain),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.SignalR/src/Commands/Runtime/RuntimeGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.SignalR/src/Commands/Runtime/RuntimeGetCommand.cs
@@ -44,7 +44,6 @@ public sealed class RuntimeGetCommand(ILogger<RuntimeGetCommand> logger, ISignal
                 options.ResourceGroup,
                 options.SignalR,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             _logger.LogInformation("Found {Count} SignalR service(s) in subscription {SubscriptionId}",

--- a/tools/Azure.Mcp.Tools.SignalR/src/Options/Runtime/RuntimeGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.SignalR/src/Options/Runtime/RuntimeGetOptions.cs
@@ -22,7 +22,4 @@ public sealed class RuntimeGetOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.SignalR/src/Services/ISignalRService.cs
+++ b/tools/Azure.Mcp.Tools.SignalR/src/Services/ISignalRService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.SignalR.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.SignalR.Services;
 
@@ -16,6 +15,5 @@ public interface ISignalRService
         string? resourceGroup,
         string? signalRName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.SignalR/src/Services/SignalRService.cs
+++ b/tools/Azure.Mcp.Tools.SignalR/src/Services/SignalRService.cs
@@ -7,7 +7,6 @@ using Azure.ResourceManager.Models;
 using Azure.ResourceManager.SignalR;
 using Azure.ResourceManager.SignalR.Models;
 using Microsoft.Mcp.Core.Models.Identity;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Caching;
 
 namespace Azure.Mcp.Tools.SignalR.Services;
@@ -28,11 +27,10 @@ public sealed class SignalRService(IAzureService azureService, ICacheService cac
         string? resourceGroup,
         string? signalRName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
-        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var runtimes = new List<Runtime>();
         if (string.IsNullOrEmpty(signalRName))
         {

--- a/tools/Azure.Mcp.Tools.SignalR/tests/Azure.Mcp.Tools.SignalR.Tests/Runtime/RuntimeGetCommandTest.cs
+++ b/tools/Azure.Mcp.Tools.SignalR/tests/Azure.Mcp.Tools.SignalR.Tests/Runtime/RuntimeGetCommandTest.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SignalR.Commands;
 using Azure.Mcp.Tools.SignalR.Commands.Runtime;
 using Azure.Mcp.Tools.SignalR.Models;
 using Azure.Mcp.Tools.SignalR.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -80,7 +79,6 @@ public class RuntimeGetCommandTests : SubscriptionCommandUnitTestsBase<RuntimeGe
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(runtimes);
         }
@@ -110,7 +108,6 @@ public class RuntimeGetCommandTests : SubscriptionCommandUnitTestsBase<RuntimeGe
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -132,7 +129,6 @@ public class RuntimeGetCommandTests : SubscriptionCommandUnitTestsBase<RuntimeGe
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -155,7 +151,6 @@ public class RuntimeGetCommandTests : SubscriptionCommandUnitTestsBase<RuntimeGe
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
@@ -176,7 +171,6 @@ public class RuntimeGetCommandTests : SubscriptionCommandUnitTestsBase<RuntimeGe
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(forbiddenException);
 

--- a/tools/Azure.Mcp.Tools.Speech/src/Commands/Stt/SttRecognizeCommand.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Commands/Stt/SttRecognizeCommand.cs
@@ -120,7 +120,6 @@ public sealed class SttRecognizeCommand(ILogger<SttRecognizeCommand> logger, ISp
                 options.Phrases,
                 options.Format,
                 options.Profanity,
-                options.RetryPolicy,
                 cancellationToken);
 
             _logger.LogInformation(

--- a/tools/Azure.Mcp.Tools.Speech/src/Commands/Tts/TtsSynthesizeCommand.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Commands/Tts/TtsSynthesizeCommand.cs
@@ -100,7 +100,6 @@ public sealed partial class TtsSynthesizeCommand(ILogger<TtsSynthesizeCommand> l
                 options.Voice,
                 options.Format,
                 options.EndpointId,
-                options.RetryPolicy,
                 cancellationToken);
 
             _logger.LogInformation(

--- a/tools/Azure.Mcp.Tools.Speech/src/Options/BaseSpeechOptions.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Options/BaseSpeechOptions.cs
@@ -9,7 +9,4 @@ public abstract class BaseSpeechOptions
 {
     [Option(Description = "The Azure AI Services endpoint URL (e.g., https://your-service.cognitiveservices.azure.com/).")]
     public required string Endpoint { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Speech/src/Services/ISpeechService.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Services/ISpeechService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.Speech.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Speech.Services;
 
@@ -15,7 +14,6 @@ public interface ISpeechService
         string[]? phrases = null,
         string? format = null,
         string? profanity = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<SynthesisResult> SynthesizeSpeechToFile(
@@ -26,6 +24,5 @@ public interface ISpeechService
         string? voice = null,
         string? format = null,
         string? endpointId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Speech/src/Services/Recognizers/FastTranscriptionRecognizer.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Services/Recognizers/FastTranscriptionRecognizer.cs
@@ -9,7 +9,6 @@ using Azure.Core;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.Speech.Models.FastTranscription;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Azure.Authentication;
 
 namespace Azure.Mcp.Tools.Speech.Services.Recognizers;
@@ -29,7 +28,6 @@ public class FastTranscriptionRecognizer(IAzureService azureService, ILogger<Fas
         string? language = null,
         string[]? phrases = null,
         string? profanity = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(endpoint), endpoint), (nameof(filePath), filePath));
@@ -49,11 +47,8 @@ public class FastTranscriptionRecognizer(IAzureService azureService, ILogger<Fas
             throw new InvalidOperationException($"Audio file is too large ({fileInfo.Length / (1024.0 * 1024):F1} MB). Fast Transcription supports files up to 300 MB.");
         }
 
-        // Apply retry policy configuration
-        var maxRetries = retryPolicy?.MaxRetries ?? 3;
-        var delaySeconds = retryPolicy?.DelaySeconds ?? 1.0;
-        var maxDelaySeconds = retryPolicy?.MaxDelaySeconds ?? 30.0;
-        var isExponentialBackoff = retryPolicy?.Mode == RetryMode.Exponential;
+        const int maxRetries = 3;
+        const double delaySeconds = 1.0;
 
         Exception? lastException = null;
 
@@ -165,12 +160,8 @@ public class FastTranscriptionRecognizer(IAzureService azureService, ILogger<Fas
                 // Calculate delay for next attempt
                 if (attempt < maxRetries)
                 {
-                    var delay = isExponentialBackoff
-                        ? Math.Min(delaySeconds * Math.Pow(2, attempt), maxDelaySeconds)
-                        : delaySeconds;
-
-                    _logger.LogDebug("Waiting {DelaySeconds} seconds before retry attempt {NextAttempt}", delay, attempt + 2);
-                    await Task.Delay(TimeSpan.FromSeconds(delay), cancellationToken);
+                    _logger.LogDebug("Waiting {DelaySeconds} seconds before retry attempt {NextAttempt}", delaySeconds, attempt + 2);
+                    await Task.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken);
                 }
             }
             catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Speech/src/Services/Recognizers/IFastTranscriptionRecognizer.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Services/Recognizers/IFastTranscriptionRecognizer.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.Speech.Models.FastTranscription;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Speech.Services.Recognizers;
 
@@ -19,7 +18,6 @@ public interface IFastTranscriptionRecognizer
     /// <param name="language">Speech recognition language</param>
     /// <param name="phrases">Optional phrases to improve recognition accuracy</param>
     /// <param name="profanity">Profanity filtering option</param>
-    /// <param name="retryPolicy">Optional retry policy for resilience</param>
     /// <returns>Continuous recognition result converted from Fast Transcription response</returns>
     Task<FastTranscriptionResult> RecognizeAsync(
         string endpoint,
@@ -27,6 +25,5 @@ public interface IFastTranscriptionRecognizer
         string? language = null,
         string[]? phrases = null,
         string? profanity = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Speech/src/Services/Recognizers/IRealtimeTranscriptionRecognizer.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Services/Recognizers/IRealtimeTranscriptionRecognizer.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.Speech.Models.Realtime;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Speech.Services.Recognizers;
 
@@ -21,7 +20,6 @@ public interface IRealtimeTranscriptionRecognizer
     /// <param name="phrases">Optional phrases to improve recognition accuracy</param>
     /// <param name="format">Output format (simple or detailed)</param>
     /// <param name="profanity">Profanity filtering option (masked, removed, or raw)</param>
-    /// <param name="retryPolicy">Optional retry policy for resilience</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>Continuous recognition result containing full text and individual segments</returns>
     Task<RealtimeRecognitionContinuousResult> RecognizeAsync(
@@ -31,6 +29,5 @@ public interface IRealtimeTranscriptionRecognizer
         string[]? phrases = null,
         string? format = null,
         string? profanity = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Speech/src/Services/Recognizers/RealtimeTranscriptionRecognizer.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Services/Recognizers/RealtimeTranscriptionRecognizer.cs
@@ -8,7 +8,6 @@ using Azure.Mcp.Tools.Speech.Models.Realtime;
 using Microsoft.CognitiveServices.Speech;
 using Microsoft.CognitiveServices.Speech.Audio;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Azure.Authentication;
 using SdkSpeechRecognitionResult = Microsoft.CognitiveServices.Speech.SpeechRecognitionResult;
 
@@ -30,7 +29,6 @@ public class RealtimeTranscriptionRecognizer(IAzureService azureService, ILogger
         string[]? phrases = null,
         string? format = null,
         string? profanity = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(endpoint), endpoint), (nameof(filePath), filePath));
@@ -49,11 +47,8 @@ public class RealtimeTranscriptionRecognizer(IAzureService azureService, ILogger
             throw new FileNotFoundException($"Audio file not found: {filePath}");
         }
 
-        // Apply retry policy configuration
-        var maxRetries = retryPolicy?.MaxRetries ?? 3;
-        var delaySeconds = retryPolicy?.DelaySeconds ?? 1.0;
-        var maxDelaySeconds = retryPolicy?.MaxDelaySeconds ?? 30.0;
-        var isExponentialBackoff = retryPolicy?.Mode == RetryMode.Exponential;
+        const int maxRetries = 3;
+        const double delaySeconds = 1.0;
 
         Exception? lastException = null;
 
@@ -225,12 +220,8 @@ public class RealtimeTranscriptionRecognizer(IAzureService azureService, ILogger
                 // Calculate delay for next attempt
                 if (attempt < maxRetries)
                 {
-                    var delay = isExponentialBackoff
-                        ? Math.Min(delaySeconds * Math.Pow(2, attempt), maxDelaySeconds)
-                        : delaySeconds;
-
-                    _logger.LogDebug("Waiting {DelaySeconds} seconds before retry attempt {NextAttempt}", delay, attempt + 2);
-                    await Task.Delay(TimeSpan.FromSeconds(delay), cancellationToken);
+                    _logger.LogDebug("Waiting {DelaySeconds} seconds before retry attempt {NextAttempt}", delaySeconds, attempt + 2);
+                    await Task.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken);
                 }
             }
             catch (Exception ex)

--- a/tools/Azure.Mcp.Tools.Speech/src/Services/SpeechService.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Services/SpeechService.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tools.Speech.Models;
 using Azure.Mcp.Tools.Speech.Services.Recognizers;
 using Azure.Mcp.Tools.Speech.Services.Synthesizers;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Speech.Services;
 
@@ -32,7 +31,6 @@ public class SpeechService(
     /// <param name="phrases">Optional phrases to improve recognition accuracy (ignored for Fast Transcription)</param>
     /// <param name="format">Output format (simple or detailed)</param>
     /// <param name="profanity">Profanity filtering option (masked, removed, or raw)</param>
-    /// <param name="retryPolicy">Optional retry policy for resilience</param>
     /// <param name="cancellationToken">Cancellation token to cancel the operation</param>
     /// <returns>Continuous recognition result containing full text and individual segments</returns>
     public async Task<SpeechRecognitionResult> RecognizeSpeechFromFile(
@@ -42,7 +40,6 @@ public class SpeechService(
         string[]? phrases = null,
         string? format = null,
         string? profanity = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(endpoint), endpoint), (nameof(filePath), filePath));
@@ -64,7 +61,7 @@ public class SpeechService(
                 try
                 {
                     var fastResult = await _fastTranscriptionRecognizer.RecognizeAsync(
-                        endpoint, filePath, locale, phrases, profanity, retryPolicy, cancellationToken);
+                        endpoint, filePath, locale, phrases, profanity, cancellationToken);
 
                     // Convert to unified result
                     return SpeechRecognitionResult.FromFastTranscriptionResult(fastResult);
@@ -79,7 +76,7 @@ public class SpeechService(
             // Use Realtime Transcription as fallback or primary choice
             _logger.LogInformation("Using Realtime Transcription for language '{Language}' with file '{FilePath}'", language, filePath);
             var realtimeResult = await _realtimeTranscriptionRecognizer.RecognizeAsync(
-                endpoint, filePath, locale, phrases, format, profanity, retryPolicy, cancellationToken);
+                endpoint, filePath, locale, phrases, format, profanity, cancellationToken);
 
             // Convert to unified result
             return SpeechRecognitionResult.FromRealtimeResult(realtimeResult);
@@ -102,7 +99,6 @@ public class SpeechService(
     /// <param name="voice">Voice name to use (e.g., en-US-JennyNeural). If not specified, default voice for language is used</param>
     /// <param name="format">Output audio format (default: Riff24Khz16BitMonoPcm)</param>
     /// <param name="endpointId">Optional endpoint ID for custom voice model</param>
-    /// <param name="retryPolicy">Optional retry policy for resilience</param>
     /// <param name="cancellationToken">Cancellation token to cancel the operation</param>
     /// <returns>Synthesis result with file information</returns>
     public async Task<SynthesisResult> SynthesizeSpeechToFile(
@@ -113,7 +109,6 @@ public class SpeechService(
         string? voice = null,
         string? format = null,
         string? endpointId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         return await _speechSynthesizer.SynthesizeToFileAsync(
@@ -124,7 +119,6 @@ public class SpeechService(
             voice,
             format,
             endpointId,
-            retryPolicy,
             cancellationToken);
     }
 }

--- a/tools/Azure.Mcp.Tools.Speech/src/Services/Synthesizers/IRealtimeTtsSynthesizer.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Services/Synthesizers/IRealtimeTtsSynthesizer.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.Speech.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Speech.Services.Synthesizers;
 
@@ -21,7 +20,6 @@ public interface IRealtimeTtsSynthesizer
     /// <param name="voice">Voice name to use (e.g., en-US-JennyNeural)</param>
     /// <param name="format">Output audio format (default: Riff24Khz16BitMonoPcm)</param>
     /// <param name="endpointId">Optional endpoint ID for custom voice model</param>
-    /// <param name="retryPolicy">Optional retry policy for resilience</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>Synthesis result with file information</returns>
     Task<SynthesisResult> SynthesizeToFileAsync(
@@ -32,6 +30,5 @@ public interface IRealtimeTtsSynthesizer
         string? voice = null,
         string? format = null,
         string? endpointId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Speech/src/Services/Synthesizers/RealtimeTtsSynthesizer.cs
+++ b/tools/Azure.Mcp.Tools.Speech/src/Services/Synthesizers/RealtimeTtsSynthesizer.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tools.Speech.Models;
 using Microsoft.CognitiveServices.Speech;
 using Microsoft.CognitiveServices.Speech.Audio;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Azure.Authentication;
 
 namespace Azure.Mcp.Tools.Speech.Services.Synthesizers;
@@ -29,7 +28,6 @@ public class RealtimeTtsSynthesizer(IAzureService azureService, ILogger<Realtime
         string? voice = null,
         string? format = null,
         string? endpointId = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(endpoint), endpoint), (nameof(text), text), (nameof(outputFilePath), outputFilePath));

--- a/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.Tests/SpeechCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.Tests/SpeechCommandTests.cs
@@ -451,44 +451,6 @@ public class SpeechCommandTests(ITestOutputHelper output, LiveServerFixture live
 
     [LiveTestOnly]
     [Fact]
-    public async Task SpeechToText_ShouldHandleRetryPolicyCorrectly()
-    {
-        // Arrange
-        var testAudioFile = Path.Join(AppContext.BaseDirectory, "TestResources", "test-audio.wav");
-        Assert.True(File.Exists(testAudioFile), $"Test audio file not found at: {testAudioFile}");
-
-        var aiServicesEndpoint = $"https://{Settings.ResourceBaseName}.cognitiveservices.azure.com/";
-        var expectedText = "My voice is my passport. Verify me.";
-
-        // Act
-        var result = await CallToolAsync(
-            "speech_stt_recognize",
-            new()
-            {
-                { "subscription", Settings.SubscriptionId },
-                { "endpoint", aiServicesEndpoint },
-                { "file", testAudioFile },
-                { "language", "en-US" },
-                { "retry-max-retries", 3 },
-                { "retry-delay", 1000 }
-            });
-
-        // Assert
-        Assert.NotNull(result);
-        using var doc = JsonDocument.Parse(result.Value.GetRawText());
-        var inner = doc.RootElement.GetProperty("result").GetRawText();
-        var resultObj = JsonSerializer.Deserialize<SpeechRecognitionResult>(inner);
-
-        // STRICT REQUIREMENT: Speech recognition must return a result
-        Assert.NotNull(resultObj);
-        Assert.Equal(RecognizerType.Fast, resultObj.RecognizerType);
-        Assert.NotNull(resultObj.FastTranscriptionResult);
-        Assert.Null(resultObj.RealtimeContinuousResult);
-        Assert.Equal(expectedText, resultObj.FastTranscriptionResult.CombinedPhrases?.FirstOrDefault()?.Text);
-    }
-
-    [LiveTestOnly]
-    [Fact]
     public async Task SpeechToText_RecognizeCompressedAudioWithRealtimeTranscription_ShouldFailWithoutGStreamer()
     {
         // This test validates speech recognition with different audio file formats

--- a/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.Tests/Stt/SttRecognizeCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.Tests/Stt/SttRecognizeCommandTests.cs
@@ -15,7 +15,6 @@ using Azure.Mcp.Tools.Speech.Services.Synthesizers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Core.Models.Command;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -88,7 +87,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string>(),
             Arg.Any<string[]>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(fastResult);
     }
@@ -111,7 +109,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string[]>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(realtimeResult);
     }
@@ -142,7 +139,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string[]>(),
             "detailed",
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(realtimeResult);
     }
@@ -245,7 +241,6 @@ public class SttRecognizeCommandTests : IDisposable
                 Arg.Any<string>(),
                 Arg.Any<string[]>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>());
 
             await _realtimeTranscriptionRecognizer.DidNotReceive().RecognizeAsync(
@@ -255,7 +250,6 @@ public class SttRecognizeCommandTests : IDisposable
                 Arg.Any<string[]>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>());
 
             Assert.NotNull(result.Result.FastTranscriptionResult);
@@ -270,7 +264,6 @@ public class SttRecognizeCommandTests : IDisposable
                 Arg.Any<string[]>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>());
 
             await _fastTranscriptionRecognizer.DidNotReceive().RecognizeAsync(
@@ -279,7 +272,6 @@ public class SttRecognizeCommandTests : IDisposable
                 Arg.Any<string>(),
                 Arg.Any<string[]>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>());
 
             Assert.NotNull(result.Result.RealtimeContinuousResult);
@@ -323,7 +315,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string>(),
             Arg.Any<string[]>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
@@ -343,7 +334,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string>(),
             Arg.Any<string[]>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
 
         // 2. Realtime recognizer was called as a fallback
@@ -356,7 +346,6 @@ public class SttRecognizeCommandTests : IDisposable
            Arg.Any<string[]>(),
            Arg.Any<string>(),
            Arg.Any<string>(),
-           Arg.Any<RetryPolicyOptions>(),
            Arg.Any<CancellationToken>());
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
@@ -377,7 +366,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string[]>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
@@ -394,7 +382,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string>(),
             Arg.Any<string[]>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
 
         // 2. Realtime recognizer was called and failed
@@ -407,7 +394,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string[]>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.Status);
@@ -492,7 +478,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string>(),
             Arg.Any<string[]>(),
             profanityOption,
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -518,7 +503,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string>(),
             Arg.Do<string[]>(phrases => capturedPhrases = phrases),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(fastResult);
 
@@ -552,7 +536,6 @@ public class SttRecognizeCommandTests : IDisposable
                 phrases.Contains("Azure") &&
                 phrases.Contains("cognitive services")),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -580,31 +563,6 @@ public class SttRecognizeCommandTests : IDisposable
             language,
             Arg.Any<string[]>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_WithRetryPolicy_ShouldPassToService()
-    {
-        // Arrange
-        var testFile = await CreateTestFileAsync("test-audio-retry.wav");
-        SetupFastTranscriptionMock("Hello with retry");
-
-        // Act
-        var response = await ExecuteCommandAsync($"--endpoint {_knownEndpoint} --file {testFile} --retry-max-retries 5");
-
-        // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-
-        // Verify the service was called with retry policy
-        await _fastTranscriptionRecognizer.Received(1).RecognizeAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string[]>(),
-            Arg.Any<string>(),
-            Arg.Is<RetryPolicyOptions>(policy => policy.MaxRetries == 5),
             Arg.Any<CancellationToken>());
     }
 
@@ -635,7 +593,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string[]>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(exceptionToThrow);
 
@@ -683,7 +640,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string[]>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(realtimeResult);
 
@@ -766,7 +722,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string>(),
             Arg.Do<string[]>(phrases => capturedPhrases = phrases),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(fastResult);
 
@@ -829,7 +784,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string>(),
             Arg.Do<string[]>(phrases => capturedPhrases = phrases),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(fastResult);
 
@@ -889,7 +843,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string>(),
             Arg.Do<string[]>(phrases => capturedPhrases = phrases),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(fastResult);
 
@@ -929,7 +882,6 @@ public class SttRecognizeCommandTests : IDisposable
                     phrases.Contains("cognitive services") &&
                     phrases.Contains("machine learning")),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                     Arg.Any<CancellationToken>());
         }
         finally
@@ -977,7 +929,6 @@ public class SttRecognizeCommandTests : IDisposable
                 Arg.Any<string>(),
                 Arg.Any<string[]>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>());
         }
         finally
@@ -1019,7 +970,6 @@ public class SttRecognizeCommandTests : IDisposable
             Arg.Any<string[]>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(realtimeResult);
 
@@ -1045,7 +995,6 @@ public class SttRecognizeCommandTests : IDisposable
                 Arg.Any<string[]>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>());
         }
         finally
@@ -1084,7 +1033,6 @@ public class SttRecognizeCommandTests : IDisposable
                 Arg.Any<string[]>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>());
 
             await _fastTranscriptionRecognizer.DidNotReceive().RecognizeAsync(
@@ -1093,7 +1041,6 @@ public class SttRecognizeCommandTests : IDisposable
                 Arg.Any<string>(),
                 Arg.Any<string[]>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>());
         }
         finally

--- a/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.Tests/Tts/TtsSynthesizeCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Speech/tests/Azure.Mcp.Tools.Speech.Tests/Tts/TtsSynthesizeCommandTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Azure.Mcp.Tools.Speech.Commands.Tts;
 using Azure.Mcp.Tools.Speech.Models;
 using Azure.Mcp.Tools.Speech.Services;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -62,7 +61,6 @@ public class TtsSynthesizeCommandTests : CommandUnitTestsBase<TtsSynthesizeComma
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -118,7 +116,6 @@ public class TtsSynthesizeCommandTests : CommandUnitTestsBase<TtsSynthesizeComma
             Arg.Is(voice),
             Arg.Is(format),
             Arg.Is(endpointId),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -145,7 +142,6 @@ public class TtsSynthesizeCommandTests : CommandUnitTestsBase<TtsSynthesizeComma
                 voice,
                 format,
                 endpointId,
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>());
         }
         finally
@@ -173,7 +169,6 @@ public class TtsSynthesizeCommandTests : CommandUnitTestsBase<TtsSynthesizeComma
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Synthesis failed"));
 
@@ -214,7 +209,6 @@ public class TtsSynthesizeCommandTests : CommandUnitTestsBase<TtsSynthesizeComma
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new UnauthorizedAccessException("Access denied"));
 
@@ -276,7 +270,6 @@ public class TtsSynthesizeCommandTests : CommandUnitTestsBase<TtsSynthesizeComma
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>());
         }
     }

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseCreateCommand.cs
@@ -51,7 +51,6 @@ public sealed class DatabaseCreateCommand(ISqlService sqlService, ILogger<Databa
                 options.ElasticPoolName,
                 options.ZoneRedundant,
                 options.ReadScale,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(database), SqlJsonContext.Default.DatabaseCreateResult);

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseDeleteCommand.cs
@@ -38,7 +38,6 @@ public sealed class DatabaseDeleteCommand(ISqlService sqlService, ILogger<Databa
                 options.Database,
                 options.ResourceGroup,
                 options.Subscription!,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(deleted, options.Database!), SqlJsonContext.Default.DatabaseDeleteResult);

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseGetCommand.cs
@@ -46,7 +46,6 @@ public sealed class DatabaseGetCommand(ISqlService sqlService, ILogger<DatabaseG
                     options.Database,
                     options.ResourceGroup,
                     options.Subscription!,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(
@@ -59,7 +58,6 @@ public sealed class DatabaseGetCommand(ISqlService sqlService, ILogger<DatabaseG
                     options.Server,
                     options.ResourceGroup,
                     options.Subscription!,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseRenameCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseRenameCommand.cs
@@ -44,7 +44,6 @@ public sealed class DatabaseRenameCommand(ISqlService sqlService, ILogger<Databa
                 options.NewDatabaseName,
                 options.ResourceGroup,
                 options.Subscription!,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(database), SqlJsonContext.Default.DatabaseRenameResult);

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Database/DatabaseUpdateCommand.cs
@@ -52,7 +52,6 @@ public sealed class DatabaseUpdateCommand(ISqlService sqlService, ILogger<Databa
                 options.ElasticPoolName,
                 options.ZoneRedundant,
                 options.ReadScale,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(database), SqlJsonContext.Default.DatabaseUpdateResult);

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/ElasticPool/ElasticPoolListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/ElasticPool/ElasticPoolListCommand.cs
@@ -44,7 +44,6 @@ public sealed class ElasticPoolListCommand(ISqlService sqlService, ILogger<Elast
                 options.Server,
                 options.ResourceGroup,
                 options.Subscription!,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(elasticPools ?? []), SqlJsonContext.Default.ElasticPoolListResult);

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/EntraAdmin/EntraAdminListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/EntraAdmin/EntraAdminListCommand.cs
@@ -41,7 +41,6 @@ public sealed class EntraAdminListCommand(ISqlService sqlService, ILogger<EntraA
                 options.Server,
                 options.ResourceGroup,
                 options.Subscription!,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(administrators ?? []), SqlJsonContext.Default.EntraAdminListResult);

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/FirewallRule/FirewallRuleCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/FirewallRule/FirewallRuleCreateCommand.cs
@@ -95,7 +95,6 @@ public sealed class FirewallRuleCreateCommand(ISqlService sqlService, ILogger<Fi
                 options.FirewallRuleName,
                 options.StartIpAddress,
                 options.EndIpAddress,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(firewallRule), SqlJsonContext.Default.FirewallRuleCreateResult);

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/FirewallRule/FirewallRuleDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/FirewallRule/FirewallRuleDeleteCommand.cs
@@ -41,7 +41,6 @@ public sealed class FirewallRuleDeleteCommand(ISqlService sqlService, ILogger<Fi
                 options.ResourceGroup,
                 options.Subscription!,
                 options.FirewallRuleName,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(deleted, options.FirewallRuleName!), SqlJsonContext.Default.FirewallRuleDeleteResult);

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/FirewallRule/FirewallRuleListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/FirewallRule/FirewallRuleListCommand.cs
@@ -41,7 +41,6 @@ public sealed class FirewallRuleListCommand(ISqlService sqlService, ILogger<Fire
                 options.Server,
                 options.ResourceGroup,
                 options.Subscription!,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(firewallRules ?? []), SqlJsonContext.Default.FirewallRuleListResult);

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerCreateCommand.cs
@@ -49,7 +49,6 @@ public sealed class ServerCreateCommand(ISqlService sqlService, ILogger<ServerCr
                 options.AdministratorPassword,
                 options.Version,
                 options.PublicNetworkAccess,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(server), SqlJsonContext.Default.ServerCreateResult);

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerDeleteCommand.cs
@@ -52,7 +52,6 @@ public sealed class ServerDeleteCommand(ISqlService sqlService, ILogger<ServerDe
                 options.Server,
                 options.ResourceGroup,
                 options.Subscription!,
-                options.RetryPolicy,
                 cancellationToken);
 
             if (deleted)

--- a/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Commands/Server/ServerGetCommand.cs
@@ -46,7 +46,6 @@ public sealed class ServerGetCommand(ISqlService sqlService, ILogger<ServerGetCo
                     options.Server,
                     options.ResourceGroup,
                     options.Subscription!,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create([server], SqlJsonContext.Default.ListSqlServer);
@@ -56,7 +55,6 @@ public sealed class ServerGetCommand(ISqlService sqlService, ILogger<ServerGetCo
                 var servers = await _sqlService.ListServersAsync(
                     options.ResourceGroup,
                     options.Subscription!,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(servers ?? [], SqlJsonContext.Default.ListSqlServer);

--- a/tools/Azure.Mcp.Tools.Sql/src/Options/BaseSqlOptions.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Options/BaseSqlOptions.cs
@@ -13,7 +13,4 @@ public class BaseSqlOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Subscription)]
     public string? Subscription { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Sql/src/Services/ISqlService.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Services/ISqlService.cs
@@ -3,7 +3,6 @@
 
 using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Options.Database;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Sql.Services;
 
@@ -16,7 +15,6 @@ public interface ISqlService
     /// <param name="databaseName">The name of the database</param>
     /// <param name="resourceGroup">The resource group name</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The SQL database information</returns>
     /// <exception cref="KeyNotFoundException">Thrown when the database is not found</exception>
@@ -25,7 +23,6 @@ public interface ISqlService
         string databaseName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -43,7 +40,6 @@ public interface ISqlService
     /// <param name="elasticPoolName">Optional elastic pool name to assign the database to</param>
     /// <param name="zoneRedundant">Optional zone redundancy setting</param>
     /// <param name="readScale">Optional read scale setting</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The created SQL database information</returns>
     Task<SqlDatabase> CreateDatabaseAsync(
@@ -59,7 +55,6 @@ public interface ISqlService
         string? elasticPoolName = null,
         bool? zoneRedundant = null,
         DatabaseReadScale? readScale = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -77,7 +72,6 @@ public interface ISqlService
     /// <param name="elasticPoolName">Optional elastic pool name to assign the database to</param>
     /// <param name="zoneRedundant">Optional zone redundancy setting</param>
     /// <param name="readScale">Optional read scale setting</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The updated SQL database information</returns>
     Task<SqlDatabase> UpdateDatabaseAsync(
@@ -93,7 +87,6 @@ public interface ISqlService
         string? elasticPoolName = null,
         bool? zoneRedundant = null,
         DatabaseReadScale? readScale = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -104,7 +97,6 @@ public interface ISqlService
     /// <param name="newDatabaseName">The desired new database name</param>
     /// <param name="resourceGroup">The resource group name</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The renamed SQL database information</returns>
     Task<SqlDatabase> RenameDatabaseAsync(
@@ -113,7 +105,6 @@ public interface ISqlService
         string newDatabaseName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -122,14 +113,12 @@ public interface ISqlService
     /// <param name="serverName">The name of the SQL server</param>
     /// <param name="resourceGroup">The name of the resource group</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A list of SQL databases</returns>
     Task<List<SqlDatabase>> ListDatabasesAsync(
         string serverName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -138,14 +127,12 @@ public interface ISqlService
     /// <param name="serverName">The name of the SQL server</param>
     /// <param name="resourceGroup">The name of the resource group</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A list of SQL server Entra administrators</returns>
     Task<List<SqlServerEntraAdministrator>> GetEntraAdministratorsAsync(
         string serverName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -154,14 +141,12 @@ public interface ISqlService
     /// <param name="serverName">The name of the SQL server</param>
     /// <param name="resourceGroup">The name of the resource group</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A list of SQL elastic pools</returns>
     Task<List<SqlElasticPool>> GetElasticPoolsAsync(
         string serverName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -170,14 +155,12 @@ public interface ISqlService
     /// <param name="serverName">The name of the SQL server</param>
     /// <param name="resourceGroup">The name of the resource group</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A list of SQL server firewall rules</returns>
     Task<List<SqlServerFirewallRule>> ListFirewallRulesAsync(
         string serverName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -189,7 +172,6 @@ public interface ISqlService
     /// <param name="firewallRuleName">The name of the firewall rule</param>
     /// <param name="startIpAddress">The start IP address of the firewall rule range</param>
     /// <param name="endIpAddress">The end IP address of the firewall rule range</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The created SQL server firewall rule</returns>
     Task<SqlServerFirewallRule> CreateFirewallRuleAsync(
@@ -199,7 +181,6 @@ public interface ISqlService
         string firewallRuleName,
         string startIpAddress,
         string endIpAddress,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -209,7 +190,6 @@ public interface ISqlService
     /// <param name="resourceGroup">The name of the resource group</param>
     /// <param name="subscription">The subscription ID or name</param>
     /// <param name="firewallRuleName">The name of the firewall rule to delete</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>True if the firewall rule was successfully deleted</returns>
     Task<bool> DeleteFirewallRuleAsync(
@@ -217,7 +197,6 @@ public interface ISqlService
         string resourceGroup,
         string subscription,
         string firewallRuleName,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -227,7 +206,6 @@ public interface ISqlService
     /// <param name="databaseName">The name of the database to delete</param>
     /// <param name="resourceGroup">The resource group name</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>True if the database was successfully deleted</returns>
     Task<bool> DeleteDatabaseAsync(
@@ -235,7 +213,6 @@ public interface ISqlService
         string databaseName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -249,7 +226,6 @@ public interface ISqlService
     /// <param name="administratorPassword">The administrator password for the SQL server</param>
     /// <param name="version">The version of SQL Server to create (optional, defaults to latest)</param>
     /// <param name="publicNetworkAccess">Whether public network access is enabled (optional)</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The created SQL server information</returns>
     Task<SqlServer> CreateServerAsync(
@@ -261,7 +237,6 @@ public interface ISqlService
         string administratorPassword,
         string? version,
         string? publicNetworkAccess,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -270,7 +245,6 @@ public interface ISqlService
     /// <param name="serverName">The name of the SQL server</param>
     /// <param name="resourceGroup">The name of the resource group</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The SQL server information</returns>
     /// <exception cref="KeyNotFoundException">Thrown when the server is not found</exception>
@@ -278,7 +252,6 @@ public interface ISqlService
         string serverName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -286,13 +259,11 @@ public interface ISqlService
     /// </summary>
     /// <param name="resourceGroup">The name of the resource group</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A list of SQL servers</returns>
     Task<List<SqlServer>> ListServersAsync(
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -301,13 +272,11 @@ public interface ISqlService
     /// <param name="serverName">The name of the SQL server</param>
     /// <param name="resourceGroup">The name of the resource group</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy options</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>True if the server was successfully deleted</returns>
     Task<bool> DeleteServerAsync(
         string serverName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
+++ b/tools/Azure.Mcp.Tools.Sql/src/Services/SqlService.cs
@@ -9,7 +9,6 @@ using Azure.Mcp.Tools.Sql.Models;
 using Azure.ResourceManager.Sql;
 using Azure.ResourceManager.Sql.Models;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Options;
 using DatabaseReadScaleOption = Azure.Mcp.Tools.Sql.Options.Database.DatabaseReadScale;
 using SdkDatabaseReadScale = Azure.ResourceManager.Sql.Models.DatabaseReadScale;
 
@@ -26,17 +25,15 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// behavior for ID-based callers.
     /// </summary>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy configuration</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>The resolved subscription ID</returns>
     private async Task<string> ResolveSubscriptionIdAsync(
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken)
     {
         return AzureService.IsSubscriptionId(subscription)
             ? subscription
-            : await AzureService.GetSubscriptionIdByName(subscription, null, retryPolicy, cancellationToken);
+            : await AzureService.GetSubscriptionIdByName(subscription, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -45,17 +42,15 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="serverName">The name of the SQL server</param>
     /// <param name="resourceGroup">The name of the resource group containing the server</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy configuration</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>The SQL Server resource</returns>
     private async Task<SqlServerResource> GetSqlServerResourceAsync(
         string serverName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
-        var subscriptionResource = await AzureService.GetSubscription(subscription, null, retryPolicy, cancellationToken);
+        var subscriptionResource = await AzureService.GetSubscription(subscription, cancellationToken: cancellationToken);
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
 
         return await resourceGroupResource.Value.GetSqlServers().GetAsync(serverName, cancellationToken: cancellationToken);
@@ -68,7 +63,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="databaseName">The name of the database to retrieve</param>
     /// <param name="resourceGroup">The name of the resource group containing the server</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>The SQL database if found, otherwise throws KeyNotFoundException</returns>
     /// <exception cref="KeyNotFoundException">Thrown when the specified database is not found</exception>
@@ -78,7 +72,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string databaseName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -89,8 +82,8 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
 
         try
         {
-            var subscriptionId = await ResolveSubscriptionIdAsync(subscription, retryPolicy, cancellationToken);
-            var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscriptionId, retryPolicy, cancellationToken);
+            var subscriptionId = await ResolveSubscriptionIdAsync(subscription, cancellationToken);
+            var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscriptionId, cancellationToken);
             var databaseResource = await sqlServerResource.GetSqlDatabases().GetAsync(databaseName, cancellationToken);
 
             return ConvertToSqlDatabaseModel(databaseResource.Value);
@@ -116,7 +109,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="elasticPoolName">Optional elastic pool name to assign the database to</param>
     /// <param name="zoneRedundant">Optional zone redundancy setting</param>
     /// <param name="readScale">Optional read scale setting</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>The created SQL database information</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
@@ -133,7 +125,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string? elasticPoolName = null,
         bool? zoneRedundant = null,
         DatabaseReadScaleOption? readScale = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -142,7 +133,7 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
             (nameof(subscription), subscription),
             (nameof(databaseName), databaseName));
 
-        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, retryPolicy, cancellationToken);
+        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, cancellationToken);
         var databaseData = new SqlDatabaseData(sqlServerResource.Data.Location);
 
         // Configure SKU if provided
@@ -220,7 +211,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="elasticPoolName">Optional elastic pool name to assign the database to</param>
     /// <param name="zoneRedundant">Optional zone redundancy setting</param>
     /// <param name="readScale">Optional read scale setting</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>The updated SQL database information</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
@@ -237,7 +227,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string? elasticPoolName = null,
         bool? zoneRedundant = null,
         DatabaseReadScaleOption? readScale = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -246,7 +235,7 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
             (nameof(subscription), subscription),
             (nameof(databaseName), databaseName));
 
-        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, retryPolicy, cancellationToken);
+        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, cancellationToken);
         var databaseResource = await sqlServerResource.GetSqlDatabases().GetAsync(databaseName, cancellationToken);
         var databaseData = databaseResource.Value.Data;
 
@@ -324,7 +313,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="newDatabaseName">The desired new database name</param>
     /// <param name="resourceGroup">The name of the resource group containing the server</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>The renamed SQL database information</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
@@ -334,7 +322,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string newDatabaseName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -344,9 +331,9 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
             (nameof(subscription), subscription),
             (nameof(newDatabaseName), newDatabaseName));
 
-        var subscriptionResource = await AzureService.GetSubscription(subscription, null, retryPolicy, cancellationToken);
+        var subscriptionResource = await AzureService.GetSubscription(subscription, cancellationToken: cancellationToken);
         var subscriptionId = subscriptionResource.Data.SubscriptionId;
-        var armClient = await CreateArmClientAsync(null, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(cancellationToken: cancellationToken);
         var currentDatabaseId = SqlDatabaseResource.CreateResourceIdentifier(
             subscriptionId,
             resourceGroup,
@@ -377,7 +364,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="serverName">The name of the SQL server to list databases from</param>
     /// <param name="resourceGroup">The name of the resource group containing the server</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>A list of SQL databases on the specified server</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
@@ -385,7 +371,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string serverName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -393,8 +378,8 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var subscriptionId = await ResolveSubscriptionIdAsync(subscription, retryPolicy, cancellationToken);
-        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscriptionId, retryPolicy, cancellationToken);
+        var subscriptionId = await ResolveSubscriptionIdAsync(subscription, cancellationToken);
+        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscriptionId, cancellationToken);
         var databases = new List<SqlDatabase>();
 
         await foreach (var database in sqlServerResource.GetSqlDatabases().GetAllAsync(cancellationToken: cancellationToken))
@@ -416,7 +401,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="serverName">The name of the SQL server to get administrators for</param>
     /// <param name="resourceGroup">The name of the resource group containing the server</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>A list of Entra ID administrators configured for the SQL server</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
@@ -424,7 +408,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string serverName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -432,7 +415,7 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, retryPolicy, cancellationToken);
+        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, cancellationToken);
         var administrators = new List<SqlServerEntraAdministrator>();
 
         await foreach (var admin in sqlServerResource.GetSqlServerAzureADAdministrators().GetAllAsync(cancellationToken))
@@ -463,7 +446,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="serverName">The name of the SQL server to get elastic pools from</param>
     /// <param name="resourceGroup">The name of the resource group containing the server</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>A list of elastic pools configured on the SQL server</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
@@ -471,7 +453,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string serverName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -479,8 +460,8 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var subscriptionId = await ResolveSubscriptionIdAsync(subscription, retryPolicy, cancellationToken);
-        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscriptionId, retryPolicy, cancellationToken);
+        var subscriptionId = await ResolveSubscriptionIdAsync(subscription, cancellationToken);
+        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscriptionId, cancellationToken);
         var elasticPools = new List<SqlElasticPool>();
 
         await foreach (var elasticPool in sqlServerResource.GetElasticPools().GetAllAsync(cancellationToken: cancellationToken))
@@ -502,7 +483,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="serverName">The name of the SQL server to get firewall rules for</param>
     /// <param name="resourceGroup">The name of the resource group containing the server</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>A list of firewall rules configured on the SQL server</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
@@ -510,7 +490,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string serverName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -518,7 +497,7 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, retryPolicy, cancellationToken);
+        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, cancellationToken);
         var firewallRules = new List<SqlServerFirewallRule>();
 
         await foreach (var firewallRule in sqlServerResource.GetSqlFirewallRules().GetAllAsync(cancellationToken))
@@ -549,7 +528,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="firewallRuleName">The name of the firewall rule to create</param>
     /// <param name="startIpAddress">The start IP address of the firewall rule range</param>
     /// <param name="endIpAddress">The end IP address of the firewall rule range</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>The created firewall rule</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
@@ -560,7 +538,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string firewallRuleName,
         string startIpAddress,
         string endIpAddress,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -571,7 +548,7 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
             (nameof(startIpAddress), startIpAddress),
             (nameof(endIpAddress), endIpAddress));
 
-        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, retryPolicy, cancellationToken);
+        var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, cancellationToken);
         var firewallRuleData = new SqlFirewallRuleData()
         {
             StartIPAddress = startIpAddress,
@@ -603,7 +580,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="resourceGroup">The name of the resource group containing the server</param>
     /// <param name="subscription">The subscription ID or name</param>
     /// <param name="firewallRuleName">The name of the firewall rule to delete</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>True if the firewall rule was successfully deleted</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
@@ -612,7 +588,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string resourceGroup,
         string subscription,
         string firewallRuleName,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
@@ -623,7 +598,7 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
 
         try
         {
-            var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, retryPolicy, cancellationToken);
+            var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, cancellationToken);
             var firewallRuleResource = await sqlServerResource.GetSqlFirewallRules().GetAsync(firewallRuleName, cancellationToken);
             var deleteOperation = await firewallRuleResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
 
@@ -657,7 +632,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="administratorPassword">The administrator password for the SQL server</param>
     /// <param name="version">The version of SQL Server to create (optional, defaults to latest)</param>
     /// <param name="publicNetworkAccess">Whether public network access is enabled (optional)</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>The created SQL server</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
@@ -670,7 +644,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string administratorPassword,
         string? version,
         string? publicNetworkAccess,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken)
     {
         ValidateRequiredParameters(
@@ -682,7 +655,7 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
             (nameof(administratorPassword), administratorPassword));
 
         // Resolve the subscription (supports both subscription IDs and names) before navigating to the resource group
-        var subscriptionResource = await AzureService.GetSubscription(subscription, null, retryPolicy, cancellationToken);
+        var subscriptionResource = await AzureService.GetSubscription(subscription, cancellationToken: cancellationToken);
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serverData = new SqlServerData(location)
         {
@@ -725,7 +698,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="serverName">The name of the SQL server</param>
     /// <param name="resourceGroup">The name of the resource group containing the server</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>The SQL server if found, otherwise throws KeyNotFoundException</returns>
     /// <exception cref="KeyNotFoundException">Thrown when the specified server is not found</exception>
@@ -734,7 +706,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string serverName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -742,7 +713,7 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var server = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, retryPolicy, cancellationToken);
+        var server = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, cancellationToken);
         var tags = server.Data.Tags?.ToDictionary() ?? [];
 
         return new(
@@ -763,21 +734,19 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// </summary>
     /// <param name="resourceGroup">The name of the resource group containing the servers</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>A list of SQL servers found in the specified resource group</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
     public async Task<List<SqlServer>> ListServersAsync(
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
             (nameof(resourceGroup), resourceGroup),
             (nameof(subscription), subscription));
 
-        var subscriptionResource = await AzureService.GetSubscription(subscription, null, retryPolicy, cancellationToken);
+        var subscriptionResource = await AzureService.GetSubscription(subscription, cancellationToken: cancellationToken);
 
         ResourceManager.Resources.ResourceGroupResource resourceGroupResource;
 
@@ -808,7 +777,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string serverName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -818,7 +786,7 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
 
         try
         {
-            var serverResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, retryPolicy, cancellationToken);
+            var serverResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, cancellationToken);
             var operation = await serverResource.DeleteAsync(WaitUntil.Started, cancellationToken);
 
             await WaitForLroCompletionAsync(operation, cancellationToken);
@@ -841,7 +809,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
     /// <param name="databaseName">The name of the database to delete</param>
     /// <param name="resourceGroup">The name of the resource group containing the server</param>
     /// <param name="subscription">The subscription ID or name</param>
-    /// <param name="retryPolicy">Optional retry policy configuration for resilient operations</param>
     /// <param name="cancellationToken">Token to observe for cancellation requests</param>
     /// <returns>True if the database was successfully deleted</returns>
     /// <exception cref="ArgumentException">Thrown when required parameters are null or empty</exception>
@@ -850,7 +817,6 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
         string databaseName,
         string resourceGroup,
         string subscription,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -861,7 +827,7 @@ public class SqlService(IAzureService azureService, ILogger<SqlService> logger)
 
         try
         {
-            var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, retryPolicy, cancellationToken);
+            var sqlServerResource = await GetSqlServerResourceAsync(serverName, resourceGroup, subscription, cancellationToken);
             var databaseResource = await sqlServerResource.GetSqlDatabases().GetAsync(databaseName, cancellationToken);
             var deleteOperation = await databaseResource.Value.DeleteAsync(WaitUntil.Started, cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Database/DatabaseCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Database/DatabaseCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Sql.Commands.Database;
 using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Options.Database;
 using Azure.Mcp.Tools.Sql.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -59,7 +58,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -112,7 +110,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Is(true),
             Arg.Is(DatabaseReadScale.Disabled),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -171,7 +168,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -206,7 +202,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(conflictException);
 
@@ -240,7 +235,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
@@ -274,7 +268,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(authException);
 
@@ -308,7 +301,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(badRequestException);
 
@@ -366,7 +358,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
                 Arg.Any<string?>(),
                 Arg.Any<bool?>(),
                 Arg.Any<DatabaseReadScale?>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(mockDatabase);
         }
@@ -424,7 +415,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -455,7 +445,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -494,7 +483,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -527,7 +515,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -566,7 +553,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -599,7 +585,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -638,7 +623,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -671,7 +655,6 @@ public class DatabaseCreateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Database/DatabaseDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Database/DatabaseDeleteCommandTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Sql.Commands.Database;
 using Azure.Mcp.Tools.Sql.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,6 @@ public class DatabaseDeleteCommandTests : SubscriptionCommandUnitTestsBase<Datab
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(true);
         }
@@ -75,7 +73,6 @@ public class DatabaseDeleteCommandTests : SubscriptionCommandUnitTestsBase<Datab
             "db1",
             "rg1",
             "sub1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -98,7 +95,6 @@ public class DatabaseDeleteCommandTests : SubscriptionCommandUnitTestsBase<Datab
             "missingdb",
             "rg1",
             "sub1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(false);
 
@@ -121,7 +117,6 @@ public class DatabaseDeleteCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -145,7 +140,6 @@ public class DatabaseDeleteCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestFailed);
 
@@ -168,7 +162,6 @@ public class DatabaseDeleteCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestFailed);
 
@@ -195,7 +188,6 @@ public class DatabaseDeleteCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -210,36 +202,6 @@ public class DatabaseDeleteCommandTests : SubscriptionCommandUnitTestsBase<Datab
             database,
             resourceGroup,
             subscription,
-            Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_WithRetryPolicyOptions()
-    {
-        Service.DeleteDatabaseAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(true);
-
-        var response = await ExecuteCommandAsync(
-            "--subscription", "sub1",
-            "--resource-group", "rg1",
-            "--server", "server1",
-            "--database", "db1",
-            "--retry-max-retries", "5");
-
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        await Service.Received(1).DeleteDatabaseAsync(
-            "server1",
-            "db1",
-            "rg1",
-            "sub1",
-            Arg.Is<RetryPolicyOptions?>(r => r != null && r.MaxRetries == 5),
             Arg.Any<CancellationToken>());
     }
 
@@ -256,7 +218,6 @@ public class DatabaseDeleteCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -272,7 +233,6 @@ public class DatabaseDeleteCommandTests : SubscriptionCommandUnitTestsBase<Datab
             dbName,
             "rg1",
             "sub1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -285,7 +245,6 @@ public class DatabaseDeleteCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(argumentException);
 
@@ -307,7 +266,6 @@ public class DatabaseDeleteCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Database/DatabaseGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Database/DatabaseGetCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Sql.Commands.Database;
 using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -34,7 +33,6 @@ public class DatabaseGetCommandTests : SubscriptionCommandUnitTestsBase<Database
             Arg.Is("testdb"),
             Arg.Is("rg"),
             Arg.Is("sub"),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -50,8 +48,8 @@ public class DatabaseGetCommandTests : SubscriptionCommandUnitTestsBase<Database
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
         Assert.Equal("Success", response.Message);
-        await Service.Received(1).GetDatabaseAsync("server1", "testdb", "rg", "sub", Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
-        await Service.DidNotReceive().ListDatabasesAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).GetDatabaseAsync("server1", "testdb", "rg", "sub", Arg.Any<CancellationToken>());
+        await Service.DidNotReceive().ListDatabasesAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -64,7 +62,6 @@ public class DatabaseGetCommandTests : SubscriptionCommandUnitTestsBase<Database
             Arg.Is("server1"),
             Arg.Is("rg"),
             Arg.Is("sub"),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabases);
 
@@ -79,8 +76,8 @@ public class DatabaseGetCommandTests : SubscriptionCommandUnitTestsBase<Database
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
         Assert.Equal("Success", response.Message);
-        await Service.Received(1).ListDatabasesAsync("server1", "rg", "sub", Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
-        await Service.DidNotReceive().GetDatabaseAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListDatabasesAsync("server1", "rg", "sub", Arg.Any<CancellationToken>());
+        await Service.DidNotReceive().GetDatabaseAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -91,7 +88,6 @@ public class DatabaseGetCommandTests : SubscriptionCommandUnitTestsBase<Database
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -117,7 +113,6 @@ public class DatabaseGetCommandTests : SubscriptionCommandUnitTestsBase<Database
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
@@ -142,7 +137,6 @@ public class DatabaseGetCommandTests : SubscriptionCommandUnitTestsBase<Database
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(authException);
 
@@ -169,10 +163,10 @@ public class DatabaseGetCommandTests : SubscriptionCommandUnitTestsBase<Database
         if (shouldSucceed)
         {
             Service
-                .ListDatabasesAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                .ListDatabasesAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(new List<SqlDatabase>());
             Service
-                .GetDatabaseAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                .GetDatabaseAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(CreateMockDatabase("db1"));
         }
 

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Database/DatabaseRenameCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Database/DatabaseRenameCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Sql.Commands.Database;
 using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -51,7 +50,6 @@ public class DatabaseRenameCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Is("newdb"), // Verify new-database-name is correctly bound (not null)
             Arg.Is("rg"),
             Arg.Is("sub"),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -74,7 +72,6 @@ public class DatabaseRenameCommandTests : SubscriptionCommandUnitTestsBase<Datab
             "newdb",
             "rg",
             "sub",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -118,7 +115,6 @@ public class DatabaseRenameCommandTests : SubscriptionCommandUnitTestsBase<Datab
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(mockDatabase);
         }
@@ -152,7 +148,6 @@ public class DatabaseRenameCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
@@ -180,7 +175,6 @@ public class DatabaseRenameCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(conflictException);
 
@@ -209,7 +203,6 @@ public class DatabaseRenameCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(badRequestException);
 
@@ -236,7 +229,6 @@ public class DatabaseRenameCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Unexpected error"));
 
@@ -282,7 +274,6 @@ public class DatabaseRenameCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Is("newdb"),
             Arg.Is("rg"),
             Arg.Is("env-sub-id"),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Database/DatabaseUpdateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Database/DatabaseUpdateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Sql.Commands.Database;
 using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Options.Database;
 using Azure.Mcp.Tools.Sql.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -59,7 +58,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Is(true),
             Arg.Is(DatabaseReadScale.Disabled),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -118,7 +116,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -153,7 +150,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
@@ -187,7 +183,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(badRequestException);
 
@@ -248,7 +243,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
                 Arg.Any<string?>(),
                 Arg.Any<bool?>(),
                 Arg.Any<DatabaseReadScale?>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(mockDatabase);
         }
@@ -306,7 +300,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Is((string?)null), // ElasticPoolName
             Arg.Is((bool?)null),   // ZoneRedundant
             Arg.Is((DatabaseReadScale?)null), // ReadScale
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -337,7 +330,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             (string?)null, // ElasticPoolName
             (bool?)null, // ZoneRedundant
             (DatabaseReadScale?)null, // ReadScale
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -381,7 +373,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -429,7 +420,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -463,7 +453,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException("Invalid server name"));
 
@@ -497,7 +486,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(authException);
 
@@ -548,7 +536,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -602,7 +589,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -656,7 +642,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -710,7 +695,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -764,7 +748,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 
@@ -818,7 +801,6 @@ public class DatabaseUpdateCommandTests : SubscriptionCommandUnitTestsBase<Datab
             Arg.Any<string?>(),
             Arg.Any<bool?>(),
             Arg.Any<DatabaseReadScale?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockDatabase);
 

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/ElasticPool/ElasticPoolListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/ElasticPool/ElasticPoolListCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Sql.Commands.ElasticPool;
 using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -52,7 +51,6 @@ public class ElasticPoolListCommandTests : SubscriptionCommandUnitTestsBase<Elas
             Arg.Is("server1"),
             Arg.Is("rg"),
             Arg.Is("sub"),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockElasticPools);
 
@@ -79,7 +77,6 @@ public class ElasticPoolListCommandTests : SubscriptionCommandUnitTestsBase<Elas
             Arg.Is("server1"),
             Arg.Is("rg"),
             Arg.Is("sub"),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockElasticPools);
 
@@ -104,7 +101,6 @@ public class ElasticPoolListCommandTests : SubscriptionCommandUnitTestsBase<Elas
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -129,7 +125,6 @@ public class ElasticPoolListCommandTests : SubscriptionCommandUnitTestsBase<Elas
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 
@@ -153,7 +148,6 @@ public class ElasticPoolListCommandTests : SubscriptionCommandUnitTestsBase<Elas
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 
@@ -183,7 +177,6 @@ public class ElasticPoolListCommandTests : SubscriptionCommandUnitTestsBase<Elas
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new List<SqlElasticPool>());
         }

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/EntraAdmin/EntraAdminListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/EntraAdmin/EntraAdminListCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Sql.Commands.EntraAdmin;
 using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -38,7 +37,6 @@ public class EntraAdminListCommandTests : SubscriptionCommandUnitTestsBase<Entra
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns([]);
         }
@@ -73,7 +71,6 @@ public class EntraAdminListCommandTests : SubscriptionCommandUnitTestsBase<Entra
             "testserver",
             "testrg",
             "testsub",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(administrators);
 
@@ -97,7 +94,6 @@ public class EntraAdminListCommandTests : SubscriptionCommandUnitTestsBase<Entra
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -121,7 +117,6 @@ public class EntraAdminListCommandTests : SubscriptionCommandUnitTestsBase<Entra
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -146,7 +141,6 @@ public class EntraAdminListCommandTests : SubscriptionCommandUnitTestsBase<Entra
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 
@@ -170,7 +164,6 @@ public class EntraAdminListCommandTests : SubscriptionCommandUnitTestsBase<Entra
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/FirewallRule/FirewallRuleCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/FirewallRule/FirewallRuleCreateCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Sql.Commands.FirewallRule;
 using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -50,7 +49,6 @@ public class FirewallRuleCreateCommandTests : SubscriptionCommandUnitTestsBase<F
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(expectedFirewallRule);
         }
@@ -88,7 +86,6 @@ public class FirewallRuleCreateCommandTests : SubscriptionCommandUnitTestsBase<F
             "TestRule",
             "192.168.1.1",
             "192.168.1.255",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedFirewallRule);
 
@@ -118,7 +115,6 @@ public class FirewallRuleCreateCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -149,7 +145,6 @@ public class FirewallRuleCreateCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 
@@ -179,7 +174,6 @@ public class FirewallRuleCreateCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 
@@ -209,7 +203,6 @@ public class FirewallRuleCreateCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 
@@ -239,7 +232,6 @@ public class FirewallRuleCreateCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(argumentException);
 
@@ -282,7 +274,6 @@ public class FirewallRuleCreateCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedFirewallRule);
 
@@ -303,55 +294,6 @@ public class FirewallRuleCreateCommandTests : SubscriptionCommandUnitTestsBase<F
             ruleName,
             startIp,
             endIp,
-            Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_WithRetryPolicyOptions()
-    {
-        // Arrange
-        var expectedFirewallRule = new SqlServerFirewallRule(
-            "TestRule",
-            "/subscriptions/testsub/resourceGroups/testrg/providers/Microsoft.Sql/servers/testserver/firewallRules/TestRule",
-            "Microsoft.Sql/servers/firewallRules",
-            "192.168.1.1",
-            "192.168.1.255");
-
-        Service.CreateFirewallRuleAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(expectedFirewallRule);
-
-        // Act
-        var response = await ExecuteCommandAsync(
-            "--subscription", "testsub",
-            "--resource-group", "testrg",
-            "--server", "testserver",
-            "--firewall-rule-name", "TestRule",
-            "--start-ip-address", "192.168.1.1",
-            "--end-ip-address", "192.168.1.255",
-            "--retry-max-retries", "3");
-
-        // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        // Verify the service was called with retry policy
-        await Service.Received(1).CreateFirewallRuleAsync(
-            "testserver",
-            "testrg",
-            "testsub",
-            "TestRule",
-            "192.168.1.1",
-            "192.168.1.255",
-            Arg.Is<RetryPolicyOptions?>(r => r != null && r.MaxRetries == 3),
             Arg.Any<CancellationToken>());
     }
 
@@ -376,7 +318,6 @@ public class FirewallRuleCreateCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedFirewallRule);
 
@@ -419,7 +360,7 @@ public class FirewallRuleCreateCommandTests : SubscriptionCommandUnitTestsBase<F
         Assert.Contains("IP address format", response.Message);
 
         // Verify service was never called due to validation failure
-        await Service.DidNotReceive().CreateFirewallRuleAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.DidNotReceive().CreateFirewallRuleAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -442,7 +383,7 @@ public class FirewallRuleCreateCommandTests : SubscriptionCommandUnitTestsBase<F
         Assert.Contains("security", response.Message);
 
         // Verify service was never called due to validation failure
-        await Service.DidNotReceive().CreateFirewallRuleAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.DidNotReceive().CreateFirewallRuleAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
 
     }
 

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/FirewallRule/FirewallRuleDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/FirewallRule/FirewallRuleDeleteCommandTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Sql.Commands.FirewallRule;
 using Azure.Mcp.Tools.Sql.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,6 @@ public class FirewallRuleDeleteCommandTests : SubscriptionCommandUnitTestsBase<F
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(true);
         }
@@ -76,7 +74,6 @@ public class FirewallRuleDeleteCommandTests : SubscriptionCommandUnitTestsBase<F
             "testrg",
             "testsub",
             "TestRule",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -102,7 +99,6 @@ public class FirewallRuleDeleteCommandTests : SubscriptionCommandUnitTestsBase<F
             "testrg",
             "testsub",
             "NonExistentRule",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(false);
 
@@ -128,7 +124,6 @@ public class FirewallRuleDeleteCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -155,7 +150,6 @@ public class FirewallRuleDeleteCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 
@@ -181,7 +175,6 @@ public class FirewallRuleDeleteCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 
@@ -211,7 +204,6 @@ public class FirewallRuleDeleteCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -228,42 +220,6 @@ public class FirewallRuleDeleteCommandTests : SubscriptionCommandUnitTestsBase<F
             resourceGroup,
             subscription,
             ruleName,
-            Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_WithRetryPolicyOptions()
-    {
-        // Arrange
-        Service.DeleteFirewallRuleAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(true);
-
-        // Act
-        var response = await ExecuteCommandAsync(
-            "--subscription", "testsub",
-            "--resource-group", "testrg",
-            "--server", "testserver",
-            "--firewall-rule-name", "TestRule",
-            "--retry-max-retries", "3");
-
-        // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        // Verify the service was called with retry policy
-        await Service.Received(1).DeleteFirewallRuleAsync(
-            "testserver",
-            "testrg",
-            "testsub",
-            "TestRule",
-            Arg.Is<RetryPolicyOptions?>(r => r != null && r.MaxRetries == 3),
             Arg.Any<CancellationToken>());
     }
 
@@ -281,7 +237,6 @@ public class FirewallRuleDeleteCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -302,7 +257,6 @@ public class FirewallRuleDeleteCommandTests : SubscriptionCommandUnitTestsBase<F
             "testrg",
             "testsub",
             ruleName,
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -316,7 +270,6 @@ public class FirewallRuleDeleteCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(argumentException);
 
@@ -342,7 +295,6 @@ public class FirewallRuleDeleteCommandTests : SubscriptionCommandUnitTestsBase<F
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/FirewallRule/FirewallRuleListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/FirewallRule/FirewallRuleListCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Sql.Commands.FirewallRule;
 using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -39,7 +38,6 @@ public class FirewallRuleListCommandTests : SubscriptionCommandUnitTestsBase<Fir
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns([]);
         }
@@ -75,7 +73,6 @@ public class FirewallRuleListCommandTests : SubscriptionCommandUnitTestsBase<Fir
             "testserver",
             "testrg",
             "testsub",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(firewallRules);
 
@@ -99,7 +96,6 @@ public class FirewallRuleListCommandTests : SubscriptionCommandUnitTestsBase<Fir
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -123,7 +119,6 @@ public class FirewallRuleListCommandTests : SubscriptionCommandUnitTestsBase<Fir
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -148,7 +143,6 @@ public class FirewallRuleListCommandTests : SubscriptionCommandUnitTestsBase<Fir
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 
@@ -172,7 +166,6 @@ public class FirewallRuleListCommandTests : SubscriptionCommandUnitTestsBase<Fir
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 
@@ -199,7 +192,6 @@ public class FirewallRuleListCommandTests : SubscriptionCommandUnitTestsBase<Fir
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -214,45 +206,7 @@ public class FirewallRuleListCommandTests : SubscriptionCommandUnitTestsBase<Fir
             serverName,
             resourceGroup,
             subscription,
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
-    [Fact]
-    public async Task ExecuteAsync_WithRetryPolicyOptions()
-    {
-        // Arrange
-        var firewallRules = new List<SqlServerFirewallRule>
-        {
-            new("TestRule", "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/servers/server/firewallRules/TestRule",
-                "Microsoft.Sql/servers/firewallRules", "10.0.0.1", "10.0.0.10")
-        };
-
-        Service.ListFirewallRulesAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(firewallRules);
-
-        // Act
-        var response = await ExecuteCommandAsync(
-            "--subscription", "testsub",
-            "--resource-group", "testrg",
-            "--server", "testserver",
-            "--retry-max-retries", "3");
-
-        // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        Assert.NotNull(response.Results);
-
-        // Verify the service was called with retry policy
-        await Service.Received(1).ListFirewallRulesAsync(
-            "testserver",
-            "testrg",
-            "testsub",
-            Arg.Is<RetryPolicyOptions?>(r => r != null && r.MaxRetries == 3),
-            Arg.Any<CancellationToken>());
-    }
 }

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Server/ServerCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Server/ServerCreateCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Sql.Commands.Server;
 using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -60,7 +59,6 @@ public class ServerCreateCommandTests : SubscriptionCommandUnitTestsBase<ServerC
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(expectedServer);
         }
@@ -106,7 +104,6 @@ public class ServerCreateCommandTests : SubscriptionCommandUnitTestsBase<ServerC
             "Password123!",
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedServer);
 
@@ -133,7 +130,6 @@ public class ServerCreateCommandTests : SubscriptionCommandUnitTestsBase<ServerC
             "Password123!",
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -163,7 +159,6 @@ public class ServerCreateCommandTests : SubscriptionCommandUnitTestsBase<ServerC
             "Password123!",
             "12.0",
             "Disabled",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedServer);
 
@@ -191,7 +186,6 @@ public class ServerCreateCommandTests : SubscriptionCommandUnitTestsBase<ServerC
             "Password123!",
             "12.0",
             "Disabled",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -222,7 +216,6 @@ public class ServerCreateCommandTests : SubscriptionCommandUnitTestsBase<ServerC
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedServer);
 
@@ -249,7 +242,6 @@ public class ServerCreateCommandTests : SubscriptionCommandUnitTestsBase<ServerC
             "Password123!",
             Arg.Is<string?>(v => v == null), // version not specified
             Arg.Is<string?>(p => p == null), // publicNetworkAccess not specified; service defaults to Disabled
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -266,7 +258,6 @@ public class ServerCreateCommandTests : SubscriptionCommandUnitTestsBase<ServerC
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException("Invalid value 'Enabeld' for public-network-access. Allowed values are 'Enabled' or 'Disabled'.", "publicNetworkAccess"));
 
@@ -298,7 +289,6 @@ public class ServerCreateCommandTests : SubscriptionCommandUnitTestsBase<ServerC
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -331,7 +321,6 @@ public class ServerCreateCommandTests : SubscriptionCommandUnitTestsBase<ServerC
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Server/ServerDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Server/ServerDeleteCommandTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Sql.Commands.Server;
 using Azure.Mcp.Tools.Sql.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -39,7 +38,6 @@ public class ServerDeleteCommandTests : SubscriptionCommandUnitTestsBase<ServerD
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(true);
         }
@@ -82,7 +80,6 @@ public class ServerDeleteCommandTests : SubscriptionCommandUnitTestsBase<ServerD
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -96,7 +93,7 @@ public class ServerDeleteCommandTests : SubscriptionCommandUnitTestsBase<ServerD
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
-        await Service.Received(1).DeleteServerAsync("testserver", "rg", "sub", Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).DeleteServerAsync("testserver", "rg", "sub", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -107,7 +104,6 @@ public class ServerDeleteCommandTests : SubscriptionCommandUnitTestsBase<ServerD
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(false);
 
@@ -131,7 +127,6 @@ public class ServerDeleteCommandTests : SubscriptionCommandUnitTestsBase<ServerD
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -157,7 +152,6 @@ public class ServerDeleteCommandTests : SubscriptionCommandUnitTestsBase<ServerD
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 
@@ -183,7 +177,6 @@ public class ServerDeleteCommandTests : SubscriptionCommandUnitTestsBase<ServerD
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(requestException);
 

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Server/ServerGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Server/ServerGetCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Sql.Commands.Server;
 using Azure.Mcp.Tools.Sql.Models;
 using Azure.Mcp.Tools.Sql.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -34,7 +33,6 @@ public class ServerGetCommandTests : SubscriptionCommandUnitTestsBase<ServerGetC
             Arg.Is("server1"),
             Arg.Is("rg"),
             Arg.Is("sub"),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockServer);
 
@@ -49,8 +47,8 @@ public class ServerGetCommandTests : SubscriptionCommandUnitTestsBase<ServerGetC
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
         Assert.Equal("Success", response.Message);
-        await Service.Received(1).GetServerAsync("server1", "rg", "sub", Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
-        await Service.DidNotReceive().ListServersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).GetServerAsync("server1", "rg", "sub", Arg.Any<CancellationToken>());
+        await Service.DidNotReceive().ListServersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -62,7 +60,6 @@ public class ServerGetCommandTests : SubscriptionCommandUnitTestsBase<ServerGetC
         Service.ListServersAsync(
             Arg.Is("rg"),
             Arg.Is("sub"),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(mockServers);
 
@@ -74,8 +71,8 @@ public class ServerGetCommandTests : SubscriptionCommandUnitTestsBase<ServerGetC
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
         Assert.Equal("Success", response.Message);
-        await Service.Received(1).ListServersAsync("rg", "sub", Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
-        await Service.DidNotReceive().GetServerAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListServersAsync("rg", "sub", Arg.Any<CancellationToken>());
+        await Service.DidNotReceive().GetServerAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -85,7 +82,6 @@ public class ServerGetCommandTests : SubscriptionCommandUnitTestsBase<ServerGetC
         Service.ListServersAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -107,7 +103,6 @@ public class ServerGetCommandTests : SubscriptionCommandUnitTestsBase<ServerGetC
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
@@ -130,7 +125,6 @@ public class ServerGetCommandTests : SubscriptionCommandUnitTestsBase<ServerGetC
         Service.ListServersAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(authException);
 
@@ -153,10 +147,10 @@ public class ServerGetCommandTests : SubscriptionCommandUnitTestsBase<ServerGetC
         if (shouldSucceed)
         {
             Service
-                .ListServersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                .ListServersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns([]);
             Service
-                .GetServerAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+                .GetServerAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(CreateMockServer("server1"));
         }
 

--- a/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Services/SqlServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Sql/tests/Azure.Mcp.Tools.Sql.Tests/Services/SqlServiceTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.Sql.Services;
 using Azure.ResourceManager;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Azure.Authentication;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -50,7 +49,7 @@ public class SqlServiceTests
         _azureService.GetSubscription(
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
+            null,
                 Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException(SubscriptionResolvedMessage));
 
@@ -61,7 +60,7 @@ public class SqlServiceTests
     public async Task GetServerAsync_ResolvesSubscriptionThroughAzureService()
     {
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _service.GetServerAsync("server1", "rg", SubscriptionName, null, TestContext.Current.CancellationToken));
+            _service.GetServerAsync("server1", "rg", SubscriptionName, TestContext.Current.CancellationToken));
 
         Assert.Equal(SubscriptionResolvedMessage, ex.Message);
         await AssertSubscriptionResolvedAsync();
@@ -71,7 +70,7 @@ public class SqlServiceTests
     public async Task ListServersAsync_ResolvesSubscriptionThroughAzureService()
     {
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _service.ListServersAsync("rg", SubscriptionName, null, TestContext.Current.CancellationToken));
+            _service.ListServersAsync("rg", SubscriptionName, TestContext.Current.CancellationToken));
 
         Assert.Equal(SubscriptionResolvedMessage, ex.Message);
         await AssertSubscriptionResolvedAsync();
@@ -90,7 +89,6 @@ public class SqlServiceTests
                 "P@ssw0rd!",
                 null,
                 null,
-                null,
                 TestContext.Current.CancellationToken));
 
         Assert.Equal(SubscriptionResolvedMessage, ex.Message);
@@ -107,7 +105,6 @@ public class SqlServiceTests
                 "newdb",
                 "rg",
                 SubscriptionName,
-                null,
                 TestContext.Current.CancellationToken));
 
         Assert.Equal(SubscriptionResolvedMessage, ex.Message);
@@ -118,37 +115,37 @@ public class SqlServiceTests
         _azureService.Received(1).GetSubscription(
             SubscriptionName,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
+            null,
             Arg.Any<CancellationToken>());
 
     [Fact]
     public async Task ListDatabasesAsync_WithSubscriptionName_ResolvesNameToId()
     {
         _azureService.IsSubscriptionId(SubscriptionName).Returns(false);
-        _azureService.GetSubscriptionIdByName(SubscriptionName, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        _azureService.GetSubscriptionIdByName(SubscriptionName, Arg.Any<string?>(), null, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException(ResolveSentinel));
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.ListDatabasesAsync(ServerName, ResourceGroup, SubscriptionName, null, TestContext.Current.CancellationToken));
+            () => _service.ListDatabasesAsync(ServerName, ResourceGroup, SubscriptionName, TestContext.Current.CancellationToken));
 
         Assert.Equal(ResolveSentinel, exception.Message);
         await _azureService.Received(1).GetSubscriptionIdByName(
-            SubscriptionName, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            SubscriptionName, Arg.Any<string?>(), null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetElasticPoolsAsync_WithSubscriptionName_ResolvesNameToId()
     {
         _azureService.IsSubscriptionId(SubscriptionName).Returns(false);
-        _azureService.GetSubscriptionIdByName(SubscriptionName, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        _azureService.GetSubscriptionIdByName(SubscriptionName, Arg.Any<string?>(), null, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException(ResolveSentinel));
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.GetElasticPoolsAsync(ServerName, ResourceGroup, SubscriptionName, null, TestContext.Current.CancellationToken));
+            () => _service.GetElasticPoolsAsync(ServerName, ResourceGroup, SubscriptionName, TestContext.Current.CancellationToken));
 
         Assert.Equal(ResolveSentinel, exception.Message);
         await _azureService.Received(1).GetSubscriptionIdByName(
-            SubscriptionName, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            SubscriptionName, Arg.Any<string?>(), null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -159,7 +156,7 @@ public class SqlServiceTests
 
         try
         {
-            await _service.ListDatabasesAsync(ServerName, ResourceGroup, SubscriptionId, null, canceled);
+            await _service.ListDatabasesAsync(ServerName, ResourceGroup, SubscriptionId, canceled);
         }
         catch
         {
@@ -167,7 +164,7 @@ public class SqlServiceTests
         }
 
         await _azureService.DidNotReceive().GetSubscriptionIdByName(
-            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string?>(), null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -178,7 +175,7 @@ public class SqlServiceTests
 
         try
         {
-            await _service.GetElasticPoolsAsync(ServerName, ResourceGroup, SubscriptionId, null, canceled);
+            await _service.GetElasticPoolsAsync(ServerName, ResourceGroup, SubscriptionId, canceled);
         }
         catch
         {
@@ -186,22 +183,22 @@ public class SqlServiceTests
         }
 
         await _azureService.DidNotReceive().GetSubscriptionIdByName(
-            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string?>(), null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetDatabaseAsync_WithSubscriptionName_ResolvesNameToId()
     {
         _azureService.IsSubscriptionId(SubscriptionName).Returns(false);
-        _azureService.GetSubscriptionIdByName(SubscriptionName, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        _azureService.GetSubscriptionIdByName(SubscriptionName, Arg.Any<string?>(), null, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException(ResolveSentinel));
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _service.GetDatabaseAsync(ServerName, DatabaseName, ResourceGroup, SubscriptionName, null, TestContext.Current.CancellationToken));
+            () => _service.GetDatabaseAsync(ServerName, DatabaseName, ResourceGroup, SubscriptionName, TestContext.Current.CancellationToken));
 
         Assert.Equal(ResolveSentinel, exception.Message);
         await _azureService.Received(1).GetSubscriptionIdByName(
-            SubscriptionName, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            SubscriptionName, Arg.Any<string?>(), null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -212,7 +209,7 @@ public class SqlServiceTests
 
         try
         {
-            await _service.GetDatabaseAsync(ServerName, DatabaseName, ResourceGroup, SubscriptionId, null, canceled);
+            await _service.GetDatabaseAsync(ServerName, DatabaseName, ResourceGroup, SubscriptionId, canceled);
         }
         catch
         {
@@ -220,7 +217,7 @@ public class SqlServiceTests
         }
 
         await _azureService.DidNotReceive().GetSubscriptionIdByName(
-            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string?>(), null, Arg.Any<CancellationToken>());
     }
 
 }

--- a/tools/Azure.Mcp.Tools.SreAgent/src/Commands/Agents/AgentsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/src/Commands/Agents/AgentsGetCommand.cs
@@ -38,7 +38,6 @@ public sealed class AgentsGetCommand(ILogger<AgentsGetCommand> logger, ISreAgent
                 options.ResourceGroup,
                 options.Agent,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             if (agent is null)

--- a/tools/Azure.Mcp.Tools.SreAgent/src/Commands/Agents/AgentsListCommand.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/src/Commands/Agents/AgentsListCommand.cs
@@ -41,7 +41,6 @@ public sealed class AgentsListCommand(ILogger<AgentsListCommand> logger, ISreAge
                 options.Subscription!,
                 options.ResourceGroup,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(agents), SreAgentJsonContext.Default.AgentsListCommandResult);

--- a/tools/Azure.Mcp.Tools.SreAgent/src/Commands/SreAgentCommandHelpers.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/src/Commands/SreAgentCommandHelpers.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.SreAgent.Commands;
 
@@ -17,7 +16,6 @@ internal static class SreAgentCommandHelpers
         string? resourceGroup,
         string agentName,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken)
     {
         var agent = await sreAgentService.GetAgentAsync(
@@ -25,7 +23,6 @@ internal static class SreAgentCommandHelpers
             resourceGroup,
             agentName,
             tenant,
-            retryPolicy,
             cancellationToken);
 
         if (agent is null)
@@ -55,7 +52,6 @@ internal static class SreAgentCommandHelpers
             options.ResourceGroup,
             options.Agent,
             options.Tenant,
-            options.RetryPolicy,
             cancellationToken);
     }
 
@@ -78,7 +74,6 @@ internal static class SreAgentCommandHelpers
             options.Subscription!,
             options.Agent,
             options.Tenant,
-            options.RetryPolicy,
             cancellationToken);
     }
 

--- a/tools/Azure.Mcp.Tools.SreAgent/src/Options/Agents/AgentsListOptions.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/src/Options/Agents/AgentsListOptions.cs
@@ -16,7 +16,4 @@ public sealed class AgentsListOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.ResourceGroup)]
     public string? ResourceGroup { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.SreAgent/src/Options/BaseSreAgentOptions.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/src/Options/BaseSreAgentOptions.cs
@@ -19,7 +19,4 @@ public class BaseSreAgentOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.ResourceGroup)]
     public string? ResourceGroup { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.SreAgent/src/Services/ISreAgentService.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/src/Services/ISreAgentService.cs
@@ -3,7 +3,6 @@
 
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options.Threads;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.SreAgent.Services;
 
@@ -16,7 +15,6 @@ public interface ISreAgentService
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -27,7 +25,6 @@ public interface ISreAgentService
         string? resourceGroup = null,
         string agentName = "",
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     #region Agents + Skills (sub-agent A)
@@ -93,7 +90,6 @@ public interface ISreAgentService
         string subscription,
         string agentName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<ConnectorTestResult> TestConnectorAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/src/Services/SreAgentService.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/src/Services/SreAgentService.cs
@@ -11,7 +11,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options.Threads;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Options;
 namespace Azure.Mcp.Tools.SreAgent.Services;
 
 /// <summary>
@@ -60,7 +59,6 @@ public sealed class SreAgentService(IAzureService azureService, ILogger<SreAgent
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
@@ -69,7 +67,7 @@ public sealed class SreAgentService(IAzureService azureService, ILogger<SreAgent
             SreAgentResourceType,
             resourceGroup,
             subscription,
-            retryPolicy,
+            null,
             ConvertToSreAgentResource,
             tenant: tenant,
             cancellationToken: cancellationToken);
@@ -82,7 +80,6 @@ public sealed class SreAgentService(IAzureService azureService, ILogger<SreAgent
         string? resourceGroup = null,
         string agentName = "",
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(subscription);
@@ -92,7 +89,7 @@ public sealed class SreAgentService(IAzureService azureService, ILogger<SreAgent
             SreAgentResourceType,
             resourceGroup,
             subscription,
-            retryPolicy,
+            null,
             ConvertToSreAgentResource,
             additionalFilter: $"name =~ '{EscapeKqlString(agentName)}'",
             tenant: tenant,
@@ -242,7 +239,6 @@ public sealed class SreAgentService(IAzureService azureService, ILogger<SreAgent
         string subscription,
         string agentName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(subscription);
@@ -250,10 +246,10 @@ public sealed class SreAgentService(IAzureService azureService, ILogger<SreAgent
 
         var agent = await ExecuteSingleResourceQueryAsync(
             SreAgentResourceType,
-            resourceGroup: null,
-            subscription: subscription,
-            retryPolicy: retryPolicy,
-            converter: ConvertToSreAgentResource,
+            null,
+            subscription,
+            null,
+            ConvertToSreAgentResource,
             additionalFilter: $"name =~ '{EscapeKqlString(agentName)}'",
             tenant: tenant,
             cancellationToken: cancellationToken);

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Agents/AgentsCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Agents/AgentsCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Agents;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -48,7 +47,7 @@ public class AgentsCreateCommandTests : SubscriptionCommandUnitTestsBase<AgentsC
     {
         if (shouldSucceed)
         {
-            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
             Service.CreateSubAgentAsync(
@@ -74,7 +73,7 @@ public class AgentsCreateCommandTests : SubscriptionCommandUnitTestsBase<AgentsC
     [Fact]
     public async Task ExecuteAsync_DeserializationValidation()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         var testAgent = new SreSubAgent { Name = "testsubagent", Properties = new SreSubAgentProperties { Instructions = "test" } };
@@ -96,7 +95,7 @@ public class AgentsCreateCommandTests : SubscriptionCommandUnitTestsBase<AgentsC
     [Fact]
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.CreateSubAgentAsync(Arg.Any<string>(), Arg.Any<SreSubAgentCreateRequest>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
@@ -111,7 +110,7 @@ public class AgentsCreateCommandTests : SubscriptionCommandUnitTestsBase<AgentsC
     [Fact]
     public async Task BindOptions_BindsOptionsCorrectly()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.CreateSubAgentAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Agents/AgentsDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Agents/AgentsDeleteCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Agents;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -45,7 +44,7 @@ public class AgentsDeleteCommandTests : SubscriptionCommandUnitTestsBase<AgentsD
     {
         if (shouldSucceed)
         {
-            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
             Service.DeleteSubAgentAsync(
@@ -71,7 +70,7 @@ public class AgentsDeleteCommandTests : SubscriptionCommandUnitTestsBase<AgentsD
     [Fact]
     public async Task ExecuteAsync_DeserializationValidation()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         var deleteResult = new SreAgentDeleteResult("testsubagent", "Agent", true);
@@ -93,7 +92,7 @@ public class AgentsDeleteCommandTests : SubscriptionCommandUnitTestsBase<AgentsD
     [Fact]
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.DeleteSubAgentAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
@@ -108,7 +107,7 @@ public class AgentsDeleteCommandTests : SubscriptionCommandUnitTestsBase<AgentsD
     [Fact]
     public async Task BindOptions_BindsOptionsCorrectly()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.DeleteSubAgentAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Agents/AgentsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Agents/AgentsGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Agents;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -42,7 +41,7 @@ public class AgentsGetCommandTests : SubscriptionCommandUnitTestsBase<AgentsGetC
     {
         if (shouldSucceed)
         {
-            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
         }
 
@@ -62,7 +61,7 @@ public class AgentsGetCommandTests : SubscriptionCommandUnitTestsBase<AgentsGetC
     public async Task ExecuteAsync_DeserializationValidation()
     {
         var testAgent = new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai", Location = "eastus2" };
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(testAgent);
 
         var response = await ExecuteCommandAsync("--subscription", "sub", "--agent", "myagent");
@@ -76,7 +75,7 @@ public class AgentsGetCommandTests : SubscriptionCommandUnitTestsBase<AgentsGetC
     [Fact]
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         var response = await ExecuteCommandAsync("--subscription", "sub", "--agent", "myagent");
@@ -88,7 +87,7 @@ public class AgentsGetCommandTests : SubscriptionCommandUnitTestsBase<AgentsGetC
     [Fact]
     public async Task BindOptions_BindsOptionsCorrectly()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent" });
 
         var response = await ExecuteCommandAsync("--subscription", "sub", "--agent", "myagent");
@@ -99,7 +98,6 @@ public class AgentsGetCommandTests : SubscriptionCommandUnitTestsBase<AgentsGetC
             Arg.Any<string?>(),
             "myagent",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Agents/AgentsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Agents/AgentsListCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Agents;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -35,7 +34,6 @@ public class AgentsListCommandTests : SubscriptionCommandUnitTestsBase<AgentsLis
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new List<SreAgentResource> { new() { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" } });
         }
@@ -63,7 +61,6 @@ public class AgentsListCommandTests : SubscriptionCommandUnitTestsBase<AgentsLis
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -76,7 +73,7 @@ public class AgentsListCommandTests : SubscriptionCommandUnitTestsBase<AgentsLis
     [Fact]
     public async Task ExecuteAsync_EmptyList_ReturnsEmptyResults()
     {
-        Service.ListAgentsAsync("sub", null, Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ListAgentsAsync("sub", null, Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new List<SreAgentResource>());
 
         var response = await ExecuteCommandAsync("--subscription", "sub");
@@ -88,12 +85,12 @@ public class AgentsListCommandTests : SubscriptionCommandUnitTestsBase<AgentsLis
     [Fact]
     public async Task ExecuteAsync_PassesResourceGroupAndTenant()
     {
-        Service.ListAgentsAsync("sub", "rg", "tenant", Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ListAgentsAsync("sub", "rg", "tenant", Arg.Any<CancellationToken>())
             .Returns(new List<SreAgentResource>());
 
         var response = await ExecuteCommandAsync("--subscription", "sub", "--resource-group", "rg", "--tenant", "tenant");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await Service.Received(1).ListAgentsAsync("sub", "rg", "tenant", Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListAgentsAsync("sub", "rg", "tenant", Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Agents/AgentsToolsCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Agents/AgentsToolsCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Agents;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,7 @@ public class AgentsToolsCreateCommandTests : SubscriptionCommandUnitTestsBase<Ag
     {
         if (shouldSucceed)
         {
-            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
             Service.CreateAgentToolAsync(
@@ -73,7 +72,7 @@ public class AgentsToolsCreateCommandTests : SubscriptionCommandUnitTestsBase<Ag
     [Fact]
     public async Task ExecuteAsync_DeserializationValidation()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         var testTool = new SreAgentTool { Name = "testtool", Properties = new SreAgentToolProperties { Type = "KustoTool" } };
@@ -95,7 +94,7 @@ public class AgentsToolsCreateCommandTests : SubscriptionCommandUnitTestsBase<Ag
     [Fact]
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.CreateAgentToolAsync(Arg.Any<string>(), Arg.Any<SreAgentToolCreateRequest>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
@@ -110,7 +109,7 @@ public class AgentsToolsCreateCommandTests : SubscriptionCommandUnitTestsBase<Ag
     [Fact]
     public async Task BindOptions_BindsOptionsCorrectly()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.CreateAgentToolAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Agents/AgentsToolsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Agents/AgentsToolsGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Agents;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -43,7 +42,7 @@ public class AgentsToolsGetCommandTests : SubscriptionCommandUnitTestsBase<Agent
     {
         if (shouldSucceed)
         {
-            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
             Service.GetAgentToolAsync(
@@ -69,7 +68,7 @@ public class AgentsToolsGetCommandTests : SubscriptionCommandUnitTestsBase<Agent
     [Fact]
     public async Task ExecuteAsync_DeserializationValidation()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         var testTool = new SreAgentTool { Name = "testtool", Properties = new SreAgentToolProperties { Type = "KustoTool" } };
@@ -91,7 +90,7 @@ public class AgentsToolsGetCommandTests : SubscriptionCommandUnitTestsBase<Agent
     [Fact]
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.GetAgentToolAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
@@ -106,7 +105,7 @@ public class AgentsToolsGetCommandTests : SubscriptionCommandUnitTestsBase<Agent
     [Fact]
     public async Task BindOptions_BindsOptionsCorrectly()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.GetAgentToolAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/CommonPrompts/CommonPromptsCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/CommonPrompts/CommonPromptsCreateCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.CommonPrompts;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,6 @@ public class CommonPromptsCreateCommandTests : SubscriptionCommandUnitTestsBase<
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
             Service.CreateOrUpdateCommonPromptAsync(
@@ -79,7 +77,6 @@ public class CommonPromptsCreateCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.CreateOrUpdateCommonPromptAsync(
@@ -104,7 +101,6 @@ public class CommonPromptsCreateCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.CreateOrUpdateCommonPromptAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/CommonPrompts/CommonPromptsDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/CommonPrompts/CommonPromptsDeleteCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.CommonPrompts;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -48,7 +47,6 @@ public class CommonPromptsDeleteCommandTests : SubscriptionCommandUnitTestsBase<
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
             Service.DeleteCommonPromptAsync(
@@ -79,7 +77,6 @@ public class CommonPromptsDeleteCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.DeleteCommonPromptAsync(
@@ -103,7 +100,6 @@ public class CommonPromptsDeleteCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
 
@@ -122,7 +118,6 @@ public class CommonPromptsDeleteCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.DeleteCommonPromptAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/CommonPrompts/CommonPromptsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/CommonPrompts/CommonPromptsGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.CommonPrompts;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,6 @@ public class CommonPromptsGetCommandTests : SubscriptionCommandUnitTestsBase<Com
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
             Service.GetCommonPromptAsync(
@@ -78,7 +76,6 @@ public class CommonPromptsGetCommandTests : SubscriptionCommandUnitTestsBase<Com
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.GetCommonPromptAsync(
@@ -102,7 +99,6 @@ public class CommonPromptsGetCommandTests : SubscriptionCommandUnitTestsBase<Com
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.GetCommonPromptAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/CommonPrompts/CommonPromptsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/CommonPrompts/CommonPromptsListCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.CommonPrompts;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -46,7 +45,6 @@ public class CommonPromptsListCommandTests : SubscriptionCommandUnitTestsBase<Co
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
             Service.ListCommonPromptsAsync(
@@ -77,7 +75,6 @@ public class CommonPromptsListCommandTests : SubscriptionCommandUnitTestsBase<Co
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.ListCommonPromptsAsync(
@@ -101,7 +98,6 @@ public class CommonPromptsListCommandTests : SubscriptionCommandUnitTestsBase<Co
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.ListCommonPromptsAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Connectors/ConnectorsCreateKustoCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Connectors/ConnectorsCreateKustoCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Connectors;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -50,7 +49,6 @@ public class ConnectorsCreateKustoCommandTests : SubscriptionCommandUnitTestsBas
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
             Service.CreateOrUpdateConnectorAsync(
@@ -84,7 +82,6 @@ public class ConnectorsCreateKustoCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.CreateOrUpdateConnectorAsync(
@@ -112,7 +109,6 @@ public class ConnectorsCreateKustoCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.CreateOrUpdateConnectorAsync(
@@ -139,7 +135,6 @@ public class ConnectorsCreateKustoCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.CreateOrUpdateConnectorAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Connectors/ConnectorsCreateMcpCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Connectors/ConnectorsCreateMcpCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Connectors;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -49,7 +48,6 @@ public class ConnectorsCreateMcpCommandTests : SubscriptionCommandUnitTestsBase<
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
             Service.CreateOrUpdateConnectorAsync(
@@ -83,7 +81,6 @@ public class ConnectorsCreateMcpCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.CreateOrUpdateConnectorAsync(
@@ -111,7 +108,6 @@ public class ConnectorsCreateMcpCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.CreateOrUpdateConnectorAsync(
@@ -138,7 +134,6 @@ public class ConnectorsCreateMcpCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.CreateOrUpdateConnectorAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Connectors/ConnectorsDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Connectors/ConnectorsDeleteCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Connectors;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -48,7 +47,6 @@ public class ConnectorsDeleteCommandTests : SubscriptionCommandUnitTestsBase<Con
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
             Service.DeleteConnectorAsync(
@@ -81,7 +79,6 @@ public class ConnectorsDeleteCommandTests : SubscriptionCommandUnitTestsBase<Con
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.DeleteConnectorAsync(
@@ -108,7 +105,6 @@ public class ConnectorsDeleteCommandTests : SubscriptionCommandUnitTestsBase<Con
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.DeleteConnectorAsync(
@@ -134,7 +130,6 @@ public class ConnectorsDeleteCommandTests : SubscriptionCommandUnitTestsBase<Con
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.DeleteConnectorAsync("sub", "rg", "agent1", "connector1", null, Arg.Any<CancellationToken>())

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Connectors/ConnectorsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Connectors/ConnectorsGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Connectors;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -48,7 +47,6 @@ public class ConnectorsGetCommandTests : SubscriptionCommandUnitTestsBase<Connec
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
             Service.GetConnectorAsync(
@@ -81,7 +79,6 @@ public class ConnectorsGetCommandTests : SubscriptionCommandUnitTestsBase<Connec
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.GetConnectorAsync(
@@ -108,7 +105,6 @@ public class ConnectorsGetCommandTests : SubscriptionCommandUnitTestsBase<Connec
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.GetConnectorAsync(
@@ -134,7 +130,6 @@ public class ConnectorsGetCommandTests : SubscriptionCommandUnitTestsBase<Connec
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.GetConnectorAsync("sub", "rg", "agent1", "connector1", null, Arg.Any<CancellationToken>())

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Connectors/ConnectorsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Connectors/ConnectorsListCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Connectors;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,6 @@ public class ConnectorsListCommandTests : SubscriptionCommandUnitTestsBase<Conne
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
             Service.ListConnectorsAsync(
@@ -79,7 +77,6 @@ public class ConnectorsListCommandTests : SubscriptionCommandUnitTestsBase<Conne
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.ListConnectorsAsync(
@@ -105,7 +102,6 @@ public class ConnectorsListCommandTests : SubscriptionCommandUnitTestsBase<Conne
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.ListConnectorsAsync(
@@ -130,7 +126,6 @@ public class ConnectorsListCommandTests : SubscriptionCommandUnitTestsBase<Conne
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.ListConnectorsAsync("sub", "rg", "agent1", null, Arg.Any<CancellationToken>())

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Connectors/ConnectorsTestCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Connectors/ConnectorsTestCommandTests.cs
@@ -47,7 +47,6 @@ public class ConnectorsTestCommandTests : SubscriptionCommandUnitTestsBase<Conne
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
             Service.TestConnectorAsync(
@@ -78,7 +77,6 @@ public class ConnectorsTestCommandTests : SubscriptionCommandUnitTestsBase<Conne
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.TestConnectorAsync(
@@ -103,7 +101,6 @@ public class ConnectorsTestCommandTests : SubscriptionCommandUnitTestsBase<Conne
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.TestConnectorAsync(
@@ -127,7 +124,6 @@ public class ConnectorsTestCommandTests : SubscriptionCommandUnitTestsBase<Conne
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.TestConnectorAsync("https://agent1.azuresre.ai", "connector1", null, Arg.Any<CancellationToken>())

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Docs/MemoriesAddCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Docs/MemoriesAddCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Docs;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,6 @@ public class MemoriesAddCommandTests : SubscriptionCommandUnitTestsBase<Memories
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
             Service.UploadMemoryAsync(
@@ -79,7 +77,6 @@ public class MemoriesAddCommandTests : SubscriptionCommandUnitTestsBase<Memories
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.UploadMemoryAsync(
@@ -104,7 +101,6 @@ public class MemoriesAddCommandTests : SubscriptionCommandUnitTestsBase<Memories
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.UploadMemoryAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Docs/MemoriesDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Docs/MemoriesDeleteCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Docs;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -48,7 +47,6 @@ public class MemoriesDeleteCommandTests : SubscriptionCommandUnitTestsBase<Memor
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
             Service.DeleteMemoryAsync(
@@ -79,7 +77,6 @@ public class MemoriesDeleteCommandTests : SubscriptionCommandUnitTestsBase<Memor
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.DeleteMemoryAsync(
@@ -103,7 +100,6 @@ public class MemoriesDeleteCommandTests : SubscriptionCommandUnitTestsBase<Memor
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
 
@@ -122,7 +118,6 @@ public class MemoriesDeleteCommandTests : SubscriptionCommandUnitTestsBase<Memor
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.DeleteMemoryAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Docs/MemoriesListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Docs/MemoriesListCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Docs;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -44,7 +43,6 @@ public class MemoriesListCommandTests : SubscriptionCommandUnitTestsBase<Memorie
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
             Service.ListMemoriesAsync(
@@ -74,7 +72,6 @@ public class MemoriesListCommandTests : SubscriptionCommandUnitTestsBase<Memorie
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.ListMemoriesAsync(
@@ -97,7 +94,6 @@ public class MemoriesListCommandTests : SubscriptionCommandUnitTestsBase<Memorie
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.ListMemoriesAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Docs/MemoriesReindexCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Docs/MemoriesReindexCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Docs;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -44,7 +43,6 @@ public class MemoriesReindexCommandTests : SubscriptionCommandUnitTestsBase<Memo
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
             Service.ReindexMemoriesAsync(
@@ -74,7 +72,6 @@ public class MemoriesReindexCommandTests : SubscriptionCommandUnitTestsBase<Memo
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.ReindexMemoriesAsync(
@@ -97,7 +94,6 @@ public class MemoriesReindexCommandTests : SubscriptionCommandUnitTestsBase<Memo
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.ReindexMemoriesAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Docs/MemoriesSearchCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Docs/MemoriesSearchCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Docs;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,6 @@ public class MemoriesSearchCommandTests : SubscriptionCommandUnitTestsBase<Memor
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
             Service.SearchMemoriesAsync(
@@ -79,7 +77,6 @@ public class MemoriesSearchCommandTests : SubscriptionCommandUnitTestsBase<Memor
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.SearchMemoriesAsync(
@@ -104,7 +101,6 @@ public class MemoriesSearchCommandTests : SubscriptionCommandUnitTestsBase<Memor
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://myagent.azuresre.ai" });
         Service.SearchMemoriesAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Hooks/HooksDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Hooks/HooksDeleteCommandTests.cs
@@ -47,7 +47,6 @@ public class HooksDeleteCommandTests : SubscriptionCommandUnitTestsBase<HooksDel
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
             Service.DeleteHookAsync(
@@ -78,7 +77,6 @@ public class HooksDeleteCommandTests : SubscriptionCommandUnitTestsBase<HooksDel
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.DeleteHookAsync(
@@ -103,7 +101,6 @@ public class HooksDeleteCommandTests : SubscriptionCommandUnitTestsBase<HooksDel
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.DeleteHookAsync(
@@ -127,7 +124,6 @@ public class HooksDeleteCommandTests : SubscriptionCommandUnitTestsBase<HooksDel
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.DeleteHookAsync("https://agent1.azuresre.ai", "hook1", null, Arg.Any<CancellationToken>())

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Hooks/HooksGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Hooks/HooksGetCommandTests.cs
@@ -47,7 +47,6 @@ public class HooksGetCommandTests : SubscriptionCommandUnitTestsBase<HooksGetCom
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
             Service.GetHookAsync(
@@ -78,7 +77,6 @@ public class HooksGetCommandTests : SubscriptionCommandUnitTestsBase<HooksGetCom
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.GetHookAsync(
@@ -103,7 +101,6 @@ public class HooksGetCommandTests : SubscriptionCommandUnitTestsBase<HooksGetCom
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.GetHookAsync(
@@ -127,7 +124,6 @@ public class HooksGetCommandTests : SubscriptionCommandUnitTestsBase<HooksGetCom
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.GetHookAsync("https://agent1.azuresre.ai", "hook1", null, Arg.Any<CancellationToken>())

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Hooks/HooksListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Hooks/HooksListCommandTests.cs
@@ -46,7 +46,6 @@ public class HooksListCommandTests : SubscriptionCommandUnitTestsBase<HooksListC
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
             Service.ListHooksAsync(
@@ -76,7 +75,6 @@ public class HooksListCommandTests : SubscriptionCommandUnitTestsBase<HooksListC
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.ListHooksAsync(
@@ -100,7 +98,6 @@ public class HooksListCommandTests : SubscriptionCommandUnitTestsBase<HooksListC
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.ListHooksAsync(
@@ -123,7 +120,6 @@ public class HooksListCommandTests : SubscriptionCommandUnitTestsBase<HooksListC
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.ListHooksAsync("https://agent1.azuresre.ai", null, Arg.Any<CancellationToken>())

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Hooks/HooksThreadActivateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Hooks/HooksThreadActivateCommandTests.cs
@@ -48,7 +48,6 @@ public class HooksThreadActivateCommandTests : SubscriptionCommandUnitTestsBase<
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
             Service.ActivateThreadHookAsync(
@@ -80,7 +79,6 @@ public class HooksThreadActivateCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.ActivateThreadHookAsync(
@@ -106,7 +104,6 @@ public class HooksThreadActivateCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.ActivateThreadHookAsync(
@@ -131,7 +128,6 @@ public class HooksThreadActivateCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.ActivateThreadHookAsync("https://agent1.azuresre.ai", "thread1", "hook1", null, Arg.Any<CancellationToken>())

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Hooks/HooksThreadDeactivateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Hooks/HooksThreadDeactivateCommandTests.cs
@@ -48,7 +48,6 @@ public class HooksThreadDeactivateCommandTests : SubscriptionCommandUnitTestsBas
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
             Service.DeactivateThreadHookAsync(
@@ -80,7 +79,6 @@ public class HooksThreadDeactivateCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.DeactivateThreadHookAsync(
@@ -106,7 +104,6 @@ public class HooksThreadDeactivateCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.DeactivateThreadHookAsync(
@@ -131,7 +128,6 @@ public class HooksThreadDeactivateCommandTests : SubscriptionCommandUnitTestsBas
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.DeactivateThreadHookAsync("https://agent1.azuresre.ai", "thread1", "hook1", null, Arg.Any<CancellationToken>())

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Hooks/HooksThreadListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Hooks/HooksThreadListCommandTests.cs
@@ -47,7 +47,6 @@ public class HooksThreadListCommandTests : SubscriptionCommandUnitTestsBase<Hook
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
             Service.ListThreadHooksAsync(
@@ -78,7 +77,6 @@ public class HooksThreadListCommandTests : SubscriptionCommandUnitTestsBase<Hook
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.ListThreadHooksAsync(
@@ -103,7 +101,6 @@ public class HooksThreadListCommandTests : SubscriptionCommandUnitTestsBase<Hook
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.ListThreadHooksAsync(
@@ -127,7 +124,6 @@ public class HooksThreadListCommandTests : SubscriptionCommandUnitTestsBase<Hook
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<Microsoft.Mcp.Core.Options.RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
         Service.ListThreadHooksAsync("https://agent1.azuresre.ai", "thread1", null, Arg.Any<CancellationToken>())

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Incidents/IncidentsActiveListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Incidents/IncidentsActiveListCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands.Incidents;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -46,7 +45,6 @@ public class IncidentsActiveListCommandTests : SubscriptionCommandUnitTestsBase<
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -77,7 +75,6 @@ public class IncidentsActiveListCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -101,7 +98,6 @@ public class IncidentsActiveListCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -125,7 +121,6 @@ public class IncidentsActiveListCommandTests : SubscriptionCommandUnitTestsBase<
             null,
             "agent1",
             "tenant1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Incidents/IncidentsCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Incidents/IncidentsCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands.Incidents;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -48,7 +47,6 @@ public class IncidentsCreateCommandTests : SubscriptionCommandUnitTestsBase<Inci
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -80,7 +78,6 @@ public class IncidentsCreateCommandTests : SubscriptionCommandUnitTestsBase<Inci
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -105,7 +102,6 @@ public class IncidentsCreateCommandTests : SubscriptionCommandUnitTestsBase<Inci
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -130,7 +126,6 @@ public class IncidentsCreateCommandTests : SubscriptionCommandUnitTestsBase<Inci
             null,
             "agent1",
             "tenant1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Incidents/IncidentsPlansCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Incidents/IncidentsPlansCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands.Incidents;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -49,7 +48,6 @@ public class IncidentsPlansCreateCommandTests : SubscriptionCommandUnitTestsBase
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -81,7 +79,6 @@ public class IncidentsPlansCreateCommandTests : SubscriptionCommandUnitTestsBase
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -102,7 +99,6 @@ public class IncidentsPlansCreateCommandTests : SubscriptionCommandUnitTestsBase
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -127,7 +123,6 @@ public class IncidentsPlansCreateCommandTests : SubscriptionCommandUnitTestsBase
             null,
             "agent1",
             "tenant1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Incidents/IncidentsPlansListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Incidents/IncidentsPlansListCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands.Incidents;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -46,7 +45,6 @@ public class IncidentsPlansListCommandTests : SubscriptionCommandUnitTestsBase<I
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -76,7 +74,6 @@ public class IncidentsPlansListCommandTests : SubscriptionCommandUnitTestsBase<I
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -97,7 +94,6 @@ public class IncidentsPlansListCommandTests : SubscriptionCommandUnitTestsBase<I
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -120,7 +116,6 @@ public class IncidentsPlansListCommandTests : SubscriptionCommandUnitTestsBase<I
             null,
             "agent1",
             "tenant1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Incidents/IncidentsSetupPagerdutyCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Incidents/IncidentsSetupPagerdutyCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands.Incidents;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -48,10 +47,9 @@ public class IncidentsSetupPagerdutyCommandTests : SubscriptionCommandUnitTestsB
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
-            Service.ResolveAgentResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Service.ResolveAgentResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns("rg");
             Service.GetConnectorAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync<HttpRequestException>();
@@ -80,10 +78,9 @@ public class IncidentsSetupPagerdutyCommandTests : SubscriptionCommandUnitTestsB
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
-        Service.ResolveAgentResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ResolveAgentResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns("rg");
         Service.GetConnectorAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync<HttpRequestException>();
@@ -105,10 +102,9 @@ public class IncidentsSetupPagerdutyCommandTests : SubscriptionCommandUnitTestsB
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
-        Service.ResolveAgentResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ResolveAgentResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns("rg");
         Service.GetConnectorAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync<HttpRequestException>();
@@ -130,10 +126,9 @@ public class IncidentsSetupPagerdutyCommandTests : SubscriptionCommandUnitTestsB
             null,
             "agent1",
             "tenant1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
-        Service.ResolveAgentResourceGroupAsync("sub", "agent1", "tenant1", Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ResolveAgentResourceGroupAsync("sub", "agent1", "tenant1", Arg.Any<CancellationToken>())
             .Returns("rg");
         Service.GetConnectorAsync("sub", "rg", "agent1", Arg.Any<string>(), "tenant1", Arg.Any<CancellationToken>())
             .ThrowsAsync<HttpRequestException>();

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Incidents/IncidentsSetupServicenowCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Incidents/IncidentsSetupServicenowCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands.Incidents;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -48,10 +47,9 @@ public class IncidentsSetupServicenowCommandTests : SubscriptionCommandUnitTests
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
-            Service.ResolveAgentResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Service.ResolveAgentResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns("rg");
             Service.GetConnectorAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync<HttpRequestException>();
@@ -80,10 +78,9 @@ public class IncidentsSetupServicenowCommandTests : SubscriptionCommandUnitTests
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
-        Service.ResolveAgentResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ResolveAgentResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns("rg");
         Service.GetConnectorAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync<HttpRequestException>();
@@ -105,10 +102,9 @@ public class IncidentsSetupServicenowCommandTests : SubscriptionCommandUnitTests
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
-        Service.ResolveAgentResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ResolveAgentResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns("rg");
         Service.GetConnectorAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync<HttpRequestException>();
@@ -130,10 +126,9 @@ public class IncidentsSetupServicenowCommandTests : SubscriptionCommandUnitTests
             null,
             "agent1",
             "tenant1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
-        Service.ResolveAgentResourceGroupAsync("sub", "agent1", "tenant1", Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.ResolveAgentResourceGroupAsync("sub", "agent1", "tenant1", Arg.Any<CancellationToken>())
             .Returns("rg");
         Service.GetConnectorAsync("sub", "rg", "agent1", Arg.Any<string>(), "tenant1", Arg.Any<CancellationToken>())
             .ThrowsAsync<HttpRequestException>();

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/ScheduledTasks/ScheduledTasksCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/ScheduledTasks/ScheduledTasksCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands.ScheduledTasks;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,6 @@ public class ScheduledTasksCreateCommandTests : SubscriptionCommandUnitTestsBase
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -79,7 +77,6 @@ public class ScheduledTasksCreateCommandTests : SubscriptionCommandUnitTestsBase
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -104,7 +101,6 @@ public class ScheduledTasksCreateCommandTests : SubscriptionCommandUnitTestsBase
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -129,7 +125,6 @@ public class ScheduledTasksCreateCommandTests : SubscriptionCommandUnitTestsBase
             null,
             "agent1",
             "tenant1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/ScheduledTasks/ScheduledTasksDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/ScheduledTasks/ScheduledTasksDeleteCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands.ScheduledTasks;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -46,7 +45,6 @@ public class ScheduledTasksDeleteCommandTests : SubscriptionCommandUnitTestsBase
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -78,7 +76,6 @@ public class ScheduledTasksDeleteCommandTests : SubscriptionCommandUnitTestsBase
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -103,7 +100,6 @@ public class ScheduledTasksDeleteCommandTests : SubscriptionCommandUnitTestsBase
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -128,7 +124,6 @@ public class ScheduledTasksDeleteCommandTests : SubscriptionCommandUnitTestsBase
             null,
             "agent1",
             "tenant1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/ScheduledTasks/ScheduledTasksGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/ScheduledTasks/ScheduledTasksGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands.ScheduledTasks;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -45,7 +44,6 @@ public class ScheduledTasksGetCommandTests : SubscriptionCommandUnitTestsBase<Sc
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -77,7 +75,6 @@ public class ScheduledTasksGetCommandTests : SubscriptionCommandUnitTestsBase<Sc
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -102,7 +99,6 @@ public class ScheduledTasksGetCommandTests : SubscriptionCommandUnitTestsBase<Sc
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -127,7 +123,6 @@ public class ScheduledTasksGetCommandTests : SubscriptionCommandUnitTestsBase<Sc
             null,
             "agent1",
             "tenant1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/ScheduledTasks/ScheduledTasksListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/ScheduledTasks/ScheduledTasksListCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands.ScheduledTasks;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -46,7 +45,6 @@ public class ScheduledTasksListCommandTests : SubscriptionCommandUnitTestsBase<S
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -77,7 +75,6 @@ public class ScheduledTasksListCommandTests : SubscriptionCommandUnitTestsBase<S
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -101,7 +98,6 @@ public class ScheduledTasksListCommandTests : SubscriptionCommandUnitTestsBase<S
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -125,7 +121,6 @@ public class ScheduledTasksListCommandTests : SubscriptionCommandUnitTestsBase<S
             null,
             "agent1",
             "tenant1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/ScheduledTasks/ScheduledTasksPauseCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/ScheduledTasks/ScheduledTasksPauseCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands.ScheduledTasks;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -45,7 +44,6 @@ public class ScheduledTasksPauseCommandTests : SubscriptionCommandUnitTestsBase<
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -77,7 +75,6 @@ public class ScheduledTasksPauseCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -102,7 +99,6 @@ public class ScheduledTasksPauseCommandTests : SubscriptionCommandUnitTestsBase<
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -127,7 +123,6 @@ public class ScheduledTasksPauseCommandTests : SubscriptionCommandUnitTestsBase<
             null,
             "agent1",
             "tenant1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/ScheduledTasks/ScheduledTasksResumeCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/ScheduledTasks/ScheduledTasksResumeCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands.ScheduledTasks;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -45,7 +44,6 @@ public class ScheduledTasksResumeCommandTests : SubscriptionCommandUnitTestsBase
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -77,7 +75,6 @@ public class ScheduledTasksResumeCommandTests : SubscriptionCommandUnitTestsBase
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -102,7 +99,6 @@ public class ScheduledTasksResumeCommandTests : SubscriptionCommandUnitTestsBase
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -127,7 +123,6 @@ public class ScheduledTasksResumeCommandTests : SubscriptionCommandUnitTestsBase
             null,
             "agent1",
             "tenant1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Skills/SkillsCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Skills/SkillsCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Skills;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -45,7 +44,7 @@ public class SkillsCreateCommandTests : SubscriptionCommandUnitTestsBase<SkillsC
     {
         if (shouldSucceed)
         {
-            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
             Service.CreateSkillAsync(
@@ -71,7 +70,7 @@ public class SkillsCreateCommandTests : SubscriptionCommandUnitTestsBase<SkillsC
     [Fact]
     public async Task ExecuteAsync_DeserializationValidation()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         var testSkill = new SreSkill { Name = "testskill", Properties = new SreSkillProperties { SkillContent = "test content" } };
@@ -93,7 +92,7 @@ public class SkillsCreateCommandTests : SubscriptionCommandUnitTestsBase<SkillsC
     [Fact]
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.CreateSkillAsync(Arg.Any<string>(), Arg.Any<SreSkillCreateRequest>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
@@ -108,7 +107,7 @@ public class SkillsCreateCommandTests : SubscriptionCommandUnitTestsBase<SkillsC
     [Fact]
     public async Task BindOptions_BindsOptionsCorrectly()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.CreateSkillAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Skills/SkillsDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Skills/SkillsDeleteCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Skills;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -44,7 +43,7 @@ public class SkillsDeleteCommandTests : SubscriptionCommandUnitTestsBase<SkillsD
     {
         if (shouldSucceed)
         {
-            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
             Service.DeleteSkillAsync(
@@ -70,7 +69,7 @@ public class SkillsDeleteCommandTests : SubscriptionCommandUnitTestsBase<SkillsD
     [Fact]
     public async Task ExecuteAsync_DeserializationValidation()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         var deleteResult = new SreAgentDeleteResult("testskill", "Skill", true);
@@ -92,7 +91,7 @@ public class SkillsDeleteCommandTests : SubscriptionCommandUnitTestsBase<SkillsD
     [Fact]
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.DeleteSkillAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
@@ -107,7 +106,7 @@ public class SkillsDeleteCommandTests : SubscriptionCommandUnitTestsBase<SkillsD
     [Fact]
     public async Task BindOptions_BindsOptionsCorrectly()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.DeleteSkillAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Skills/SkillsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Skills/SkillsListCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Skills;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -41,7 +40,7 @@ public class SkillsListCommandTests : SubscriptionCommandUnitTestsBase<SkillsLis
     {
         if (shouldSucceed)
         {
-            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+            Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
             Service.ListSkillsAsync(
@@ -66,7 +65,7 @@ public class SkillsListCommandTests : SubscriptionCommandUnitTestsBase<SkillsLis
     [Fact]
     public async Task ExecuteAsync_DeserializationValidation()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         var skills = new List<SreSkill>
@@ -88,7 +87,7 @@ public class SkillsListCommandTests : SubscriptionCommandUnitTestsBase<SkillsLis
     [Fact]
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.ListSkillsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
@@ -103,7 +102,7 @@ public class SkillsListCommandTests : SubscriptionCommandUnitTestsBase<SkillsLis
     [Fact]
     public async Task BindOptions_BindsOptionsCorrectly()
     {
-        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAgentAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "myagent", Endpoint = "https://test.azuresre.ai" });
 
         Service.ListSkillsAsync(

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Threads;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,6 @@ public class ThreadsCreateCommandTests : SubscriptionCommandUnitTestsBase<Thread
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -92,7 +90,6 @@ public class ThreadsCreateCommandTests : SubscriptionCommandUnitTestsBase<Thread
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -133,7 +130,6 @@ public class ThreadsCreateCommandTests : SubscriptionCommandUnitTestsBase<Thread
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -158,7 +154,6 @@ public class ThreadsCreateCommandTests : SubscriptionCommandUnitTestsBase<Thread
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsDeleteCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsDeleteCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Threads;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -48,7 +47,6 @@ public class ThreadsDeleteCommandTests : SubscriptionCommandUnitTestsBase<Thread
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -77,7 +75,6 @@ public class ThreadsDeleteCommandTests : SubscriptionCommandUnitTestsBase<Thread
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -106,7 +103,6 @@ public class ThreadsDeleteCommandTests : SubscriptionCommandUnitTestsBase<Thread
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -131,7 +127,6 @@ public class ThreadsDeleteCommandTests : SubscriptionCommandUnitTestsBase<Thread
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Threads;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,6 @@ public class ThreadsGetCommandTests : SubscriptionCommandUnitTestsBase<ThreadsGe
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -83,7 +81,6 @@ public class ThreadsGetCommandTests : SubscriptionCommandUnitTestsBase<ThreadsGe
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -116,7 +113,6 @@ public class ThreadsGetCommandTests : SubscriptionCommandUnitTestsBase<ThreadsGe
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -141,7 +137,6 @@ public class ThreadsGetCommandTests : SubscriptionCommandUnitTestsBase<ThreadsGe
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsInvestigateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsInvestigateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Threads;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -49,7 +48,6 @@ public class ThreadsInvestigateCommandTests : SubscriptionCommandUnitTestsBase<T
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -94,7 +92,6 @@ public class ThreadsInvestigateCommandTests : SubscriptionCommandUnitTestsBase<T
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -134,7 +131,6 @@ public class ThreadsInvestigateCommandTests : SubscriptionCommandUnitTestsBase<T
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -159,7 +155,6 @@ public class ThreadsInvestigateCommandTests : SubscriptionCommandUnitTestsBase<T
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsInvestigateYoloCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsInvestigateYoloCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Threads;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -49,7 +48,6 @@ public class ThreadsInvestigateYoloCommandTests : SubscriptionCommandUnitTestsBa
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -101,7 +99,6 @@ public class ThreadsInvestigateYoloCommandTests : SubscriptionCommandUnitTestsBa
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -148,7 +145,6 @@ public class ThreadsInvestigateYoloCommandTests : SubscriptionCommandUnitTestsBa
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -173,7 +169,6 @@ public class ThreadsInvestigateYoloCommandTests : SubscriptionCommandUnitTestsBa
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsListCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Threads;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -46,7 +45,6 @@ public class ThreadsListCommandTests : SubscriptionCommandUnitTestsBase<ThreadsL
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -81,7 +79,6 @@ public class ThreadsListCommandTests : SubscriptionCommandUnitTestsBase<ThreadsL
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -112,7 +109,6 @@ public class ThreadsListCommandTests : SubscriptionCommandUnitTestsBase<ThreadsL
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -136,7 +132,6 @@ public class ThreadsListCommandTests : SubscriptionCommandUnitTestsBase<ThreadsL
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsSendMessageCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Threads/ThreadsSendMessageCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands;
 using Azure.Mcp.Tools.SreAgent.Commands.Threads;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -48,7 +47,6 @@ public class ThreadsSendMessageCommandTests : SubscriptionCommandUnitTestsBase<T
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -94,7 +92,6 @@ public class ThreadsSendMessageCommandTests : SubscriptionCommandUnitTestsBase<T
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -136,7 +133,6 @@ public class ThreadsSendMessageCommandTests : SubscriptionCommandUnitTestsBase<T
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 
@@ -162,7 +158,6 @@ public class ThreadsSendMessageCommandTests : SubscriptionCommandUnitTestsBase<T
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "test-agent", Endpoint = "https://test.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Workflows/WorkflowsApplyCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.SreAgent/tests/Azure.Mcp.Tools.SreAgent.Tests/Workflows/WorkflowsApplyCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.SreAgent.Commands.Workflows;
 using Azure.Mcp.Tools.SreAgent.Models;
 using Azure.Mcp.Tools.SreAgent.Options;
 using Azure.Mcp.Tools.SreAgent.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -45,7 +44,6 @@ public class WorkflowsApplyCommandTests : SubscriptionCommandUnitTestsBase<Workf
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -79,7 +77,6 @@ public class WorkflowsApplyCommandTests : SubscriptionCommandUnitTestsBase<Workf
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -106,7 +103,6 @@ public class WorkflowsApplyCommandTests : SubscriptionCommandUnitTestsBase<Workf
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 
@@ -133,7 +129,6 @@ public class WorkflowsApplyCommandTests : SubscriptionCommandUnitTestsBase<Workf
             null,
             "agent1",
             "tenant1",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(new SreAgentResource { Name = "agent1", Endpoint = "https://agent1.azuresre.ai" });
 

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountCreateCommand.cs
@@ -46,7 +46,6 @@ public sealed class AccountCreateCommand(ILogger<AccountCreateCommand> logger, I
                 options.AccessTier,
                 options.EnableHierarchicalNamespace,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new AccountCreateCommandResult(account), StorageJsonContext.Default.AccountCreateCommandResult);

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Account/AccountGetCommand.cs
@@ -38,7 +38,6 @@ public sealed class AccountGetCommand(ILogger<AccountGetCommand> logger, IStorag
                 options.Subscription!,
                 options.ResourceGroup,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new AccountGetCommandResult(accounts?.Results ?? [], accounts?.AreResultsTruncated ?? false), StorageJsonContext.Default.AccountGetCommandResult);

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobGetCommand.cs
@@ -50,7 +50,6 @@ public sealed class BlobGetCommand(ILogger<BlobGetCommand> logger, IStorageServi
                 options.Subscription!,
                 options.Prefix,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken
             );
 

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobUploadCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobUploadCommand.cs
@@ -43,7 +43,6 @@ public sealed class BlobUploadCommand(ILogger<BlobUploadCommand> logger, IStorag
                 options.LocalFilePath,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(result, StorageJsonContext.Default.BlobUploadResult);

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerCreateCommand.cs
@@ -46,7 +46,6 @@ public sealed class ContainerCreateCommand(ILogger<ContainerCreateCommand> logge
                 options.Container,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new ContainerCreateCommandResult(containerInfo), StorageJsonContext.Default.ContainerCreateCommandResult);

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerGetCommand.cs
@@ -49,7 +49,6 @@ public sealed class ContainerGetCommand(ILogger<ContainerGetCommand> logger, ISt
                 options.Subscription!,
                 options.Prefix,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken
             );
 

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Table/TableListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Table/TableListCommand.cs
@@ -37,7 +37,6 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger, IStorageS
                 options.Account,
                 options.Subscription!,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new TableListCommandResult(tables ?? []), StorageJsonContext.Default.TableListCommandResult);

--- a/tools/Azure.Mcp.Tools.Storage/src/Options/Account/AccountCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Options/Account/AccountCreateOptions.cs
@@ -32,6 +32,4 @@ public class AccountCreateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Storage/src/Options/Account/AccountGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Options/Account/AccountGetOptions.cs
@@ -20,6 +20,4 @@ public class AccountGetOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/BlobGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/BlobGetOptions.cs
@@ -26,6 +26,4 @@ public class BlobGetOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/BlobUploadOptions.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/BlobUploadOptions.cs
@@ -26,6 +26,4 @@ public class BlobUploadOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/Container/ContainerCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/Container/ContainerCreateOptions.cs
@@ -20,6 +20,4 @@ public class ContainerCreateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/Container/ContainerGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/Container/ContainerGetOptions.cs
@@ -23,6 +23,4 @@ public class ContainerGetOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Storage/src/Options/Table/TableListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Options/Table/TableListOptions.cs
@@ -17,6 +17,4 @@ public class TableListOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Storage/src/Services/IStorageService.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Services/IStorageService.cs
@@ -3,7 +3,6 @@
 
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.Storage.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Storage.Services;
 
@@ -14,7 +13,6 @@ public interface IStorageService
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<StorageAccountResult> CreateStorageAccount(
@@ -26,7 +24,6 @@ public interface IStorageService
         string? accessTier = null,
         bool? enableHierarchicalNamespace = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<BlobInfo>> GetBlobDetails(
@@ -36,7 +33,6 @@ public interface IStorageService
         string subscription,
         string? prefix = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<ContainerInfo>> GetContainerDetails(
@@ -45,7 +41,6 @@ public interface IStorageService
         string subscription,
         string? prefix = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<ContainerInfo> CreateContainer(
@@ -53,7 +48,6 @@ public interface IStorageService
         string container,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<BlobUploadResult> UploadBlob(
@@ -63,13 +57,11 @@ public interface IStorageService
         string localFilePath,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<List<string>> ListTables(
         string account,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
@@ -12,7 +12,6 @@ using Azure.Mcp.Tools.Storage.Services.Models;
 using Azure.ResourceManager;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Core.Services.Azure.Authentication;
 
 namespace Azure.Mcp.Tools.Storage.Services;
@@ -33,7 +32,6 @@ public sealed class StorageService(IAzureService azureService)
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
@@ -47,7 +45,7 @@ public sealed class StorageService(IAzureService azureService)
                 "Microsoft.Storage/storageAccounts",
                 resourceGroup,
                 subscription,
-                retryPolicy,
+                null,
                 ConvertToAccountInfoModel,
                 tenant: tenant,
                 cancellationToken: cancellationToken);
@@ -56,10 +54,10 @@ public sealed class StorageService(IAzureService azureService)
         {
             var storageAccount = await ExecuteSingleResourceQueryAsync(
                 "Microsoft.Storage/storageAccounts",
-                resourceGroup: resourceGroup,
-                subscription: subscription,
-                retryPolicy: retryPolicy,
-                converter: ConvertToAccountInfoModel,
+                resourceGroup,
+                subscription,
+                null,
+                ConvertToAccountInfoModel,
                 additionalFilter: $"name =~ '{EscapeKqlString(account)}'",
                 tenant: tenant,
                 cancellationToken: cancellationToken) ?? throw new KeyNotFoundException($"Storage account '{account}' not found in subscription '{subscription}'.");
@@ -77,7 +75,6 @@ public sealed class StorageService(IAzureService azureService)
         string? accessTier = null,
         bool? enableHierarchicalNamespace = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -87,13 +84,17 @@ public sealed class StorageService(IAzureService azureService)
             (nameof(subscription), subscription));
 
         // Create ArmClient for deployments
-        ArmClient armClient = await CreateArmClientWithApiVersionAsync("Microsoft.Storage/storageAccounts", "2024-01-01", tenant, retryPolicy, cancellationToken);
+        ArmClient armClient = await CreateArmClientWithApiVersionAsync(
+            "Microsoft.Storage/storageAccounts",
+            "2024-01-01",
+            tenant: tenant,
+            cancellationToken: cancellationToken);
 
         // Resolve subscription display name to GUID (consistent with all other storage operations).
         // Skip resolution when subscription is already a GUID to avoid an unnecessary round-trip.
         var subscriptionId = AzureService.IsSubscriptionId(subscription)
             ? subscription
-            : (await AzureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken)).Data.SubscriptionId;
+            : (await AzureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken)).Data.SubscriptionId;
 
         // Prepare data
         ResourceIdentifier accountId = new($"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Storage/storageAccounts/{account}");
@@ -158,7 +159,6 @@ public sealed class StorageService(IAzureService azureService)
         string subscription,
         string? prefix = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -166,7 +166,7 @@ public sealed class StorageService(IAzureService azureService)
             (nameof(container), container),
             (nameof(subscription), subscription));
 
-        var blobServiceClient = await CreateBlobServiceClient(account, tenant, retryPolicy, cancellationToken);
+        var blobServiceClient = await CreateBlobServiceClient(account, tenant, cancellationToken);
         var containerClient = blobServiceClient.GetBlobContainerClient(container);
 
         var blobInfos = new List<Storage.Models.BlobInfo>();
@@ -238,12 +238,11 @@ public sealed class StorageService(IAzureService azureService)
         string subscription,
         string? prefix = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(account), account), (nameof(subscription), subscription));
 
-        var blobServiceClient = await CreateBlobServiceClient(account, tenant, retryPolicy, cancellationToken);
+        var blobServiceClient = await CreateBlobServiceClient(account, tenant, cancellationToken);
         var containers = new List<ContainerInfo>();
 
         if (string.IsNullOrEmpty(container))
@@ -297,7 +296,6 @@ public sealed class StorageService(IAzureService azureService)
         string container,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -305,7 +303,7 @@ public sealed class StorageService(IAzureService azureService)
             (nameof(container), container),
             (nameof(subscription), subscription));
 
-        var blobServiceClient = await CreateBlobServiceClient(account, tenant, retryPolicy, cancellationToken);
+        var blobServiceClient = await CreateBlobServiceClient(account, tenant, cancellationToken);
         var containerClient = blobServiceClient.GetBlobContainerClient(container);
 
         await containerClient.CreateAsync(PublicAccessType.None, cancellationToken: cancellationToken);
@@ -330,11 +328,10 @@ public sealed class StorageService(IAzureService azureService)
     private async Task<BlobServiceClient> CreateBlobServiceClient(
         string account,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         var uri = GetBlobEndpoint(account);
-        var options = ConfigureRetryPolicy(AddDefaultPolicies(new BlobClientOptions()), retryPolicy);
+        var options = AddDefaultPolicies(new BlobClientOptions());
         options.Transport = new HttpClientTransport(AzureService.GetClient());
         return new BlobServiceClient(new(uri), await GetCredential(tenant, cancellationToken), options);
     }
@@ -371,7 +368,6 @@ public sealed class StorageService(IAzureService azureService)
         string localFilePath,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -386,7 +382,7 @@ public sealed class StorageService(IAzureService azureService)
             throw new FileNotFoundException($"Local file not found: {localFilePath}");
         }
 
-        var blobServiceClient = await CreateBlobServiceClient(account, tenant, retryPolicy, cancellationToken);
+        var blobServiceClient = await CreateBlobServiceClient(account, tenant, cancellationToken);
         var blobContainerClient = blobServiceClient.GetBlobContainerClient(container);
         var blobClient = blobContainerClient.GetBlobClient(blob);
 
@@ -426,10 +422,9 @@ public sealed class StorageService(IAzureService azureService)
         string account,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var options = ConfigureRetryPolicy(AddDefaultPolicies(new TableClientOptions()), retryPolicy);
+        var options = AddDefaultPolicies(new TableClientOptions());
         options.Transport = new HttpClientTransport(AzureService.GetClient());
         var defaultUri = GetTableEndpoint(account);
         return new TableServiceClient(new(defaultUri), await GetCredential(tenant, cancellationToken), options);
@@ -439,7 +434,6 @@ public sealed class StorageService(IAzureService azureService)
         string account,
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(account), account), (nameof(subscription), subscription));
@@ -451,7 +445,6 @@ public sealed class StorageService(IAzureService azureService)
             account,
             subscription,
             tenant,
-            retryPolicy,
             cancellationToken);
 
         await foreach (var table in tableServiceClient.QueryAsync(cancellationToken: cancellationToken))

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Account/AccountCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Account/AccountCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Commands.Account;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -66,7 +65,6 @@ public class AccountCreateCommandTests : SubscriptionCommandUnitTestsBase<Accoun
                 Arg.Any<string>(),
                 Arg.Any<bool?>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(expectedAccount);
         }
@@ -103,7 +101,6 @@ public class AccountCreateCommandTests : SubscriptionCommandUnitTestsBase<Accoun
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(conflictException);
 
@@ -134,7 +131,6 @@ public class AccountCreateCommandTests : SubscriptionCommandUnitTestsBase<Accoun
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(notFoundException);
 
@@ -165,7 +161,6 @@ public class AccountCreateCommandTests : SubscriptionCommandUnitTestsBase<Accoun
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(authException);
 
@@ -194,7 +189,6 @@ public class AccountCreateCommandTests : SubscriptionCommandUnitTestsBase<Accoun
             Arg.Any<string>(),
             Arg.Any<bool?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(Task.FromException<StorageAccountResult>(new Exception("Test error")));
 
@@ -243,7 +237,6 @@ public class AccountCreateCommandTests : SubscriptionCommandUnitTestsBase<Accoun
             "Cool",
             true,
             null,
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedAccount);
 
@@ -268,7 +261,6 @@ public class AccountCreateCommandTests : SubscriptionCommandUnitTestsBase<Accoun
             "Cool",
             true,
             null,
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Account/AccountGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Account/AccountGetCommandTests.cs
@@ -8,7 +8,6 @@ using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Commands.Account;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -33,7 +32,6 @@ public class AccountGetCommandTests : SubscriptionCommandUnitTestsBase<AccountGe
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedAccounts);
 
@@ -59,7 +57,6 @@ public class AccountGetCommandTests : SubscriptionCommandUnitTestsBase<AccountGe
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(new ResourceQueryResults<StorageAccountInfo>([], false));
 
@@ -84,7 +81,6 @@ public class AccountGetCommandTests : SubscriptionCommandUnitTestsBase<AccountGe
             Arg.Is(subscription),
             Arg.Any<string?>(),
             null,
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
@@ -124,7 +120,6 @@ public class AccountGetCommandTests : SubscriptionCommandUnitTestsBase<AccountGe
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(expectedAccount);
         }
@@ -160,7 +155,6 @@ public class AccountGetCommandTests : SubscriptionCommandUnitTestsBase<AccountGe
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedAccount);
 
@@ -184,7 +178,7 @@ public class AccountGetCommandTests : SubscriptionCommandUnitTestsBase<AccountGe
         var subscription = "sub123";
 
         Service.GetAccountDetails(
-            Arg.Is(account), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Arg.Is(account), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -204,7 +198,7 @@ public class AccountGetCommandTests : SubscriptionCommandUnitTestsBase<AccountGe
         var subscription = "sub123";
 
         Service.GetAccountDetails(
-            Arg.Is(account), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Arg.Is(account), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Storage account not found"));
 
         // Act
@@ -223,7 +217,7 @@ public class AccountGetCommandTests : SubscriptionCommandUnitTestsBase<AccountGe
         var subscription = "sub123";
 
         Service.GetAccountDetails(
-            Arg.Is(account), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Arg.Is(account), Arg.Is(subscription), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.Forbidden, "Authorization failed"));
 
         // Act
@@ -240,7 +234,7 @@ public class AccountGetCommandTests : SubscriptionCommandUnitTestsBase<AccountGe
         // Arrange
         const string resourceGroup = "test-rg";
         const string subscription = "sub123";
-        Service.GetAccountDetails(Arg.Any<string?>(), Arg.Is(subscription), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>())
+        Service.GetAccountDetails(Arg.Any<string?>(), Arg.Is(subscription), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new ResourceQueryResults<StorageAccountInfo>([], false));
 
         // Act
@@ -248,6 +242,6 @@ public class AccountGetCommandTests : SubscriptionCommandUnitTestsBase<AccountGe
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
-        await Service.Received(1).GetAccountDetails(Arg.Any<string?>(), Arg.Is(subscription), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).GetAccountDetails(Arg.Any<string?>(), Arg.Is(subscription), Arg.Is(resourceGroup), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/BlobGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/BlobGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Commands.Blob;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -36,7 +35,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedBlobs);
 
@@ -69,7 +67,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -101,7 +98,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
@@ -154,7 +150,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(expectedBlobs);
         }
@@ -193,7 +188,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns([expected]);
 
@@ -230,7 +224,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -263,7 +256,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Blob not found"));
 
@@ -295,7 +287,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.Forbidden, "Authorization failed"));
 

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/BlobUploadCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/BlobUploadCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Commands.Blob;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -43,7 +42,6 @@ public class BlobUploadCommandTests : SubscriptionCommandUnitTestsBase<BlobUploa
             Arg.Is(localFilePath),
             Arg.Is(subscription),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
@@ -75,7 +73,6 @@ public class BlobUploadCommandTests : SubscriptionCommandUnitTestsBase<BlobUploa
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
@@ -115,7 +112,6 @@ public class BlobUploadCommandTests : SubscriptionCommandUnitTestsBase<BlobUploa
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(expectedResult);
         }

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/Container/ContainerCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/Container/ContainerCreateCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Commands.Blob.Container;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -47,7 +46,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(expected);
         }
@@ -79,7 +77,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.Conflict, "Container already exists"));
 
@@ -103,7 +100,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.Forbidden, "Authorization failed"));
 
@@ -127,7 +123,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Storage account not found"));
 
@@ -151,7 +146,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -183,7 +177,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
             container,
             subscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expected);
 
@@ -200,7 +193,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
             container,
             subscription,
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/Container/ContainerGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/Container/ContainerGetCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Commands.Blob.Container;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -34,7 +33,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedContainers);
 
@@ -62,7 +60,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -89,7 +86,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
@@ -132,7 +128,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(expectedContainers);
         }
@@ -169,7 +164,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns([expected]);
 
@@ -203,7 +197,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -233,7 +226,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Container not found"));
 
@@ -262,7 +254,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
             Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.Forbidden, "Authorization failed"));
 

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/StorageCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/StorageCommandTests.cs
@@ -318,8 +318,7 @@ public class StorageCommandTests(ITestOutputHelper output, TestProxyFixture fixt
             {
             { "subscription", Settings.SubscriptionName },
             { "tenant", Settings.TenantId },
-            { "account", Settings.ResourceBaseName },
-            { "retry-max-retries", 0 }
+            { "account", Settings.ResourceBaseName }
             });
 
         var actual = result.AssertProperty("containers");
@@ -337,8 +336,7 @@ public class StorageCommandTests(ITestOutputHelper output, TestProxyFixture fixt
             { "subscription", Settings.SubscriptionName },
             { "tenant", Settings.TenantId },
             { "account", Settings.ResourceBaseName },
-            { "prefix", "ba" },
-            { "retry-max-retries", 0 }
+            { "prefix", "ba" }
             });
 
         var actual = result.AssertProperty("containers");

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Table/TableListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Table/TableListCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Services;
 using Azure.Mcp.Tools.Storage.Table.Commands;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -28,7 +27,6 @@ public class TableListCommandTests : SubscriptionCommandUnitTestsBase<TableListC
             Arg.Is(_knownStorageAccount),
             Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedTables);
 
@@ -51,7 +49,6 @@ public class TableListCommandTests : SubscriptionCommandUnitTestsBase<TableListC
             Arg.Is(_knownStorageAccount),
             Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -89,7 +86,6 @@ public class TableListCommandTests : SubscriptionCommandUnitTestsBase<TableListC
             Arg.Is(_knownStorageAccount),
             Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointCreateCommand.cs
@@ -45,7 +45,6 @@ public sealed class CloudEndpointCreateCommand(ILogger<CloudEndpointCreateComman
                 options.StorageAccountResourceId,
                 options.AzureFileShareName,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(endpoint), StorageSyncJsonContext.Default.CloudEndpointCreateCommandResult);

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointDeleteCommand.cs
@@ -42,7 +42,6 @@ public sealed class CloudEndpointDeleteCommand(ILogger<CloudEndpointDeleteComman
                 options.SyncGroupName,
                 options.CloudEndpointName,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Message = "Cloud endpoint deleted successfully";

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointGetCommand.cs
@@ -47,7 +47,6 @@ public sealed class CloudEndpointGetCommand(ILogger<CloudEndpointGetCommand> log
                     options.SyncGroupName,
                     options.CloudEndpointName,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 if (endpoint == null)
@@ -71,7 +70,6 @@ public sealed class CloudEndpointGetCommand(ILogger<CloudEndpointGetCommand> log
                     options.Name,
                     options.SyncGroupName,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(endpoints ?? []), StorageSyncJsonContext.Default.CloudEndpointGetCommandResult);

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointTriggerChangeDetectionCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/CloudEndpoint/CloudEndpointTriggerChangeDetectionCommand.cs
@@ -45,7 +45,6 @@ public sealed class CloudEndpointTriggerChangeDetectionCommand(ILogger<CloudEndp
                 options.ChangeDetectionMode,
                 options.Paths,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Message = "Change detection triggered successfully";

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/RegisteredServer/RegisteredServerGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/RegisteredServer/RegisteredServerGetCommand.cs
@@ -46,7 +46,6 @@ public sealed class RegisteredServerGetCommand(ILogger<RegisteredServerGetComman
                     options.Name,
                     options.ServerId,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 if (server == null)
@@ -69,7 +68,6 @@ public sealed class RegisteredServerGetCommand(ILogger<RegisteredServerGetComman
                     options.ResourceGroup,
                     options.Name,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(servers ?? []), StorageSyncJsonContext.Default.RegisteredServerGetCommandResult);

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/RegisteredServer/RegisteredServerUnregisterCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/RegisteredServer/RegisteredServerUnregisterCommand.cs
@@ -41,7 +41,6 @@ public sealed class RegisteredServerUnregisterCommand(ILogger<RegisteredServerUn
                 options.Name,
                 options.ServerId,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Message = "Server unregistered successfully";

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/RegisteredServer/RegisteredServerUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/RegisteredServer/RegisteredServerUpdateCommand.cs
@@ -43,7 +43,6 @@ public sealed class RegisteredServerUpdateCommand(ILogger<RegisteredServerUpdate
                 options.ServerId,
                 null, // TODO (alzimmer): Doesn't appear this command actually updates anything.
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(server), StorageSyncJsonContext.Default.RegisteredServerUpdateCommandResult);

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointCreateCommand.cs
@@ -49,7 +49,6 @@ public sealed class ServerEndpointCreateCommand(ILogger<ServerEndpointCreateComm
                 options.TierFilesOlderThanDays,
                 options.LocalCacheMode,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(endpoint), StorageSyncJsonContext.Default.ServerEndpointCreateCommandResult);

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointDeleteCommand.cs
@@ -42,7 +42,6 @@ public sealed class ServerEndpointDeleteCommand(ILogger<ServerEndpointDeleteComm
                 options.SyncGroupName,
                 options.ServerEndpointName,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Message = "Server endpoint deleted successfully";

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointGetCommand.cs
@@ -47,7 +47,6 @@ public sealed class ServerEndpointGetCommand(ILogger<ServerEndpointGetCommand> l
                     options.SyncGroupName,
                     options.ServerEndpointName,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 if (endpoint == null)
@@ -71,7 +70,6 @@ public sealed class ServerEndpointGetCommand(ILogger<ServerEndpointGetCommand> l
                     options.Name,
                     options.SyncGroupName,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(endpoints ?? []), StorageSyncJsonContext.Default.ServerEndpointGetCommandResult);

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/ServerEndpoint/ServerEndpointUpdateCommand.cs
@@ -47,7 +47,6 @@ public sealed class ServerEndpointUpdateCommand(ILogger<ServerEndpointUpdateComm
                 options.TierFilesOlderThanDays,
                 options.LocalCacheMode,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(endpoint), StorageSyncJsonContext.Default.ServerEndpointUpdateCommandResult);

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceCreateCommand.cs
@@ -43,7 +43,6 @@ public sealed class StorageSyncServiceCreateCommand(ILogger<StorageSyncServiceCr
                 options.Location,
                 options.Tags?.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(tag => tag.Split('=', 2)).ToDictionary(kv => kv[0], kv => kv[1]),
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(service), StorageSyncJsonContext.Default.StorageSyncServiceCreateCommandResult);

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceDeleteCommand.cs
@@ -40,7 +40,6 @@ public sealed class StorageSyncServiceDeleteCommand(ILogger<StorageSyncServiceDe
                 options.ResourceGroup,
                 options.Name,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Message = "Storage sync service deleted successfully";

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceGetCommand.cs
@@ -55,7 +55,6 @@ public sealed class StorageSyncServiceGetCommand(ILogger<StorageSyncServiceGetCo
                     options.ResourceGroup!,
                     options.Name,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 if (service == null)
@@ -77,7 +76,6 @@ public sealed class StorageSyncServiceGetCommand(ILogger<StorageSyncServiceGetCo
                     options.Subscription!,
                     options.ResourceGroup,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(services ?? []), StorageSyncJsonContext.Default.StorageSyncServiceGetCommandResult);

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/StorageSyncService/StorageSyncServiceUpdateCommand.cs
@@ -44,7 +44,6 @@ public sealed class StorageSyncServiceUpdateCommand(ILogger<StorageSyncServiceUp
                 options.Tags?.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(tag => tag.Split('=', 2)).ToDictionary(kv => kv[0], kv => kv[1]),
                 options.IdentityType,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(service), StorageSyncJsonContext.Default.StorageSyncServiceUpdateCommandResult);

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/SyncGroup/SyncGroupCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/SyncGroup/SyncGroupCreateCommand.cs
@@ -42,7 +42,6 @@ public sealed class SyncGroupCreateCommand(ILogger<SyncGroupCreateCommand> logge
                 options.Name,
                 options.SyncGroupName,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Results = ResponseResult.Create(new(syncGroup), StorageSyncJsonContext.Default.SyncGroupCreateCommandResult);

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/SyncGroup/SyncGroupDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/SyncGroup/SyncGroupDeleteCommand.cs
@@ -41,7 +41,6 @@ public sealed class SyncGroupDeleteCommand(ILogger<SyncGroupDeleteCommand> logge
                 options.Name,
                 options.SyncGroupName,
                 options.Tenant,
-                options.RetryPolicy,
                 cancellationToken);
 
             context.Response.Message = "Sync group deleted successfully";

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Commands/SyncGroup/SyncGroupGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Commands/SyncGroup/SyncGroupGetCommand.cs
@@ -46,7 +46,6 @@ public sealed class SyncGroupGetCommand(ILogger<SyncGroupGetCommand> logger, ISt
                     options.Name,
                     options.SyncGroupName,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 if (syncGroup == null)
@@ -69,7 +68,6 @@ public sealed class SyncGroupGetCommand(ILogger<SyncGroupGetCommand> logger, ISt
                     options.ResourceGroup,
                     options.Name,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
 
                 context.Response.Results = ResponseResult.Create(new(syncGroups ?? []), StorageSyncJsonContext.Default.SyncGroupGetCommandResult);

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/CloudEndpoint/CloudEndpointCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/CloudEndpoint/CloudEndpointCreateOptions.cs
@@ -50,6 +50,4 @@ public sealed class CloudEndpointCreateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/CloudEndpoint/CloudEndpointDeleteOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/CloudEndpoint/CloudEndpointDeleteOptions.cs
@@ -38,6 +38,4 @@ public sealed class CloudEndpointDeleteOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/CloudEndpoint/CloudEndpointGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/CloudEndpoint/CloudEndpointGetOptions.cs
@@ -38,6 +38,4 @@ public sealed class CloudEndpointGetOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/CloudEndpoint/CloudEndpointTriggerChangeDetectionOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/CloudEndpoint/CloudEndpointTriggerChangeDetectionOptions.cs
@@ -56,6 +56,4 @@ public sealed class CloudEndpointTriggerChangeDetectionOptions : ISubscriptionOp
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/RegisteredServer/RegisteredServerGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/RegisteredServer/RegisteredServerGetOptions.cs
@@ -32,6 +32,4 @@ public sealed class RegisteredServerGetOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/RegisteredServer/RegisteredServerUnregisterOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/RegisteredServer/RegisteredServerUnregisterOptions.cs
@@ -32,6 +32,4 @@ public sealed class RegisteredServerUnregisterOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/RegisteredServer/RegisteredServerUpdateOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/RegisteredServer/RegisteredServerUpdateOptions.cs
@@ -32,6 +32,4 @@ public sealed class RegisteredServerUpdateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/ServerEndpoint/ServerEndpointCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/ServerEndpoint/ServerEndpointCreateOptions.cs
@@ -74,6 +74,4 @@ public sealed class ServerEndpointCreateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/ServerEndpoint/ServerEndpointDeleteOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/ServerEndpoint/ServerEndpointDeleteOptions.cs
@@ -38,6 +38,4 @@ public sealed class ServerEndpointDeleteOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/ServerEndpoint/ServerEndpointGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/ServerEndpoint/ServerEndpointGetOptions.cs
@@ -38,6 +38,4 @@ public sealed class ServerEndpointGetOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/ServerEndpoint/ServerEndpointUpdateOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/ServerEndpoint/ServerEndpointUpdateOptions.cs
@@ -62,6 +62,4 @@ public sealed class ServerEndpointUpdateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/StorageSyncService/StorageSyncServiceCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/StorageSyncService/StorageSyncServiceCreateOptions.cs
@@ -38,6 +38,4 @@ public sealed class StorageSyncServiceCreateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/StorageSyncService/StorageSyncServiceDeleteOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/StorageSyncService/StorageSyncServiceDeleteOptions.cs
@@ -26,6 +26,4 @@ public sealed class StorageSyncServiceDeleteOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/StorageSyncService/StorageSyncServiceGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/StorageSyncService/StorageSyncServiceGetOptions.cs
@@ -26,6 +26,4 @@ public sealed class StorageSyncServiceGetOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/StorageSyncService/StorageSyncServiceUpdateOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/StorageSyncService/StorageSyncServiceUpdateOptions.cs
@@ -44,6 +44,4 @@ public sealed class StorageSyncServiceUpdateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/SyncGroup/SyncGroupCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/SyncGroup/SyncGroupCreateOptions.cs
@@ -32,6 +32,4 @@ public sealed class SyncGroupCreateOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/SyncGroup/SyncGroupDeleteOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/SyncGroup/SyncGroupDeleteOptions.cs
@@ -32,6 +32,4 @@ public sealed class SyncGroupDeleteOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Options/SyncGroup/SyncGroupGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Options/SyncGroup/SyncGroupGetOptions.cs
@@ -32,6 +32,4 @@ public sealed class SyncGroupGetOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Services/IStorageSyncService.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Services/IStorageSyncService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.StorageSync.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.StorageSync.Services;
 
@@ -21,7 +20,6 @@ public interface IStorageSyncService
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -32,7 +30,6 @@ public interface IStorageSyncService
         string resourceGroup,
         string storageSyncServiceName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -45,7 +42,6 @@ public interface IStorageSyncService
         string location,
         Dictionary<string, string>? tags = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -59,7 +55,6 @@ public interface IStorageSyncService
         Dictionary<string, string>? tags = null,
         string? identityType = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -70,7 +65,6 @@ public interface IStorageSyncService
         string resourceGroup,
         string storageSyncServiceName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     #endregion
@@ -85,7 +79,6 @@ public interface IStorageSyncService
         string resourceGroup,
         string storageSyncServiceName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -97,7 +90,6 @@ public interface IStorageSyncService
         string storageSyncServiceName,
         string syncGroupName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -109,7 +101,6 @@ public interface IStorageSyncService
         string storageSyncServiceName,
         string syncGroupName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -121,7 +112,6 @@ public interface IStorageSyncService
         string storageSyncServiceName,
         string syncGroupName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     #endregion
@@ -137,7 +127,6 @@ public interface IStorageSyncService
         string storageSyncServiceName,
         string syncGroupName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -150,7 +139,6 @@ public interface IStorageSyncService
         string syncGroupName,
         string cloudEndpointName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -165,7 +153,6 @@ public interface IStorageSyncService
         string storageAccountResourceId,
         string azureFileShareName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -178,7 +165,6 @@ public interface IStorageSyncService
         string syncGroupName,
         string cloudEndpointName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -194,7 +180,6 @@ public interface IStorageSyncService
         string? changeDetectionMode = null,
         IList<string>? paths = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     #endregion
@@ -210,7 +195,6 @@ public interface IStorageSyncService
         string storageSyncServiceName,
         string syncGroupName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -223,7 +207,6 @@ public interface IStorageSyncService
         string syncGroupName,
         string serverEndpointName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -242,7 +225,6 @@ public interface IStorageSyncService
         int? tierFilesOlderThanDays = null,
         string? localCacheMode = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -259,7 +241,6 @@ public interface IStorageSyncService
         int? tierFilesOlderThanDays = null,
         string? localCacheMode = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -272,7 +253,6 @@ public interface IStorageSyncService
         string syncGroupName,
         string serverEndpointName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     #endregion
@@ -287,7 +267,6 @@ public interface IStorageSyncService
         string resourceGroup,
         string storageSyncServiceName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -299,7 +278,6 @@ public interface IStorageSyncService
         string storageSyncServiceName,
         string registeredServerId,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -311,7 +289,6 @@ public interface IStorageSyncService
         string storageSyncServiceName,
         string registeredServerId,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -323,7 +300,6 @@ public interface IStorageSyncService
         string storageSyncServiceName,
         string registeredServerId,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -336,7 +312,6 @@ public interface IStorageSyncService
         string registeredServerId,
         Dictionary<string, object>? properties = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     #endregion

--- a/tools/Azure.Mcp.Tools.StorageSync/src/Services/StorageSyncService.cs
+++ b/tools/Azure.Mcp.Tools.StorageSync/src/Services/StorageSyncService.cs
@@ -8,7 +8,6 @@ using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.StorageSync;
 using Azure.ResourceManager.StorageSync.Models;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.StorageSync.Services;
 
@@ -24,12 +23,11 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string subscription,
         string? resourceGroup = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(subscription), subscription));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
 
         var services = new List<StorageSyncServiceDataSchema>();
@@ -72,7 +70,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string resourceGroup,
         string storageSyncServiceName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -83,7 +80,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
 
         try
         {
-            var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+            var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
             var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
             var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
             var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -106,7 +103,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string location,
         Dictionary<string, string>? tags = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -115,7 +111,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(storageSyncServiceName), storageSyncServiceName),
             (nameof(location), location));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
 
@@ -150,7 +146,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         Dictionary<string, string>? tags = null,
         string? identityType = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -158,7 +153,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(resourceGroup), resourceGroup),
             (nameof(storageSyncServiceName), storageSyncServiceName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -201,7 +196,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string resourceGroup,
         string storageSyncServiceName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -209,7 +203,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(resourceGroup), resourceGroup),
             (nameof(storageSyncServiceName), storageSyncServiceName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -228,7 +222,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string resourceGroup,
         string storageSyncServiceName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -236,7 +229,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(resourceGroup), resourceGroup),
             (nameof(storageSyncServiceName), storageSyncServiceName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -256,7 +249,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string storageSyncServiceName,
         string syncGroupName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -267,7 +259,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
 
         try
         {
-            var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+            var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
             var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
             var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
             var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -288,7 +280,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string storageSyncServiceName,
         string syncGroupName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -297,7 +288,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(storageSyncServiceName), storageSyncServiceName),
             (nameof(syncGroupName), syncGroupName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -315,7 +306,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string storageSyncServiceName,
         string syncGroupName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -324,7 +314,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(storageSyncServiceName), storageSyncServiceName),
             (nameof(syncGroupName), syncGroupName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -343,7 +333,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string storageSyncServiceName,
         string syncGroupName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -352,7 +341,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(storageSyncServiceName), storageSyncServiceName),
             (nameof(syncGroupName), syncGroupName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -374,7 +363,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string syncGroupName,
         string cloudEndpointName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -386,7 +374,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
 
         try
         {
-            var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+            var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
             var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
             var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
             var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -411,7 +399,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string storageAccountResourceId,
         string azureFileShareName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -423,7 +410,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(storageAccountResourceId), storageAccountResourceId),
             (nameof(azureFileShareName), azureFileShareName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
 
         // Get subscription data to access tenant ID
@@ -465,7 +452,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string syncGroupName,
         string cloudEndpointName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -475,7 +461,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(syncGroupName), syncGroupName),
             (nameof(cloudEndpointName), cloudEndpointName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -498,7 +484,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string? changeDetectionMode = null,
         IList<string>? paths = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -509,7 +494,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(cloudEndpointName), cloudEndpointName),
             (nameof(directoryPath), directoryPath));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -549,7 +534,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string storageSyncServiceName,
         string syncGroupName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -558,7 +542,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(storageSyncServiceName), storageSyncServiceName),
             (nameof(syncGroupName), syncGroupName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -580,7 +564,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string syncGroupName,
         string serverEndpointName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -592,7 +575,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
 
         try
         {
-            var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+            var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
             var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
             var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
             var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -621,7 +604,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         int? tierFilesOlderThanDays = null,
         string? localCacheMode = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -633,7 +615,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(serverResourceId), serverResourceId),
             (nameof(serverLocalPath), serverLocalPath));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -681,7 +663,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         int? tierFilesOlderThanDays = null,
         string? localCacheMode = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -691,7 +672,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(syncGroupName), syncGroupName),
             (nameof(serverEndpointName), serverEndpointName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -730,7 +711,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string syncGroupName,
         string serverEndpointName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -740,7 +720,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(syncGroupName), syncGroupName),
             (nameof(serverEndpointName), serverEndpointName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -759,7 +739,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string resourceGroup,
         string storageSyncServiceName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -767,7 +746,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
             (nameof(resourceGroup), resourceGroup),
             (nameof(storageSyncServiceName), storageSyncServiceName));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -787,7 +766,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string storageSyncServiceName,
         string registeredServerId,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -801,7 +779,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
 
         try
         {
-            var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+            var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
             var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
             var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
             var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -822,7 +800,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string storageSyncServiceName,
         string registeredServerId,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -834,7 +811,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         // Validate registeredServerId is a valid GUID
         var serverGuid = CheckGuid(registeredServerId, nameof(registeredServerId));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -855,7 +832,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string registeredServerId,
         Dictionary<string, object>? properties = null,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -867,7 +843,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         // Validate registeredServerId is a valid GUID
         var serverGuid = CheckGuid(registeredServerId, nameof(registeredServerId));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);
@@ -889,7 +865,6 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         string storageSyncServiceName,
         string registeredServerId,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
@@ -901,7 +876,7 @@ public sealed class StorageSyncService(IAzureService azureService, ILogger<Stora
         // Validate registeredServerId is a valid GUID
         var serverGuid = CheckGuid(registeredServerId, nameof(registeredServerId));
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, null, cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
         var subscriptionResource = armClient.GetSubscriptionResource(SubscriptionResource.CreateResourceIdentifier(subscription));
         var resourceGroupResource = await subscriptionResource.GetResourceGroupAsync(resourceGroup, cancellationToken);
         var serviceResource = await resourceGroupResource.Value.GetStorageSyncServices().GetAsync(storageSyncServiceName, cancellationToken);


### PR DESCRIPTION
## What does this PR do?

Removed custom retry policy options from Service Fabric, SignalR, Speech, SQL, SRE Agent, Storage, and Storage Sync tools.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*