### PR TITLE
docs: fix Redis create command parameters in azmcp-commands.md

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3839,9 +3839,11 @@ azmcp role assignment list --subscription <subscription> \
 # ✅ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp redis create --subscription <subscription> \
                    --resource-group <resource-group> \
-                   --name <name> \
-                   --sku <sku> \
+                   --resource <resource> \
                    --location <location> \
+                   [--sku <sku>] \
+                   [--access-keys-authentication <true|false>] \
+                   [--public-network-access <true|false>] \
                    [--modules <modules>]
 ```
 


### PR DESCRIPTION
## Summary

Fixes #3073. PR #3065 migrated the Redis toolset to the two-generic command design (`SubscriptionCommand<TOptions, TResult>` with `[Option]` attributes on flat POCOs). This changed the `azmcp redis create` CLI parameter name for the resource name from `--name` to `--resource`, changed `--sku` from required to optional (default: `Balanced_B0`), and added two new options (`--access-keys-authentication`, `--public-network-access`), but `servers/Azure.Mcp.Server/docs/azmcp-commands.md` was never updated to reflect these changes.

This PR updates the `azmcp redis create` usage block in `azmcp-commands.md` so parameter names, presence, and requiredness match the current `ResourceCreateOptions.cs` and `ResourceCreateCommand.cs` source of truth:

- `--name <name>` → `--resource <resource>` (matches `ResourceCreateOptions.Resource`)
- `--sku <sku>` → `[--sku <sku>]` (optional, default: `Balanced_B0`)
- Added `[--access-keys-authentication <true|false>]` (optional, default: `false`)
- Added `[--public-network-access <true|false>]` (optional, default: `false`)

No other Redis documentation surfaces (`e2eTestPrompts.md`, `consolidated-tools.json`) reference the old `--name` flag directly, so no further changes were required. `azmcp redis list` was verified against `ResourceListOptions.cs`/`ResourceListCommand.cs` and is already accurate (only `--subscription`/`--tenant`).

## Testing

- Verified updated usage block against current `ResourceCreateOptions.cs`, `ResourceCreateCommand.cs`, `ResourceListOptions.cs`, and `ResourceListCommand.cs` in `tools/Azure.Mcp.Tools.Redis/src`.
- Ran `.\eng\common\spelling\Invoke-Cspell.ps1` on the changed file — 0 issues found.
- Documentation-only change; no build/test run required per repo guidance.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
