### PR TITLE
Add CI check for documentation command-name coverage

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/copilot-fix-268-doc-command-coverage.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/copilot-fix-268-doc-command-coverage.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Added a CI test that verifies every registered CLI command is documented with the correct command path in azmcp-commands.md and every tool is documented in e2eTestPrompts.md, and fixed several stale/incorrect command names in azmcp-commands.md (e.g. get_azure_bestpractices, sreagent connectors/incidents/threads/docs subcommands, managedlustre blob job commands) and added the missing monitor table type list and monitor_webtests_get documentation entries."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3132,8 +3132,7 @@ azmcp marketplace product get --subscription <subscription> \
 
 ```bash
 # Get best practices for secure, production-grade Azure usage
-# ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp get azure bestpractices get --resource <resource> --action <action>
+azmcp get_azure_bestpractices get --resource <resource> --action <action>
 
 # Resource options:
 #   general        - General Azure best practices
@@ -3149,7 +3148,7 @@ azmcp get azure bestpractices get --resource <resource> --action <action>
 # Get best practices for building AI applications, workflows and agents in Azure
 # Call this before generating code for any AI application, working with Microsoft Agent Framework,
 # or implementing AI solutions in Azure.
-azmcp get azure bestpractices ai_app
+azmcp get_azure_bestpractices ai_app
 
 # AI App Development:
 #   ai_app - Comprehensive guidance for AI applications including:
@@ -3220,6 +3219,12 @@ azmcp monitor activitylog list --subscription <subscription> \
 azmcp monitor table list --subscription <subscription> \
                          --workspace <workspace> \
                          --resource-group <resource-group>
+
+# List available table types in a Log Analytics workspace
+# ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
+azmcp monitor table type list --subscription <subscription> \
+                              --workspace <workspace> \
+                              --resource-group <resource-group>
 
 # List Log Analytics workspaces in a subscription
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
@@ -3515,8 +3520,7 @@ azmcp managedlustre fs expansion delete --subscription <subscription> \
                                         --expansion-job-name <expansion-job-name>
 
 # Create an autoexport job for an Azure Managed Lustre filesystem
-# ✅ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp managedlustre fs blob autoexport create --subscription <subscription> \
+azmcp managedlustre fs blob_autoexport create --subscription <subscription> \
                                              --resource-group <resource-group> \
                                              --filesystem-name <filesystem-name> \
                                              [--job-name <job-name>] \
@@ -3524,38 +3528,33 @@ azmcp managedlustre fs blob autoexport create --subscription <subscription> \
                                              [--admin-status <Enable|Disable>]
 
 # Cancel an autoexport job for an Azure Managed Lustre filesystem
-# ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp managedlustre fs blob autoexport cancel --subscription <subscription> \
+azmcp managedlustre fs blob_autoexport cancel --subscription <subscription> \
                                              --resource-group <resource-group> \
                                              --filesystem-name <filesystem-name> \
                                              --job-name <job-name>
 
 # Get details of autoexport jobs for an Azure Managed Lustre filesystem
 # Returns a specific job if job-name is provided, or lists all jobs if omitted
-# ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp managedlustre fs blob autoexport get --subscription <subscription> \
+azmcp managedlustre fs blob_autoexport get --subscription <subscription> \
                                           --resource-group <resource-group> \
                                           --filesystem-name <filesystem-name> \
                                           [--job-name <job-name>]
 
 # Delete an autoexport job for an Azure Managed Lustre filesystem
-# ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp managedlustre fs blob autoexport delete --subscription <subscription> \
+azmcp managedlustre fs blob_autoexport delete --subscription <subscription> \
                                              --resource-group <resource-group> \
                                              --filesystem-name <filesystem-name> \
                                              --job-name <job-name>
 
 # Get details of autoimport jobs for an Azure Managed Lustre filesystem
 # Returns a specific job if job-name is provided, or lists all jobs if omitted
-# ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp managedlustre fs blob autoimport get --subscription <subscription> \
+azmcp managedlustre fs blob_autoimport get --subscription <subscription> \
                                            --resource-group <resource-group> \
                                            --filesystem-name <filesystem-name> \
                                            [--job-name <job-name>]
 
 # Create an autoimport job for an Azure Managed Lustre filesystem
-# ✅ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp managedlustre fs blob autoimport create --subscription <subscription> \
+azmcp managedlustre fs blob_autoimport create --subscription <subscription> \
                                              --resource-group <resource-group> \
                                              --filesystem-name <filesystem-name> \
                                              [--job-name <job-name>] \
@@ -3566,22 +3565,19 @@ azmcp managedlustre fs blob autoimport create --subscription <subscription> \
                                              [--maximum-errors <number>]
 
 # Cancel an autoimport job for an Azure Managed Lustre filesystem
-# ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp managedlustre fs blob autoimport cancel --subscription <subscription> \
+azmcp managedlustre fs blob_autoimport cancel --subscription <subscription> \
                                               --resource-group <resource-group> \
                                               --filesystem-name <filesystem-name> \
                                               --job-name <job-name>
 
 # Delete an autoimport job for an Azure Managed Lustre filesystem
-# ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp managedlustre fs blob autoimport delete --subscription <subscription> \
+azmcp managedlustre fs blob_autoimport delete --subscription <subscription> \
                                               --resource-group <resource-group> \
                                               --filesystem-name <filesystem-name> \
                                               --job-name <job-name>
 
 # Create a one-time import job for an Azure Managed Lustre filesystem
-# ✅ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp managedlustre fs blob import create --subscription <subscription> \
+azmcp managedlustre fs blob_import create --subscription <subscription> \
                                          --resource-group <resource-group> \
                                          --filesystem-name <filesystem-name> \
                                          [--job-name <job-name>] \
@@ -3591,22 +3587,19 @@ azmcp managedlustre fs blob import create --subscription <subscription> \
 
 # Get details of one-time import jobs for an Azure Managed Lustre filesystem
 # Returns a specific job if job-name is provided, or lists all jobs if omitted
-# ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp managedlustre fs blob import get --subscription <subscription> \
+azmcp managedlustre fs blob_import get --subscription <subscription> \
                                       --resource-group <resource-group> \
                                       --filesystem-name <filesystem-name> \
                                       [--job-name <job-name>]
 
 # Cancel a running one-time import job for an Azure Managed Lustre filesystem
-# ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp managedlustre fs blob import cancel --subscription <subscription> \
+azmcp managedlustre fs blob_import cancel --subscription <subscription> \
                                          --resource-group <resource-group> \
                                          --filesystem-name <filesystem-name> \
                                          --job-name <job-name>
 
 # Delete a one-time import job for an Azure Managed Lustre filesystem
-# ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp managedlustre fs blob import delete --subscription <subscription> \
+azmcp managedlustre fs blob_import delete --subscription <subscription> \
                                          --resource-group <resource-group> \
                                          --filesystem-name <filesystem-name> \
                                          --job-name <job-name>
@@ -4359,16 +4352,14 @@ azmcp sreagent connectors get --subscription <subscription> \
                               --name <connector-name>
 
 # Create or update a Kusto data connector
-# ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp sreagent connectors create kusto --subscription <subscription> \
+azmcp sreagent connectors create_kusto --subscription <subscription> \
                                        --resource-group <resource-group> \
                                        --agent <agent-name> \
                                        --name <connector-name> \
                                        --cluster-url <kusto-cluster-url>
 
 # Create or update an MCP connector
-# ✅ Destructive | ✅ Idempotent | ✅ OpenWorld | ❌ ReadOnly | ✅ Secret | ❌ LocalRequired
-azmcp sreagent connectors create mcp --subscription <subscription> \
+azmcp sreagent connectors create_mcp --subscription <subscription> \
                                      --resource-group <resource-group> \
                                      --agent <agent-name> \
                                      --name <connector-name> \
@@ -4459,7 +4450,7 @@ azmcp sreagent threads create --subscription <subscription> \
                               --agent <agent-name>
 
 # Send a message to an existing thread
-azmcp sreagent threads send-message --subscription <subscription> \
+azmcp sreagent threads send_message --subscription <subscription> \
                                     --resource-group <resource-group> \
                                     --agent <agent-name> \
                                     --thread <thread-id> \
@@ -4480,8 +4471,7 @@ azmcp sreagent threads investigate --subscription <subscription> \
                                    --message <investigation-prompt>
 
 # Run an investigation prompt with auto-approval (yolo mode)
-# ❌ Destructive | ❌ Idempotent | ✅ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp sreagent threads investigate yolo --subscription <subscription> \
+azmcp sreagent threads investigate_yolo --subscription <subscription> \
                                         --resource-group <resource-group> \
                                         --agent <agent-name> \
                                         --message <investigation-prompt>
@@ -4525,7 +4515,8 @@ azmcp sreagent scheduledtasks delete --subscription <subscription> --resource-gr
 
 ```bash
 # List active incidents
-azmcp sreagent incidents active-list --subscription <subscription> \
+# ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
+azmcp sreagent incidents active list --subscription <subscription> \
                                      --resource-group <resource-group> \
                                      --agent <agent-name>
 
@@ -4542,14 +4533,12 @@ azmcp sreagent incidents create --subscription <subscription> \
                                 --steps <step-1> <step-2>
 
 # List incident response plans
-# ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp sreagent incidents plans list --subscription <subscription> \
+azmcp sreagent incidents plans_list --subscription <subscription> \
                                     --resource-group <resource-group> \
                                     --agent <agent-name>
 
 # Create an incident response plan
-# ❌ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp sreagent incidents plans create --subscription <subscription> \
+azmcp sreagent incidents plans_create --subscription <subscription> \
                                       --resource-group <resource-group> \
                                       --agent <agent-name> \
                                       --name <plan-name> \
@@ -4557,8 +4546,8 @@ azmcp sreagent incidents plans create --subscription <subscription> \
                                       --trigger-condition <condition>
 
 # Configure PagerDuty / ServiceNow connectors
-azmcp sreagent incidents setup-pagerduty   --subscription <s> --resource-group <rg> --agent <a> --api-key-env <env>
-azmcp sreagent incidents setup-servicenow  --subscription <s> --resource-group <rg> --agent <a> --instance-url <url> --auth-type <type>
+azmcp sreagent incidents setup_pagerduty  --subscription <s> --resource-group <rg> --agent <a> --api-key-env <env>
+azmcp sreagent incidents setup_servicenow --subscription <s> --resource-group <rg> --agent <a> --instance-url <url> --auth-type <type>
 ```
 
 #### Workflows
@@ -4587,23 +4576,19 @@ azmcp sreagent workflows apply --subscription <s> --resource-group <rg> --agent 
 azmcp sreagent docs get --topic <topic>
 
 # List all memories in the knowledge base
-# ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp sreagent docs memories list --subscription <s> --resource-group <rg> --agent <a>
+azmcp sreagent docs memories_list --subscription <s> --resource-group <rg> --agent <a>
 
 # Search and manage knowledge base memories
-# ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp sreagent docs memories search --subscription <s> --resource-group <rg> --agent <a> --search <text>
-# ❌ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp sreagent docs memories add    --subscription <s> --resource-group <rg> --agent <a> --name <doc> --content <body>
-# ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp sreagent docs memories delete --subscription <s> --resource-group <rg> --agent <a> --name <doc>
+azmcp sreagent docs memories_search --subscription <s> --resource-group <rg> --agent <a> --search <text>
+azmcp sreagent docs memories_add    --subscription <s> --resource-group <rg> --agent <a> --name <doc> --content <body>
+azmcp sreagent docs memories_delete --subscription <s> --resource-group <rg> --agent <a> --name <doc>
 
 # Trigger a full reindex of the knowledge base
-# ❌ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp sreagent docs memories reindex --subscription <s> --resource-group <rg> --agent <a>
+azmcp sreagent docs memories_reindex --subscription <s> --resource-group <rg> --agent <a>
 
 # Generate architecture documentation
-azmcp sreagent architecture generate --requirements <text>
+# ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
+azmcp sreagent architecture plan --requirements <text>
 
 # Manage common prompts
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -895,6 +895,9 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | monitor_table_type_list | Show me the available table types in the Log Analytics workspace <workspace_name> | none |
 | monitor_webtests_createorupdate | Create a new Standard Web Test with name <webtest_resource_name> in my subscription in <resource_group> in a given <appinsights_component> | none |
 | monitor_webtests_createorupdate | Update an existing Standard Web Test with name <webtest_resource_name> in my subscription in <resource_group> in a given <appinsights_component> | none |
+| monitor_webtests_get | List all web tests in my subscription | none |
+| monitor_webtests_get | Show me the web tests in resource group <resource_group> | none |
+| monitor_webtests_get | Get the details of web test <webtest_resource_name> in resource group <resource_group> | none |
 | monitor_workspace_list | List all Log Analytics workspaces in my subscription | none |
 | monitor_workspace_list | Show me my Log Analytics workspaces | none |
 | monitor_workspace_list | Show me the Log Analytics workspaces in my subscription | none |

--- a/servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.Tests/Infrastructure/DocumentationCommandCoverageTests.cs
+++ b/servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.Tests/Infrastructure/DocumentationCommandCoverageTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Models;
+using Xunit;
+
+namespace Azure.Mcp.Server.Tests.Infrastructure;
+
+/// <summary>
+/// Validates that command names referenced in the repository's user-facing documentation
+/// (<c>azmcp-commands.md</c> and <c>e2eTestPrompts.md</c>) are present and correct, i.e. they
+/// match the commands actually registered by the Azure MCP server.
+///
+/// This guards against the scenario described in
+/// https://github.com/microsoft/mcp/issues/268: a command is added, renamed, or removed in code
+/// but the documentation is never updated to match, leaving stale or missing command names for
+/// users and AI agents that rely on these files for discovery.
+/// </summary>
+public sealed class DocumentationCommandCoverageTests
+{
+    private static readonly string s_repoRoot = GetRepoRoot();
+
+    [Fact]
+    public void AzmcpCommandsDoc_Should_Document_Every_Registered_Command()
+    {
+        var factory = CreateCommandFactory();
+        var realCommandPaths = GetRealCommandPaths(factory);
+        Assert.True(realCommandPaths.Count > 100, $"Expected 100+ registered commands, found {realCommandPaths.Count}.");
+
+        var docsPath = Path.Combine(s_repoRoot, "servers", "Azure.Mcp.Server", "docs", "azmcp-commands.md");
+        var docText = NormalizeLineEndings(File.ReadAllText(docsPath));
+
+        var missing = realCommandPaths
+            .Where(path => !DocContainsCommand(docText, path))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            $"{missing.Count} command(s) are registered in the server but are not documented as an " +
+            "'azmcp <command>' usage example in servers/Azure.Mcp.Server/docs/azmcp-commands.md:\n  " +
+            string.Join("\n  ", missing) +
+            "\n\nAdd a documented example (with the correct command path) for each command above.");
+    }
+
+    [Fact]
+    public void E2ETestPromptsDoc_Should_Cover_Every_Registered_Tool_With_No_Stale_Names()
+    {
+        var factory = CreateCommandFactory();
+        var realToolNames = GetVisibleCommands(factory.AllCommands)
+            .Select(kvp => kvp.Key)
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.True(realToolNames.Count > 100, $"Expected 100+ registered tools, found {realToolNames.Count}.");
+
+        var docsPath = Path.Combine(s_repoRoot, "servers", "Azure.Mcp.Server", "docs", "e2eTestPrompts.md");
+        var docToolNames = ExtractToolNamesFromE2EDoc(docsPath);
+
+        var missing = realToolNames.Except(docToolNames).OrderBy(n => n, StringComparer.Ordinal).ToList();
+        var stale = docToolNames.Except(realToolNames).OrderBy(n => n, StringComparer.Ordinal).ToList();
+
+        Assert.True(missing.Count == 0 && stale.Count == 0,
+            BuildToolNameMismatchMessage(missing, stale));
+    }
+
+    private static string BuildToolNameMismatchMessage(List<string> missing, List<string> stale)
+    {
+        var message = "servers/Azure.Mcp.Server/docs/e2eTestPrompts.md is out of sync with the registered tools.\n";
+
+        if (missing.Count > 0)
+        {
+            message += $"\n{missing.Count} tool(s) have no test prompt and must be added:\n  " + string.Join("\n  ", missing) + "\n";
+        }
+
+        if (stale.Count > 0)
+        {
+            message += $"\n{stale.Count} tool name(s) in the doc do not match any registered tool " +
+                "(likely renamed or removed) and must be updated or removed:\n  " + string.Join("\n  ", stale) + "\n";
+        }
+
+        return message;
+    }
+
+    /// <summary>
+    /// Builds the exact "azmcp"-relative CLI invocation path (e.g. "storage account get") for every
+    /// visible, registered command by walking the actual <see cref="CommandGroup"/> hierarchy.
+    ///
+    /// This intentionally does NOT use <see cref="ICommandFactory.AllCommands"/>'s underscore-joined
+    /// keys (e.g. "storage_account_get") and blindly replace every underscore with a space, because a
+    /// handful of command groups/leaf commands (e.g. "get_azure_bestpractices", "send_message") contain
+    /// literal underscores that are part of the CLI token itself, not group separators. Walking the
+    /// hierarchy directly preserves those literal names and produces the exact string a user would type.
+    /// </summary>
+    private static List<string> GetRealCommandPaths(ICommandFactory factory)
+    {
+        var paths = new List<string>();
+
+        foreach (var topGroup in factory.RootGroup.SubGroup)
+        {
+            CollectCommandPaths(topGroup, prefix: null, paths);
+        }
+
+        return paths;
+    }
+
+    private static void CollectCommandPaths(CommandGroup group, string? prefix, List<string> paths)
+    {
+        var currentPrefix = string.IsNullOrEmpty(prefix) ? group.Name : $"{prefix} {group.Name}";
+
+        foreach (var (_, command) in GetVisibleCommands(group.Commands))
+        {
+            paths.Add($"{currentPrefix} {command.Name}");
+        }
+
+        foreach (var subGroup in group.SubGroup)
+        {
+            CollectCommandPaths(subGroup, currentPrefix, paths);
+        }
+    }
+
+    /// <summary>
+    /// Mirrors the (internal) filtering <see cref="CommandFactory"/> applies before exposing commands
+    /// via <c>tools list</c>: commands marked with <see cref="HiddenCommandAttribute"/> are internal CLI
+    /// plumbing (e.g. the "tools list" command itself) and are not expected to be documented.
+    /// </summary>
+    private static IEnumerable<KeyValuePair<string, IBaseCommand>> GetVisibleCommands(IEnumerable<KeyValuePair<string, IBaseCommand>> commands)
+        => commands.Where(kvp => kvp.Value.GetType().GetCustomAttribute<HiddenCommandAttribute>() is null);
+
+    private static bool DocContainsCommand(string docText, string commandPath)
+    {
+        var pattern = $@"(?m)^azmcp[ \t]+{Regex.Escape(commandPath)}(?=[ \t]|\\|$)";
+        return Regex.IsMatch(docText, pattern);
+    }
+
+    private static HashSet<string> ExtractToolNamesFromE2EDoc(string docsPath)
+    {
+        var toolNames = new HashSet<string>(StringComparer.Ordinal);
+
+        // Table rows look like: "| storage_account_get | <prompt text> | none |".
+        // The header ("| Tool Name | ...") and separator ("|:---|...") rows are excluded because
+        // real tool names always start with a lowercase letter and never contain spaces/colons.
+        var rowPattern = new Regex(@"^\|\s*([a-z][a-z0-9_\-]*)\s*\|", RegexOptions.Compiled);
+
+        foreach (var line in File.ReadLines(docsPath))
+        {
+            var match = rowPattern.Match(line);
+            if (match.Success)
+            {
+                toolNames.Add(match.Groups[1].Value);
+            }
+        }
+
+        return toolNames;
+    }
+
+    private static string NormalizeLineEndings(string text) => text.Replace("\r\n", "\n");
+
+    private static ICommandFactory CreateCommandFactory()
+    {
+        var serviceCollection = new ServiceCollection();
+        Program.ConfigureServices(serviceCollection);
+        var services = serviceCollection.BuildServiceProvider();
+        return services.GetRequiredService<ICommandFactory>();
+    }
+
+    private static string GetRepoRoot()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        var dir = new DirectoryInfo(currentDir);
+
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "global.json")) &&
+                Directory.Exists(Path.Combine(dir.FullName, "servers")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not find repository root containing global.json and servers directory");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #268 by adding a deterministic, automated CI check that verifies command names in the repository's documentation are present and correct, matching what is actually registered by the server at runtime.

- **New test:** `servers/Azure.Mcp.Server/tests/Azure.Mcp.Server.Tests/Infrastructure/DocumentationCommandCoverageTests.cs`
  - `AzmcpCommandsDoc_Should_Document_Every_Registered_Command`: builds every real, visible CLI command path by walking the actual `CommandGroup`/`Command` hierarchy (not the underscore-joined `AllCommands` keys, which can be lossy for names containing literal underscores), then asserts each path appears as a documented `azmcp <path>` usage example in `azmcp-commands.md`.
  - `E2ETestPromptsDoc_Should_Cover_Every_Registered_Tool_With_No_Stale_Names`: asserts every registered tool name has at least one prompt row in `e2eTestPrompts.md`, and flags any tool name in that doc that no longer maps to a real registered tool (renamed/removed).
  - Both tests fail with an explicit, actionable list of missing/stale command names, so future command additions/renames/removals that aren't reflected in docs will break the build.

- **Fixed 29 stale/incorrect command-path lines** in `azmcp-commands.md` uncovered by the new test (mostly commands whose leaf/group name contains a literal underscore, e.g. `sreagent connectors create_kusto`, `managedlustre fs blob_autoexport ...`, `get_azure_bestpractices ai_app`, `sreagent threads send_message`, `sreagent incidents setup_pagerduty`/`setup_servicenow`, `sreagent docs memories_*`, `sreagent incidents plans_*`, `sreagent threads investigate_yolo`), plus one command (`sreagent architecture plan`, previously documented as the non-existent `architecture generate`) and one incident-list path (`sreagent incidents active list`, previously `active-list`).
- **Added a missing documented command**: `monitor table type list` (was registered but entirely undocumented).
- Re-ran `eng/scripts/Update-AzCommandsMetadata.ps1` once to regenerate the `# ✅/❌ ...` metadata annotation comments for the corrected lines, and confirmed the script is idempotent afterward (a second run produces zero diff), so `CommandMetadataSyncTests` still passes.
- Added a missing `monitor_webtests_get` entry (3 prompt rows) to `e2eTestPrompts.md`.
- Added a changelog entry under `servers/Azure.Mcp.Server/changelog-entries/copilot-fix-268-doc-command-coverage.yaml`.

### Known, pre-existing, out-of-scope limitation

A handful of commands/groups have a literal underscore in their registered `Name` (e.g. `create_kusto`, `send_message`, `blob_autoexport`). Four call sites (`CommandFactory.BuildLearnCommandInfo` x3, `ToolsListCommand.CreateCommand`) reconstruct a display path by blindly doing `tokenizedName.Replace('_', ' ')` on the underscore-joined lookup key, which corrupts the self-reported `.command` field in `tools list`/`--learn` output for those ~19 commands (e.g. reporting `create kusto` instead of the real `create_kusto`). This also means `Update-AzCommandsMetadata.ps1`'s dictionary (keyed off that same buggy field) can no longer prefix-match those now-corrected doc lines, so they lose their `✅/❌` metadata annotation comment. This is a separate, pre-existing production bug in a different subsystem (not documentation), carries real regression risk to fix (affects `CommandFactoryTests`, `ToolsListCommandTests`, and the self-reported CLI path for `--learn`), and is not required by any existing or new test, so it is intentionally left out of scope here. Filing a follow-up would be reasonable.

## Testing

- `dotnet test --no-build -- --filter-namespace "Azure.Mcp.Server.Tests.Infrastructure"` — 43/43 passed (includes the 2 new tests and the pre-existing `CommandMetadataSyncTests`).
- `dotnet test --no-build` (full `Azure.Mcp.Server.Tests` project) — 43/43 passed.
- `dotnet build` (full solution) — succeeded, 0 errors/warnings.
- `dotnet format --include=".../DocumentationCommandCoverageTests.cs" --verify-no-changes` — no formatting changes needed.
- `.\eng\scripts\Build-Local.ps1 -VerifyNpx` — succeeded (all 3 servers built/packaged, `npx ... tools list` smoke tests passed for Azure.Mcp.Server and Fabric.Mcp.Server).
- `.\eng\common\spelling\Invoke-Cspell.ps1` — clean, no spelling errors.
- Verified `Update-AzCommandsMetadata.ps1` idempotency (second run produces zero diff).

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
