### PR TITLE
fix: restore feed-available Azure VSIX dependencies

### DIFF
--- a/servers/Azure.Mcp.Server/vscode/package-lock.json
+++ b/servers/Azure.Mcp.Server/vscode/package-lock.json
@@ -2346,9 +2346,9 @@
             "optional": true
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.7",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
-            "integrity": "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==",
+            "version": "2.10.12",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
+            "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2458,9 +2458,9 @@
             "license": "ISC"
         },
         "node_modules/browserslist": {
-            "version": "4.28.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+            "version": "4.28.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
             "dev": true,
             "funding": [
                 {
@@ -2478,11 +2478,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.9.0",
-                "caniuse-lite": "^1.0.30001759",
-                "electron-to-chromium": "^1.5.263",
-                "node-releases": "^2.0.27",
-                "update-browserslist-db": "^1.2.0"
+                "baseline-browser-mapping": "^2.10.12",
+                "caniuse-lite": "^1.0.30001782",
+                "electron-to-chromium": "^1.5.328",
+                "node-releases": "^2.0.36",
+                "update-browserslist-db": "^1.2.3"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -2612,9 +2612,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001778",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz",
-            "integrity": "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==",
+            "version": "1.0.30001782",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
+            "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
             "dev": true,
             "funding": [
                 {
@@ -3259,9 +3259,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.313",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
-            "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
+            "version": "1.5.328",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
+            "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
             "dev": true,
             "license": "ISC"
         },
@@ -4740,9 +4740,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
-            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
## Summary

This lockfile-only follow-up unblocks the Azure MCP VSIX release. The Azure release pipeline passes `ServerName: Azure.Mcp.Server`; `New-BuildInfo.ps1` scopes `build_info.json` to Azure, and `Pack-Vsix.ps1` processes only those listed servers, so Fabric and Template lockfiles are intentionally unchanged.

Merged PR #3497 restored a feed-available browserslist dependency set, but it retained vulnerable `browserslist` 4.28.1. The subsequent Azure release still failed because `js-yaml` 4.3.2, introduced by Dependabot PR #3461, remains quarantined and unavailable in the Azure Artifacts feed.

## Feed audit and dependency state

Rather than discovering unavailable packages one `npm ci` failure at a time, the audit enumerated every exact tarball in the Azure lockfile and performed authenticated one-byte ranged GET requests against `https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/`. The resulting coherent feed-available set is:

- `browserslist` 4.28.2
- `baseline-browser-mapping` 2.10.12
- `caniuse-lite` 1.0.30001782
- `electron-to-chromium` 1.5.328
- `js-yaml` 4.3.1
- `node-releases` 2.0.36
- `update-browserslist-db` 1.2.3

The browserslist dependency ranges are updated to the exact 4.28.2 package metadata. Version 4.28.2 is the first browserslist release containing the prototype-pollution fix.

## Temporary security tradeoff

`js-yaml` 4.3.1 is the newest version currently available in the internal feed. This is a temporary security tradeoff because 4.3.2 adds a security hard limit/counting fix for merge sequences. These packages are dev-only transitive dependencies used during VSIX builds, with no runtime or shipped VSIX behavior impact. Expedited feed approval of 4.3.2 is preferable, and the lockfile must be re-upgraded immediately after its quarantine clears.

## Validation

- Clean authenticated `npm ci --omit=optional` against the Azure SDK Azure Artifacts npm registry
- `npm ls browserslist baseline-browser-mapping caniuse-lite electron-to-chromium js-yaml node-releases update-browserslist-db --depth=2`
- `npm run compile`
- `npm run build`
- `dotnet build servers/Azure.Mcp.Server/src/Azure.Mcp.Server.csproj`
- `.\eng\scripts\Build-Local.ps1 -VerifyNpx`
- `.\eng\common\spelling\Invoke-Cspell.ps1`

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.