### PR TITLE
[Part 9] Remove RetryPolicyOptions from tools

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/remove-retry-policy-options-part9.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/remove-retry-policy-options-part9.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: Breaking Changes
+    description: Removed custom retry policy options from Virtual Desktop and Workbooks tools.

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/Hostpool/HostpoolListCommand.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/Hostpool/HostpoolListCommand.cs
@@ -44,7 +44,6 @@ public sealed class HostpoolListCommand(ILogger<HostpoolListCommand> logger, IVi
                     options.Subscription!,
                     options.ResourceGroup,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
             else
@@ -52,7 +51,6 @@ public sealed class HostpoolListCommand(ILogger<HostpoolListCommand> logger, IVi
                 hostpools = await _virtualDesktopService.ListHostpoolsAsync(
                     options.Subscription!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
 

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/SessionHost/SessionHostListCommand.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/SessionHost/SessionHostListCommand.cs
@@ -45,7 +45,6 @@ public sealed class SessionHostListCommand(ILogger<SessionHostListCommand> logge
                     options.Subscription!,
                     options.HostpoolResourceId,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
             else if (!string.IsNullOrEmpty(options.ResourceGroup))
@@ -55,7 +54,6 @@ public sealed class SessionHostListCommand(ILogger<SessionHostListCommand> logge
                     options.ResourceGroup,
                     options.Hostpool!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
             else
@@ -64,7 +62,6 @@ public sealed class SessionHostListCommand(ILogger<SessionHostListCommand> logge
                     options.Subscription!,
                     options.Hostpool!,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
 

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/SessionHost/SessionHostUserSessionListCommand.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Commands/SessionHost/SessionHostUserSessionListCommand.cs
@@ -47,7 +47,6 @@ public sealed class SessionHostUserSessionListCommand(ILogger<SessionHostUserSes
                     options.HostpoolResourceId,
                     options.Sessionhost,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
             else if (!string.IsNullOrEmpty(options.ResourceGroup))
@@ -58,7 +57,6 @@ public sealed class SessionHostUserSessionListCommand(ILogger<SessionHostUserSes
                     options.Hostpool!,
                     options.Sessionhost,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
             else
@@ -68,7 +66,6 @@ public sealed class SessionHostUserSessionListCommand(ILogger<SessionHostUserSes
                     options.Hostpool!,
                     options.Sessionhost,
                     options.Tenant,
-                    options.RetryPolicy,
                     cancellationToken);
             }
 

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Options/Hostpool/BaseHostPoolOptions.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Options/Hostpool/BaseHostPoolOptions.cs
@@ -23,7 +23,4 @@ public class BaseHostPoolOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Options/Hostpool/HostpoolListOptions.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Options/Hostpool/HostpoolListOptions.cs
@@ -16,7 +16,4 @@ public sealed class HostpoolListOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Services/IVirtualDesktopService.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Services/IVirtualDesktopService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.VirtualDesktop.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.VirtualDesktop.Services;
 
@@ -11,28 +10,24 @@ public interface IVirtualDesktopService
     Task<IReadOnlyList<HostPool>> ListHostpoolsAsync(
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<HostPool>> ListHostpoolsByResourceGroupAsync(
         string subscription,
         string resourceGroup,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<SessionHost>> ListSessionHostsAsync(
         string subscription,
         string hostPoolName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<SessionHost>> ListSessionHostsByResourceIdAsync(
         string subscription,
         string hostPoolResourceId,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<SessionHost>> ListSessionHostsByResourceGroupAsync(
@@ -40,7 +35,6 @@ public interface IVirtualDesktopService
         string resourceGroup,
         string hostPoolName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<UserSession>> ListUserSessionsAsync(
@@ -48,7 +42,6 @@ public interface IVirtualDesktopService
         string hostPoolName,
         string sessionHostName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<UserSession>> ListUserSessionsByResourceIdAsync(
@@ -56,7 +49,6 @@ public interface IVirtualDesktopService
         string hostPoolResourceId,
         string sessionHostName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<UserSession>> ListUserSessionsByResourceGroupAsync(
@@ -65,6 +57,5 @@ public interface IVirtualDesktopService
         string hostPoolName,
         string sessionHostName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/src/Services/VirtualDesktopService.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/src/Services/VirtualDesktopService.cs
@@ -4,7 +4,6 @@
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.VirtualDesktop.Models;
 using Azure.ResourceManager.DesktopVirtualization;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.VirtualDesktop.Services;
 
@@ -15,10 +14,9 @@ public class VirtualDesktopService(IAzureService azureService) : IVirtualDesktop
     public async Task<IReadOnlyList<HostPool>> ListHostpoolsAsync(
         string subscription,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var sub = await _azureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var sub = await _azureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var hostpools = new List<HostPool>();
         await foreach (HostPoolResource resource in sub.GetHostPoolsAsync(cancellationToken))
         {
@@ -31,10 +29,9 @@ public class VirtualDesktopService(IAzureService azureService) : IVirtualDesktop
         string subscription,
         string resourceGroup,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var sub = await _azureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var sub = await _azureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var hostpools = new List<HostPool>();
 
         var resourceGroupResource = await sub.GetResourceGroupAsync(resourceGroup, cancellationToken);
@@ -49,10 +46,9 @@ public class VirtualDesktopService(IAzureService azureService) : IVirtualDesktop
         string subscription,
         string hostPoolName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var sub = await _azureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var sub = await _azureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var sessionHosts = new List<SessionHost>();
 
         await foreach (HostPoolResource resource in sub.GetHostPoolsAsync(cancellationToken))
@@ -77,10 +73,9 @@ public class VirtualDesktopService(IAzureService azureService) : IVirtualDesktop
         string hostPoolName,
         string sessionHostName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var sub = await _azureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var sub = await _azureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var userSessions = new List<UserSession>();
 
         await foreach (HostPoolResource resource in sub.GetHostPoolsAsync(cancellationToken))
@@ -111,10 +106,9 @@ public class VirtualDesktopService(IAzureService azureService) : IVirtualDesktop
         string subscription,
         string hostPoolResourceId,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var sub = await _azureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var sub = await _azureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var sessionHosts = new List<SessionHost>();
 
         var armClient = sub.GetCachedClient(client => client);
@@ -132,10 +126,9 @@ public class VirtualDesktopService(IAzureService azureService) : IVirtualDesktop
         string hostPoolResourceId,
         string sessionHostName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var sub = await _azureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var sub = await _azureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var userSessions = new List<UserSession>();
 
         var armClient = sub.GetCachedClient(client => client);
@@ -160,10 +153,9 @@ public class VirtualDesktopService(IAzureService azureService) : IVirtualDesktop
         string resourceGroup,
         string hostPoolName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var sub = await _azureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var sub = await _azureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var sessionHosts = new List<SessionHost>();
 
         var resourceGroupResource = await sub.GetResourceGroupAsync(resourceGroup, cancellationToken);
@@ -183,10 +175,9 @@ public class VirtualDesktopService(IAzureService azureService) : IVirtualDesktop
         string hostPoolName,
         string sessionHostName,
         string? tenant = null,
-        RetryPolicyOptions? retryPolicy = null,
         CancellationToken cancellationToken = default)
     {
-        var sub = await _azureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken);
+        var sub = await _azureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken);
         var userSessions = new List<UserSession>();
 
         var resourceGroupResource = await sub.GetResourceGroupAsync(resourceGroup, cancellationToken);

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.Tests/Hostpool/HostpoolListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.Tests/Hostpool/HostpoolListCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.VirtualDesktop.Commands.Hostpool;
 using Azure.Mcp.Tools.VirtualDesktop.Models;
 using Azure.Mcp.Tools.VirtualDesktop.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -40,9 +39,9 @@ public class HostpoolListCommandTests : SubscriptionCommandUnitTestsBase<Hostpoo
                 new() { Name = "hostpool1" },
                 new() { Name = "hostpool2" }
             }.AsReadOnly();
-            Service.ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Service.ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(hostpools);
-            Service.ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+            Service.ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(hostpools);
         }
 
@@ -66,9 +65,9 @@ public class HostpoolListCommandTests : SubscriptionCommandUnitTestsBase<Hostpoo
     public async Task ExecuteAsync_ReturnsEmptyResult_WhenNoHostpools()
     {
         // Arrange
-        Service.ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([]);
-        Service.ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act
@@ -83,7 +82,7 @@ public class HostpoolListCommandTests : SubscriptionCommandUnitTestsBase<Hostpoo
     public async Task ExecuteAsync_HandlesServiceErrors()
     {
         // Arrange
-        Service.ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
         // Act
@@ -104,7 +103,7 @@ public class HostpoolListCommandTests : SubscriptionCommandUnitTestsBase<Hostpoo
             new() { Name = "hostpool1" },
             new() { Name = "hostpool2" }
         }.AsReadOnly();
-        Service.ListHostpoolsAsync("test-sub", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListHostpoolsAsync("test-sub", null, Arg.Any<CancellationToken>())
             .Returns(expectedHostpools);
 
         // Act
@@ -114,7 +113,7 @@ public class HostpoolListCommandTests : SubscriptionCommandUnitTestsBase<Hostpoo
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        await Service.Received(1).ListHostpoolsAsync("test-sub", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListHostpoolsAsync("test-sub", null, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -126,7 +125,7 @@ public class HostpoolListCommandTests : SubscriptionCommandUnitTestsBase<Hostpoo
             new() { Name = "hostpool1" },
             new() { Name = "hostpool2" }
         }.AsReadOnly();
-        Service.ListHostpoolsByResourceGroupAsync("test-sub", "test-rg", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListHostpoolsByResourceGroupAsync("test-sub", "test-rg", null, Arg.Any<CancellationToken>())
             .Returns(expectedHostpools);
 
         // Act
@@ -136,8 +135,8 @@ public class HostpoolListCommandTests : SubscriptionCommandUnitTestsBase<Hostpoo
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        await Service.Received(1).ListHostpoolsByResourceGroupAsync("test-sub", "test-rg", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
-        await Service.DidNotReceive().ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListHostpoolsByResourceGroupAsync("test-sub", "test-rg", null, Arg.Any<CancellationToken>());
+        await Service.DidNotReceive().ListHostpoolsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -149,7 +148,7 @@ public class HostpoolListCommandTests : SubscriptionCommandUnitTestsBase<Hostpoo
             new() { Name = "hostpool1" },
             new() { Name = "hostpool2" }
         }.AsReadOnly();
-        Service.ListHostpoolsAsync("test-sub", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListHostpoolsAsync("test-sub", null, Arg.Any<CancellationToken>())
             .Returns(expectedHostpools);
 
         // Act
@@ -159,15 +158,15 @@ public class HostpoolListCommandTests : SubscriptionCommandUnitTestsBase<Hostpoo
         Assert.Equal(HttpStatusCode.OK, response.Status);
         Assert.NotNull(response.Results);
 
-        await Service.Received(1).ListHostpoolsAsync("test-sub", null, Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
-        await Service.DidNotReceive().ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).ListHostpoolsAsync("test-sub", null, Arg.Any<CancellationToken>());
+        await Service.DidNotReceive().ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsEmptyResult_WhenNoHostpoolsInResourceGroup()
     {
         // Arrange
-        Service.ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>(), Arg.Any<CancellationToken>())
+        Service.ListHostpoolsByResourceGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.Tests/SessionHost/SessionHostListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.Tests/SessionHost/SessionHostListCommandTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.VirtualDesktop.Commands.SessionHost;
 using Azure.Mcp.Tools.VirtualDesktop.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -50,7 +49,6 @@ public class SessionHostListCommandTests : SubscriptionCommandUnitTestsBase<Sess
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(mockSessionHosts);
 
@@ -58,7 +56,6 @@ public class SessionHostListCommandTests : SubscriptionCommandUnitTestsBase<Sess
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(mockSessionHosts);
 
@@ -67,7 +64,6 @@ public class SessionHostListCommandTests : SubscriptionCommandUnitTestsBase<Sess
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<RetryPolicyOptions>(),
                 Arg.Any<CancellationToken>())
                 .Returns(mockSessionHosts);
         }
@@ -103,7 +99,6 @@ public class SessionHostListCommandTests : SubscriptionCommandUnitTestsBase<Sess
             "sub123",
             "pool1",
             null,
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedSessionHosts);
 
@@ -119,7 +114,6 @@ public class SessionHostListCommandTests : SubscriptionCommandUnitTestsBase<Sess
             "sub123",
             "pool1",
             null,
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -138,7 +132,6 @@ public class SessionHostListCommandTests : SubscriptionCommandUnitTestsBase<Sess
             "sub123",
             resourceId,
             null,
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedSessionHosts);
 
@@ -154,14 +147,12 @@ public class SessionHostListCommandTests : SubscriptionCommandUnitTestsBase<Sess
             "sub123",
             resourceId,
             null,
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
 
         await Service.DidNotReceive().ListSessionHostsAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -180,7 +171,6 @@ public class SessionHostListCommandTests : SubscriptionCommandUnitTestsBase<Sess
             "rg1",
             "pool1",
             null,
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedSessionHosts);
 
@@ -197,7 +187,6 @@ public class SessionHostListCommandTests : SubscriptionCommandUnitTestsBase<Sess
             "rg1",
             "pool1",
             null,
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -209,7 +198,6 @@ public class SessionHostListCommandTests : SubscriptionCommandUnitTestsBase<Sess
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -217,7 +205,6 @@ public class SessionHostListCommandTests : SubscriptionCommandUnitTestsBase<Sess
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -238,7 +225,6 @@ public class SessionHostListCommandTests : SubscriptionCommandUnitTestsBase<Sess
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -246,7 +232,6 @@ public class SessionHostListCommandTests : SubscriptionCommandUnitTestsBase<Sess
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 

--- a/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.Tests/SessionHost/SessionHostUserSessionListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.VirtualDesktop/tests/Azure.Mcp.Tools.VirtualDesktop.Tests/SessionHost/SessionHostUserSessionListCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.VirtualDesktop.Commands.SessionHost;
 using Azure.Mcp.Tools.VirtualDesktop.Models;
 using Azure.Mcp.Tools.VirtualDesktop.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -57,7 +56,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(userSessions.AsReadOnly());
 
@@ -66,7 +64,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(userSessions.AsReadOnly());
 
@@ -76,7 +73,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<RetryPolicyOptions?>(),
                 Arg.Any<CancellationToken>())
                 .Returns(userSessions.AsReadOnly());
         }
@@ -130,7 +126,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             "test-hostpool",
             "test-sessionhost",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
@@ -150,7 +145,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             "test-hostpool",
             "test-sessionhost",
             null,
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -177,7 +171,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             resourceId,
             "test-sessionhost",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
@@ -197,7 +190,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             resourceId,
             "test-sessionhost",
             null,
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
 
         await Service.DidNotReceive().ListUserSessionsAsync(
@@ -205,7 +197,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -232,7 +223,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             "test-hostpool",
             "test-sessionhost",
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
@@ -254,7 +244,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             "test-hostpool",
             "test-sessionhost",
             null,
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
 
         await Service.DidNotReceive().ListUserSessionsAsync(
@@ -262,7 +251,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
 
         await Service.DidNotReceive().ListUserSessionsByResourceIdAsync(
@@ -270,7 +258,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -285,7 +272,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
@@ -294,7 +280,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
@@ -319,7 +304,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -328,7 +312,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
 
@@ -354,7 +337,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(exception);
 
@@ -363,7 +345,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(exception);
 
@@ -389,7 +370,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(exception);
 
@@ -398,7 +378,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(exception);
 
@@ -436,7 +415,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             "test-hostpool",
             "test-sessionhost",
             "test-tenant",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
@@ -445,7 +423,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>())
             .Returns(userSessions.AsReadOnly());
 
@@ -466,7 +443,6 @@ public class SessionHostUserSessionListCommandTests : SubscriptionCommandUnitTes
             "test-hostpool",
             "test-sessionhost",
             "test-tenant",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/CreateWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/CreateWorkbooksCommand.cs
@@ -48,7 +48,6 @@ public sealed class CreateWorkbooksCommand(ILogger<CreateWorkbooksCommand> logge
                  * otherwise the workbook will display an error when opening.
                  */
                 options.SourceId ?? "azure monitor",
-                options.RetryPolicy,
                 options.Tenant,
                 cancellationToken) ?? throw new InvalidOperationException("Failed to create workbook");
 

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/DeleteWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/DeleteWorkbooksCommand.cs
@@ -51,7 +51,6 @@ public sealed class DeleteWorkbooksCommand(ILogger<DeleteWorkbooksCommand> logge
         {
             var result = await _workbooksService.DeleteWorkbooksAsync(
                 options.WorkbookIds,
-                options.RetryPolicy,
                 options.Tenant,
                 cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ListWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ListWorkbooksCommand.cs
@@ -64,7 +64,6 @@ public sealed class ListWorkbooksCommand(ILogger<ListWorkbooksCommand> logger, I
                 options.MaxResults == null || options.MaxResults.Value < 1 ? 50 : Math.Min(options.MaxResults.Value, 1000),
                 options.IncludeTotalCount ?? true,
                 ParseOutputFormat(options.OutputFormat),
-                options.RetryPolicy,
                 options.Tenant,
                 cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ShowWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/ShowWorkbooksCommand.cs
@@ -50,7 +50,6 @@ public sealed class ShowWorkbooksCommand(ILogger<ShowWorkbooksCommand> logger, I
         {
             var result = await _workbooksService.GetWorkbooksAsync(
                 options.WorkbookIds,
-                options.RetryPolicy,
                 options.Tenant,
                 cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/UpdateWorkbooksCommand.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Commands/Workbooks/UpdateWorkbooksCommand.cs
@@ -35,7 +35,6 @@ public sealed class UpdateWorkbooksCommand(ILogger<UpdateWorkbooksCommand> logge
                 options.WorkbookId,
                 options.DisplayName,
                 options.SerializedContent,
-                options.RetryPolicy,
                 options.Tenant,
                 cancellationToken) ?? throw new InvalidOperationException("Failed to update workbook");
 

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Options/Workbook/CreateWorkbookOptions.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Options/Workbook/CreateWorkbookOptions.cs
@@ -26,6 +26,4 @@ public sealed class CreateWorkbookOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Options/Workbook/DeleteWorkbookOptions.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Options/Workbook/DeleteWorkbookOptions.cs
@@ -14,6 +14,4 @@ public sealed class DeleteWorkbookOptions
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Options/Workbook/ListWorkbooksOptions.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Options/Workbook/ListWorkbooksOptions.cs
@@ -43,8 +43,6 @@ public sealed class ListWorkbooksOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 
     /// <summary>
     /// Creates a WorkbookFilters object from the command options.

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Options/Workbook/ShowWorkbooksOptions.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Options/Workbook/ShowWorkbooksOptions.cs
@@ -14,6 +14,4 @@ public sealed class ShowWorkbooksOptions
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Options/Workbook/UpdateWorkbooksOptions.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Options/Workbook/UpdateWorkbooksOptions.cs
@@ -20,6 +20,4 @@ public sealed class UpdateWorkbooksOptions
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [OptionContainer(Prefix = "retry")]
-    public RetryPolicyOptions? RetryPolicy { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Services/IWorkbooksService.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Services/IWorkbooksService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Mcp.Tools.Workbooks.Models;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Workbooks.Services;
 
@@ -19,7 +18,6 @@ public interface IWorkbooksService
         int maxResults = 50,
         bool includeTotalCount = true,
         OutputFormat outputFormat = OutputFormat.Standard,
-        RetryPolicyOptions? retryPolicy = null,
         string? tenant = null,
         CancellationToken cancellationToken = default);
 
@@ -29,7 +27,6 @@ public interface IWorkbooksService
     /// </summary>
     Task<WorkbookBatchResult> GetWorkbooksAsync(
         IReadOnlyList<string> workbookIds,
-        RetryPolicyOptions? retryPolicy = null,
         string? tenant = null,
         CancellationToken cancellationToken = default);
 
@@ -42,7 +39,6 @@ public interface IWorkbooksService
         string displayName,
         string serializedData,
         string sourceId,
-        RetryPolicyOptions? retryPolicy = null,
         string? tenant = null,
         CancellationToken cancellationToken = default);
 
@@ -53,7 +49,6 @@ public interface IWorkbooksService
         string workbookId,
         string? displayName = null,
         string? serializedContent = null,
-        RetryPolicyOptions? retryPolicy = null,
         string? tenant = null,
         CancellationToken cancellationToken = default);
 
@@ -62,7 +57,6 @@ public interface IWorkbooksService
     /// </summary>
     Task<WorkbookDeleteBatchResult> DeleteWorkbooksAsync(
         IReadOnlyList<string> workbookIds,
-        RetryPolicyOptions? retryPolicy = null,
         string? tenant = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Workbooks/src/Services/WorkbooksService.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/src/Services/WorkbooksService.cs
@@ -10,7 +10,6 @@ using Azure.ResourceManager.ApplicationInsights.Models;
 using Azure.ResourceManager.ResourceGraph;
 using Azure.ResourceManager.ResourceGraph.Models;
 using Microsoft.Extensions.Logging;
-using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Workbooks.Services;
 
@@ -33,7 +32,6 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
         int maxResults = 50,
         bool includeTotalCount = true,
         OutputFormat outputFormat = OutputFormat.Standard,
-        RetryPolicyOptions? retryPolicy = null,
         string? tenant = null,
         CancellationToken cancellationToken = default)
     {
@@ -52,7 +50,7 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
             foreach (var sub in subscriptions)
             {
                 // Resolve subscription name to ID if needed
-                var subscriptionResource = await AzureService.GetSubscription(sub, tenant, retryPolicy, cancellationToken);
+                var subscriptionResource = await AzureService.GetSubscription(sub, tenant, cancellationToken: cancellationToken);
                 query.Subscriptions.Add(subscriptionResource.Data.SubscriptionId);
             }
         }
@@ -79,7 +77,7 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
         int? totalCount = null;
         if (includeTotalCount)
         {
-            totalCount = await GetTotalCountAsync(subscriptions, resourceGroups, filters, tenant, retryPolicy, cancellationToken);
+            totalCount = await GetTotalCountAsync(subscriptions, resourceGroups, filters, tenant, cancellationToken);
         }
 
         return new(workbooks, totalCount, ContinuationToken: null);
@@ -87,7 +85,6 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
 
     public async Task<WorkbookBatchResult> GetWorkbooksAsync(
         IReadOnlyList<string> workbookIds,
-        RetryPolicyOptions? retryPolicy = null,
         string? tenant = null,
         CancellationToken cancellationToken = default)
     {
@@ -104,7 +101,7 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
             await _throttle.WaitAsync(cancellationToken);
             try
             {
-                var workbook = await GetSingleWorkbookAsync(id, retryPolicy, tenant, cancellationToken);
+                var workbook = await GetSingleWorkbookAsync(id, tenant, cancellationToken);
                 if (workbook is null)
                 {
                     throw new InvalidOperationException($"Workbook with ID '{id}' was not found or returned null.");
@@ -144,7 +141,6 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
         string displayName,
         string serializedData,
         string sourceId,
-        RetryPolicyOptions? retryPolicy = null,
         string? tenant = null,
         CancellationToken cancellationToken = default)
     {
@@ -157,7 +153,7 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
 
         ValidateSerializedData(serializedData);
 
-        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, retryPolicy, cancellationToken)
+        var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, cancellationToken: cancellationToken)
             ?? throw new InvalidOperationException($"Subscription '{subscription}' not found");
 
         var resourceGroupResource = await subscriptionResource.GetResourceGroups().GetAsync(resourceGroupName, cancellationToken);
@@ -191,7 +187,6 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
         string workbookId,
         string? displayName = null,
         string? serializedContent = null,
-        RetryPolicyOptions? retryPolicy = null,
         string? tenant = null,
         CancellationToken cancellationToken = default)
     {
@@ -202,7 +197,7 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
             ValidateSerializedData(serializedContent);
         }
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
 
         var workbookResourceId = new ResourceIdentifier(workbookId);
         var workbookResource = armClient.GetApplicationInsightsWorkbookResource(workbookResourceId)
@@ -239,7 +234,6 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
 
     public async Task<WorkbookDeleteBatchResult> DeleteWorkbooksAsync(
         IReadOnlyList<string> workbookIds,
-        RetryPolicyOptions? retryPolicy = null,
         string? tenant = null,
         CancellationToken cancellationToken = default)
     {
@@ -256,7 +250,7 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
             await _throttle.WaitAsync(cancellationToken);
             try
             {
-                await DeleteSingleWorkbookAsync(id, retryPolicy, tenant, cancellationToken);
+                await DeleteSingleWorkbookAsync(id, tenant, cancellationToken);
                 return (Id: id, Error: (WorkbookError?)null);
             }
             catch (Exception ex)
@@ -289,13 +283,12 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
 
     private async Task<WorkbookInfo?> GetSingleWorkbookAsync(
         string workbookId,
-        RetryPolicyOptions? retryPolicy,
         string? tenant,
         CancellationToken cancellationToken)
     {
         ValidateWorkbookId(workbookId);
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
 
         var workbookResourceId = new ResourceIdentifier(workbookId);
         var workbookResource = armClient.GetApplicationInsightsWorkbookResource(workbookResourceId)
@@ -316,13 +309,12 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
 
     private async Task DeleteSingleWorkbookAsync(
         string workbookId,
-        RetryPolicyOptions? retryPolicy,
         string? tenant,
         CancellationToken cancellationToken)
     {
         ValidateWorkbookId(workbookId);
 
-        var armClient = await CreateArmClientAsync(tenant, retryPolicy, cancellationToken: cancellationToken);
+        var armClient = await CreateArmClientAsync(tenantIdOrName: tenant, cancellationToken: cancellationToken);
 
         var workbookResourceId = new ResourceIdentifier(workbookId);
         var workbookResource = armClient.GetApplicationInsightsWorkbookResource(workbookResourceId)
@@ -338,7 +330,6 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
         IReadOnlyList<string>? resourceGroups,
         WorkbookFilters? filters,
         string? tenant,
-        RetryPolicyOptions? retryPolicy,
         CancellationToken cancellationToken)
     {
         try
@@ -357,7 +348,7 @@ public class WorkbooksService(IAzureService azureService, ILogger<WorkbooksServi
             {
                 foreach (var sub in subscriptions)
                 {
-                    var subscriptionResource = await AzureService.GetSubscription(sub, tenant, retryPolicy, cancellationToken);
+                    var subscriptionResource = await AzureService.GetSubscription(sub, tenant, cancellationToken: cancellationToken);
                     query.Subscriptions.Add(subscriptionResource.Data.SubscriptionId);
                 }
             }

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.Tests/CreateWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.Tests/CreateWorkbooksCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Workbooks.Commands.Workbooks;
 using Azure.Mcp.Tools.Workbooks.Models;
 using Azure.Mcp.Tools.Workbooks.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -69,7 +68,6 @@ public class CreateWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<Crea
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(workbook);
@@ -91,7 +89,6 @@ public class CreateWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<Crea
             "Test Workbook",
             """{"items":[{"type":"text","content":"Test content"}]}""",
             "azure monitor",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -121,7 +118,6 @@ public class CreateWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<Crea
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(workbook);
@@ -141,7 +137,6 @@ public class CreateWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<Crea
             "Test Workbook",
             """{"items":[{"type":"text","content":"Test content"}]}""",
             "custom-source",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -156,7 +151,6 @@ public class CreateWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<Crea
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns((WorkbookInfo?)null);
@@ -182,7 +176,6 @@ public class CreateWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<Crea
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Service error"));
@@ -223,7 +216,6 @@ public class CreateWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<Crea
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(workbook);
@@ -242,7 +234,6 @@ public class CreateWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<Crea
             "My Test Workbook",
             """{"version": "Notebook/1.0","items": [{"type": "1","content": "Hello World"}]}""",
             "azure monitor",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -258,7 +249,6 @@ public class CreateWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<Crea
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(workbook);
@@ -277,7 +267,6 @@ public class CreateWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<Crea
             "Test Workbook",
             """{"items":[]}""",
             "azure monitor",
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Is<string?>(t => t == null),
             Arg.Any<CancellationToken>());
     }
@@ -371,7 +360,6 @@ public class CreateWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<Crea
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(workbook);
@@ -389,49 +377,6 @@ public class CreateWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<Crea
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithRetryOptions_PassesCorrectParameters()
-    {
-        // Arrange
-        var workbook = new WorkbookInfo("test-id", null, null, null, null, null, null, null, null, null, null, null);
-        Service.CreateWorkbookAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(workbook);
-
-        // Act
-        await ExecuteCommandAsync(
-            "--subscription", "test-sub",
-            "--resource-group", "test-rg",
-            "--display-name", "Test Workbook",
-            "--serialized-content", """{"items":[]}""",
-            "--retry-max-retries", "5",
-            "--retry-delay", "2.5",
-            "--retry-max-delay", "30",
-            "--retry-mode", "Exponential");
-
-        // Assert
-        await Service.Received(1).CreateWorkbookAsync(
-            "test-sub",
-            "test-rg",
-            "Test Workbook",
-            """{"items":[]}""",
-            "azure monitor",
-            Arg.Is<RetryPolicyOptions?>(opts =>
-                opts != null &&
-                opts.MaxRetries == 5 &&
-                opts.DelaySeconds == 2.5 &&
-                opts.MaxDelaySeconds == 30),
-            Arg.Any<string?>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
     public async Task ExecuteAsync_HandlesExceptionCorrectly_WhenExceptionOccurs()
     {
         // Arrange
@@ -441,7 +386,6 @@ public class CreateWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<Crea
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException("Invalid workbook data"));

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.Tests/DeleteWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.Tests/DeleteWorkbooksCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tools.Workbooks.Commands;
 using Azure.Mcp.Tools.Workbooks.Commands.Workbooks;
 using Azure.Mcp.Tools.Workbooks.Models;
 using Azure.Mcp.Tools.Workbooks.Services;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -46,7 +45,6 @@ public class DeleteWorkbooksCommandTests : CommandUnitTestsBase<DeleteWorkbooksC
 
         Service.DeleteWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(batchResult);
@@ -73,7 +71,6 @@ public class DeleteWorkbooksCommandTests : CommandUnitTestsBase<DeleteWorkbooksC
 
         Service.DeleteWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(batchResult);
@@ -100,7 +97,6 @@ public class DeleteWorkbooksCommandTests : CommandUnitTestsBase<DeleteWorkbooksC
 
         Service.DeleteWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(batchResult);
@@ -129,7 +125,6 @@ public class DeleteWorkbooksCommandTests : CommandUnitTestsBase<DeleteWorkbooksC
 
         Service.DeleteWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(batchResult);
@@ -152,7 +147,6 @@ public class DeleteWorkbooksCommandTests : CommandUnitTestsBase<DeleteWorkbooksC
 
         Service.DeleteWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Service error"));
@@ -176,7 +170,6 @@ public class DeleteWorkbooksCommandTests : CommandUnitTestsBase<DeleteWorkbooksC
 
         Service.DeleteWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(batchResult);
@@ -187,7 +180,6 @@ public class DeleteWorkbooksCommandTests : CommandUnitTestsBase<DeleteWorkbooksC
         // Assert
         await Service.Received(1).DeleteWorkbooksAsync(
             Arg.Is<IReadOnlyList<string>>(ids => ids.Contains(workbookId)),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Is("test-tenant"),
             Arg.Any<CancellationToken>());
     }
@@ -202,7 +194,6 @@ public class DeleteWorkbooksCommandTests : CommandUnitTestsBase<DeleteWorkbooksC
 
         Service.DeleteWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(batchResult);
@@ -213,7 +204,6 @@ public class DeleteWorkbooksCommandTests : CommandUnitTestsBase<DeleteWorkbooksC
         // Assert
         await Service.Received(1).DeleteWorkbooksAsync(
             Arg.Is<IReadOnlyList<string>>(ids => ids.Contains(workbookId)),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Is<string?>(t => t == null),
             Arg.Any<CancellationToken>());
     }
@@ -239,7 +229,6 @@ public class DeleteWorkbooksCommandTests : CommandUnitTestsBase<DeleteWorkbooksC
 
         Service.DeleteWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(batchResult);
@@ -254,32 +243,4 @@ public class DeleteWorkbooksCommandTests : CommandUnitTestsBase<DeleteWorkbooksC
         Assert.Contains(validWorkbookId, result.Succeeded);
     }
 
-    [Fact]
-    public async Task ExecuteAsync_WithRetryPolicy_PassesRetryOptions()
-    {
-        // Arrange
-        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
-
-        var batchResult = new WorkbookDeleteBatchResult([workbookId], []);
-
-        Service.DeleteWorkbooksAsync(
-            Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(batchResult);
-
-        // Act
-        await ExecuteCommandAsync("--workbook-ids", workbookId, "--retry-max-retries", "5", "--retry-delay", "2");
-
-        // Assert
-        await Service.Received(1).DeleteWorkbooksAsync(
-            Arg.Is<IReadOnlyList<string>>(ids => ids.Contains(workbookId)),
-            Arg.Is<RetryPolicyOptions?>(options =>
-                options != null &&
-                options.MaxRetries == 5 &&
-                options.DelaySeconds == 2),
-            Arg.Any<string?>(),
-            Arg.Any<CancellationToken>());
-    }
 }

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.Tests/ListWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.Tests/ListWorkbooksCommandTests.cs
@@ -7,7 +7,6 @@ using Azure.Mcp.Tools.Workbooks.Commands;
 using Azure.Mcp.Tools.Workbooks.Commands.Workbooks;
 using Azure.Mcp.Tools.Workbooks.Models;
 using Azure.Mcp.Tools.Workbooks.Services;
-using Microsoft.Mcp.Core.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -90,7 +89,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -131,7 +129,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -159,7 +156,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Service error"));
@@ -188,7 +184,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -207,7 +202,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Is("test-tenant"),
             Arg.Any<CancellationToken>());
     }
@@ -224,7 +218,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -242,7 +235,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Is<string?>(t => t == null),
             Arg.Any<CancellationToken>());
     }
@@ -301,7 +293,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -354,7 +345,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -377,7 +367,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -413,7 +402,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -436,7 +424,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -473,7 +460,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -496,7 +482,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -533,7 +518,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -558,7 +542,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -594,7 +577,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -616,7 +598,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -635,7 +616,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -657,7 +637,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -678,7 +657,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -700,7 +678,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -736,7 +713,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Is(true), // includeTotalCount
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -764,7 +740,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Is(25), // maxResults
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -782,7 +757,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Is(25),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -803,7 +777,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Is(expectedFormat),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -821,7 +794,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Is(expectedFormat),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -839,7 +811,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -857,7 +828,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -876,7 +846,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -894,7 +863,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -915,7 +883,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -934,7 +901,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -952,7 +918,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -971,7 +936,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -992,7 +956,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Is(expectedMaxResults),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -1010,7 +973,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Is(expectedMaxResults),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -1030,7 +992,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Is(expectedMaxResults),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -1048,7 +1009,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Is(expectedMaxResults),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -1067,7 +1027,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -1085,7 +1044,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Is(true),  // Default should be true
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -1128,7 +1086,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -1157,7 +1114,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -1181,7 +1137,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Is(expectedFormat),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -1199,7 +1154,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Is(expectedFormat),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -1217,7 +1171,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Is(OutputFormat.Standard),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -1235,7 +1188,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Is(OutputFormat.Standard),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -1253,7 +1205,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Is(true), // should default to true
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);
@@ -1269,7 +1220,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Is(true),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
@@ -1289,7 +1239,6 @@ public class ListWorkbooksCommandTests : SubscriptionCommandUnitTestsBase<ListWo
             Arg.Any<int>(),
             Arg.Any<bool>(),
             Arg.Any<OutputFormat>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(listResult);

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.Tests/ShowWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.Tests/ShowWorkbooksCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tools.Workbooks.Commands;
 using Azure.Mcp.Tools.Workbooks.Commands.Workbooks;
 using Azure.Mcp.Tools.Workbooks.Models;
 using Azure.Mcp.Tools.Workbooks.Services;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -69,7 +68,6 @@ public class ShowWorkbooksCommandTests : CommandUnitTestsBase<ShowWorkbooksComma
 
         Service.GetWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(batchResult);
@@ -129,7 +127,6 @@ public class ShowWorkbooksCommandTests : CommandUnitTestsBase<ShowWorkbooksComma
 
         Service.GetWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(batchResult);
@@ -172,7 +169,6 @@ public class ShowWorkbooksCommandTests : CommandUnitTestsBase<ShowWorkbooksComma
 
         Service.GetWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(batchResult);
@@ -197,7 +193,6 @@ public class ShowWorkbooksCommandTests : CommandUnitTestsBase<ShowWorkbooksComma
 
         Service.GetWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Service error"));
@@ -220,7 +215,6 @@ public class ShowWorkbooksCommandTests : CommandUnitTestsBase<ShowWorkbooksComma
 
         Service.GetWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(batchResult);
@@ -231,7 +225,6 @@ public class ShowWorkbooksCommandTests : CommandUnitTestsBase<ShowWorkbooksComma
         // Assert
         await Service.Received(1).GetWorkbooksAsync(
             Arg.Is<IReadOnlyList<string>>(ids => ids.Contains(workbookId)),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Is("test-tenant"),
             Arg.Any<CancellationToken>());
     }
@@ -245,7 +238,6 @@ public class ShowWorkbooksCommandTests : CommandUnitTestsBase<ShowWorkbooksComma
 
         Service.GetWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(batchResult);
@@ -256,7 +248,6 @@ public class ShowWorkbooksCommandTests : CommandUnitTestsBase<ShowWorkbooksComma
         // Assert
         await Service.Received(1).GetWorkbooksAsync(
             Arg.Is<IReadOnlyList<string>>(ids => ids.Contains(workbookId)),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Is<string?>(t => t == null),
             Arg.Any<CancellationToken>());
     }
@@ -332,7 +323,6 @@ public class ShowWorkbooksCommandTests : CommandUnitTestsBase<ShowWorkbooksComma
 
         Service.GetWorkbooksAsync(
             Arg.Any<IReadOnlyList<string>>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(batchResult);

--- a/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.Tests/UpdateWorkbooksCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Workbooks/tests/Azure.Mcp.Tools.Workbooks.Tests/UpdateWorkbooksCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Mcp.Tools.Workbooks.Commands;
 using Azure.Mcp.Tools.Workbooks.Commands.Workbooks;
 using Azure.Mcp.Tools.Workbooks.Models;
 using Azure.Mcp.Tools.Workbooks.Services;
-using Microsoft.Mcp.Core.Options;
 using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -69,7 +68,6 @@ public class UpdateWorkbooksCommandTests : CommandUnitTestsBase<UpdateWorkbooksC
             Arg.Is(workbookId),
             Arg.Is("Updated Test Workbook"),
             Arg.Is("{\"version\":\"Notebook/1.0\",\"updated\":true}"),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
@@ -112,7 +110,6 @@ public class UpdateWorkbooksCommandTests : CommandUnitTestsBase<UpdateWorkbooksC
             Arg.Is(workbookId),
             Arg.Is("New Display Name Only"),
             Arg.Is((string?)null),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
@@ -153,7 +150,6 @@ public class UpdateWorkbooksCommandTests : CommandUnitTestsBase<UpdateWorkbooksC
             Arg.Is(workbookId),
             Arg.Is((string?)null),
             Arg.Is(newSerializedContent),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
@@ -197,7 +193,6 @@ public class UpdateWorkbooksCommandTests : CommandUnitTestsBase<UpdateWorkbooksC
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
@@ -213,7 +208,6 @@ public class UpdateWorkbooksCommandTests : CommandUnitTestsBase<UpdateWorkbooksC
             Arg.Is(workbookId),
             Arg.Is(displayName),
             Arg.Is(serializedContent),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Is<string?>(t => t == null),
             Arg.Any<CancellationToken>());
     }
@@ -228,7 +222,6 @@ public class UpdateWorkbooksCommandTests : CommandUnitTestsBase<UpdateWorkbooksC
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<WorkbookInfo?>(null));
@@ -251,7 +244,6 @@ public class UpdateWorkbooksCommandTests : CommandUnitTestsBase<UpdateWorkbooksC
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Service error"));
@@ -331,7 +323,6 @@ public class UpdateWorkbooksCommandTests : CommandUnitTestsBase<UpdateWorkbooksC
             Arg.Is(workbookId),
             Arg.Is("Updated Complex Workbook"),
             Arg.Is(complexSerializedData),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
@@ -378,7 +369,6 @@ public class UpdateWorkbooksCommandTests : CommandUnitTestsBase<UpdateWorkbooksC
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(updatedWorkbook);
@@ -394,55 +384,7 @@ public class UpdateWorkbooksCommandTests : CommandUnitTestsBase<UpdateWorkbooksC
             Arg.Is(workbookId),
             Arg.Is("Test Workbook"),
             Arg.Is((string?)null),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Is(tenantId),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_WithRetryOptions_PassesCorrectParameters()
-    {
-        // Arrange
-        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
-
-        var updatedWorkbook = new WorkbookInfo(
-            WorkbookId: workbookId,
-            DisplayName: "Test Workbook",
-            Description: "Test Description",
-            Category: "workbook",
-            Location: "eastus",
-            Kind: "shared",
-            Tags: "{}",
-            SerializedData: "{\"version\":\"Notebook/1.0\"}",
-            Version: "1.0",
-            TimeModified: DateTimeOffset.UtcNow,
-            UserId: "user1",
-            SourceId: "azure monitor"
-        );
-
-        Service.UpdateWorkbookAsync(
-            Arg.Any<string>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
-            Arg.Any<string?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(updatedWorkbook);
-
-        // Act
-        await ExecuteCommandAsync(
-            "--workbook-id", workbookId,
-            "--display-name", "Test Workbook",
-            "--retry-max-retries", "5",
-            "--retry-delay", "2.5");
-
-        // Assert
-        await Service.Received(1).UpdateWorkbookAsync(
-            Arg.Is(workbookId),
-            Arg.Is("Test Workbook"),
-            Arg.Is((string?)null),
-            Arg.Is<RetryPolicyOptions?>(x => x != null && x.MaxRetries == 5 && System.Math.Abs(x.DelaySeconds.GetValueOrDefault() - 2.5) < 1e-6),
-            Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -457,7 +399,6 @@ public class UpdateWorkbooksCommandTests : CommandUnitTestsBase<UpdateWorkbooksC
             Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
-            Arg.Any<RetryPolicyOptions?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(exception);


### PR DESCRIPTION
## What does this PR do?

Removed custom retry policy options from Virtual Desktop and Workbooks tools.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*