### PR TITLE
docs: remove obsolete retry options

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -12,11 +12,6 @@ The following options are available for most commands:
 | `--subscription` | No | Environment variable `AZURE_SUBSCRIPTION_ID` | Azure subscription ID for target resources |
 | `--tenant-id` | No | - | Azure tenant ID for authentication |
 | `--auth-method` | No | 'credential' | Authentication method ('credential', 'key', 'connectionString') |
-| `--retry-max-retries` | No | 3 | Maximum retry attempts for failed operations |
-| `--retry-delay` | No | 2 | Delay between retry attempts (seconds) |
-| `--retry-max-delay` | No | 10 | Maximum delay between retries (seconds) |
-| `--retry-mode` | No | 'exponential' | Retry strategy ('fixed' or 'exponential') |
-| `--retry-network-timeout` | No | 100 | Network operation timeout (seconds) |
 | `--learn` | No | false | Discover available sub-commands and their parameters without executing any Azure operation. Use on a command group to list commands in that group, or on a specific command to see its options. |
 
 ### Discovery with `--learn`
@@ -570,7 +565,7 @@ azmcp appconfig kv set --subscription <subscription> \
 ### Azure App Lens Operations
 
 > [!NOTE]
-> The `applens resource diagnose` command does not support `--auth-method` or any `--retry-*` options.
+> The `applens resource diagnose` command does not support `--auth-method`.
 
 ```bash
 # Diagnose resource using Azure App Lens
@@ -2951,7 +2946,7 @@ azmcp keyvault secret get --subscription <subscription> \
 ### Azure Kubernetes Service (AKS) Operations
 
 > [!NOTE]
-> The `aks cluster get` and `aks nodepool get` commands do not support `--auth-method` (the `--retry-*` options are still supported).
+> The `aks cluster get` and `aks nodepool get` commands do not support `--auth-method` or any `--retry-*` options.
 
 ```bash
 # Gets Azure Kubernetes Service (AKS) cluster details
@@ -5001,7 +4996,7 @@ azmcp bicepschema get --resource-type <resource-type> \
 ### Cloud Architect
 
 > [!NOTE]
-> The `cloudarchitect design` command is a local, stateless tool and does not support `--subscription`, `--tenant-id`, `--auth-method`, or any `--retry-*` options.
+> The `cloudarchitect design` command is a local, stateless tool and does not support `--subscription`, `--tenant-id`, or `--auth-method`.
 
 ```bash
 # Design Azure cloud architectures through guided questions

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -10,7 +10,7 @@ The following options are available for most commands:
 | Option | Required | Default | Description |
 |-----------|----------|---------|-------------|
 | `--subscription` | No | Environment variable `AZURE_SUBSCRIPTION_ID` | Azure subscription ID for target resources |
-| `--tenant-id` | No | - | Azure tenant ID for authentication |
+| `--tenant` | No | - | Azure tenant ID for authentication |
 | `--auth-method` | No | 'credential' | Authentication method ('credential', 'key', 'connectionString') |
 | `--learn` | No | false | Discover available sub-commands and their parameters without executing any Azure operation. Use on a command group to list commands in that group, or on a specific command to see its options. |
 
@@ -3961,6 +3961,11 @@ azmcp resilience drill run resource get --service-group <service-group> \
 
 ### Azure Resource Group Operations
 
+> [!NOTE]
+> The core `group list` and `group resource list` commands also support
+> `--retry-max-retries`, `--retry-delay`, `--retry-max-delay`, `--retry-mode`,
+> and `--retry-network-timeout`.
+
 ```bash
 # List resource groups in a subscription
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
@@ -4773,12 +4778,17 @@ azmcp storagesync serverendpoint update --subscription <subscription> \
 
 ### Azure Subscription Management
 
+> [!NOTE]
+> The core `subscription list` command also supports `--retry-max-retries`,
+> `--retry-delay`, `--retry-max-delay`, `--retry-mode`, and
+> `--retry-network-timeout`.
+
 ```bash
 # List available Azure subscriptions with default subscription indicator
 # Returns subscriptionId, displayName, state, tenantId, and isDefault for each subscription
 # The isDefault field is true for the default subscription set via 'az account set' or AZURE_SUBSCRIPTION_ID env var
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp subscription list [--tenant-id <tenant-id>]
+azmcp subscription list [--tenant <tenant-id>]
 ```
 
 ### Azure Terraform Best Practices
@@ -4996,7 +5006,7 @@ azmcp bicepschema get --resource-type <resource-type> \
 ### Cloud Architect
 
 > [!NOTE]
-> The `cloudarchitect design` command is a local, stateless tool and does not support `--subscription`, `--tenant-id`, or `--auth-method`.
+> The `cloudarchitect design` command is a local, stateless tool and does not support `--subscription`, `--tenant`, or `--auth-method`.
 
 ```bash
 # Design Azure cloud architectures through guided questions


### PR DESCRIPTION
## What does this PR do?

Removes the obsolete global `--retry-*` options from the Azure MCP command reference now that `RetryPolicyOptions` has been removed from all tool commands.

It also updates the AppLens, AKS, and Cloud Architect notes so they no longer imply that the removed global retry options are generally available.

## GitHub issue number?

Fixes #3418

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md)
    - [x] Added comprehensive tests for new/modified functionality — N/A; documentation-only change. `dotnet build servers/Azure.Mcp.Server/` and the spelling check pass.
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md) — N/A; minor documentation correction.
- [x] For MCP tool changes: N/A; this PR does not add or modify an MCP tool.
    - [x] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles — N/A.
    - [x] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation — N/A.
    - [x] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme) — N/A.
    - [x] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts — N/A.
    - [x] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json) — N/A.
    - [x] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label — N/A.
    - [x] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description — N/A.
- [x] Extra steps for **Azure MCP Server** tool changes: N/A; no tool implementation changed.
    - [x] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) — this is the only changed file.
    - [x] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI) — N/A; no tool metadata changed.
    - [x] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md) — N/A.
    - [x] 👉 For Community (non-Microsoft team member) PRs:
        - [x] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [x] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline* — N/A; documentation-only change, no live Azure behavior affected.
