### PR TITLE
docs: add structured output mode examples

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -184,6 +184,29 @@ azmcp server start \
     [--read-only]
 ```
 
+#### Structured Output Mode
+
+Enables MCP protocol `outputSchema` and `structuredContent` fields for
+compatible clients. Two structured output modes are available:
+
+- `duplicated` returns the complete result in both `content` and `structuredContent`.
+- `compact` returns concise text in `content` and the complete result in `structuredContent`.
+
+```bash
+# Return the complete result in both content fields
+azmcp server start \
+    --mode all \
+    --structured-output-mode duplicated
+
+# Return concise text alongside the complete structured result
+azmcp server start \
+    --mode all \
+    --structured-output-mode compact
+```
+
+For instructions on adding structured output to a command, see the
+[Output Schema Migration Guide](../../../docs/output-schema-migration.md).
+
 #### Consolidated Mode
 
 Exposes carefully curated tools that group related Azure operations together based on common user workflows and tasks. This mode provides the optimal balance between discoverability and usability by organizing consolidated tools that combine multiple related operations.

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -193,12 +193,12 @@ compatible clients. Two structured output modes are available:
 - `compact` returns concise text in `content` and the complete result in `structuredContent`.
 
 ```bash
-# Return the complete result in both content fields
+# Return the complete result in content and structuredContent
 azmcp server start \
     --mode all \
     --structured-output-mode duplicated
 
-# Return concise text alongside the complete structured result
+# Return concise text in content and the complete result in structuredContent
 azmcp server start \
     --mode all \
     --structured-output-mode compact


### PR DESCRIPTION
## What does this PR do?

Documents `--structured-output-mode` in both normal and compact modes, including example commands and expected output behavior. It also links the migration guide so users can evaluate the schema transition from the command reference.

Validation performed:

- Ran the repository-pinned CSpell check on `servers/Azure.Mcp.Server/docs/azmcp-commands.md` (0 issues)
- Ran `git diff --check`
- Verified the migration guide link target exists

## GitHub issue number?

Closes #3467

## Pre-merge Checklist

- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality — not applicable; this is a documentation-only change
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies — not applicable; no product behavior changes

The MCP tool and Azure MCP Server tool-change checklists do not apply because this PR only updates the command reference.
