### PR TITLE
Group npm security updates across lockfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,9 +19,6 @@ updates:
       - "/servers/Fabric.Mcp.Server/vscode"
       - "/servers/Template.Mcp.Server/vscode"
       - "/eng/vsix-tools"
-      - "/eng/common/tsp-client"
-      - "/eng/common/spelling"
-      - "/eng/common/scripts/eval"
     schedule:
       interval: "weekly"
     # Configure security updates without enabling routine npm version updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,22 @@ updates:
     # Feel free to extend this to other packages as needed
     allow:
       - dependency-name: "Azure.Bicep.Types"
+
+  # Group npm security updates for the same dependency across the monorepo
+  - package-ecosystem: "npm"
+    directories:
+      - "/servers/Azure.Mcp.Server/vscode"
+      - "/servers/Fabric.Mcp.Server/vscode"
+      - "/servers/Template.Mcp.Server/vscode"
+      - "/eng/vsix-tools"
+      - "/eng/common/tsp-client"
+      - "/eng/common/spelling"
+      - "/eng/common/scripts/eval"
+    schedule:
+      interval: "weekly"
+    # Configure security updates without enabling routine npm version updates
+    open-pull-requests-limit: 0
+    groups:
+      npm-security-updates:
+        applies-to: "security-updates"
+        group-by: "dependency-name"


### PR DESCRIPTION
## What does this PR do?

Configures Dependabot to group npm security updates by dependency name across the repository's current npm lockfile roots.

When the same vulnerable dependency affects multiple lockfiles, Dependabot can create one remediation PR that updates all applicable manifests. The underlying Dependabot alerts remain separate records for each vulnerable dependency occurrence.

Routine npm version-update PRs remain disabled with `open-pull-requests-limit: 0`; the configuration applies grouping to security updates only.

## GitHub issue number?

N/A

## Validation

- Parsed and formatted `.github/dependabot.yml` with Prettier
- Ran the repository spelling check
- Confirmed all configured directories contain current npm manifests and lockfiles

## Pre-merge Checklist

- [x] Read the contribution guidelines
- [x] PR title clearly describes the change
- [x] Commit history is clean with a descriptive message
- [x] Tests are not applicable to this configuration-only change
- [x] Changelog entry is not required for this repository-maintenance change

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.