### PR TITLE
Fix stale FoundryExtensions parameter names in docs (#2953)

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -2758,7 +2758,7 @@ azmcp foundryextensions knowledge index list \
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp foundryextensions knowledge index schema \
     --endpoint <project-endpoint> \
-    --index-name <index-name>
+    --index <index-name>
 
 # Create chat completions using Azure OpenAI in Microsoft Foundry
 # ❌ Destructive | ❌ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
@@ -2766,7 +2766,7 @@ azmcp foundryextensions openai chat-completions-create \
     --subscription <subscription> \
     --resource-group <resource-group> \
     --resource-name <resource-name> \
-    --deployment-name <deployment-name> \
+    --deployment <deployment-name> \
     --message-array <json-message-array>
 
 # Create text completions using Azure OpenAI in Microsoft Foundry
@@ -2775,7 +2775,7 @@ azmcp foundryextensions openai create-completion \
     --subscription <subscription> \
     --resource-group <resource-group> \
     --resource-name <resource-name> \
-    --deployment-name <deployment-name> \
+    --deployment <deployment-name> \
     --prompt-text <prompt>
 
 # Create embeddings using Azure OpenAI in Microsoft Foundry
@@ -2784,7 +2784,7 @@ azmcp foundryextensions openai embeddings-create \
     --subscription <subscription> \
     --resource-group <resource-group> \
     --resource-name <resource-name> \
-    --deployment-name <deployment-name> \
+    --deployment <deployment-name> \
     --input-text <text>
 
 # List available Azure OpenAI model deployments in a Microsoft Foundry resource


### PR DESCRIPTION
## Summary

Fixes #2953. PR #2949 migrated the FoundryExtensions toolset from the legacy `FoundryExtensionsOptionDefinitions.cs` string-based option names to the new `[Option]` attribute pattern, where CLI parameter names are auto-derived from C# property names via kebab-case conversion. The docs in `azmcp-commands.md` still referenced the old, now-stale parameter names.

Corrected four stale parameter names in the Microsoft Foundry Extensions section of `servers/Azure.Mcp.Server/docs/azmcp-commands.md`:

- `azmcp foundryextensions knowledge index schema`: `--index-name` -> `--index`
- `azmcp foundryextensions openai chat-completions-create`: `--deployment-name` -> `--deployment`
- `azmcp foundryextensions openai create-completion`: `--deployment-name` -> `--deployment`
- `azmcp foundryextensions openai embeddings-create`: `--deployment-name` -> `--deployment`

This is a docs-only change; no command/tool code was modified. I compared the current `[Option]` attributes/commands in `tools/Azure.Mcp.Tools.FoundryExtensions/src` against `azmcp-commands.md` and `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md` and confirmed these were the only stale parameter names in scope (the e2e test prompts file contains only natural-language prompts with no `--flag` references, so no changes were needed there).

## Testing

- Verified the corrected parameter names match the `[Option]`-derived names in `KnowledgeIndexSchemaOptions.cs`, `OpenAiChatCompletionsCreateOptions.cs`, `OpenAiCompletionsCreateOptions.cs`, and `OpenAiEmbeddingsCreateOptions.cs`.
- Ran `.\eng\common\spelling\Invoke-Cspell.ps1` against the changed file: 0 issues found.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
