### PR TITLE
docs(compute): document VM/VMSS delete not-found behavior and SSH key validation

### DIFF
--- a/servers/Azure.Mcp.Server/cspell.yaml
+++ b/servers/Azure.Mcp.Server/cspell.yaml
@@ -57,6 +57,7 @@ words:
   - myuser
   - nettrace
   - newname
+  - nistp
   - noauth
   - nodetype
   - notanarea

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -1430,7 +1430,7 @@ azmcp compute vm create --subscription <subscription> \
                         [--os-disk-size-gb <os-disk-size-gb>] \
                         [--os-disk-type <os-disk-type>]
 
-Defaults to Standard_D2s_v5 size when `--vm-size` is not specified. `--image` is required and has no default; specify an alias (e.g., `Ubuntu2404`, `Win2022Datacenter`), a Marketplace URN (`publisher:offer:sku:version`), or a shared gallery image ID (starting with `/sharedGalleries/`). When new NSG rules are created, SSH/RDP access is allowed from any source unless `--source-address-prefix` is provided.
+Defaults to Standard_D2s_v5 size when `--vm-size` is not specified. `--image` is required and has no default; specify an alias (e.g., `Ubuntu2404`, `Win2022Datacenter`), a Marketplace URN (`publisher:offer:sku:version`), or a shared gallery image ID (starting with `/sharedGalleries/`). When new NSG rules are created, SSH/RDP access is allowed from any source unless `--source-address-prefix` is provided. When providing `--ssh-public-key`, supply the key content directly (e.g., `ssh-rsa AAAA...`, `ssh-ed25519 AAAA...`). In stdio mode, a file path to a `.pub` file (e.g., `~/.ssh/id_rsa.pub`) is also accepted and resolved locally. In HTTP/remote mode, only key content is accepted — file paths are rejected for security and return an error asking for the key content directly.
 
 # Examples:
 
@@ -1544,7 +1544,7 @@ azmcp compute vm create --subscription "my-sub" \
 | `--admin-username` | Yes | Admin username |
 | `--image` | Yes | Image alias (e.g., `Ubuntu2404`), Marketplace URN (`publisher:offer:sku:version`), or shared gallery image ID (`/sharedGalleries/...`). No default. |
 | `--admin-password` | Conditional | Admin password (required for Windows, optional for Linux) |
-| `--ssh-public-key` | Conditional | SSH public key (for Linux VMs) |
+| `--ssh-public-key` | Conditional | SSH public key content for Linux VMs. Accepted formats: `ssh-rsa`, `ssh-ed25519`, `ssh-dss`, `ecdsa-sha2-nistp256`, `ecdsa-sha2-nistp384`, `ecdsa-sha2-nistp521`, `sk-ssh-ed25519@openssh.com`, `sk-ecdsa-sha2-nistp256@openssh.com`. In stdio mode, a file path (e.g., `~/.ssh/id_rsa.pub`) may be provided instead. In HTTP/remote mode, only key content is accepted — file paths are rejected for security. |
 | `--vm-size` | No | VM size (default: Standard_D2s_v5) |
 | `--os-type` | No | OS type: 'linux' or 'windows' (auto-detected from image) |
 | `--virtual-network` | No | Virtual network name |
@@ -1632,6 +1632,7 @@ azmcp compute vm delete --subscription "my-subscription" \
 **Command Behavior:**
 - Deletes the VM. Associated resources (disks, NICs, public IPs) are NOT automatically deleted.
 - **With `--force-deletion`**: Passes `forceDeletion=true` to the Azure API, which force-deletes the VM even if it is in a running or failed state.
+- **Not-found handling**: If the specified VM does not exist, the command returns `Success: false` with a descriptive message ("...was not found in resource group '...'. Nothing was deleted.") rather than throwing an error. This makes the operation idempotent.
 
 **Parameters:**
 | Parameter | Required | Description |
@@ -1793,7 +1794,7 @@ azmcp compute vmss create --subscription <subscription> \
                           [--os-disk-size-gb <os-disk-size-gb>] \
                           [--os-disk-type <os-disk-type>]
 
-Defaults to two Standard_D2s_v5 instances when size or instance count are not provided. `--image` is required and has no default; specify an alias (e.g., `Ubuntu2404`, `Win2022Datacenter`), a Marketplace URN (`publisher:offer:sku:version`), or a shared gallery image ID (starting with `/sharedGalleries/`).
+Defaults to two Standard_D2s_v5 instances when size or instance count are not provided. `--image` is required and has no default; specify an alias (e.g., `Ubuntu2404`, `Win2022Datacenter`), a Marketplace URN (`publisher:offer:sku:version`), or a shared gallery image ID (starting with `/sharedGalleries/`). When providing `--ssh-public-key`, supply the key content directly (e.g., `ssh-rsa AAAA...`, `ssh-ed25519 AAAA...`). In stdio mode, a file path to a `.pub` file (e.g., `~/.ssh/id_rsa.pub`) is also accepted and resolved locally. In HTTP/remote mode, only key content is accepted — file paths are rejected for security and return an error asking for the key content directly.
 
 # Examples:
 
@@ -1830,7 +1831,7 @@ azmcp compute vmss create --subscription "my-subscription" \
 | `--admin-username` | Yes | Admin username |
 | `--image` | Yes | Image alias (e.g., `Ubuntu2404`), Marketplace URN (`publisher:offer:sku:version`), or shared gallery image ID (`/sharedGalleries/...`). No default. |
 | `--admin-password` | Conditional | Admin password (required for Windows) |
-| `--ssh-public-key` | Conditional | SSH public key (for Linux VMSS) |
+| `--ssh-public-key` | Conditional | SSH public key content for Linux VMSS. Accepted formats: `ssh-rsa`, `ssh-ed25519`, `ssh-dss`, `ecdsa-sha2-nistp256`, `ecdsa-sha2-nistp384`, `ecdsa-sha2-nistp521`, `sk-ssh-ed25519@openssh.com`, `sk-ecdsa-sha2-nistp256@openssh.com`. In stdio mode, a file path (e.g., `~/.ssh/id_rsa.pub`) may be provided instead. In HTTP/remote mode, only key content is accepted — file paths are rejected for security. |
 | `--vm-size` | No | VM size (default: Standard_D2s_v5) |
 | `--os-type` | No | OS type: 'linux' or 'windows' |
 | `--virtual-network` | No | Virtual network name |
@@ -1920,6 +1921,7 @@ azmcp compute vmss delete --subscription "my-subscription" \
 **Command Behavior:**
 - Deletes the VMSS and all its VM instances. This operation is irreversible.
 - **With `--force-deletion`**: Passes `forceDeletion=true` to the Azure API, which force-deletes the VMSS even if it is in a running or failed state.
+- **Not-found handling**: If the specified VMSS does not exist, the command returns `Success: false` with a descriptive message ("...was not found in resource group '...'. Nothing was deleted.") rather than throwing an error. This makes the operation idempotent.
 
 **Parameters:**
 | Parameter | Required | Description |

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -313,6 +313,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | compute_vm_create | Create VM <vm-name> in <location> with SSH key authentication | none |
 | compute_vm_create | Deploy a new VM with a 128GB Premium SSD OS disk in resource group <resource-group-name> | none |
 | compute_vm_create | Create a VM with Standard_E4s_v3 size and no public IP in <resource-group-name> | none |
+| compute_vm_create | Create Linux VM <vm-name> using SSH public key content 'ssh-ed25519 AAAAC3...' in <resource-group-name> | none |
 | compute_vm_get | List all virtual machines in my subscription | none |
 | compute_vm_get | Show me all VMs in my subscription | none |
 | compute_vm_get | What virtual machines do I have? | none |
@@ -335,6 +336,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | compute_vm_delete | Remove virtual machine <vm-name> from resource group <resource-group-name> | none |
 | compute_vm_delete | Destroy VM <vm-name> in resource group <resource-group-name> | none |
 | compute_vm_delete | Force delete VM <vm-name> in resource group <resource-group-name> using force-deletion | none |
+| compute_vm_delete | Delete VM <vm-name> that does not exist in resource group <resource-group-name> | none |
 | compute_vm_power-state | Power on and start VM <vm-name> in resource group <resource-group-name> | none |
 | compute_vm_power-state | Stop the running virtual machine <vm-name> and power it off in resource group <resource-group-name> | none |
 | compute_vm_power-state | Deallocate VM <vm-name> in resource group <resource-group-name> to release compute resources while keeping the VM | none |
@@ -347,6 +349,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | compute_vmss_create | Create a VMSS with 3 instances in <resource-group-name> | clarification-required |
 | compute_vmss_create | Deploy a virtual machine scale set with Rolling upgrade policy and 5 instances | clarification-required |
 | compute_vmss_create | Create Linux VMSS with SSH authentication in <resource-group-name> | none |
+| compute_vmss_create | Create scale set <vmss-name> using SSH public key content 'ssh-ed25519 AAAAC3...' in <resource-group-name> | none |
 | compute_vmss_get | List all virtual machine scale sets in my subscription | none |
 | compute_vmss_get | List virtual machine scale sets in resource group <resource-group-name> | none |
 | compute_vmss_get | What scale sets are in resource group <resource-group-name>? | none |
@@ -362,6 +365,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | compute_vmss_delete | Remove VMSS <vmss-name> from resource group <resource-group-name> | none |
 | compute_vmss_delete | Destroy virtual machine scale set <vmss-name> in resource group <resource-group-name> | none |
 | compute_vmss_delete | Force delete VMSS <vmss-name> in resource group <resource-group-name> using force-deletion | none |
+| compute_vmss_delete | Delete scale set <vmss-name> that does not exist in resource group <resource-group-name> | none |
 | compute_disk_get | List all managed disks in my subscription | none |
 | compute_disk_get | Show me all disks in resource group <resource-group> | none |
 | compute_disk_get | Get details of disk <disk-name> in resource group <resource-group> | none |


### PR DESCRIPTION
## Summary

Documentation-only fix addressing two doc-gap issues in the Azure Compute (VM/VMSS) toolset docs. No code changes were needed — the current `VmDeleteCommand`, `VmssDeleteCommand`, and `ComputeService.ResolveSshPublicKey` implementations already behave exactly as described below, and existing unit tests (`VmDeleteCommandTests`, `VmssDeleteCommandTests`, `SshKeyValidationTests`) already cover this behavior.

### Fixes #2772 — VM/VMSS delete not-found behavior undocumented
- `azmcp compute vm delete` and `azmcp compute vmss delete` Command Behavior sections in `azmcp-commands.md` now document that when the target VM/VMSS does not exist, the command returns `Success: false` with a descriptive "...was not found in resource group '...'. Nothing was deleted." message rather than throwing an error, making the operation idempotent.
- Added `e2eTestPrompts.md` prompts exercising the delete-of-nonexistent-resource scenario for `compute_vm_delete` and `compute_vmss_delete`.

### Fixes #2765 — `--ssh-public-key` validation behavior undocumented
- `azmcp compute vm create` and `azmcp compute vmss create` parameter tables and description paragraphs in `azmcp-commands.md` now document:
  - Accepted SSH public key content prefixes: `ssh-rsa`, `ssh-ed25519`, `ssh-dss`, `ecdsa-sha2-nistp256`, `ecdsa-sha2-nistp384`, `ecdsa-sha2-nistp521`, `sk-ssh-ed25519@openssh.com`, `sk-ecdsa-sha2-nistp256@openssh.com`.
  - stdio mode: a file path (e.g., `~/.ssh/id_rsa.pub`) may be provided and is resolved locally.
  - HTTP/remote mode: only key content is accepted; file paths are rejected for security.
- Added `e2eTestPrompts.md` prompts exercising SSH public key content (not file path) for `compute_vm_create` and `compute_vmss_create`.

### Other
- Added `nistp` to `servers/Azure.Mcp.Server/cspell.yaml` (new term introduced by the SSH key prefix documentation).

## Testing

- Verified current source behavior against both issues by reading `VmDeleteCommand.cs`, `VmssDeleteCommand.cs`, and `ComputeService.cs` (`DeleteVmAsync`, `DeleteVmssAsync`, `ResolveSshPublicKey`, `IsValidSshPublicKeyContent`, `LooksLikeFilePath`) — behavior matches what is now documented; no testable code defect found, so no production code was changed.
- Confirmed existing unit test coverage already validates this behavior (`VmDeleteCommandTests.cs`, `VmssDeleteCommandTests.cs`, `SshKeyValidationTests.cs`), so no new tests were required.
- `dotnet build tools/Azure.Mcp.Tools.Compute/src` — Build succeeded, 0 warnings, 0 errors.
- `.\eng\common\spelling\Invoke-Cspell.ps1` — ran against the changed doc files; 0 new issues (5 pre-existing, unrelated `traceidratio` issues remain in the Azure Monitor toolset, untouched by this PR).

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.