### PR TITLE
Add PostgreSQL 'What can you do' subsection to README

### DIFF
--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -1104,6 +1104,14 @@ Example prompts that generate Azure CLI commands:
 * "Get Azure Data Explorer databases in cluster 'mycluster'"
 * "Sample 10 rows from table 'StormEvents' in Azure Data Explorer database 'db1'"
 
+### 🐘 Azure Database for PostgreSQL
+
+* "List all PostgreSQL servers in my subscription"
+* "Show me the tables in the PostgreSQL database 'mydb' in server 'myserver'"
+* "Show me the schema of table 'users' in the PostgreSQL database 'mydb' in server 'myserver'"
+* "Show me all items that contain the word 'error' in the PostgreSQL database 'mydb' in server 'myserver'"
+* "Show me the configuration of PostgreSQL server 'myserver'"
+
 ### 📣 Azure Event Grid
 
 * "List all Event Grid topics in subscription 'my-subscription'"

--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -1107,10 +1107,10 @@ Example prompts that generate Azure CLI commands:
 ### 🐘 Azure Database for PostgreSQL
 
 * "List all PostgreSQL servers in my subscription"
-* "Show me the tables in the PostgreSQL database 'mydb' in server 'myserver'"
-* "Show me the schema of table 'users' in the PostgreSQL database 'mydb' in server 'myserver'"
-* "Show me all items that contain the word 'error' in the PostgreSQL database 'mydb' in server 'myserver'"
-* "Show me the configuration of PostgreSQL server 'myserver'"
+* "Show me the tables in the PostgreSQL database 'mydb' in server 'myserver' as user 'myuser'"
+* "Show me the schema of table 'users' in the PostgreSQL database 'mydb' in server 'myserver' as user 'myuser'"
+* "Show me all items that contain the word 'error' in the PostgreSQL database 'mydb' in server 'myserver' as user 'myuser'"
+* "Show me the configuration of PostgreSQL server 'myserver' in resource group 'my-resource-group' as user 'myuser'"
 
 ### 📣 Azure Event Grid
 


### PR DESCRIPTION
## Summary

Closes the last remaining gap from #2947. Investigation showed microsoft/mcp main already documents PostgreSQL tools in zmcp-commands.md (### Azure Database for PostgreSQL Operations), 2eTestPrompts.md (## Azure Database for PostgreSQL table), and the README.md "Complete List of Supported Azure Services" table. The one item still missing was the README.md **"What can you do with the Azure MCP Server?"** subsection for PostgreSQL.

- Added a ### 🐘 Azure Database for PostgreSQL subsection under "What can you do with the Azure MCP Server?" in servers/Azure.Mcp.Server/README.md, placed alphabetically between "Azure Data Explorer" and "Azure Event Grid" (matching the file's existing ordering).
- Included 5 representative prompts covering postgres list (servers/databases/tables), postgres table schema get, postgres database query, and postgres server config get, phrased consistently with the existing 2eTestPrompts.md entries and neighboring README subsections.
- No duplication: verified the command reference, e2e prompts, and supported-services list entries already exist and are accurate against the current Azure.Mcp.Tools.Postgres option classes (PostgresListOptions, BaseServerOptions, DatabaseQueryOptions, TableSchemaGetOptions), so no other doc mismatches were found for the PostgreSQL scope.

## Testing

- \.\eng\common\spelling\Invoke-Cspell.ps1\ on the changed file — 0 issues found.
- Manual diff review confirming the new subsection matches the structure/format of neighboring README "What can you do" subsections and doesn't duplicate existing PostgreSQL documentation elsewhere in the file.

Fixes #2947

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with write access to the repo need to validate the contents of this PR before leaving a comment with the text /azp run mcp - pullrequest - live. This will trigger the necessary livetest workflows to complete required validation.
