### PR TITLE
docs: document AVM pattern module support for avm versions and avm get

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -4906,14 +4906,15 @@ azmcp azureterraform azapi get --resource-type <resource-type> \
 
 ```bash
 # List all available Azure Verified Modules (AVM) for Terraform (both resource and pattern modules)
+# Returns each module with a moduleType field: 'resource' (avm-res-*) or 'pattern' (avm-ptn-*)
 # ❌ Destructive | ✅ Idempotent | ✅ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp azureterraform avm list
 
-# List all available versions of a specified Azure Verified Module
+# List all available versions of a specified Azure Verified Module (both resource and pattern modules)
 # ❌ Destructive | ✅ Idempotent | ✅ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp azureterraform avm versions --module-name <module-name>
 
-# Retrieve the documentation (README.md) for a specific version of an Azure Verified Module
+# Retrieve the documentation (README.md) for a specific version of an Azure Verified Module (both resource and pattern modules)
 # ❌ Destructive | ✅ Idempotent | ✅ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp azureterraform avm get --module-name <module-name> \
                              --module-version <module-version>


### PR DESCRIPTION
## Summary

Fixes #2986. PR #2946 added Azure Verified Modules (AVM) **pattern module** (`avm-ptn-*`) support to the Azure Terraform tools, but only the `avm list` command's entry in `azmcp-commands.md` was updated to mention it. This left the `avm versions` and `avm get` command docs implying they only worked with resource modules (`avm-res-*`).

This PR updates `servers/Azure.Mcp.Server/docs/azmcp-commands.md`:
- `avm list`: adds a line documenting the new `moduleType` field (`'resource'` or `'pattern'`) returned for each module.
- `avm versions`: comment now notes support for both resource and pattern modules, matching the updated C# tool description in `AvmVersionListCommand`.
- `avm get`: comment now notes support for both resource and pattern modules, matching the updated C# tool description in `AvmDocumentationGetCommand`.

No code changes were needed — `README.md` and `e2eTestPrompts.md` were already correctly updated in PR #2946.

## Testing

- Docs-only change; no build/test impact.
- Ran `.\eng\common\spelling\Invoke-Cspell.ps1` against the changed file: `CSpell: Files checked: 1, Issues found: 0 in 0 files.`

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
