### PR TITLE
docs: fix policy assignment list --scope and --tenant in azmcp-commands.md

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3791,7 +3791,8 @@ azmcp quota usage check --subscription <subscription> \
 # List Azure Policy Assignments
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp policy assignment list --subscription <subscription> \
-                             --scope <scope>
+                             [--scope <scope>] \
+                             [--tenant <tenant>]
 ```
 
 ### Azure Pricing Operations


### PR DESCRIPTION
## Summary

Fixes #3132

PR #3068 ("Migrate Policy tools to new tool design") migrated `PolicyAssignmentListCommand` to the two-generic `SubscriptionCommand<TOptions, TResult>` pattern. As part of this migration:

- `--scope` changed from **required** to **optional** (`PolicyAssignmentListOptions.Scope` is now `string?`)
- `--tenant` was **added** via `ISubscriptionOption`

`servers/Azure.Mcp.Server/docs/azmcp-commands.md` still documented `--scope` as required and did not mention `--tenant`. This PR updates the `azmcp policy assignment list` usage block to:

```bash
azmcp policy assignment list --subscription <subscription> \
                             [--scope <scope>] \
                             [--tenant <tenant>]
```

No prompt changes were needed — `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md` contains no existing prompts for `azmcp_policy_assignment_list`.

## Testing

- Verified `PolicyAssignmentListOptions.cs` and `PolicyAssignmentListCommand.cs` confirm `Scope` is nullable/optional and `Tenant` is present via `ISubscriptionOption`, matching the corrected docs.
- Ran `.\eng\common\spelling\Invoke-Cspell.ps1` against the changed file — 0 issues found.
- Documentation-only change; no build or test run required.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
