### PR TITLE
Azure Backup: fix remaining PR #3279 SDK regressions (CRR RSV+DPP, DPP polymorphic list resilience)

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/shrja-azurebackup-pr3279-batch2.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/shrja-azurebackup-pr3279-batch2.yaml
@@ -1,0 +1,29 @@
+changes:
+  - section: "Bug Fixes"
+    description: >-
+      Azure Backup: `azmcp_azurebackup_disasterrecovery_enable-crr` — DPP vault Enable-CRR
+      now preserves existing `FeatureSettings` sibling fields on the PATCH payload. The
+      newer Azure.ResourceManager.DataProtectionBackup api-version rejects a bare
+      `FeatureSettings` PATCH containing only `CrossRegionRestoreState`. This is a
+      follow-on to the SDK upgrade in PR #3279.
+  - section: "Bug Fixes"
+    description: >-
+      Azure Backup: `azmcp_azurebackup_disasterrecovery_enable-crr` — RSV vault Enable-CRR
+      Vault-PATCH fallback (triggered by `BMSUserErrorRedundancySettingsUseVaultApi`) now
+      preserves the existing `RedundancySettings.StandardTierStorageRedundancy` sibling
+      field on the PATCH payload. The newer Azure.ResourceManager.RecoveryServices
+      api-version rejects state-only PATCH on `Properties.RedundancySettings`. Follow-on
+      to PR #3279.
+  - section: "Bug Fixes"
+    description: >-
+      Azure Backup: `azmcp_azurebackup_protecteditem_undelete` — searching for the
+      soft-deleted backup instance no longer blanks out the entire list when the DPP
+      SDK throws on an unknown polymorphic discriminator introduced by a newer service
+      version. Uses the resilient enumerator pattern already established in
+      `ListPoliciesAsync`.
+  - section: "Bug Fixes"
+    description: >-
+      Azure Backup: `azmcp_azurebackup_recoverypoint_get` (list mode) — DPP recovery-point
+      enumeration no longer blanks out the entire list when a single item throws on an
+      unknown polymorphic discriminator introduced by a newer service version. Uses the
+      resilient enumerator pattern already established in `ListPoliciesAsync`.

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs
@@ -536,18 +536,49 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
         var vaultId = DataProtectionBackupVaultResource.CreateResourceIdentifier(subscription, resourceGroup, vaultName);
         var vaultResource = armClient.GetDataProtectionBackupVaultResource(vaultId);
 
-        // List soft-deleted backup instances and find the one matching the datasource ID
+        // List soft-deleted backup instances and find the one matching the datasource ID.
+        // Wrap the enumerator so a single soft-deleted item with an unknown polymorphic
+        // discriminator (introduced by a newer service version) does not blank out the
+        // whole search. Matches the resilient-enumerator pattern used by
+        // ListPoliciesAsync and ListProtectedItemsAsync.
         var deletedCollection = vaultResource.GetDeletedDataProtectionBackupInstances();
 
         DeletedDataProtectionBackupInstanceResource? matchedInstance = null;
-        await foreach (var deletedInstance in deletedCollection.GetAllAsync(cancellationToken))
+        var enumerator = deletedCollection.GetAllAsync(cancellationToken).GetAsyncEnumerator(cancellationToken);
+        const int maxConsecutiveFailures = 3;
+        var consecutiveFailures = 0;
+        try
         {
-            var deletedDatasourceId = deletedInstance.Data?.Properties?.DataSourceInfo?.ResourceId?.ToString();
-            if (string.Equals(deletedDatasourceId, datasourceId, StringComparison.OrdinalIgnoreCase))
+            while (true)
             {
-                matchedInstance = deletedInstance;
-                break;
+                try
+                {
+                    if (!await enumerator.MoveNextAsync())
+                    {
+                        break;
+                    }
+
+                    var deletedInstance = enumerator.Current;
+                    var deletedDatasourceId = deletedInstance.Data?.Properties?.DataSourceInfo?.ResourceId?.ToString();
+                    if (string.Equals(deletedDatasourceId, datasourceId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        matchedInstance = deletedInstance;
+                        break;
+                    }
+                    consecutiveFailures = 0;
+                }
+                catch (Exception ex) when (ex is FormatException or ArgumentException or ArgumentNullException or InvalidOperationException)
+                {
+                    if (++consecutiveFailures >= maxConsecutiveFailures)
+                    {
+                        break;
+                    }
+                }
             }
+        }
+        finally
+        {
+            await enumerator.DisposeAsync();
         }
 
         if (matchedInstance is null)
@@ -694,9 +725,39 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
         var collection = instanceResource.GetDataProtectionBackupRecoveryPoints();
 
         var points = new List<RecoveryPointInfo>();
-        await foreach (var rp in collection.GetAllAsync(cancellationToken: cancellationToken))
+        // The DPP recovery-point deserializer may throw on unknown polymorphic
+        // discriminators introduced by newer service versions. Skip the offending
+        // item instead of blanking out the entire recovery-point list. Matches the
+        // pattern used by ListPoliciesAsync and ListProtectedItemsAsync.
+        var enumerator = collection.GetAllAsync(cancellationToken: cancellationToken).GetAsyncEnumerator(cancellationToken);
+        const int maxConsecutiveFailures = 3;
+        var consecutiveFailures = 0;
+        try
         {
-            points.Add(MapToRecoveryPointInfo(rp.Data));
+            while (true)
+            {
+                try
+                {
+                    if (!await enumerator.MoveNextAsync())
+                    {
+                        break;
+                    }
+
+                    points.Add(MapToRecoveryPointInfo(enumerator.Current.Data));
+                    consecutiveFailures = 0;
+                }
+                catch (Exception ex) when (ex is FormatException or ArgumentException or ArgumentNullException or InvalidOperationException)
+                {
+                    if (++consecutiveFailures >= maxConsecutiveFailures)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            await enumerator.DisposeAsync();
         }
 
         return points;
@@ -843,19 +904,30 @@ public sealed class DppBackupOperations(IAzureService azureService) : BaseAzureS
         // CloudInternalError on the DPP backend, which is indistinguishable from a real
         // platform failure - so we avoid the call entirely when CRR is already enabled.
         var vault = await vaultResource.GetAsync(cancellationToken);
-        if (vault.Value.Data.Properties?.FeatureSettings?.CrossRegionRestoreState == CrossRegionRestoreState.Enabled)
+        var existingFeatureSettings = vault.Value.Data.Properties?.FeatureSettings;
+        if (existingFeatureSettings?.CrossRegionRestoreState == CrossRegionRestoreState.Enabled)
         {
             return new OperationResult("Succeeded", null, $"Cross-Region Restore is already enabled for vault '{vaultName}'.");
+        }
+
+        // Preserve any sibling feature-setting fields (e.g. CrossSubscriptionRestoreState) that
+        // the newer DPP api-version requires to be present on the PATCH payload. Sending a bare
+        // FeatureSettings PATCH with only CrossRegionRestoreState populated is rejected as an
+        // incomplete PATCH after the Azure.ResourceManager.DataProtectionBackup upgrade.
+        var featureSettings = new BackupVaultFeatureSettings
+        {
+            CrossRegionRestoreState = CrossRegionRestoreState.Enabled
+        };
+        if (existingFeatureSettings?.CrossSubscriptionRestoreState is { } crossSubState)
+        {
+            featureSettings.CrossSubscriptionRestoreState = crossSubState;
         }
 
         var patchData = new DataProtectionBackupVaultPatch
         {
             Properties = new DataProtectionBackupVaultPatchProperties
             {
-                FeatureSettings = new BackupVaultFeatureSettings
-                {
-                    CrossRegionRestoreState = CrossRegionRestoreState.Enabled
-                }
+                FeatureSettings = featureSettings
             }
         };
         var operation = await vaultResource.UpdateAsync(WaitUntil.Started, patchData, cancellationToken);

--- a/tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.cs
+++ b/tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.cs
@@ -971,14 +971,27 @@ public sealed partial class RsvBackupOperations(IAzureService azureService) : Ba
         catch (RequestFailedException ex) when (ex.ErrorCode == "BMSUserErrorRedundancySettingsUseVaultApi")
         {
             // Legacy API rejected — vault requires Vault PATCH API for redundancy settings.
+            // Preserve any sibling RedundancySettings fields (e.g. StandardTierStorageRedundancy)
+            // that the newer Recovery Services api-version requires to be present on the PATCH
+            // payload. Sending a bare RedundancySettings PATCH with only CrossRegionRestore
+            // populated is rejected as an incomplete PATCH after the Azure.ResourceManager.
+            // RecoveryServices upgrade (state-only PATCH is no longer accepted for
+            // Properties.RedundancySettings on api-version 2026-02-01+).
+            var existingRedundancy = vault.Value.Data.Properties?.RedundancySettings;
+            var redundancySettings = new VaultPropertiesRedundancySettings
+            {
+                CrossRegionRestore = CrossRegionRestore.Enabled
+            };
+            if (existingRedundancy?.StandardTierStorageRedundancy is { } tierRedundancy)
+            {
+                redundancySettings.StandardTierStorageRedundancy = tierRedundancy;
+            }
+
             var patchData = new RecoveryServicesVaultPatch(vault.Value.Data.Location)
             {
                 Properties = new RecoveryServicesVaultProperties
                 {
-                    RedundancySettings = new VaultPropertiesRedundancySettings
-                    {
-                        CrossRegionRestore = CrossRegionRestore.Enabled
-                    }
+                    RedundancySettings = redundancySettings
                 }
             };
 


### PR DESCRIPTION
## Summary

Follow-on to **PR #3279** (`Azure.ResourceManager.RecoveryServices` 1.2.0→1.3.0,
`Azure.ResourceManager.DataProtectionBackup` 1.7.1→1.8.0), building on the fixes
already landed in **PR #3430** (RSV soft-delete/immutability read-modify-write)
and **PR #3448** (protected-item list resilience + RSV/DPP exception classification).

This PR fixes four remaining latent regressions I identified while auditing every
`GetAllAsync` enumeration and every `*Patch` payload construction in the two files
touched by the SDK upgrade. All four share one of the two failure patterns already
documented in #3430 and #3448.

## Fixes

### R-4 · DPP `disasterrecovery_enable-crr` — read-modify-write `FeatureSettings`

**File:** `tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs`
`ConfigureCrossRegionRestoreAsync`

The DPP vault Enable-CRR path was constructing a bare `BackupVaultFeatureSettings`
with only `CrossRegionRestoreState` set and PATCHing it. On the newer
`Azure.ResourceManager.DataProtectionBackup` api-version this is rejected as an
incomplete PATCH the same way soft-delete/immutability were rejected in #3430.

Fix: after the pre-check `GetAsync`, preserve any existing sibling field
(`CrossSubscriptionRestoreState`) on the PATCH payload; only mutate
`CrossRegionRestoreState`.

### R-2 · RSV `disasterrecovery_enable-crr` — read-modify-write `RedundancySettings`

**File:** `tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.cs`
`ConfigureCrossRegionRestoreAsync`

Same pattern for the RSV Vault-PATCH fallback (the branch that runs after the
legacy `BackupResourceConfig` PUT returns `BMSUserErrorRedundancySettingsUseVaultApi`).
The catch block was constructing a bare `VaultPropertiesRedundancySettings` with
only `CrossRegionRestore` set. On the newer `Azure.ResourceManager.RecoveryServices`
api-version this is rejected as state-only PATCH on `Properties.RedundancySettings`.

Fix: use `vault.Value.Data.Properties?.RedundancySettings` (already fetched
earlier in the method) to preserve `StandardTierStorageRedundancy` on the PATCH
payload; only mutate `CrossRegionRestore`.

### R-5 · DPP `protecteditem_undelete` — resilient deleted-instance search

**File:** `tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs`
`UndeleteProtectedItemAsync`

The soft-deleted backup instance search was a bare `await foreach` over
`deletedCollection.GetAllAsync(...)`. If any single deleted instance carries an
unknown polymorphic discriminator introduced by a newer service version, the DPP
SDK throws inside enumeration and the entire lookup blanks out — customer gets
"No soft-deleted backup instance found" even when the match exists.

Fix: replace with the resilient `while (true)` + `MoveNextAsync()` + skip-on-throw
enumerator that `ListPoliciesAsync` and (from #3448) `ListProtectedItemsAsync`
already use. Catches `FormatException` / `ArgumentException` / `ArgumentNullException` /
`InvalidOperationException`; caps `maxConsecutiveFailures = 3`.

### R-6 · DPP `recoverypoint_get` (list mode) — resilient recovery-point enumeration

**File:** `tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs`
`ListRecoveryPointsAsync`

Same pattern for the DPP recovery-point list. A single recovery point with an
unknown polymorphic discriminator was blanking the whole list.

Fix: same resilient enumerator.

## Testing

- Build: `dotnet build tools/Azure.Mcp.Tools.AzureBackup/src` → clean.
- Full server build: `dotnet build servers/Azure.Mcp.Server` → **0 warnings, 0 errors** (14 min).
- Unit tests: `dotnet test tools/Azure.Mcp.Tools.AzureBackup/tests/Azure.Mcp.Tools.AzureBackup.Tests` →
  **799 total, 791 passed, 8 skipped (live-test skips), 0 failed**.
- Cspell: clean on all three changed files.

### Why no new unit tests

R-2/R-4 payload changes and R-5/R-6 enumerator resilience live inside
`RsvBackupOperations` / `DppBackupOperations`, which construct `ArmClient`-backed
resources via static factories. These are not unit-testable at the current
`IRsvBackupOperations` / `IDppBackupOperations` mocking boundary — the same
reason the pre-existing `ListPoliciesAsync` resilient enumerator (the direct
template used for R-5/R-6) also has no dedicated unit test. Fix validation
happens via live tests and existing recorded fixtures.

## Files changed

- `tools/Azure.Mcp.Tools.AzureBackup/src/Services/RsvBackupOperations.cs` — R-2
- `tools/Azure.Mcp.Tools.AzureBackup/src/Services/DppBackupOperations.cs` — R-4, R-5, R-6
- `servers/Azure.Mcp.Server/changelog-entries/shrja-azurebackup-pr3279-batch2.yaml` — four
  `Bugs Fixed` entries

## Related PRs

- **PR #3279** — root-cause SDK upgrade
- **PR #3430** — RSV soft-delete / immutability read-modify-write (Pattern A precedent)
- **PR #3448** — DPP `ListProtectedItemsAsync` resilient enumerator + RSV/DPP mixed-side
  exception classification (Pattern B precedent for R-5/R-6)

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
