### PR TITLE
Document --label/--label-filter and --key/--key-filter mutual exclusion for appconfig kv get

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -537,6 +537,8 @@ azmcp appconfig kv delete --subscription <subscription> \
                           [--label <label>]
 
 # Get key-value settings in an App Configuration store
+# Use --key to retrieve a single key-value, or --key-filter for wildcard matches (e.g., 'App*'). --key and --key-filter are mutually exclusive.
+# Use --label to scope to a specific label, or --label-filter for wildcard label matches. --label and --label-filter are mutually exclusive.
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp appconfig kv get --subscription <subscription> \
                        --account <account> \


### PR DESCRIPTION
## Summary

Fixes #2939

`azmcp appconfig kv get` has validation (added in #2871, `KeyValueGetCommand.ValidateOptions`) that rejects providing both `--key` and `--key-filter` together, and rejects providing both `--label` and `--label-filter` together. This mutual-exclusion behavior was not documented, so users would hit a validation error with no explanation.

This PR documents the exact, existing validation rules for `appconfig kv get` in `servers/Azure.Mcp.Server/docs/azmcp-commands.md`:
- `--key` and `--key-filter` are mutually exclusive.
- `--label` and `--label-filter` are mutually exclusive.

No behavior, options, or code paths were changed — this is a documentation-only fix that reflects the validation logic already present in `KeyValueGetCommand.cs`. No prompt updates were needed in `e2eTestPrompts.md` since none of the existing `appconfig_kv_get` prompts combine `--key`/`--key-filter` or `--label`/`--label-filter`.

## Testing

- Reviewed `KeyValueGetCommand.ValidateOptions` and `KeyValueGetOptions.cs` to confirm the documented rules exactly match current validation behavior (no invented behavior).
- Confirmed `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md` required no changes.
- Ran `.\eng\common\spelling\Invoke-Cspell.ps1` on the changed file — 0 spelling issues.
- Self-reviewed the diff for accuracy, formatting consistency with surrounding docs, and scope (only the doc file changed).

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
