### PR TITLE
fix: temporarily restore quarantined VSIX dependencies

### DIFF
--- a/servers/Azure.Mcp.Server/vscode/package-lock.json
+++ b/servers/Azure.Mcp.Server/vscode/package-lock.json
@@ -2346,9 +2346,9 @@
             "optional": true
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.11.20",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
-            "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
+            "version": "2.10.7",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
+            "integrity": "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2458,9 +2458,9 @@
             "license": "ISC"
         },
         "node_modules/browserslist": {
-            "version": "4.28.8",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
-            "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
             "funding": [
                 {
@@ -2478,11 +2478,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.11.12",
-                "caniuse-lite": "^1.0.30001809",
-                "electron-to-chromium": "^1.5.402",
-                "node-releases": "^2.0.53",
-                "update-browserslist-db": "^1.3.0"
+                "baseline-browser-mapping": "^2.9.0",
+                "caniuse-lite": "^1.0.30001759",
+                "electron-to-chromium": "^1.5.263",
+                "node-releases": "^2.0.27",
+                "update-browserslist-db": "^1.2.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -2612,9 +2612,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001810",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
-            "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+            "version": "1.0.30001778",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz",
+            "integrity": "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==",
             "dev": true,
             "funding": [
                 {
@@ -3259,9 +3259,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.418",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.418.tgz",
-            "integrity": "sha512-UzS26r3AEbG5wSoGVpJKqwHIU9zwQN7LHdVIThDrJpS0I5KdlXFMEb8543fhc9dVnIIAST6ar8rhwa00AL5MlA==",
+            "version": "1.5.313",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
+            "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
             "dev": true,
             "license": "ISC"
         },
@@ -5533,14 +5533,11 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.54",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
-            "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+            "version": "2.0.36",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+            "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
             "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
+            "license": "MIT"
         },
         "node_modules/node-sarif-builder": {
             "version": "3.3.0",
@@ -7665,9 +7662,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
-            "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "dev": true,
             "funding": [
                 {

--- a/servers/Azure.Mcp.Server/vscode/package-lock.json
+++ b/servers/Azure.Mcp.Server/vscode/package-lock.json
@@ -4959,20 +4959,10 @@
             }
         },
         "node_modules/linkify-it": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
-            "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
             "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/puzrin"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/markdown-it"
-                }
-            ],
             "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
@@ -5134,25 +5124,15 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.3.1",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.1.tgz",
-            "integrity": "sha512-4Ej49aYTDFIQ+uBkfX8GBvJGccoARxxPep+7aWTs55ozbjQJpW9M26Fe53vnGgvLeVzva/amzjQQaQu9w0vMhA==",
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
             "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/puzrin"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/markdown-it"
-                }
-            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
-                "entities": "^4.5.0",
-                "linkify-it": "^5.0.2",
+                "entities": "^4.4.0",
+                "linkify-it": "^5.0.0",
                 "mdurl": "^2.0.0",
                 "punycode.js": "^2.3.1",
                 "uc.micro": "^2.1.0"


### PR DESCRIPTION
## Summary

Temporarily restore the last feed-available dependency sets for the Azure MCP VS Code extension so the VSIX release pipeline's exact `npm ci --omit=optional` command succeeds against the `azure-sdk-for-js` Azure Artifacts registry.

## Root cause

Azure MCP release pipeline build [20260901.5 (build 6775522)](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6775522&view=logs&j=50227db5-5527-584b-60d0-8ac88ac087e0&t=32070fc9-cfda-53b2-b300-54fe3fa5d5da&s=7c290454-2af0-5157-4da8-c2d59673e976) configures npm to use the `azure-sdk-for-js` Azure Artifacts feed. Newly merged Dependabot lockfile bumps reference packages that remain unavailable during the feed's two-day quarantine:

- PR #3452 upgraded `browserslist` from 4.28.1 to 4.28.8, which requires `update-browserslist-db ^1.3.0`; resolving 1.3.2 fails with E404.
- PR #3470 upgraded `markdown-it` from 14.1.1 to 14.3.1; resolving 14.3.1 then fails with E404 after the browserslist set is restored.

Directly pinning `update-browserslist-db` 1.2.3 under browserslist 4.28.8 would violate its `^1.3.0` dependency range. This change therefore restores both complete, coherent lockfile-only dependency sets from before those Dependabot updates. `package.json` is unchanged.

This is a temporary mitigation and should be reverted after the Azure Artifacts quarantine clears.

## Versions restored

| Package | From | To |
|---|---:|---:|
| `browserslist` | 4.28.8 | 4.28.1 |
| `update-browserslist-db` | 1.3.2 | 1.2.3 |
| `baseline-browser-mapping` | 2.11.20 | 2.10.7 |
| `caniuse-lite` | 1.0.30001810 | 1.0.30001778 |
| `electron-to-chromium` | 1.5.418 | 1.5.313 |
| `node-releases` | 2.0.54 | 2.0.36 |
| `markdown-it` | 14.3.1 | 14.1.1 |
| `linkify-it` | 5.0.2 | 5.0.0 |

## Validation

- Clean `npm ci --omit=optional` using an empty user configuration and the exact `https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/` registry
- Verified the installed dependency tree contains all eight restored versions
- `npm run compile`
- `npm run build`
- `dotnet build servers/Azure.Mcp.Server/src/Azure.Mcp.Server.csproj`
- `./eng/scripts/Build-Local.ps1 -VerifyNpx`
- `./eng/common/spelling/Invoke-Cspell.ps1`

## Feature impact

No Azure MCP runtime or shipped VSIX functionality changes. All restored packages are dev-only transitive dependencies used by webpack or `@vscode/vsce`, not runtime dependencies bundled into the extension. Builds temporarily use older browser compatibility, Electron/Chromium, and Node release datasets plus the prior packaging-time Markdown parser/linkifier. Webpack targets Node, and the extension TypeScript compile and production bundle remain successful.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.