### PR TITLE
Capture telemetry-specific command failure messages

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Commands/BaseCommand`2.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/BaseCommand`2.cs
@@ -118,6 +118,7 @@ public abstract class BaseCommand<[DynamicallyAccessedMembers(TrimAnnotations.Co
         }
 
         CommandResponse response = await ExecuteAsync(context, options, cancellationToken);
+        CaptureTelemetryFailureMessage(context, response);
         return response;
     }
 
@@ -135,6 +136,20 @@ public abstract class BaseCommand<[DynamicallyAccessedMembers(TrimAnnotations.Co
                 $"Command type '{GetType().FullName}' called {nameof(SetResult)} without overriding {nameof(ResultTypeInfo)}.");
 
         context.Response.Results = ResponseResult.Create(result, typeInfo);
+    }
+
+    /// <summary>
+    /// Adds a command-provided, sanitized message to telemetry for failed responses.
+    /// </summary>
+    /// <param name="context">The command execution context containing the telemetry activity.</param>
+    /// <param name="response">The command response containing the optional telemetry message.</param>
+    private static void CaptureTelemetryFailureMessage(CommandContext context, CommandResponse response)
+    {
+        var isError = response.Status < HttpStatusCode.OK || response.Status >= HttpStatusCode.Ambiguous;
+        if (isError && !string.IsNullOrWhiteSpace(response.TelemetryFailureMessage))
+        {
+            context.Activity?.SetTag(TagName.ExceptionMessage, response.TelemetryFailureMessage);
+        }
     }
 
     protected virtual void HandleException(CommandContext context, Exception ex)

--- a/core/Microsoft.Mcp.Core/src/Commands/BaseCommand`2.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/BaseCommand`2.cs
@@ -148,7 +148,7 @@ public abstract class BaseCommand<[DynamicallyAccessedMembers(TrimAnnotations.Co
         var isError = response.Status < HttpStatusCode.OK || response.Status >= HttpStatusCode.Ambiguous;
         if (isError && !string.IsNullOrWhiteSpace(response.TelemetryFailureMessage))
         {
-            context.Activity?.SetTag(TagName.ExceptionMessage, response.TelemetryFailureMessage);
+            context.Activity?.SetTag(TagName.ToolFailureMessage, response.TelemetryFailureMessage);
         }
     }
 

--- a/core/Microsoft.Mcp.Core/src/Commands/TelemetryConstants.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/TelemetryConstants.cs
@@ -69,6 +69,11 @@ public class TagName
     public const string ToolName = "ToolName";
 
     /// <summary>
+    /// A sanitized message describing why an MCP tool returned a failed result.
+    /// </summary>
+    public const string ToolFailureMessage = "ToolFailureMessage";
+
+    /// <summary>
     /// Name of the area of the tool that was executed.
     /// </summary>
     public const string ToolArea = "ToolArea";

--- a/core/Microsoft.Mcp.Core/src/Models/Command/CommandResponse.cs
+++ b/core/Microsoft.Mcp.Core/src/Models/Command/CommandResponse.cs
@@ -18,6 +18,14 @@ public class CommandResponse
     [JsonPropertyName("message")]
     public string Message { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets or sets a sanitized message to include in failure telemetry.
+    /// This value must not contain secrets, PII, or other sensitive information.
+    /// Ideally, use a static string so telemetry values are easier to group and analyze.
+    /// </summary>
+    [JsonIgnore]
+    public string? TelemetryFailureMessage { get; set; }
+
     [JsonPropertyName("results")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ResponseResult? Results { get; set; }

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Commands/CommandTelemetryTests.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Commands/CommandTelemetryTests.cs
@@ -41,7 +41,8 @@ public sealed class CommandTelemetryTests
             activity);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
-        Assert.Equal("Sanitized failure details.", activity.GetTagItem(TagName.ExceptionMessage));
+        Assert.Equal("Sanitized failure details.", activity.GetTagItem(TagName.ToolFailureMessage));
+        Assert.Null(activity.GetTagItem(TagName.ExceptionMessage));
     }
 
     [Fact]
@@ -52,6 +53,7 @@ public sealed class CommandTelemetryTests
             new TelemetryTestCommand(HttpStatusCode.OK, "Successful operation details."),
             activity);
 
+        Assert.Null(activity.GetTagItem(TagName.ToolFailureMessage));
         Assert.Null(activity.GetTagItem(TagName.ExceptionMessage));
     }
 
@@ -68,11 +70,12 @@ public sealed class CommandTelemetryTests
             new TelemetryTestCommand(HttpStatusCode.BadRequest, telemetryFailureMessage),
             activity);
 
+        Assert.Null(activity.GetTagItem(TagName.ToolFailureMessage));
         Assert.Equal("Existing failure details.", activity.GetTagItem(TagName.ExceptionMessage));
     }
 
     [Fact]
-    public async Task ExecuteAsync_ExplicitTelemetryFailureMessage_ReplacesExistingTelemetry()
+    public async Task ExecuteAsync_ExplicitTelemetryFailureMessage_PreservesExceptionTelemetry()
     {
         using var activity = CreateActivity();
         activity.SetTag(TagName.ExceptionMessage, "Generic failure details.");
@@ -81,7 +84,8 @@ public sealed class CommandTelemetryTests
             new TelemetryTestCommand(HttpStatusCode.BadRequest, "Command-specific failure details."),
             activity);
 
-        Assert.Equal("Command-specific failure details.", activity.GetTagItem(TagName.ExceptionMessage));
+        Assert.Equal("Command-specific failure details.", activity.GetTagItem(TagName.ToolFailureMessage));
+        Assert.Equal("Generic failure details.", activity.GetTagItem(TagName.ExceptionMessage));
     }
 
     [Fact]

--- a/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Commands/CommandTelemetryTests.cs
+++ b/core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Commands/CommandTelemetryTests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.Diagnostics;
+using System.Net;
+using System.Text.Json;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Extensions;
+using Microsoft.Mcp.Core.Models;
+using Microsoft.Mcp.Core.Models.Command;
+using Xunit;
+
+namespace Microsoft.Mcp.Core.Tests.Commands;
+
+public sealed class CommandTelemetryTests
+{
+    [CommandMetadata(
+        Id = "00000000-0000-0000-0000-0000000000cf",
+        Name = "test-telemetry",
+        Title = "Test Telemetry Command",
+        Description = "A command used only to exercise command telemetry in tests.")]
+    private sealed class TelemetryTestCommand(HttpStatusCode status, string? telemetryFailureMessage)
+        : BaseCommand<EmptyOptions, string>
+    {
+        public override Task<CommandResponse> ExecuteAsync(
+            CommandContext context, EmptyOptions options, CancellationToken cancellationToken)
+        {
+            context.Response.Status = status;
+            context.Response.TelemetryFailureMessage = telemetryFailureMessage;
+            return Task.FromResult(context.Response);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FailedResponse_CapturesTelemetryFailureMessage()
+    {
+        using var activity = CreateActivity();
+        var response = await ExecuteAsync(
+            new TelemetryTestCommand(HttpStatusCode.BadRequest, "Sanitized failure details."),
+            activity);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Equal("Sanitized failure details.", activity.GetTagItem(TagName.ExceptionMessage));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SuccessfulResponse_DoesNotCaptureTelemetryFailureMessage()
+    {
+        using var activity = CreateActivity();
+        await ExecuteAsync(
+            new TelemetryTestCommand(HttpStatusCode.OK, "Successful operation details."),
+            activity);
+
+        Assert.Null(activity.GetTagItem(TagName.ExceptionMessage));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ExecuteAsync_EmptyTelemetryFailureMessage_PreservesExistingTelemetry(string? telemetryFailureMessage)
+    {
+        using var activity = CreateActivity();
+        activity.SetTag(TagName.ExceptionMessage, "Existing failure details.");
+
+        await ExecuteAsync(
+            new TelemetryTestCommand(HttpStatusCode.BadRequest, telemetryFailureMessage),
+            activity);
+
+        Assert.Equal("Existing failure details.", activity.GetTagItem(TagName.ExceptionMessage));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ExplicitTelemetryFailureMessage_ReplacesExistingTelemetry()
+    {
+        using var activity = CreateActivity();
+        activity.SetTag(TagName.ExceptionMessage, "Generic failure details.");
+
+        await ExecuteAsync(
+            new TelemetryTestCommand(HttpStatusCode.BadRequest, "Command-specific failure details."),
+            activity);
+
+        Assert.Equal("Command-specific failure details.", activity.GetTagItem(TagName.ExceptionMessage));
+    }
+
+    [Fact]
+    public void Serialize_DoesNotIncludeTelemetryFailureMessage()
+    {
+        var response = new CommandResponse
+        {
+            Status = HttpStatusCode.BadRequest,
+            Message = "Client-visible message.",
+            TelemetryFailureMessage = "Telemetry-only message."
+        };
+
+        var json = JsonSerializer.Serialize(response, ModelsJsonContext.Default.CommandResponse);
+
+        Assert.DoesNotContain("telemetryFailureMessage", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Telemetry-only message.", json, StringComparison.Ordinal);
+        Assert.Contains("Client-visible message.", json, StringComparison.Ordinal);
+    }
+
+    private static Activity CreateActivity()
+    {
+        var activity = new Activity("test-activity");
+        activity.Start();
+        return activity;
+    }
+
+    private static async Task<CommandResponse> ExecuteAsync(
+        TelemetryTestCommand command,
+        Activity activity)
+    {
+        Assert.True(command.GetCommand().TryParseFromDictionary(null, out ParseResult? parseResult, out var parseError));
+        Assert.Null(parseError);
+        Assert.NotNull(parseResult);
+
+        return await ((IBaseCommand)command).ExecuteAsync(
+            new CommandContext(activity),
+            parseResult,
+            TestContext.Current.CancellationToken);
+    }
+}

--- a/servers/Azure.Mcp.Server/changelog-entries/1787940865316.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1787940865316.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Features Added"
+    description: "Added support for commands to provide sanitized telemetry messages for failed tool calls."

--- a/servers/Fabric.Mcp.Server/changelog-entries/1787940867021.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/1787940867021.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Features Added"
+    description: "Added support for commands to provide sanitized telemetry messages for failed tool calls."


### PR DESCRIPTION
## What does this PR do?
Adds an opt-in `TelemetryFailureMessage` to `CommandResponse` so individual commands can provide a sanitized, telemetry-specific message when a tool call fails.

The property is excluded from client-visible serialization. For non-2xx responses, the shared command execution path records the value as `ToolFailureMessage`; successful responses ignore it. This keeps failed command results distinct from `exception.*` telemetry, which remains reserved for thrown exceptions. The documentation recommends static messages so telemetry values are easy to group and analyze.

Added focused tests for failure capture, success suppression, blank messages, coexistence with exception telemetry, and serialization exclusion. Added Azure and Fabric changelog entries.

## GitHub issue number?
Fixes https://github.com/microsoft/mcp/issues/3395

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes: Not applicable; this changes shared command telemetry infrastructure without adding or modifying a tool.
- [ ] Extra steps for **Azure MCP Server** tool changes: Not applicable; this does not change an Azure MCP tool.

## Validation
- `dotnet test core/Microsoft.Mcp.Core/tests/Microsoft.Mcp.Core.Tests/Microsoft.Mcp.Core.Tests.csproj -- --filter-class Microsoft.Mcp.Core.Tests.Commands.CommandTelemetryTests`
- `dotnet build core/Microsoft.Mcp.Core/src/Microsoft.Mcp.Core.csproj --no-restore --nologo`
- Changed-file cspell validation
- Full local build and npm packaging, followed by smoke tests of the generated Azure, Fabric, and Template npm wrappers

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.