### PR TITLE
Fix MySQL docs: correct required/optional parameters for list and server commands

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -2360,13 +2360,14 @@ azmcp kusto query [--cluster-uri <cluster-uri> | --subscription <subscription> -
 
 ```bash
 # Hierarchical list command for MySQL resources
-# Without parameters: lists all MySQL servers in the resource group
-# With --server: lists all databases on that server
-# With --server and --database: lists all tables in that database
+# Without parameters: lists all MySQL servers in the subscription
+# With --resource-group: lists servers in that resource group
+# With --server: lists all databases on that server (--user required)
+# With --server and --database: lists all tables in that database (--user required)
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp mysql list --subscription <subscription> \
-                 --resource-group <resource-group> \
-                 --user <user> \
+                 [--resource-group <resource-group>] \
+                 [--user <user>] \
                  [--server <server>] \
                  [--database <database>]
 
@@ -2392,14 +2393,12 @@ azmcp mysql table schema get --subscription <subscription> \
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp mysql server config get --subscription <subscription> \
                               --resource-group <resource-group> \
-                              --user <user> \
                               --server <server>
 
 # Retrieve a specific parameter of a MySQL server
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp mysql server param get --subscription <subscription> \
                              --resource-group <resource-group> \
-                             --user <user> \
                              --server <server> \
                              --param <parameter>
 
@@ -2407,7 +2406,6 @@ azmcp mysql server param get --subscription <subscription> \
 # ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp mysql server param set --subscription <subscription> \
                              --resource-group <resource-group> \
-                             --user <user> \
                              --server <server> \
                              --param <parameter> \
                              --value <value>


### PR DESCRIPTION
Fixes #2887

## Summary

PR #2677 changed the MySQL toolset behavior so that:
- `azmcp mysql list` no longer requires `--resource-group` (omitting it lists all servers in the subscription) or `--user` (only required when `--server` is specified for data-plane operations).
- `azmcp mysql server config get`, `azmcp mysql server param get`, and `azmcp mysql server param set` no longer require `--user`, since these are ARM-only operations that do not open a direct database connection.

However, `servers/Azure.Mcp.Server/docs/azmcp-commands.md` was never updated to reflect these changes, leaving the documented parameter requirements out of sync with the actual command behavior.

This PR corrects `azmcp-commands.md`:
- `mysql list`: marks `--resource-group` and `--user` as optional (bracketed), corrects the "lists all MySQL servers in the resource group" comment to say "in the subscription", and adds a comment clarifying `--resource-group` scoping and that `--user` is required when `--server`/`--database` are used.
- `mysql server config get`, `mysql server param get`, `mysql server param set`: removes the now-incorrect required `--user <user>` parameter from each example.

`mysql database query` and `mysql table schema get` were verified against source (`MySqlDatabaseOptions`) and correctly still require `--user`, so no change was needed there. No option classes, validation rules, or prompts required changes — this is a documentation-only fix.

## Testing

- Compared each MySQL option class (`MySqlListOptions`, `MySqlServerOptions`, `MySqlDatabaseOptions`, `ServerParamGetOptions`, `ServerParamSetOptions`, `DatabaseQueryOptions`, `TableSchemaGetOptions`) and `MySqlListCommand.ValidateOptions` against `azmcp-commands.md` to confirm required/optional notation now matches.
- Reviewed `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md` MySQL prompts; no mismatches found, no changes needed.
- Ran `.\eng\common\spelling\Invoke-Cspell.ps1` on the changed file: 0 issues found.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
