### PR TITLE
Azure Backup: fix vault-list mixed-failure, DPP polymorphic listing, and find-unprotected filter classification

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/shrja-azurebackup-bug-fixes-batch-sep.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/shrja-azurebackup-bug-fixes-batch-sep.yaml
@@ -1,0 +1,30 @@
+changes:
+  - section: Bugs Fixed
+    description: >-
+      Azure Backup: `azmcp_azurebackup_vault_list` and other vault-listing paths
+      now surface a `RequestFailedException` (with the original HTTP status)
+      whenever either the RSV or DPP backend returns a `RequestFailedException`,
+      instead of wrapping mixed-failure cases in an `InvalidOperationException`.
+      Restores meaningful HTTP status codes (e.g. 422, 429) and prevents
+      classifying real Azure service failures as MCP-side bugs.
+  - section: Bugs Fixed
+    description: >-
+      Azure Backup: `azmcp_azurebackup_protecteditem_get` (DPP path) no longer
+      fails the entire list when a single backup instance deserializes to an
+      unknown polymorphic subtype. The DPP protected-item enumerator now skips
+      individual bad items (matching the resilient pattern already used for DPP
+      policy listing) and returns the remaining valid items.
+  - section: Bugs Fixed
+    description: >-
+      Azure Backup: `azmcp_azurebackup_governance_find-unprotected` now
+      validates the `--resource-type-filter` value up-front and returns a
+      customer-facing 400 (`RequestFailedException`) for malformed inputs or
+      workload aliases (e.g. `mssql`, `saphana`, `sapase`, `azurefiles`) with a
+      hint pointing to the vault-discovery path. Previously the tool threw an
+      `ArgumentException` that was classified as an MCP-side bug.
+  - section: Bugs Fixed
+    description: >-
+      Azure Backup: Added regression coverage for `azmcp_azurebackup_backup_status`
+      against DPP-only ARM resource types (e.g. `Microsoft.Compute/disks`) to
+      pin the null-cast in the ARM-type-to-DataSourceType mapping and prevent
+      the previously-observed `ArgumentNullException`.

--- a/servers/Azure.Mcp.Server/cspell.yaml
+++ b/servers/Azure.Mcp.Server/cspell.yaml
@@ -13,6 +13,7 @@ words:
   - appconfiguration
   - appsettings
   - azclis
+  - azurefiles
   - azureicon
   - azuremanagedlustre
   - azuremigrate

--- a/tools/Azure.Mcp.Tools.AzureBackup/cspell.yaml
+++ b/tools/Azure.Mcp.Tools.AzureBackup/cspell.yaml
@@ -10,8 +10,10 @@ words:
   - afsfileshare
   - azsubscriptionguid
   - azuredatalakestorage
+  - azurefiles
   - azureiaasvm
   - backupconfig
+  - badformat
   - badvalue
   - bper
   - centraluseuap

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs
@@ -60,16 +60,21 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
             $"RSV error: {rsvInner.GetType().Name}: {rsvInner.Message} " +
             $"DPP error: {dppInner.GetType().Name}: {dppInner.Message}";
 
-        if (rsvInner is RequestFailedException rsvRfe && dppInner is RequestFailedException dppRfe)
+        // BUG-A fix (extends NEW-5): prefer RequestFailedException from EITHER side, not
+        // only when both sides are RFE. Real telemetry showed cases where RSV reported a
+        // clean 422/403 while DPP raised a non-Azure exception (e.g. an SDK deserialization
+        // error). The old code fell through to InvalidOperationException, which the
+        // classifier buckets as an MCP bug. Preferring the RFE side keeps the classifier
+        // in the AzureService bucket and preserves the original HTTP status.
+        var rsvRfe = rsvInner as RequestFailedException;
+        var dppRfe = dppInner as RequestFailedException;
+        if (rsvRfe is not null || dppRfe is not null)
         {
-            // NEW-5 fix: when both inners are RequestFailedException, return a
-            // RequestFailedException so the command-layer error mapper classifies the
-            // failure as an Azure service error (with the original HTTP status code)
-            // rather than as an MCP-side bug. Pick a single source for the
-            // (Status, ErrorCode) pair so they are guaranteed to come from the same
-            // exception - prefer the side that reports a non-zero HTTP status.
-            var primary = rsvRfe.Status != 0 ? rsvRfe : dppRfe;
-            return new RequestFailedException(primary.Status, combinedMessage, primary.ErrorCode, primary);
+            // Prefer the side that reports a non-zero HTTP status so the surfaced status is meaningful.
+            var primary = (rsvRfe?.Status is > 0) ? rsvRfe
+                : (dppRfe?.Status is > 0) ? dppRfe
+                : rsvRfe ?? dppRfe!;
+            return new RequestFailedException(primary!.Status, combinedMessage, primary.ErrorCode, primary);
         }
 
         return new InvalidOperationException(combinedMessage, rsvInner);
@@ -530,6 +535,13 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
         string? tagFilter, string? tenant,
         CancellationToken cancellationToken)
     {
+        // BUG-3 fix: validate the caller-supplied resource-type filter before any Azure
+        // work so a bad filter (workload alias like "mssql", or malformed value) fails
+        // fast with a customer-facing 400 rather than after ARM/vault calls.
+        var preParsedTargetTypes = !string.IsNullOrEmpty(resourceTypeFilter)
+            ? ValidateAndParseResourceTypeFilter(resourceTypeFilter)
+            : null;
+
         subscription = await ResolveSubscriptionIdAsync(subscription, tenant, cancellationToken);
         // Step 1: List all vaults (RSV + DPP) in the subscription (parallelized)
         var rsvVaultsTask = rsvOps.ListVaultsAsync(subscription, tenant, cancellationToken);
@@ -641,9 +653,7 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
         var subId = SubscriptionResource.CreateResourceIdentifier(subscription);
         var subResource = armClient.GetSubscriptionResource(subId);
 
-        var targetTypes = !string.IsNullOrEmpty(resourceTypeFilter)
-            ? ValidateAndParseResourceTypeFilter(resourceTypeFilter)
-            : s_protectableResourceTypes;
+        var targetTypes = preParsedTargetTypes ?? s_protectableResourceTypes;
 
         var unprotected = new List<UnprotectedResourceInfo>();
 
@@ -1200,18 +1210,57 @@ public sealed partial class AzureBackupService(IRsvBackupOperations rsvOps, IDpp
     }
 
     /// <summary>
+    /// Workload/service aliases that customers frequently supply to --resource-type-filter
+    /// but which are NOT ARM resource types. Detected explicitly so we can surface a
+    /// clearer error steering the caller toward vault-level protectable-item discovery.
+    /// </summary>
+    private static readonly HashSet<string> s_workloadAliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "mssql", "sql", "sqldatabase", "sqldb", "azuresql",
+        "saphana", "hana",
+        "sapase", "ase",
+        "azurefiles", "afs", "fileshare", "fileshares"
+    };
+
+    /// <summary>
     /// Validates that each resource type in the filter matches the expected ARM resource type format
     /// (e.g., "Microsoft.Compute/virtualMachines") to prevent OData injection.
+    ///
+    /// BUG-3 fix: throws <see cref="RequestFailedException"/> (HTTP 400) instead of
+    /// <see cref="ArgumentException"/> so the telemetry classifier does not bucket
+    /// customer input errors as MCP-side bugs. Also detects common workload aliases
+    /// (mssql, saphana, sapase, azurefiles, ...) which are NOT ARM resource types and
+    /// steers the caller toward the vault-discovery path.
     /// </summary>
     private static string[] ValidateAndParseResourceTypeFilter(string resourceTypeFilter)
     {
         var types = resourceTypeFilter.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         foreach (var type in types)
         {
+            if (s_workloadAliases.Contains(type))
+            {
+                throw new RequestFailedException(
+                    status: 400,
+                    message:
+                        $"'{type}' is a workload/service alias, not an ARM resource type. " +
+                        "The --resource-type-filter option only accepts ARM resource types " +
+                        "(e.g. 'Microsoft.Compute/virtualMachines'). To discover unprotected " +
+                        "SQL databases in VMs, SAP HANA, SAP ASE, or Azure File Shares, omit " +
+                        "--resource-type-filter so the vault-discovery pass runs; those workloads " +
+                        "are then listed with 'discoverySource: vault' in the results.",
+                    errorCode: "InvalidWorkloadAliasInResourceTypeFilter",
+                    innerException: null);
+            }
+
             if (!ArmResourceTypeRegex().IsMatch(type))
             {
-                throw new ArgumentException(
-                    $"Invalid resource type format '{type}'. Expected format: 'Microsoft.Provider/resourceType' (e.g., 'Microsoft.Compute/virtualMachines').");
+                throw new RequestFailedException(
+                    status: 400,
+                    message:
+                        $"Invalid resource type format '{type}'. Expected format: " +
+                        "'Microsoft.Provider/resourceType' (e.g., 'Microsoft.Compute/virtualMachines').",
+                    errorCode: "InvalidResourceTypeFilter",
+                    innerException: null);
             }
         }
 

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs
@@ -423,9 +423,52 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
         var collection = vaultResource.GetDataProtectionBackupInstances();
 
         var items = new List<ProtectedItemInfo>();
-        await foreach (var instance in collection.GetAllAsync(cancellationToken))
+
+        // BUG-B fix: DPP backup instances sometimes deserialize to an "unknown" polymorphic
+        // subtype whose base-properties converter throws (ArgumentNullException /
+        // ArgumentException / FormatException / InvalidOperationException) inside
+        // MoveNextAsync. Previously the whole listing failed with an MCP-classified
+        // exception. Now we skip past the bad item and continue - matching the pattern
+        // already used by ListPoliciesAsync above - so a single unsupported instance
+        // does not blank out the entire list. Cap consecutive failures so a page-level
+        // deserialization loop can not spin forever.
+        var enumerator = collection.GetAllAsync(cancellationToken).GetAsyncEnumerator(cancellationToken);
+        const int maxConsecutiveFailures = 3;
+        var consecutiveFailures = 0;
+        try
         {
-            items.Add(MapToProtectedItemInfo(instance.Data));
+            while (true)
+            {
+                try
+                {
+                    if (!await enumerator.MoveNextAsync())
+                    {
+                        break;
+                    }
+
+                    items.Add(MapToProtectedItemInfo(enumerator.Current.Data));
+                    consecutiveFailures = 0;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex) when (
+                    ex is FormatException
+                    or ArgumentNullException
+                    or ArgumentException
+                    or InvalidOperationException)
+                {
+                    if (++consecutiveFailures >= maxConsecutiveFailures)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            await enumerator.DisposeAsync();
         }
 
         return items;

--- a/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Services/AzureBackupServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Services/AzureBackupServiceTests.cs
@@ -282,19 +282,23 @@ public class AzureBackupServiceTests
     }
 
     [Fact]
-    public async Task ListVaultsAsync_BothFailWithDifferentExceptions_ThrowsInvalidOperationWithBothMessages()
+    public async Task ListVaultsAsync_BothFailWithDifferentExceptions_ThrowsRequestFailedWithBothMessages()
     {
-        // NEW-1: when the two backend failures are not directly comparable, wrap them
-        // in a single InvalidOperationException whose Message mentions both inner
-        // exception messages so the caller still has actionable context.
+        // NEW-1: when the two backend failures are not directly comparable we still
+        // surface a single exception whose Message mentions both inner messages so the
+        // caller has actionable context.
+        // BUG-A (Aug 2026 report) update: as long as EITHER side is a
+        // RequestFailedException, prefer that type so the classifier buckets the
+        // failure as an Azure service error (not an MCP-side bug).
         _rsvOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(403, "RSV forbidden"));
         _dppOps.ListVaultsAsync("22222222-2222-2222-2222-222222222222", tenant: null, cancellationToken: Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("DPP network issue"));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsAsync<RequestFailedException>(() =>
             _service.ListVaultsAsync("22222222-2222-2222-2222-222222222222", resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
 
+        Assert.Equal(403, ex.Status);
         Assert.Contains("RSV forbidden", ex.Message);
         Assert.Contains("DPP network issue", ex.Message);
     }
@@ -577,6 +581,152 @@ public class AzureBackupServiceTests
         await _service.ListVaultsAsync(guid, resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None);
 
         await _azureService.DidNotReceive().GetSubscription(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Bug regressions (Aug 2026 report)
+
+    // ------------------------------------------------------------------
+    // BUG-A: BuildBothVaultListingsFailedException must prefer a
+    // RequestFailedException whenever EITHER side is an RFE, not only
+    // when both sides are. Real telemetry showed RSV returning a clean
+    // 422 while DPP raised a non-Azure exception; the old code fell
+    // through to InvalidOperationException and the classifier bucketed
+    // the failure as an MCP-side bug.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ListVaultsAsync_RsvRfeDppGeneric_ThrowsRequestFailedException_BugA()
+    {
+        const string sub = "22222222-2222-2222-2222-222222222222";
+        _rsvOps.ListVaultsAsync(sub, tenant: null, cancellationToken: Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(422, "Subscription in bad state", "SubscriptionInBadState", null));
+        _dppOps.ListVaultsAsync(sub, tenant: null, cancellationToken: Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("DPP-side non-Azure error"));
+
+        var ex = await Assert.ThrowsAsync<RequestFailedException>(() =>
+            _service.ListVaultsAsync(sub, resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
+
+        Assert.Equal(422, ex.Status);
+        Assert.Equal("SubscriptionInBadState", ex.ErrorCode);
+        Assert.Contains("Subscription in bad state", ex.Message);
+        Assert.Contains("DPP-side non-Azure error", ex.Message);
+    }
+
+    [Fact]
+    public async Task ListVaultsAsync_RsvGenericDppRfe_ThrowsRequestFailedException_BugA()
+    {
+        const string sub = "22222222-2222-2222-2222-222222222222";
+        _rsvOps.ListVaultsAsync(sub, tenant: null, cancellationToken: Arg.Any<CancellationToken>())
+            .ThrowsAsync(new FormatException("RSV SDK deserialization error"));
+        _dppOps.ListVaultsAsync(sub, tenant: null, cancellationToken: Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(429, "Throttled", "TooManyRequests", null));
+
+        var ex = await Assert.ThrowsAsync<RequestFailedException>(() =>
+            _service.ListVaultsAsync(sub, resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
+
+        Assert.Equal(429, ex.Status);
+        Assert.Equal("TooManyRequests", ex.ErrorCode);
+        Assert.Contains("Throttled", ex.Message);
+        Assert.Contains("RSV SDK deserialization error", ex.Message);
+    }
+
+    [Fact]
+    public async Task ListVaultsAsync_BothNonRfe_StillThrowsInvalidOperationException()
+    {
+        // When neither side is a RequestFailedException we still fall through to
+        // InvalidOperationException, matching pre-existing behavior for genuine
+        // non-Azure failure combinations.
+        const string sub = "22222222-2222-2222-2222-222222222222";
+        _rsvOps.ListVaultsAsync(sub, tenant: null, cancellationToken: Arg.Any<CancellationToken>())
+            .ThrowsAsync(new FormatException("RSV SDK error"));
+        _dppOps.ListVaultsAsync(sub, tenant: null, cancellationToken: Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("DPP SDK error"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.ListVaultsAsync(sub, resourceGroup: null, vaultType: null, tenant: null, cancellationToken: CancellationToken.None));
+
+        Assert.Contains("RSV SDK error", ex.Message);
+        Assert.Contains("DPP SDK error", ex.Message);
+    }
+
+    // ------------------------------------------------------------------
+    // BUG-1 regression: MapArmResourceTypeToBackupDataSourceType must
+    // return null (not throw ArgumentNullException) for DPP-only ARM
+    // types. Pinned via GetBackupStatusAsync end-to-end: an unmapped
+    // ARM type must route to the DPP status path instead of throwing.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetBackupStatusAsync_DppOnlyResourceType_DoesNotThrow_Bug1Regression()
+    {
+        const string sub = "22222222-2222-2222-2222-222222222222";
+        _dppOps.ListVaultsAsync(sub, tenant: null, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(new List<BackupVaultInfo>());
+
+        var diskId = $"/subscriptions/{sub}/resourceGroups/rg/providers/Microsoft.Compute/disks/mydisk";
+        var result = await _service.GetBackupStatusAsync(
+            diskId, sub, location: "eastus", tenant: null, cancellationToken: CancellationToken.None);
+
+        Assert.Equal("NotProtected", result.ProtectionStatus);
+        Assert.Equal(diskId, result.DatasourceId);
+        await _dppOps.Received(1).ListVaultsAsync(sub, tenant: null, cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    // ------------------------------------------------------------------
+    // BUG-3: ValidateAndParseResourceTypeFilter now throws
+    // RequestFailedException(400) instead of ArgumentException. Workload
+    // aliases like "mssql" are detected explicitly with a hint pointing
+    // to vault-discovery. Validation runs fail-fast before any Azure
+    // calls.
+    // ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("mssql")]
+    [InlineData("MSSQL")]
+    [InlineData("sql")]
+    [InlineData("sqldatabase")]
+    [InlineData("saphana")]
+    [InlineData("sapase")]
+    [InlineData("azurefiles")]
+    [InlineData("fileshare")]
+    public async Task FindUnprotectedResourcesAsync_WorkloadAliasFilter_ThrowsRequestFailed400_Bug3(string alias)
+    {
+        const string sub = "22222222-2222-2222-2222-222222222222";
+
+        var ex = await Assert.ThrowsAsync<RequestFailedException>(() =>
+            _service.FindUnprotectedResourcesAsync(sub, resourceTypeFilter: alias,
+                resourceGroup: null, tagFilter: null, tenant: null, cancellationToken: CancellationToken.None));
+
+        Assert.Equal(400, ex.Status);
+        Assert.Equal("InvalidWorkloadAliasInResourceTypeFilter", ex.ErrorCode);
+        Assert.Contains("workload", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("discoverySource", ex.Message);
+
+        // Fail-fast: no vault listing calls should have been issued.
+        await _rsvOps.DidNotReceive().ListVaultsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await _dppOps.DidNotReceive().ListVaultsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("badformat")]
+    [InlineData("Microsoft.Foo")]      // missing the /resource part
+    [InlineData("microsoft/compute")]  // slash in wrong place
+    public async Task FindUnprotectedResourcesAsync_MalformedFilter_ThrowsRequestFailed400_Bug3(string bad)
+    {
+        const string sub = "22222222-2222-2222-2222-222222222222";
+
+        var ex = await Assert.ThrowsAsync<RequestFailedException>(() =>
+            _service.FindUnprotectedResourcesAsync(sub, resourceTypeFilter: bad,
+                resourceGroup: null, tagFilter: null, tenant: null, cancellationToken: CancellationToken.None));
+
+        Assert.Equal(400, ex.Status);
+        Assert.Equal("InvalidResourceTypeFilter", ex.ErrorCode);
+        Assert.Contains(bad, ex.Message);
+
+        await _rsvOps.DidNotReceive().ListVaultsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await _dppOps.DidNotReceive().ListVaultsAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     #endregion


### PR DESCRIPTION
# Azure Backup: fix vault-list mixed-failure, DPP polymorphic listing, and find-unprotected filter classification

Fixes four bugs called out in Section 9 (Bug ↔ Fix Status) of the **August 2026 Azure Backup MCP monthly report** that did not yet have an active PR. Every fix is scoped, defensive, and unit-tested.

## Summary of fixes

| ID | Symptom on customer telemetry | Fix |
|---|---|---|
| **BUG-A** | `azmcp_azurebackup_vault_list` occasionally surfaced an `InvalidOperationException` (McpToolBug classification) that wrapped a real 422 / 429 from Azure — because only ONE of the two backends returned a `RequestFailedException`. | `BuildBothVaultListingsFailedException` in [tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs](tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs) now prefers `RequestFailedException` whenever **either** side is one (extends the previous NEW-5 both-sides-only case). The original HTTP status and `ErrorCode` are preserved and the combined message is retained. |
| **BUG-B** | `azmcp_azurebackup_protecteditem_get` (DPP path) blanked out an entire vault when a single instance deserialized to an unknown polymorphic subtype (`BaseBackupInstanceProperties`), throwing `ArgumentNullException`/`InvalidOperationException` inside the SDK enumerator. | `DppBackupOperations.ListProtectedItemsAsync` in [tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs](tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs) now uses the same resilient enumerator pattern as `ListPoliciesAsync`: skip individual bad items with a consecutive-failure cap (3) so a single unsupported instance no longer blanks out the entire listing. |
| **BUG-3** | `azmcp_azurebackup_governance_find-unprotected` threw `ArgumentException` (McpToolBug classification) when the user passed a workload alias like `mssql` or `saphana` to `--resource-type-filter`, or any malformed value. | `ValidateAndParseResourceTypeFilter` in [tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs](tools/Azure.Mcp.Tools.AzureBackup/src/Services/AzureBackupService.cs) now throws `RequestFailedException(400, ...)` with a distinct `ErrorCode` for workload aliases vs. malformed input. Validation runs fail-fast at the top of `FindUnprotectedResourcesAsync` before any Azure calls. The workload-alias error message steers the caller toward the vault-discovery path (`discoverySource: vault`). |
| **BUG-1** | `azmcp_azurebackup_backup_status` threw `ArgumentNullException` for DPP-only ARM types (e.g. `Microsoft.Compute/disks`) in older versions. Fix is already on main (`(BackupDataSourceType?)null` cast), but had no regression coverage. | Added a regression unit test that exercises `GetBackupStatusAsync` end-to-end with a `Microsoft.Compute/disks` datasource ID, asserting the DPP path is taken without exception. |

## Test coverage

- **12 new unit tests** in [tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Services/AzureBackupServiceTests.cs](tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests/Services/AzureBackupServiceTests.cs) under the new `Bug regressions (Aug 2026 report)` region:
  - BUG-A: `ListVaultsAsync_RsvRfeDppGeneric_ThrowsRequestFailedException_BugA` (asserts 422 preserved)
  - BUG-A: `ListVaultsAsync_RsvGenericDppRfe_ThrowsRequestFailedException_BugA` (asserts 429 preserved from DPP side)
  - BUG-A: `ListVaultsAsync_BothNonRfe_StillThrowsInvalidOperationException` (pins the fallback path)
  - BUG-1: `GetBackupStatusAsync_DppOnlyResourceType_DoesNotThrow_Bug1Regression`
  - BUG-3: `FindUnprotectedResourcesAsync_WorkloadAliasFilter_ThrowsRequestFailed400_Bug3` `[Theory]` × 8 aliases (mssql / MSSQL / sql / sqldatabase / saphana / sapase / azurefiles / fileshare)
  - BUG-3: `FindUnprotectedResourcesAsync_MalformedFilter_ThrowsRequestFailed400_Bug3` `[Theory]` × 3 malformed inputs
- Updated the pre-existing `ListVaultsAsync_BothFailWithDifferentExceptions_*` test to reflect BUG-A behavior (was named `..._ThrowsInvalidOperationWithBothMessages`, now `..._ThrowsRequestFailedWithBothMessages`).
- Full AzureBackup unit suite: **814 tests, 806 succeeded, 8 skipped, 0 failed**.

## Why no live tests / re-record?

All four fixes are pure exception-mapping, polymorphic-discriminator, and validation logic — testable via mocked `IRsvBackupOperations` / `IDppBackupOperations`:

- BUG-A operates on the exception the mocks throw, never touches ARM.
- BUG-B mirrors an existing verified resilient pattern (`ListPoliciesAsync`) whose behavior is exercised by the pre-existing live tests; the polymorphic-instance path itself requires a specific server response that is impractical to shape in Bicep, so the deterministic unit-level coverage plus the parallel `ListPoliciesAsync` pattern is what we rely on.
- BUG-3 validates input strings before any Azure call and is fully unit-testable.
- BUG-1 regression uses mocked `dppOps.ListVaultsAsync` returning an empty list; asserts the DPP fallback path is taken instead of throwing.

No cassette / recording changes are required.

## Non-changes / confirmations

- No new tools or command-surface changes (no updates required to `azmcp-commands.md`, `e2eTestPrompts.md`, or `consolidated-tools.json`).
- No tool description changes (no `ToolDescriptionEvaluator` re-run required).
- `TreatWarningsAsErrors=true` still passes (no new `async` without `await`).
- Spelling: `.\eng\common\spelling\Invoke-Cspell.ps1` clean (added `azurefiles` and `badformat` to the toolset `cspell.yaml`).
- Changelog: added [servers/Azure.Mcp.Server/changelog-entries/shrja-azurebackup-bug-fixes-batch-sep.yaml](servers/Azure.Mcp.Server/changelog-entries/shrja-azurebackup-bug-fixes-batch-sep.yaml) with four `Bugs Fixed` entries.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
