### PR TITLE
docs: mark --resource-group as optional for aks cluster get

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -2989,7 +2989,7 @@ azmcp keyvault secret get --subscription <subscription> \
 # Gets Azure Kubernetes Service (AKS) cluster details
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp aks cluster get --subscription <subscription> \
-                      --resource-group <resource-group> \
+                      [--resource-group <resource-group>] \
                       [--cluster <cluster>]
 
 # Gets Azure Kubernetes Service (AKS) nodepool details


### PR DESCRIPTION
## Summary

Fixes #2930

`ClusterGetCommand` (introduced by PR #2852) refactored `AksService` to use `BaseAzureResourceService` (Azure Resource Graph queries) instead of direct ARM calls. As part of that change:
- The validation requiring `--resource-group` whenever `--cluster` was specified was removed from `ClusterGetCommand.cs`.
- `AksService.GetClusters`'s `ValidateRequiredParameters` call now only requires `clusterName`, not `resourceGroup`.
- `ClusterGetOptions.ResourceGroup` is `string?` (nullable/optional) and is now fully honored as optional — a cluster can be looked up by name across all resource groups in a subscription without `--resource-group`.

However, `servers/Azure.Mcp.Server/docs/azmcp-commands.md` still documented `--resource-group` as a required parameter (no brackets) for `azmcp aks cluster get`. This PR wraps it in brackets to correctly reflect that it is optional, consistent with the current command validation, options, and service behavior.

I verified `azmcp aks nodepool get` is unaffected — it still requires both `--resource-group` and `--cluster`, and its validation (`ValidateRequiredParameters` in `AksService.GetNodePools`) still enforces this. I also checked `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md` for related prompt mismatches; the existing `aks_cluster_get` prompts already correctly include examples both with and without a resource group, so no changes were needed there.

## Changes

- `servers/Azure.Mcp.Server/docs/azmcp-commands.md`: Changed `azmcp aks cluster get` signature to show `[--resource-group <resource-group>]` instead of `--resource-group <resource-group>`.

## Testing

- Confirmed current `ClusterGetCommand.ValidateOptions` performs no resource-group requirement check and `ClusterGetOptions.ResourceGroup` is `string?` (optional).
- Confirmed `AksService.GetClusters` only requires `subscription` (and `clusterName` in the single-cluster path); `resourceGroup` is not required.
- Ran `.\eng\common\spelling\Invoke-Cspell.ps1` against the changed file — 0 issues found.
- This is a documentation-only change; no code, tests, or build outputs are affected. No changelog entry added per `docs/changelog-entries.md` (documentation-only changes are excluded unless major).

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.