### PR TITLE
Clarify Service Bus peek commands remain intentionally unregistered (fixes doc-gap #2763)

### DIFF
--- a/tools/Azure.Mcp.Tools.ServiceBus/src/ServiceBusSetup.cs
+++ b/tools/Azure.Mcp.Tools.ServiceBus/src/ServiceBusSetup.cs
@@ -21,10 +21,10 @@ public class ServiceBusSetup : IAreaSetup
         services.AddSingleton<IServiceBusService, ServiceBusService>();
 
         services.AddSingleton<QueueDetailsCommand>();
-        // services.AddSingleton<QueuePeekCommand>();  // Not yet exposed; enable when ready
+        // services.AddSingleton<QueuePeekCommand>();  // Intentionally unregistered: message body binary-data serialization is unresolved (see #2763, #2680). Do not register, document, or add e2e prompts for this command until it is enabled.
         services.AddSingleton<TopicDetailsCommand>();
         services.AddSingleton<SubscriptionDetailsCommand>();
-        // services.AddSingleton<SubscriptionPeekCommand>();  // Not yet exposed; enable when ready
+        // services.AddSingleton<SubscriptionPeekCommand>();  // Intentionally unregistered: message body binary-data serialization is unresolved (see #2763, #2680). Do not register, document, or add e2e prompts for this command until it is enabled.
     }
 
     public CommandGroup RegisterCommands(IServiceProvider serviceProvider)
@@ -32,14 +32,14 @@ public class ServiceBusSetup : IAreaSetup
         var serviceBus = new CommandGroup(Name, "Service Bus operations - Commands to manage Azure Service Bus queues, topics, and subscriptions for reliable asynchronous messaging and enterprise integration. Supports point-to-point and publish-subscribe patterns, dead-letter handling, and decoupled architectures. Not intended for real-time communication, direct API calls, or database operations. Uses a hierarchical MCP command model with command, parameters, and learn=true.", Title);
 
         var queue = new CommandGroup("queue", "Queue operations - Commands for using Azure Service Bus queues.");
-        // queue.AddCommand<QueuePeekCommand>(serviceProvider);  // Not yet exposed; enable when ready
+        // queue.AddCommand<QueuePeekCommand>(serviceProvider);  // Intentionally unregistered: message body binary-data serialization is unresolved (see #2763, #2680). Do not register, document, or add e2e prompts for this command until it is enabled.
         queue.AddCommand<QueueDetailsCommand>(serviceProvider);
 
         var topic = new CommandGroup("topic", "Topic operations - Commands for using Azure Service Bus topics and subscriptions.");
         topic.AddCommand<TopicDetailsCommand>(serviceProvider);
 
         var subscription = new CommandGroup("subscription", "Subscription operations - Commands for using subscriptions within a Service Bus topic.");
-        // subscription.AddCommand<SubscriptionPeekCommand>(serviceProvider);  // Not yet exposed; enable when ready
+        // subscription.AddCommand<SubscriptionPeekCommand>(serviceProvider);  // Intentionally unregistered: message body binary-data serialization is unresolved (see #2763, #2680). Do not register, document, or add e2e prompts for this command until it is enabled.
         subscription.AddCommand<SubscriptionDetailsCommand>(serviceProvider);
 
         serviceBus.AddSubGroup(queue);


### PR DESCRIPTION
## Summary

Fixes #2763.

Issue #2763 was auto-generated by the repo's doc-gap-detector workflow, which flagged that `azmcp servicebus queue peek` and `azmcp servicebus topic subscription peek` were "missing" from `servers/Azure.Mcp.Server/docs/azmcp-commands.md` and `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`.

After inspecting the current `QueuePeekCommand`/`SubscriptionPeekCommand` implementations, their options, and — critically — their **registrations** in `tools/Azure.Mcp.Tools.ServiceBus/src/ServiceBusSetup.cs`, I found that these two commands are **not part of the current CLI surface at all**:

- PR #2680 intentionally commented out both `services.AddSingleton<...>()` calls and both `CommandGroup.AddCommand<...>()` calls for `QueuePeekCommand` and `SubscriptionPeekCommand`, with the note `// Not yet exposed; enable when ready`.
- The corresponding tests (`Queue_peek_messages`, `Topic_subscription_peek_messages`) are marked `[Fact(Skip = "The command for this test has been commented out until we know how to surface binary data.")]`.
- `servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json` only lists `servicebus_queue_details`, `servicebus_topic_details`, and `servicebus_topic_subscription_details` — no `*_peek` tools.
- Building the server and running `azmcp servicebus queue --help` / `azmcp servicebus topic subscription --help` confirms only the `details` subcommand exists; `peek` is not a recognized subcommand.

Given this, adding `peek` command-reference entries and e2e prompts (as the issue's implementation guide suggested) would document functionality that does not currently exist for users, contradicting the actual CLI behavior. Instead of introducing misleading documentation, this PR:

- Expands the existing disabling comments in `ServiceBusSetup.cs` to explicitly explain **why** the peek commands remain unregistered (unresolved message body binary-data serialization) and to instruct that they must not be registered, documented, or given e2e prompts until that underlying issue is resolved.
- Leaves `azmcp-commands.md` and `e2eTestPrompts.md` unchanged, since they already correctly reflect only the currently-registered `details` commands.

This directly resolves the confusion behind #2763: there is no actual documentation gap for currently-registered Service Bus commands, and the root cause (stale/ambiguous inline comments that didn't explain the "why") is now addressed so future doc-gap automation and contributors have clear context.

No functional behavior changes; the `peek` commands remain disabled exactly as before.

## Testing

- `dotnet build tools/Azure.Mcp.Tools.ServiceBus/src/Azure.Mcp.Tools.ServiceBus.csproj` — succeeds (0 warnings, 0 errors).
- `dotnet build servers/Azure.Mcp.Server/src/Azure.Mcp.Server.csproj` — succeeds.
- `dotnet test tools/Azure.Mcp.Tools.ServiceBus/tests/Azure.Mcp.Tools.ServiceBus.Tests/Azure.Mcp.Tools.ServiceBus.Tests.csproj` — 57 total, 55 succeeded, 2 skipped (the pre-existing skipped peek tests), 0 failed.
- Ran the built `azmcp.exe` locally and confirmed `servicebus queue --help` / `servicebus topic subscription --help` only expose `details`, verifying the peek commands are indeed unregistered in the current CLI surface.
- `.\eng\common\spelling\Invoke-Cspell.ps1` — no spelling issues found.
- No changelog entry added, since this is a comment-only clarification with no user-facing behavior change (per `docs/changelog-entries.md` guidance to skip entries for internal, non-user-facing changes).

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.