### PR TITLE
docs: Add --tracking-id and --filter to resourcehealth health-events list docs

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -4083,6 +4083,8 @@ azmcp resourcehealth availability-status get --subscription <subscription> \
 azmcp resourcehealth health-events list --subscription <subscription> \
                                                 [--event-type <event-type>] \
                                                 [--status <status>] \
+                                                [--tracking-id <tracking-id>] \
+                                                [--filter <odata-filter>] \
                                                 [--query-start-time <start-time>] \
                                                 [--query-end-time <end-time>]
 ```

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -1054,8 +1054,6 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | resourcehealth_health-events_list | What service issues have occurred in the last 30 days? | none |
 | resourcehealth_health-events_list | List active service health events in my subscription | none |
 | resourcehealth_health-events_list | Show me planned maintenance events for my Azure services | none |
-| resourcehealth_health-events_list | Get the service health event with tracking ID <tracking_id> | none |
-| resourcehealth_health-events_list | Show me service health events matching the filter <odata_filter_expression> | none |
 
 ## Azure Policy
 | Tool Name | Test Prompt | Interaction |

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -1054,6 +1054,8 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | resourcehealth_health-events_list | What service issues have occurred in the last 30 days? | none |
 | resourcehealth_health-events_list | List active service health events in my subscription | none |
 | resourcehealth_health-events_list | Show me planned maintenance events for my Azure services | none |
+| resourcehealth_health-events_list | Get the service health event with tracking ID <tracking_id> | none |
+| resourcehealth_health-events_list | Show me service health events matching the filter <odata_filter_expression> | none |
 
 ## Azure Policy
 | Tool Name | Test Prompt | Interaction |

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -1054,8 +1054,8 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | resourcehealth_health-events_list | What service issues have occurred in the last 30 days? | none |
 | resourcehealth_health-events_list | List active service health events in my subscription | none |
 | resourcehealth_health-events_list | Show me planned maintenance events for my Azure services | none |
-| resourcehealth_health-events_list | Get the service health event with tracking ID <tracking_id> | none |
-| resourcehealth_health-events_list | Show me service health events matching the filter <odata_filter_expression> | none |
+| resourcehealth_health-events_list | Get the service health event with tracking ID <tracking-id> | none |
+| resourcehealth_health-events_list | Show me service health events matching the filter <odata-filter> | none |
 
 ## Azure Policy
 | Tool Name | Test Prompt | Interaction |


### PR DESCRIPTION
## Summary

Fixes #2982

PR #2952 migrated zmcp resourcehealth health-events list to the new [Option]-attribute tool design, which made --tracking-id and --filter officially registered, first-class command parameters. These options existed in the code before the migration (registered manually via RegisterOptions()), but the documentation was never updated to reflect them as explicit options.

This is a docs-only change that:
- Updates the zmcp resourcehealth health-events list example in servers/Azure.Mcp.Server/docs/azmcp-commands.md to include --tracking-id <tracking-id> and --filter <odata-filter>, matching all 6 options defined in ServiceHealthEventsListOptions.cs.
- Adds two new test prompts to the ## Azure Resource Health table in servers/Azure.Mcp.Server/docs/e2eTestPrompts.md for esourcehealth_health-events_list, exercising filtering by tracking ID and by OData filter expression.

## Testing

- Ran .\eng\common\spelling\Invoke-Cspell.ps1 — no spelling issues found.
- No source code was changed; this is a documentation-only update, so no build/test run was required.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with write access to the repo need to validate the contents of this PR before leaving a comment with the text /azp run mcp - pullrequest - live. This will trigger the necessary livetest workflows to complete required validation.