### PR TITLE
Add e2e test prompts for File Shares NFS encryption in transit

### DIFF
--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -559,6 +559,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | fileshares_fileshare_create | Create file share <file_share_name> in resource group <resource_group_name> with 100 GB storage | none |
 | fileshares_fileshare_create | Create a file share named <file_share_name> in location <location> with resource group <resource_group_name> | none |
 | fileshares_fileshare_create | Set up a new file share <file_share_name> in resource group <resource_group_name> | none |
+| fileshares_fileshare_create | Create an NFS file share <file_share_name> in resource group <resource_group_name> with encryption in transit enabled | none |
 | fileshares_fileshare_delete | Delete the file share <file_share_name> from resource group <resource_group_name> | none |
 | fileshares_fileshare_delete | Remove file share <file_share_name> in resource group <resource_group_name> | none |
 | fileshares_fileshare_get | List all file shares in my subscription | none |
@@ -595,6 +596,8 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | fileshares_fileshare_peconnection_update | Change the status of private endpoint connection <connection_name> to Rejected | clarification-required |
 | fileshares_fileshare_update | Update file share <file_share_name> in resource group <resource_group_name> | none |
 | fileshares_fileshare_update | Update the provisioned storage for file share <file_share_name> to 200 GB | none |
+| fileshares_fileshare_update | Enable NFS encryption in transit for file share <file_share_name> in resource group <resource_group_name> | none |
+| fileshares_fileshare_update | Disable NFS encryption in transit on file share <file_share_name> in resource group <resource_group_name> | none |
 | fileshares_fileshare_update | Modify file share <file_share_name> in resource group <resource_group_name> with new settings | clarification-required |
 | fileshares_usage | Get Azure Files usage data for file share <file_share_name> in resource group <resource_group_name> | none |
 | fileshares_usage | Show me the usage statistics for file share <file_share_name> | none |

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -559,7 +559,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | fileshares_fileshare_create | Create file share <file_share_name> in resource group <resource_group_name> with 100 GB storage | none |
 | fileshares_fileshare_create | Create a file share named <file_share_name> in location <location> with resource group <resource_group_name> | none |
 | fileshares_fileshare_create | Set up a new file share <file_share_name> in resource group <resource_group_name> | none |
-| fileshares_fileshare_create | Create an NFS file share <file_share_name> in resource group <resource_group_name> with encryption in transit enabled | none |
+| fileshares_fileshare_create | Create an NFS file share <file_share_name> in location <location> in resource group <resource_group_name> with NFS encryption in transit enabled | none |
 | fileshares_fileshare_delete | Delete the file share <file_share_name> from resource group <resource_group_name> | none |
 | fileshares_fileshare_delete | Remove file share <file_share_name> in resource group <resource_group_name> | none |
 | fileshares_fileshare_get | List all file shares in my subscription | none |


### PR DESCRIPTION
Fixes #2695

## Summary

PR #2648 added a `--nfs-encryption-in-transit <Enabled|Disabled>` option to both `fileshares_fileshare_create` and `fileshares_fileshare_update` (alongside the existing `--nfs-root-squash` option), backed by the GA `Azure.ResourceManager.FileShares` 1.0.0 SDK. `azmcp-commands.md` was already updated with this option at that time, but `e2eTestPrompts.md` had no test prompts exercising it.

I inspected the current NFS encryption-in-transit semantics before adding prompts:
- Both commands set `NfsEncryptionInTransit`/`NfsRootSquash` onto the same underlying `NfsProtocolProperties` object (`FileSharesService.CreateOrUpdateFileShareAsync` / `PatchFileShareAsync`), so this is an NFS-protocol-specific setting.
- `fileshares_fileshare_create` supports `--protocol <NFS>` to select the protocol at creation time, so the new create prompt specifies an NFS file share explicitly.
- `fileshares_fileshare_update` has no `--protocol` option (protocol is immutable after creation), so the new update prompts only reference enabling/disabling encryption in transit on an existing share, without specifying a protocol — avoiding an unsupported combination.
- `azmcp-commands.md` already documents `--nfs-encryption-in-transit` correctly for both commands, so no command-doc changes were needed for this issue.

### Changes
- `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`: added 3 new test prompts to the Azure File Shares section:
  - `fileshares_fileshare_create`: "Create an NFS file share \<file_share_name\> in resource group \<resource_group_name\> with encryption in transit enabled"
  - `fileshares_fileshare_update`: "Enable NFS encryption in transit for file share \<file_share_name\> in resource group \<resource_group_name\>"
  - `fileshares_fileshare_update`: "Disable NFS encryption in transit on file share \<file_share_name\> in resource group \<resource_group_name\>"

## Testing

- Reviewed `FileShareCreateCommand.cs`, `FileShareUpdateCommand.cs`, `FileShareCreateOptions.cs`, `FileShareUpdateOptions.cs`, `FileSharesService.cs`, and `azmcp-commands.md` to confirm current NFS encryption-in-transit option semantics and that no other doc mismatch exists in scope.
- Ran `.\eng\common\spelling\Invoke-Cspell.ps1` against the changed file — 0 issues found.
- This is a documentation-only change (test prompts); no source code was modified, so no build/unit test run was required.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
