### PR TITLE
Honor the elicitation decision field when evaluating approval

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/BaseToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/BaseToolLoaderTests.cs
@@ -346,7 +346,14 @@ public class BaseToolLoaderTests
         var mockResponse = new JsonRpcResponse
         {
             Id = new RequestId(1),
-            Result = JsonSerializer.SerializeToNode(new ElicitResult { Action = "accept" })
+            Result = JsonSerializer.SerializeToNode(new ElicitResult
+            {
+                Action = "accept",
+                Content = new Dictionary<string, JsonElement>
+                {
+                    ["decision"] = JsonSerializer.SerializeToElement("accept")
+                }
+            })
         };
         mockServer.SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<CancellationToken>())
             .Returns(mockResponse);
@@ -393,6 +400,76 @@ public class BaseToolLoaderTests
             request, "test-tool", baseCommand, false, logger, TestContext.Current.CancellationToken);
 
         // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsError);
+        Assert.Contains("cancelled by user", ((TextContentBlock)result.Content[0]).Text);
+    }
+
+    [Fact]
+    public async Task HandleSecretElicitation_WhenUserSubmitsRejectDecision_RejectsOperation()
+    {
+        // Arrange - client submits the form (envelope action "accept") but the user selected
+        // "Reject", so the selection is carried in Content["decision"]. The operation must NOT
+        // execute in this scenario.
+        var mockServer = Substitute.For<McpServer>();
+        mockServer.ClientCapabilities.Returns(new ClientCapabilities { Elicitation = new ElicitationCapability() { Form = new() } });
+        var mockResponse = new JsonRpcResponse
+        {
+            Id = new RequestId(1),
+            Result = JsonSerializer.SerializeToNode(new ElicitResult
+            {
+                Action = "accept",
+                Content = new Dictionary<string, JsonElement>
+                {
+                    ["decision"] = JsonSerializer.SerializeToElement("reject")
+                }
+            })
+        };
+        mockServer.SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<CancellationToken>())
+            .Returns(mockResponse);
+
+        var request = McpTestUtilities.CreateToolCallRequest("test-tool", mockServer);
+        var logger = Substitute.For<ILogger>();
+
+        var baseCommand = Substitute.For<IBaseCommand>();
+        baseCommand.Metadata.Returns(new ToolMetadata { Secret = true });
+
+        // Act
+        var result = await BaseToolLoader.HandleElicitationAsync(
+            request, "test-tool", baseCommand, false, logger, TestContext.Current.CancellationToken);
+
+        // Assert - a rejected decision must block the operation
+        Assert.NotNull(result);
+        Assert.True(result.IsError);
+        Assert.Contains("cancelled by user", ((TextContentBlock)result.Content[0]).Text);
+    }
+
+    [Fact]
+    public async Task HandleSecretElicitation_WhenAcceptEnvelopeButNoDecision_RejectsOperation()
+    {
+        // Arrange - envelope action is "accept" but no decision value is present. The handler
+        // must treat this as not approved rather than assume approval.
+        var mockServer = Substitute.For<McpServer>();
+        mockServer.ClientCapabilities.Returns(new ClientCapabilities { Elicitation = new ElicitationCapability() { Form = new() } });
+        var mockResponse = new JsonRpcResponse
+        {
+            Id = new RequestId(1),
+            Result = JsonSerializer.SerializeToNode(new ElicitResult { Action = "accept" })
+        };
+        mockServer.SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<CancellationToken>())
+            .Returns(mockResponse);
+
+        var request = McpTestUtilities.CreateToolCallRequest("test-tool", mockServer);
+        var logger = Substitute.For<ILogger>();
+
+        var baseCommand = Substitute.For<IBaseCommand>();
+        baseCommand.Metadata.Returns(new ToolMetadata { Secret = true });
+
+        // Act
+        var result = await BaseToolLoader.HandleElicitationAsync(
+            request, "test-tool", baseCommand, false, logger, TestContext.Current.CancellationToken);
+
+        // Assert - a missing decision must block the operation
         Assert.NotNull(result);
         Assert.True(result.IsError);
         Assert.Contains("cancelled by user", ((TextContentBlock)result.Content[0]).Text);

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/BaseToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/BaseToolLoaderTests.cs
@@ -375,8 +375,10 @@ public class BaseToolLoaderTests
             Arg.Any<CancellationToken>());
     }
 
-    [Fact]
-    public async Task HandleSecretElicitation_WhenUserDeclines_RejectsOperation()
+    [Theory]
+    [InlineData("decline")]
+    [InlineData("cancel")]
+    public async Task HandleSecretElicitation_WhenEnvelopeNotAcceptedWithAcceptDecision_RejectsOperation(string action)
     {
         // Arrange
         var mockServer = Substitute.For<McpServer>();
@@ -384,7 +386,14 @@ public class BaseToolLoaderTests
         var mockResponse = new JsonRpcResponse
         {
             Id = new RequestId(1),
-            Result = JsonSerializer.SerializeToNode(new ElicitResult { Action = "decline" })
+            Result = JsonSerializer.SerializeToNode(new ElicitResult
+            {
+                Action = action,
+                Content = new Dictionary<string, JsonElement>
+                {
+                    ["decision"] = JsonSerializer.SerializeToElement("accept")
+                }
+            })
         };
         mockServer.SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<CancellationToken>())
             .Returns(mockResponse);

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/BaseToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/BaseToolLoader.cs
@@ -19,6 +19,10 @@ namespace Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
 /// <param name="logger">Logger instance for this tool loader.</param>
 public abstract class BaseToolLoader(ILogger logger) : IToolLoader
 {
+    private const string ElicitationDecisionPropertyName = "decision";
+    private const string ElicitationAcceptDecision = "accept";
+    private const string ElicitationRejectDecision = "reject";
+
     /// <summary>
     /// Logger instance for this tool loader.
     /// </summary>
@@ -271,18 +275,18 @@ public abstract class BaseToolLoader(ILogger logger) : IToolLoader
                 {
                     Properties = new Dictionary<string, ElicitRequestParams.PrimitiveSchemaDefinition>
                     {
-                        ["decision"] = new ElicitRequestParams.TitledSingleSelectEnumSchema
+                        [ElicitationDecisionPropertyName] = new ElicitRequestParams.TitledSingleSelectEnumSchema
                         {
                             Title = "Decision",
                             Description = "Approve or reject this sensitive operation.",
                             OneOf = new List<ElicitRequestParams.EnumSchemaOption>
                             {
-                                new() { Title = "Approve", Const = "accept" },
-                                new() { Title = "Reject", Const = "reject" }
+                                new() { Title = "Approve", Const = ElicitationAcceptDecision },
+                                new() { Title = "Reject", Const = ElicitationRejectDecision }
                             }
                         }
                     },
-                    Required = ["decision"]
+                    Required = [ElicitationDecisionPropertyName]
                 }
             };
 
@@ -295,9 +299,10 @@ public abstract class BaseToolLoader(ILogger logger) : IToolLoader
             // "Reject" (their selection lives in Content["decision"]). Require the envelope
             // action to be "accept" AND the decision value to be "accept"; otherwise treat the
             // operation as not approved and do not execute it.
-            bool envelopeAccepted = string.Equals(protocolResponse.Action, "accept", StringComparison.Ordinal);
-            string? decision = TryGetElicitationDecision(protocolResponse.Content);
-            bool approved = envelopeAccepted && string.Equals(decision, "accept", StringComparison.Ordinal);
+            bool decisionProvided = TryGetElicitationDecision(protocolResponse.Content, out string? decision);
+            bool approved = protocolResponse.IsAccepted &&
+                decisionProvided &&
+                string.Equals(decision, ElicitationAcceptDecision, StringComparison.Ordinal);
 
             if (!approved)
             {
@@ -332,19 +337,19 @@ public abstract class BaseToolLoader(ILogger logger) : IToolLoader
     /// selection when a client submits the form, so it must be inspected to honor a rejection.
     /// </summary>
     /// <param name="content">The content payload returned in the elicitation response.</param>
-    /// <returns>
-    /// The decision string (e.g. "accept" or "reject") when present as a string value; otherwise
-    /// <c>null</c>.
-    /// </returns>
-    private static string? TryGetElicitationDecision(IDictionary<string, JsonElement>? content)
+    /// <param name="decision">The decision string when present as a string value; otherwise, <c>null</c>.</param>
+    /// <returns><c>true</c> when a string decision was found; otherwise, <c>false</c>.</returns>
+    private static bool TryGetElicitationDecision(IDictionary<string, JsonElement>? content, out string? decision)
     {
         if (content != null &&
-            content.TryGetValue("decision", out var decisionElement) &&
+            content.TryGetValue(ElicitationDecisionPropertyName, out var decisionElement) &&
             decisionElement.ValueKind == JsonValueKind.String)
         {
-            return decisionElement.GetString();
+            decision = decisionElement.GetString();
+            return decision != null;
         }
 
-        return null;
+        decision = null;
+        return false;
     }
 }

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/BaseToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/BaseToolLoader.cs
@@ -288,13 +288,25 @@ public abstract class BaseToolLoader(ILogger logger) : IToolLoader
 
             var protocolResponse = await request.Server.ElicitAsync(protocolRequest, cancellationToken);
 
-            if (protocolResponse.Action != "accept")
+            // Determine approval from BOTH the transport-level envelope action and the user's
+            // selection carried in the response content. The elicitation schema declares a
+            // required "decision" field, so the envelope action alone is not sufficient: a
+            // client that submits the form returns Action == "accept" even when the user picked
+            // "Reject" (their selection lives in Content["decision"]). Require the envelope
+            // action to be "accept" AND the decision value to be "accept"; otherwise treat the
+            // operation as not approved and do not execute it.
+            bool envelopeAccepted = string.Equals(protocolResponse.Action, "accept", StringComparison.Ordinal);
+            string? decision = TryGetElicitationDecision(protocolResponse.Content);
+            bool approved = envelopeAccepted && string.Equals(decision, "accept", StringComparison.Ordinal);
+
+            if (!approved)
             {
-                logger.LogInformation("User {Action} the elicitation for tool '{Tool}'. Operation not executed.",
-                    protocolResponse.Action, toolName);
+                logger.LogInformation(
+                    "User did not approve the elicitation for tool '{Tool}' (action: '{Action}', decision: '{Decision}'). Operation not executed.",
+                    toolName, protocolResponse.Action, decision ?? "none");
                 return McpHelper.InjectToolIdMetadata(new CallToolResult
                 {
-                    Content = [new TextContentBlock { Text = $"Operation cancelled by user ({protocolResponse.Action})." }],
+                    Content = [new TextContentBlock { Text = "Operation cancelled by user." }],
                     IsError = true
                 }, command.Id);
             }
@@ -311,5 +323,28 @@ public abstract class BaseToolLoader(ILogger logger) : IToolLoader
                 IsError = true
             }, command.Id);
         }
+    }
+
+    /// <summary>
+    /// Extracts the user's approve/reject decision from an elicitation response content payload.
+    /// The elicitation schema declares a required "decision" field whose value is either
+    /// "accept" or "reject". This value—not the transport envelope action—represents the user's
+    /// selection when a client submits the form, so it must be inspected to honor a rejection.
+    /// </summary>
+    /// <param name="content">The content payload returned in the elicitation response.</param>
+    /// <returns>
+    /// The decision string (e.g. "accept" or "reject") when present as a string value; otherwise
+    /// <c>null</c>.
+    /// </returns>
+    private static string? TryGetElicitationDecision(IDictionary<string, JsonElement>? content)
+    {
+        if (content != null &&
+            content.TryGetValue("decision", out var decisionElement) &&
+            decisionElement.ValueKind == JsonValueKind.String)
+        {
+            return decisionElement.GetString();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
HandleElicitationAsync evaluated only the transport-level envelope action and ignored the user's selection in the elicitation form's required 'decision' field. A client that submits the form returns action == 'accept' even when the user selects 'Reject', so the operation ran anyway.

Require both the envelope action and the decision content to equal 'accept', reading the value via a new TryGetElicitationDecision helper. Add regression tests for the reject-with-accept-envelope and missing-decision cases.