### PR TITLE
docs: add Resource Health filter options

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3992,6 +3992,8 @@ azmcp resourcehealth availability-status get --subscription <subscription> \
 azmcp resourcehealth health-events list --subscription <subscription> \
                                                 [--event-type <event-type>] \
                                                 [--status <status>] \
+                                                [--tracking-id <tracking-id>] \
+                                                [--filter <odata-filter>] \
                                                 [--query-start-time <start-time>] \
                                                 [--query-end-time <end-time>]
 ```

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -1024,8 +1024,10 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | resourcehealth_availability-status_get | Get Azure Resource Health availability status for all resources in my subscription | none |
 | resourcehealth_availability-status_get | Show me the health status of all my Azure resources | none |
 | resourcehealth_availability-status_get | What resources in resource group <resource_group_name> have health issues? | none |
+| resourcehealth_health-events_list | Get the service health event with tracking ID <tracking-id> | none |
 | resourcehealth_health-events_list | List all service health events in my subscription | none |
 | resourcehealth_health-events_list | Show me Azure service health events for subscription <subscription_id> | none |
+| resourcehealth_health-events_list | Show me service health events matching the filter <odata-filter-expression> | none |
 | resourcehealth_health-events_list | What service issues have occurred in the last 30 days? | none |
 | resourcehealth_health-events_list | List active service health events in my subscription | none |
 | resourcehealth_health-events_list | Show me planned maintenance events for my Azure services | none |


### PR DESCRIPTION
## What does this PR do?
Documents the `--tracking-id` and `--filter` options for `azmcp resourcehealth health-events list`.

Adds matching end-to-end prompt examples so both documented filtering paths are covered.

## GitHub issue number?
Fixes #2982

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality — N/A for documentation-only changes; both affected projects build successfully and CSpell passes
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md) — N/A, documentation correction only
- [ ] For MCP tool changes: N/A — this PR changes documentation only
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles — N/A
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation — N/A
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme) — N/A
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts — N/A
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json) — N/A
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label — N/A
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description — N/A
- [x] Extra steps for **Azure MCP Server** tool changes:
    - [x] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI) — N/A, no command metadata changed
    - [x] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [x] 👉 For Community (non-Microsoft team member) PRs:
        - [x] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline* — N/A, documentation-only change
