### PR TITLE
Fix Search index query docs: remove stale --subscription parameter

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -385,8 +385,7 @@ azmcp search index get --service <service> \
 
 # Query AI Search index
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp search index query --subscription <subscription> \
-                         --service <service> \
+azmcp search index query --service <service> \
                          --index <index> \
                          --query <query> \
                          [--query-type <simple|full|semantic>] \


### PR DESCRIPTION
Fixes #3048

## Summary

`PR #2954` migrated `IndexQueryCommand` from `SubscriptionCommand` to `AuthenticatedCommand` and removed the `Subscription` property from `IndexQueryOptions`, but `azmcp-commands.md` still documented `--subscription <subscription>` as a parameter for `azmcp search index query`. This parameter no longer exists on the command, so the docs were out of sync with the actual tool.

This PR removes the stale `--subscription <subscription>` line from the `azmcp search index query` example in `servers/Azure.Mcp.Server/docs/azmcp-commands.md`.

I compared all current Search toolset command options/registrations (`IndexQueryOptions`, `IndexGetOptions`, `ServiceListOptions`, `KnowledgeSourceGetOptions`, `KnowledgeBaseRetrieveOptions`, `KnowledgeBaseGetOptions`) against the docs and `e2eTestPrompts.md`/`ToolDescriptionEvaluator/prompts.json` prompts, and confirmed no other Search command documentation or prompt drift exists (`ServiceListOptions` still legitimately implements `ISubscriptionOption`, so `search service list --subscription` remains correct).

This is a docs-only fix and is scoped independently of #3136, which targets an external docs repository and is intentionally left out of this change.

## Testing

- `.\eng\common\spelling\Invoke-Cspell.ps1` — passed for the changed file (pre-existing unrelated `traceidratio` spelling findings in `Azure.Mcp.Tools.Monitor` instrumentation files are untouched by this change)
- Manual review of `tools/Azure.Mcp.Tools.Search/src/Options/Index/IndexQueryOptions.cs` and `tools/Azure.Mcp.Tools.Search/src/Commands/Index/IndexQueryCommand.cs` confirms `--subscription` is no longer a valid parameter for `azmcp search index query`

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
