### PR TITLE
Add Advisor recommendation Chaos review tool

### DIFF
--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -954,6 +954,7 @@ For full configuration options, see the [Sovereign Clouds documentation](https:/
 ### 📊 Azure Advisor
 
 * "List my Advisor recommendations"
+* "Review whether an Advisor-recommended VMSS is ready for a Compute Zone Down Chaos experiment"
 * "Apply Advisor recommendations to IaaC files"
 * "Before I deploy virtual machines, list the Advisor recommendation metadata that could apply to them"
 * "Show Advisor service retirements on or after March 31, 2026"
@@ -1310,7 +1311,7 @@ Example prompts that generate Azure CLI commands:
 The Azure MCP Server provides tools for interacting with **44+ Azure service areas**:
 
 - 🧮 **Microsoft Foundry** - AI model management, AI model deployment, and knowledge index management
-- 📊 **Azure Advisor** - Advisor recommendations
+- 📊 **Azure Advisor** - Advisor recommendations, recommendation metadata, and read-only Chaos readiness review
 - 🔎 **Azure AI Search** - Search engine/vector database operations
 - 🎤 **Azure AI Services Speech** - Speech-to-text recognition and text-to-speech synthesis
 - ⚙️ **Azure App Configuration** - Configuration management

--- a/servers/Azure.Mcp.Server/changelog-entries/shruti-advisor-chaos-review.yml
+++ b/servers/Azure.Mcp.Server/changelog-entries/shruti-advisor-chaos-review.yml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Features Added"
+    description: "Added the read-only `azmcp advisor recommendation chaos-review` tool to verify an exact active Advisor recommendation and review Compute Zone Down Chaos readiness for its virtual machine scale set, including eligibility, compatible Chaos resources, validation state, permissions, and run blockers."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -342,6 +342,20 @@ azmcp advisor recommendation list --subscription <subscription> \
                                   [--tracking-ids <tracking-id1> <tracking-id2> ...] \
                                   [--retirement-date <eq|lt|le|gt|ge>:<yyyy-MM-dd>]
 
+# Perform a read-only Compute Zone Down Chaos readiness review for one Advisor-recommended VMSS.
+# Verifies an exact active Advisor recommendation using its type ID and VMSS ARM resource ID. Optional workspace, scenario,
+# and configuration ARM IDs must come from a previous review result and resolve ambiguous candidates.
+# Returns eligibility, missing setup or permissions, compatible candidates, validation state, and run history.
+# This command never creates or modifies Chaos resources, permissions, validations, runs, or Advisor approval plans.
+# ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
+azmcp advisor recommendation chaos-review --subscription <subscription> \
+                                          --recommendation-type-id <recommendation-type-id> \
+                                          --resource <vmss-resource-id> \
+                                          [--workspace <workspace-resource-id>] \
+                                          [--scenario <scenario-resource-id>] \
+                                          [--configuration <configuration-resource-id>] \
+                                          [--tenant <tenant>]
+
 # Summarize Advisor recommendations grouped by a chosen field (recommendation-type, category, impact, or resource-type)
 # --group-by is optional and defaults to 'category' when omitted
 # Only active recommendations (status 'New') are aggregated; dismissed and postponed ones are excluded

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -30,6 +30,10 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | advisor_metadata_list | Show Advisor service retirements on or after March 31, 2026 | none |
 | advisor_recommendation_apply | Apply Advisor recommendations to this ARM template | context-required |
 | advisor_recommendation_apply | Apply Advisor recommendations to this Terraform file for Storage Account | context-required |
+| advisor_recommendation_chaos-review | Review Compute Zone Down Chaos readiness for Advisor recommendation type <recommendation-type-id> affecting VMSS <resource-id> in subscription <subscription> | none |
+| advisor_recommendation_chaos-review | Check whether Advisor-recommended VMSS <resource-id> is ready for a Chaos Studio zone-down experiment using recommendation type <recommendation-type-id> in subscription <subscription> | none |
+| advisor_recommendation_chaos-review | Show missing Chaos workspace, scenario, configuration, validation, permission, or active-run blockers for Advisor recommendation type <recommendation-type-id> on VMSS <resource-id> in subscription <subscription> | none |
+| advisor_recommendation_chaos-review | Continue the Advisor Chaos readiness review for VMSS <resource-id> using workspace <workspace-resource-id>, scenario <scenario-resource-id>, and configuration <configuration-resource-id> in subscription <subscription> with recommendation type <recommendation-type-id> | none |
 | advisor_recommendation_list | List all recommendations in my subscription | none |
 | advisor_recommendation_list | Show me Advisor recommendations in the subscription <subscription> | none |
 | advisor_recommendation_list | List all Advisor recommendations in the subscription <subscription> | none |

--- a/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json
+++ b/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json
@@ -1064,6 +1064,39 @@
       ]
     },
     {
+      "name": "review_azure_advisor_chaos_readiness",
+      "description": "Review whether one Azure Advisor-recommended virtual machine scale set is ready for an Azure Chaos Studio Compute Zone Down experiment. Verifies an exact active Advisor recommendation using its type ID and VMSS ARM resource ID, then checks VMSS eligibility, discovers covering Chaos workspaces, identifies compatible recommended scenarios and exact configurations, inspects validation state and scenario run history, and reports deterministic setup, permission, selection, validation, or active-run blockers. Optional workspace, scenario, and configuration ARM IDs must come from a previous review result. This tool is read-only and never creates or changes Chaos resources, permissions, validations, runs, experiments, or Advisor approval plans.",
+      "toolMetadata": {
+        "destructive": {
+          "value": false,
+          "description": "This tool performs only read operations and does not create or modify Azure resources."
+        },
+        "idempotent": {
+          "value": true,
+          "description": "Running this operation repeatedly with the same inputs performs the same readiness checks without side effects."
+        },
+        "openWorld": {
+          "value": false,
+          "description": "This tool is limited to one Advisor-recommended VMSS and its related Azure Chaos Studio resources."
+        },
+        "readOnly": {
+          "value": true,
+          "description": "This tool reads VMSS and Chaos Studio state without modifying it."
+        },
+        "secret": {
+          "value": false,
+          "description": "This tool does not handle sensitive or secret information."
+        },
+        "localRequired": {
+          "value": false,
+          "description": "This tool is available in both local and remote server modes."
+        }
+      },
+      "mappedToolList": [
+        "advisor_recommendation_chaos-review"
+      ]
+    },
+    {
       "name": "list_azure_advisor_recommendation_metadata",
       "description": "List the global Azure Advisor recommendation metadata catalog, also known as recommendation types, from Azure Resource Graph. Use it even when no recommendation instances exist: discover available types for greenfield environments, filter by supported resource type during brownfield onboarding, or find service-retirement metadata by Service Health tracking ID and retirement date. Service-retirement filters apply to the ServiceUpgradeAndRetirement subcategory; conflicting subcategory filters are rejected. Returns localized IDs, names, categories, subcategories, impact, priority, descriptions, benefits, actions, scope, source query, and service-retirement details. Supports language, resource type, impact, category, subcategory, tracking ID, and retirement date filters, ordered High, Medium, then Low impact.",
       "toolMetadata": {

--- a/tools/Azure.Mcp.Tools.Advisor/src/AdvisorSetup.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/AdvisorSetup.cs
@@ -18,7 +18,9 @@ public class AdvisorSetup : IAreaSetup
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddSingleton<IAdvisorService, AdvisorService>();
+        services.AddSingleton<IAdvisorChaosReviewService, AdvisorChaosReviewService>();
         services.AddSingleton<RecommendationListCommand>();
+        services.AddSingleton<RecommendationChaosReviewCommand>();
         services.AddSingleton<RecommendationSummaryCommand>();
         services.AddSingleton<RecommendationApplyCommand>();
         services.AddSingleton<RecommendationMetadataListCommand>();
@@ -31,7 +33,9 @@ public class AdvisorSetup : IAreaSetup
         var advisor = new CommandGroup(Name, "Azure Advisor operations - Query Azure Advisor recommendations across subscriptions OR Apply Azure Advisor recommendations to your IaaC files (ARM, Terraform). Use when you need subscription-scoped visibility into Advisor recommendations OR want to apply Advisor recommendations to your IaaC files. Requires Azure subscription context for querying Advisor recommendations.", Title);
 
         // Create Advisor subgroups
-        var recommendation = new CommandGroup("recommendation", "Advisor recommendations - Commands for listing, summarizing, and applying Advisor recommendations in your Azure subscription.");
+        var recommendation = new CommandGroup(
+            "recommendation",
+            "Advisor recommendations - Commands for listing, summarizing, reviewing Compute Zone Down Chaos readiness, and applying Advisor recommendations in your Azure subscription.");
         advisor.AddSubGroup(recommendation);
 
         var metadata = new CommandGroup(
@@ -41,6 +45,7 @@ public class AdvisorSetup : IAreaSetup
 
         // Register Advisor commands
         recommendation.AddCommand<RecommendationListCommand>(serviceProvider);
+        recommendation.AddCommand<RecommendationChaosReviewCommand>(serviceProvider);
         recommendation.AddCommand<RecommendationSummaryCommand>(serviceProvider);
         recommendation.AddCommand<RecommendationApplyCommand>(serviceProvider);
         metadata.AddCommand<RecommendationMetadataListCommand>(serviceProvider);

--- a/tools/Azure.Mcp.Tools.Advisor/src/Commands/AdvisorJsonContext.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Commands/AdvisorJsonContext.cs
@@ -2,12 +2,14 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Azure.Mcp.Tools.Advisor.Commands.Metadata;
 using Azure.Mcp.Tools.Advisor.Commands.Recommendation;
+using Azure.Mcp.Tools.Advisor.Models.Chaos;
 using Azure.Mcp.Tools.Advisor.Services.Models;
 
 namespace Azure.Mcp.Tools.Advisor.Commands;
 
 [JsonSerializable(typeof(MetadataGetCommand.MetadataGetResult))]
 [JsonSerializable(typeof(RecommendationMetadataListCommand.RecommendationMetadataListResult))]
+[JsonSerializable(typeof(RecommendationChaosReviewCommand.RecommendationChaosReviewResult))]
 [JsonSerializable(typeof(RecommendationListCommand.RecommendationListResult))]
 [JsonSerializable(typeof(RecommendationSummaryCommand.RecommendationSummaryResult))]
 [JsonSerializable(typeof(List<string>))]
@@ -27,6 +29,13 @@ namespace Azure.Mcp.Tools.Advisor.Commands;
 [JsonSerializable(typeof(Models.RecommendationMetadata))]
 [JsonSerializable(typeof(Models.RecommendationGroup))]
 [JsonSerializable(typeof(Models.RecommendationSummary))]
+[JsonSerializable(typeof(ChaosRemediationStatus))]
+[JsonSerializable(typeof(ChaosTargetReview))]
+[JsonSerializable(typeof(ChaosWorkspaceCandidate))]
+[JsonSerializable(typeof(ChaosScenarioCandidate))]
+[JsonSerializable(typeof(ChaosConfigurationCandidate))]
+[JsonSerializable(typeof(ChaosValidationStatus))]
+[JsonSerializable(typeof(ChaosRunSummary))]
 [JsonSerializable(typeof(string))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,

--- a/tools/Azure.Mcp.Tools.Advisor/src/Commands/Recommendation/RecommendationChaosReviewCommand.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Commands/Recommendation/RecommendationChaosReviewCommand.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Azure.Mcp.Core.Commands.Subscription;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Azure.Mcp.Tools.Advisor.Models.Chaos;
+using Azure.Mcp.Tools.Advisor.Options.Recommendation;
+using Azure.Mcp.Tools.Advisor.Services;
+using Azure.Mcp.Tools.Advisor.Services.Models;
+using Azure.Mcp.Tools.Advisor.Validation;
+using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Commands;
+using Microsoft.Mcp.Core.Models.Command;
+
+namespace Azure.Mcp.Tools.Advisor.Commands.Recommendation;
+
+[CommandMetadata(
+    Id = "7fdc5f3e-4baf-4da9-950d-e339192db36b",
+    Name = "chaos-review",
+    Title = "Review Advisor Compute Zone Down Chaos Readiness",
+    Description = """
+        Perform a read-only Azure Advisor Compute Zone Down remediation review for one exact virtual machine scale set.
+        Use this tool when the user wants to check whether an Advisor-recommended VMSS is ready for an Azure Chaos Studio zone-down experiment, determine what setup or permissions are missing, inspect compatible Chaos workspaces, scenarios, and configurations, or view related scenario run history.
+        Requires and verifies an exact active Advisor recommendation type ID GUID and exact Microsoft.Compute/virtualMachineScaleSets ARM resource ID.
+        Optional workspace, scenario, and configuration ARM IDs must come from a previous review result and are used only to resolve an otherwise ambiguous selection.
+        Returns deterministic readiness, blocker reason codes, candidate ARM IDs, validation state, required read permission, and active or historical runs.
+        This tool never creates or changes a Chaos workspace, configuration, role assignment, validation, experiment, or Advisor approval plan.
+        """,
+    Destructive = false,
+    Idempotent = true,
+    OpenWorld = false,
+    ReadOnly = true,
+    Secret = false,
+    LocalRequired = false)]
+public sealed class RecommendationChaosReviewCommand(
+    ILogger<RecommendationChaosReviewCommand> logger,
+    IAdvisorChaosReviewService chaosReviewService,
+    ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<RecommendationChaosReviewOptions, RecommendationChaosReviewCommand.RecommendationChaosReviewResult>(subscriptionResolver)
+{
+    private readonly ILogger<RecommendationChaosReviewCommand> _logger = logger;
+    private readonly IAdvisorChaosReviewService _chaosReviewService = chaosReviewService;
+
+    public override void ValidateOptions(
+        RecommendationChaosReviewOptions options,
+        ValidationResult validationResult)
+    {
+        base.ValidateOptions(options, validationResult);
+
+        var hasRecommendationType = Guid.TryParseExact(
+            options.RecommendationTypeId?.Trim(),
+            "D",
+            out var recommendationTypeId) &&
+            recommendationTypeId != Guid.Empty;
+        if (!hasRecommendationType)
+        {
+            validationResult.Errors.Add(
+                "--recommendation-type-id must be a non-empty GUID in xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx format.");
+        }
+
+        var resourceRecommendationTypeId = hasRecommendationType
+            ? recommendationTypeId
+            : new Guid("00000000-0000-0000-0000-000000000001");
+        if (!ChaosRemediationTarget.TryCreate(
+                resourceRecommendationTypeId,
+                options.Resource,
+                out _,
+                out var resourceError))
+        {
+            validationResult.Errors.Add(
+                $"--resource must be an exact Microsoft.Compute/virtualMachineScaleSets ARM resource ID. {resourceError}");
+        }
+
+        ValidateOptionalResource(
+            "--workspace",
+            options.Workspace,
+            ChaosResourceIdValidator.IsWorkspace,
+            "Microsoft.Chaos/workspaces",
+            validationResult);
+        ValidateOptionalResource(
+            "--scenario",
+            options.Scenario,
+            ChaosResourceIdValidator.IsScenario,
+            "Microsoft.Chaos/workspaces/scenarios",
+            validationResult);
+        ValidateOptionalResource(
+            "--configuration",
+            options.Configuration,
+            ChaosResourceIdValidator.IsConfiguration,
+            "Microsoft.Chaos/workspaces/scenarios/configurations",
+            validationResult);
+
+        if (options.Workspace is not null &&
+            options.Scenario is not null &&
+            !IsChild(options.Scenario, options.Workspace, "scenarios"))
+        {
+            validationResult.Errors.Add(
+                "--scenario must be a child of the selected --workspace.");
+        }
+
+        if (options.Scenario is not null &&
+            options.Configuration is not null &&
+            !IsChild(options.Configuration, options.Scenario, "configurations"))
+        {
+            validationResult.Errors.Add(
+                "--configuration must be a child of the selected --scenario.");
+        }
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(
+        CommandContext context,
+        RecommendationChaosReviewOptions options,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var review = await _chaosReviewService.ReviewChaosRemediationAsync(
+                options.Subscription!,
+                Guid.Parse(options.RecommendationTypeId),
+                options.Resource,
+                options.Workspace,
+                options.Scenario,
+                options.Configuration,
+                options.Tenant,
+                cancellationToken);
+
+            context.Response.Results = ResponseResult.Create(
+                new(review),
+                AdvisorJsonContext.Default.RecommendationChaosReviewResult);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Error reviewing Advisor Chaos readiness. Subscription: {Subscription}, RecommendationTypeId: {RecommendationTypeId}, Resource: {Resource}.",
+                options.Subscription,
+                options.RecommendationTypeId,
+                options.Resource);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    protected override string GetErrorMessage(Exception ex) => ex switch
+    {
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.Unauthorized =>
+            "Azure authentication failed while reviewing Chaos readiness. Sign in again and retry.",
+        RequestFailedException reqEx when reqEx.Status == (int)HttpStatusCode.Forbidden =>
+            "Authorization failed while resolving the Azure subscription for the Chaos review.",
+        RequestFailedException reqEx => reqEx.Message,
+        _ => base.GetErrorMessage(ex)
+    };
+
+    private static void ValidateOptionalResource(
+        string optionName,
+        string? value,
+        Func<string?, bool> validator,
+        string expectedResourceType,
+        ValidationResult validationResult)
+    {
+        if (value is not null && !validator(value))
+        {
+            validationResult.Errors.Add(
+                $"{optionName} must be an exact {expectedResourceType} ARM resource ID.");
+        }
+    }
+
+    private static bool IsChild(
+        string child,
+        string parent,
+        string collectionName) =>
+        child.StartsWith(
+            $"{parent.TrimEnd('/')}/{collectionName}/",
+            StringComparison.OrdinalIgnoreCase);
+
+    public sealed record RecommendationChaosReviewResult(
+        ChaosRemediationStatus Review);
+}

--- a/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosConfigurationCandidate.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosConfigurationCandidate.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Advisor.Models.Chaos;
+
+/// <summary>Compatible Chaos configuration with its exact target contract.</summary>
+public sealed record ChaosConfigurationCandidate(
+    string Id,
+    string Name,
+    string ScenarioId,
+    string ScenarioName,
+    string Zone,
+    string Location,
+    string Duration,
+    string? ProvisioningState,
+    DateTimeOffset LastModifiedAt,
+    IReadOnlyList<string> TargetResourceIds);

--- a/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosRemediationStatus.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosRemediationStatus.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Advisor.Models.Chaos;
+
+/// <summary>Read-only Chaos readiness, candidates, and selected resources for one VMSS.</summary>
+public sealed record ChaosRemediationStatus
+{
+    public string Status { get; init; } = string.Empty;
+
+    public bool Ready { get; init; }
+
+    public bool MutationPerformed { get; init; }
+
+    public string? ReasonCode { get; init; }
+
+    public string Message { get; init; } = string.Empty;
+
+    public ChaosTargetReview Target { get; init; } = null!;
+
+    public IReadOnlyList<ChaosWorkspaceCandidate> WorkspaceCandidates { get; init; } = [];
+
+    public ChaosWorkspaceCandidate? Workspace { get; init; }
+
+    public IReadOnlyList<ChaosScenarioCandidate> ScenarioCandidates { get; init; } = [];
+
+    public ChaosScenarioCandidate? Scenario { get; init; }
+
+    public IReadOnlyList<ChaosConfigurationCandidate> ConfigurationCandidates { get; init; } = [];
+
+    public ChaosConfigurationCandidate? Configuration { get; init; }
+
+    public IReadOnlyList<ChaosRunSummary> Runs { get; init; } = [];
+
+    public string? RequiredPermission { get; init; }
+
+    public ChaosValidationStatus? Validation { get; init; }
+}

--- a/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosRunSummary.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosRunSummary.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Advisor.Models.Chaos;
+
+/// <summary>Active or historical Chaos scenario run returned for the selected scenario.</summary>
+public sealed record ChaosRunSummary(
+    string Id,
+    string RunId,
+    string WorkspaceResourceId,
+    string ScenarioResourceId,
+    string ScenarioName,
+    string ConfigurationResourceId,
+    string ConfigurationName,
+    string Status,
+    DateTimeOffset? StartTime,
+    DateTimeOffset? EndTime,
+    IReadOnlyList<string> ResourceIds);

--- a/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosScenarioCandidate.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosScenarioCandidate.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Advisor.Models.Chaos;
+
+/// <summary>Compatible Chaos scenario identified by exact ARM ID and action contract.</summary>
+public sealed record ChaosScenarioCandidate(
+    string Id,
+    string Name,
+    string? RecommendationStatus,
+    IReadOnlyList<string> ActionIds);

--- a/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosTargetReview.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosTargetReview.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Advisor.Models.Chaos;
+
+/// <summary>Current read-only eligibility status for one selected VMSS.</summary>
+public sealed record ChaosTargetReview(
+    string Status,
+    bool Eligible,
+    string? ReasonCode,
+    string Message,
+    string? RecommendationTypeId,
+    string? ResourceId,
+    string? Location,
+    IReadOnlyList<string> Zones,
+    long? Capacity,
+    string? ProvisioningState,
+    string? RequiredPermission = null);

--- a/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosValidationStatus.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosValidationStatus.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Advisor.Models.Chaos;
+
+/// <summary>Latest validation state for the selected Chaos configuration.</summary>
+public sealed record ChaosValidationStatus(
+    string Status,
+    DateTimeOffset StartTime,
+    DateTimeOffset? EndTime,
+    int PermissionErrorCount,
+    int ResourceErrorCount);

--- a/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosWorkspaceCandidate.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Models/Chaos/ChaosWorkspaceCandidate.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Advisor.Models.Chaos;
+
+/// <summary>Hydrated Chaos workspace candidate that covers the selected VMSS.</summary>
+public sealed record ChaosWorkspaceCandidate(
+    string Id,
+    string Name,
+    string? Location,
+    string? ProvisioningState,
+    string? IdentityType,
+    string? PrincipalId,
+    IReadOnlyList<string> Scopes,
+    bool Selectable,
+    string? ReasonCode = null);

--- a/tools/Azure.Mcp.Tools.Advisor/src/Options/Recommendation/RecommendationChaosReviewOptions.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Options/Recommendation/RecommendationChaosReviewOptions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Options;
+using Microsoft.Mcp.Core.Options;
+
+namespace Azure.Mcp.Tools.Advisor.Options.Recommendation;
+
+public sealed class RecommendationChaosReviewOptions : ISubscriptionOption
+{
+    [Option(Description = "The exact active Azure Advisor recommendation type ID GUID to verify.")]
+    public required string RecommendationTypeId { get; set; }
+
+    [Option(Description = "The exact ARM resource ID of the Microsoft.Compute/virtualMachineScaleSets resource affected by the active Advisor recommendation.")]
+    public required string Resource { get; set; }
+
+    [Option(Description = "Optional exact Microsoft.Chaos workspace ARM ID selected from a prior review result.")]
+    public string? Workspace { get; set; }
+
+    [Option(Description = "Optional exact Microsoft.Chaos scenario ARM ID selected from a prior review result.")]
+    public string? Scenario { get; set; }
+
+    [Option(Description = "Optional exact Microsoft.Chaos scenario configuration ARM ID selected from a prior review result.")]
+    public string? Configuration { get; set; }
+
+    [Option(Description = OptionDescriptions.Subscription)]
+    public string? Subscription { get; set; }
+
+    [Option(Description = OptionDescriptions.Tenant)]
+    public string? Tenant { get; set; }
+}

--- a/tools/Azure.Mcp.Tools.Advisor/src/Services/AdvisorChaosReviewService.Parsing.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Services/AdvisorChaosReviewService.Parsing.cs
@@ -1,0 +1,843 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Xml;
+using Azure.Mcp.Tools.Advisor.Models.Chaos;
+
+namespace Azure.Mcp.Tools.Advisor.Services;
+
+public sealed partial class AdvisorChaosReviewService
+{
+    private static IReadOnlyList<WorkspaceCandidate> ParseWorkspaces(string body)
+    {
+        using var document = JsonDocument.Parse(body);
+        var values = GetRequiredArray(document.RootElement, "value");
+        return values.EnumerateArray()
+            .Select(ParseWorkspace)
+            .ToArray();
+    }
+
+    private static WorkspaceCandidate ParseWorkspace(string body)
+    {
+        using var document = JsonDocument.Parse(body);
+        return ParseWorkspace(document.RootElement);
+    }
+
+    private static WorkspaceCandidate ParseWorkspace(JsonElement workspace) =>
+        new(
+            GetRequiredString(workspace, "id"),
+            GetRequiredString(workspace, "name"),
+            GetString(workspace, "location"),
+            GetString(workspace, "properties", "provisioningState"),
+            GetString(workspace, "identity", "type"),
+            GetString(workspace, "identity", "principalId"),
+            GetStringArray(workspace, "properties", "scopes"));
+
+    private static ChaosWorkspaceCandidate ToWorkspaceCandidate(
+        WorkspaceCandidate workspace,
+        bool selectable,
+        string? reasonCode) =>
+        new(
+            workspace.Id,
+            workspace.Name,
+            workspace.Location,
+            workspace.ProvisioningState,
+            workspace.IdentityType,
+            workspace.PrincipalId,
+            workspace.Scopes,
+            selectable,
+            reasonCode);
+
+    private static IReadOnlyList<ScenarioCandidate> ParseScenarios(string body)
+    {
+        using var document = JsonDocument.Parse(body);
+        var values = GetRequiredArray(document.RootElement, "value");
+        return values.EnumerateArray()
+            .Select(scenario => new ScenarioCandidate(
+                GetRequiredString(scenario, "id"),
+                GetRequiredString(scenario, "name"),
+                GetString(scenario, "properties", "recommendation", "recommendationStatus"),
+                GetActionIds(scenario)))
+            .ToArray();
+    }
+
+    private static IReadOnlyList<ConfigurationCandidate> ParseConfigurations(string body)
+    {
+        using var document = JsonDocument.Parse(body);
+        var values = GetRequiredArray(document.RootElement, "value");
+        return values.EnumerateArray()
+            .Select(configuration => new ConfigurationCandidate(
+                GetRequiredString(configuration, "id"),
+                GetRequiredString(configuration, "name"),
+                GetString(configuration, "properties", "provisioningState"),
+                GetString(configuration, "properties", "scenarioId"),
+                GetConfigurationTargets(configuration),
+                GetStringArray(
+                    configuration,
+                    "properties",
+                    "resourceTargeting",
+                    "include",
+                    "locations"),
+                GetStringArray(
+                    configuration,
+                    "properties",
+                    "resourceTargeting",
+                    "include",
+                    "zones"),
+                GetConfigurationParameter(configuration, "duration"),
+                HasExactConfigurationParameterContract(configuration),
+                HasExactResourceTargetingContract(configuration),
+                ParseDateTime(GetString(
+                    configuration,
+                    "systemData",
+                    "lastModifiedAt"))))
+            .ToArray();
+    }
+
+    private static IReadOnlyList<RunCandidate> ParseRuns(string body)
+    {
+        using var document = JsonDocument.Parse(body);
+        var values = GetRequiredArray(document.RootElement, "value");
+        var runs = new List<RunCandidate>();
+
+        foreach (var value in values.EnumerateArray())
+        {
+            var status = GetString(value, "properties", "status");
+            var id = GetString(value, "id");
+            var name = GetString(value, "name");
+            var configurationName = GetString(
+                value,
+                "properties",
+                "scenarioConfigurationName");
+            var resources = GetRunResources(value);
+
+            if (string.IsNullOrWhiteSpace(status) ||
+                string.IsNullOrWhiteSpace(id) ||
+                string.IsNullOrWhiteSpace(name) ||
+                string.IsNullOrWhiteSpace(configurationName))
+            {
+                if (string.IsNullOrWhiteSpace(status) || IsActiveRun(status))
+                {
+                    throw new JsonException(
+                        "The run list contains an incomplete active or potentially active run.");
+                }
+
+                continue;
+            }
+
+            runs.Add(new(
+                id,
+                name,
+                status,
+                configurationName,
+                resources,
+                ParseDateTime(GetString(value, "properties", "startTime")),
+                ParseDateTime(GetString(value, "properties", "endTime"))));
+        }
+
+        return runs;
+    }
+
+    private static ChaosRunSummary ToRunCandidate(
+        ChaosWorkspaceCandidate workspace,
+        ChaosScenarioCandidate scenario,
+        RunCandidate run)
+    {
+        if (!IsSafeResourceNameSegment(run.ConfigurationName))
+        {
+            throw new JsonException(
+                "The Chaos run configuration name is not a safe ARM resource name.");
+        }
+
+        return new(
+            run.Id,
+            run.Name,
+            workspace.Id,
+            scenario.Id,
+            scenario.Name,
+            $"{scenario.Id.TrimEnd('/')}/configurations/{run.ConfigurationName}",
+            run.ConfigurationName,
+            run.Status,
+            run.StartTime,
+            run.EndTime,
+            run.ResourceIds);
+    }
+
+    private static IReadOnlyList<string> GetActionIds(JsonElement scenario)
+    {
+        if (!TryGetProperty(scenario, out var actions, "properties", "actions") ||
+            actions.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return actions.EnumerateArray()
+            .Select(action => GetString(action, "actionId"))
+            .Where(actionId => !string.IsNullOrWhiteSpace(actionId))
+            .Select(actionId => actionId!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> GetConfigurationTargets(JsonElement configuration)
+    {
+        var targets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        AddStrings(
+            targets,
+            configuration,
+            "properties",
+            "resourceTargeting",
+            "include",
+            "resources");
+
+        if (TryGetProperty(configuration, out var parameters, "properties", "parameters") &&
+            parameters.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var parameter in parameters.EnumerateArray())
+            {
+                if (!string.Equals(
+                        GetString(parameter, "key"),
+                        "targetResourceIds",
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var value = GetString(parameter, "value");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    continue;
+                }
+
+                using var targetDocument = JsonDocument.Parse(value);
+                if (targetDocument.RootElement.ValueKind != JsonValueKind.Array)
+                {
+                    throw new JsonException("targetResourceIds must be a JSON array.");
+                }
+
+                foreach (var target in targetDocument.RootElement.EnumerateArray())
+                {
+                    if (target.ValueKind == JsonValueKind.String &&
+                        !string.IsNullOrWhiteSpace(target.GetString()))
+                    {
+                        targets.Add(target.GetString()!);
+                    }
+                }
+            }
+        }
+
+        return targets.ToArray();
+    }
+
+    private static IReadOnlyList<string> GetRunResources(JsonElement run)
+    {
+        if (!TryGetProperty(run, out var resources, "properties", "resources") ||
+            resources.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return resources.EnumerateArray()
+            .Select(resource => GetString(resource, "id"))
+            .Where(resourceId => !string.IsNullOrWhiteSpace(resourceId))
+            .Select(resourceId => resourceId!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string? GetConfigurationParameter(
+        JsonElement configuration,
+        string key)
+    {
+        if (!TryGetProperty(configuration, out var parameters, "properties", "parameters") ||
+            parameters.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        return parameters.EnumerateArray()
+            .Where(parameter => string.Equals(
+                GetString(parameter, "key"),
+                key,
+                StringComparison.OrdinalIgnoreCase))
+            .Select(parameter => GetString(parameter, "value"))
+            .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+    }
+
+    private static void AddStrings(
+        HashSet<string> target,
+        JsonElement root,
+        params string[] path)
+    {
+        if (!TryGetProperty(root, out var values, path) ||
+            values.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        foreach (var value in values.EnumerateArray())
+        {
+            if (value.ValueKind == JsonValueKind.String &&
+                !string.IsNullOrWhiteSpace(value.GetString()))
+            {
+                target.Add(value.GetString()!);
+            }
+        }
+    }
+
+    private static bool HasExactConfigurationParameterContract(
+        JsonElement configuration)
+    {
+        if (!TryGetProperty(
+                configuration,
+                out var parameters,
+                "properties",
+                "parameters") ||
+            parameters.ValueKind != JsonValueKind.Array ||
+            parameters.GetArrayLength() != 2)
+        {
+            return false;
+        }
+
+        var keys = parameters.EnumerateArray()
+            .Select(parameter => GetString(parameter, "key"))
+            .Where(key => !string.IsNullOrWhiteSpace(key))
+            .ToArray();
+        return keys.Length == 2 &&
+            keys.Count(key => string.Equals(
+                key,
+                "duration",
+                StringComparison.OrdinalIgnoreCase)) == 1 &&
+            keys.Count(key => string.Equals(
+                key,
+                "targetResourceIds",
+                StringComparison.OrdinalIgnoreCase)) == 1;
+    }
+
+    private static bool HasExactResourceTargetingContract(
+        JsonElement configuration)
+    {
+        if (!TryGetProperty(
+                configuration,
+                out var targeting,
+                "properties",
+                "resourceTargeting") ||
+            targeting.ValueKind != JsonValueKind.Object ||
+            !targeting.TryGetProperty("include", out var include) ||
+            include.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        foreach (var property in include.EnumerateObject())
+        {
+            if (property.Name is not ("locations" or "zones") ||
+                property.Value.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+        }
+
+        if (!include.TryGetProperty("locations", out _) ||
+            !include.TryGetProperty("zones", out _))
+        {
+            return false;
+        }
+
+        if (!targeting.TryGetProperty("exclude", out var exclude))
+        {
+            return true;
+        }
+
+        return exclude.ValueKind == JsonValueKind.Object &&
+            exclude.EnumerateObject().All(property =>
+                property.Value.ValueKind == JsonValueKind.Array &&
+                property.Value.GetArrayLength() == 0);
+    }
+
+    private static bool IsSupportedDuration(string? duration)
+    {
+        if (string.IsNullOrWhiteSpace(duration))
+        {
+            return false;
+        }
+
+        try
+        {
+            var parsed = XmlConvert.ToTimeSpan(duration);
+            return parsed >= TimeSpan.FromMinutes(1) &&
+                parsed <= TimeSpan.FromDays(3);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+        catch (OverflowException)
+        {
+            return false;
+        }
+    }
+
+    private static (int PermissionErrors, int ResourceErrors)
+        GetValidationErrorCounts(JsonElement validation)
+    {
+        if (!TryGetProperty(
+                validation,
+                out var errors,
+                "properties",
+                "validationErrors") ||
+            errors.ValueKind != JsonValueKind.Object)
+        {
+            return (0, 0);
+        }
+
+        return (
+            GetArrayLength(errors, "permission"),
+            GetArrayLength(errors, "resource"));
+    }
+
+    private static int GetArrayLength(
+        JsonElement root,
+        string propertyName) =>
+        root.TryGetProperty(propertyName, out var value) &&
+        value.ValueKind == JsonValueKind.Array
+            ? value.GetArrayLength()
+            : 0;
+
+    private static bool IsActiveRun(string status) =>
+        !string.Equals(status, "Succeeded", StringComparison.OrdinalIgnoreCase) &&
+        !string.Equals(status, "Failed", StringComparison.OrdinalIgnoreCase) &&
+        !string.Equals(status, "Canceled", StringComparison.OrdinalIgnoreCase) &&
+        !string.Equals(status, "Cancelled", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsValidationPending(string status) =>
+        string.Equals(status, "Resolving", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(status, "Generating", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(status, "Validating", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(status, "Accepted", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(status, "NotStarted", StringComparison.OrdinalIgnoreCase);
+
+    private static DateTimeOffset? ParseDateTime(string? value) =>
+        DateTimeOffset.TryParse(value, out var parsed) ? parsed : null;
+
+    private static bool IsExactRunResource(
+        string runResourceId,
+        string scenarioId,
+        string runId) =>
+        Guid.TryParse(runId, out var parsedRunId) &&
+        parsedRunId != Guid.Empty &&
+        string.Equals(
+            runResourceId.TrimEnd('/'),
+            $"{scenarioId.TrimEnd('/')}/runs/{parsedRunId:D}",
+            StringComparison.OrdinalIgnoreCase);
+
+    private static bool DoesWorkspaceScopeCoverTarget(
+        string? workspaceScope,
+        string targetResourceId,
+        Uri managementEndpoint)
+    {
+        if (string.IsNullOrWhiteSpace(workspaceScope) ||
+            !TryGetArmPath(workspaceScope, managementEndpoint, out var scopePath) ||
+            !TryGetArmPath(targetResourceId, managementEndpoint, out var targetPath))
+        {
+            return false;
+        }
+
+        var canonicalScope = scopePath.TrimEnd('/');
+        var canonicalTarget = targetPath.TrimEnd('/');
+        var scopeSegments = canonicalScope.Split(
+            '/',
+            StringSplitOptions.RemoveEmptyEntries);
+        var targetSegments = canonicalTarget.Split(
+            '/',
+            StringSplitOptions.RemoveEmptyEntries);
+        if (scopeSegments.Length < 2 ||
+            targetSegments.Length < 2 ||
+            !string.Equals(
+                scopeSegments[0],
+                "subscriptions",
+                StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(
+                targetSegments[0],
+                "subscriptions",
+                StringComparison.OrdinalIgnoreCase) ||
+            !Guid.TryParse(scopeSegments[1], out var scopeSubscriptionId) ||
+            !Guid.TryParse(targetSegments[1], out var targetSubscriptionId) ||
+            scopeSubscriptionId != targetSubscriptionId)
+        {
+            return false;
+        }
+
+        return string.Equals(
+                canonicalScope,
+                canonicalTarget,
+                StringComparison.OrdinalIgnoreCase) ||
+            canonicalTarget.StartsWith(
+                $"{canonicalScope}/",
+                StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsExactChaosWorkspaceResourceId(
+        string resourceId,
+        Guid subscriptionId,
+        string workspaceName,
+        Uri managementEndpoint)
+    {
+        if (!TryGetArmPath(resourceId, managementEndpoint, out var path))
+        {
+            return false;
+        }
+
+        var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length == 8 &&
+            string.Equals(segments[0], "subscriptions", StringComparison.OrdinalIgnoreCase) &&
+            Guid.TryParse(segments[1], out var parsedSubscriptionId) &&
+            parsedSubscriptionId == subscriptionId &&
+            string.Equals(segments[2], "resourceGroups", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(segments[3]) &&
+            string.Equals(segments[4], "providers", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(segments[5], "Microsoft.Chaos", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(segments[6], "workspaces", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(segments[7], workspaceName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsExactChildResourceId(
+        string resourceId,
+        string parentResourceId,
+        string collectionName,
+        string resourceName,
+        Uri managementEndpoint)
+    {
+        if (!IsSafeResourceNameSegment(resourceName) ||
+            !IsSafeResourceNameSegment(collectionName) ||
+            !TryGetArmPath(resourceId, managementEndpoint, out var path) ||
+            !TryGetArmPath(parentResourceId, managementEndpoint, out var parentPath))
+        {
+            return false;
+        }
+
+        return string.Equals(
+            path.TrimEnd('/'),
+            $"{parentPath.TrimEnd('/')}/{collectionName}/{resourceName}",
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool AreRunResourcesWithinTarget(
+        RunCandidate run,
+        string targetResourceId,
+        Uri managementEndpoint) =>
+        run.ResourceIds.Count > 0 &&
+        run.ResourceIds.All(resourceId =>
+            IsResourceAtOrBelowTarget(
+                resourceId,
+                targetResourceId,
+                managementEndpoint));
+
+    private static bool IsResourceAtOrBelowTarget(
+        string? resourceId,
+        string targetResourceId,
+        Uri managementEndpoint)
+    {
+        if (string.IsNullOrWhiteSpace(resourceId) ||
+            !TryGetArmPath(resourceId, managementEndpoint, out var resourcePath) ||
+            !TryGetArmPath(targetResourceId, managementEndpoint, out var targetPath))
+        {
+            return false;
+        }
+
+        var canonicalTarget = targetPath.TrimEnd('/');
+        var canonicalResource = resourcePath.TrimEnd('/');
+        return string.Equals(
+                canonicalResource,
+                canonicalTarget,
+                StringComparison.OrdinalIgnoreCase) ||
+            canonicalResource.StartsWith(
+                $"{canonicalTarget}/",
+                StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsSafeResourceNameSegment(string? value) =>
+        !string.IsNullOrWhiteSpace(value) &&
+        value.Length <= 260 &&
+        value is not "." and not ".." &&
+        !value.Any(character =>
+            character is '/' or '\\' or '%' or '?' or '#' or '<' or '>' or '&' or ':') &&
+        !value.Any(char.IsControl);
+
+    private static T? SelectById<T>(
+        IReadOnlyList<T> candidates,
+        string? selectedId,
+        Func<T, string> getId)
+        where T : class
+    {
+        if (selectedId is null)
+        {
+            return candidates.Count == 1 ? candidates[0] : null;
+        }
+
+        var matches = candidates
+            .Where(candidate => string.Equals(
+                getId(candidate).TrimEnd('/'),
+                selectedId.TrimEnd('/'),
+                StringComparison.OrdinalIgnoreCase))
+            .Take(2)
+            .ToArray();
+        return matches.Length == 1 ? matches[0] : null;
+    }
+
+    private static string WithChaosApiVersion(string resourceId) =>
+        $"{resourceId}?api-version={Uri.EscapeDataString(ChaosApiVersion)}";
+
+    private static bool TryValidateArmUri(string? value, Uri managementEndpoint)
+    {
+        if (string.IsNullOrWhiteSpace(value) ||
+            value.Length > 4096 ||
+            value.Contains('#', StringComparison.Ordinal) ||
+            value.Any(char.IsControl))
+        {
+            return false;
+        }
+
+        if (value.StartsWith("/", StringComparison.Ordinal))
+        {
+            return !value.StartsWith("//", StringComparison.Ordinal);
+        }
+
+        return Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
+            uri.Scheme == Uri.UriSchemeHttps &&
+            string.Equals(
+                uri.Host,
+                managementEndpoint.Host,
+                StringComparison.OrdinalIgnoreCase) &&
+            uri.Port == managementEndpoint.Port &&
+            string.IsNullOrEmpty(uri.UserInfo) &&
+            string.IsNullOrEmpty(uri.Fragment);
+    }
+
+    private static bool TryGetArmPath(
+        string value,
+        Uri managementEndpoint,
+        out string path)
+    {
+        path = string.Empty;
+        if (!TryValidateArmUri(value, managementEndpoint))
+        {
+            return false;
+        }
+
+        if (value.StartsWith("/", StringComparison.Ordinal))
+        {
+            path = value.Split('?', 2)[0];
+            return true;
+        }
+
+        path = new Uri(value, UriKind.Absolute).AbsolutePath;
+        return true;
+    }
+
+    private static ChaosRemediationStatus Status(
+        string status,
+        bool ready,
+        string? reasonCode,
+        string message,
+        ChaosTargetReview target,
+        ChaosWorkspaceCandidate? workspace = null,
+        IReadOnlyList<ChaosWorkspaceCandidate>? workspaceCandidates = null,
+        ChaosScenarioCandidate? scenario = null,
+        IReadOnlyList<ChaosScenarioCandidate>? scenarioCandidates = null,
+        ChaosConfigurationCandidate? configuration = null,
+        IReadOnlyList<ChaosConfigurationCandidate>? configurationCandidates = null,
+        IReadOnlyList<ChaosRunSummary>? runCandidates = null,
+        string? requiredPermission = null,
+        ChaosValidationStatus? validation = null) =>
+        new()
+        {
+            Status = status,
+            Ready = ready,
+            ReasonCode = reasonCode,
+            Message = message,
+            Target = target,
+            WorkspaceCandidates = workspaceCandidates ?? [],
+            Workspace = workspace,
+            ScenarioCandidates = scenarioCandidates ?? [],
+            Scenario = scenario,
+            ConfigurationCandidates = configurationCandidates ?? [],
+            Configuration = configuration,
+            Runs = runCandidates ?? [],
+            RequiredPermission = requiredPermission,
+            Validation = validation,
+        };
+
+    private static ChaosRemediationStatus StatusReadFailure(
+        string reasonCode,
+        string message,
+        string? recommendationTypeId,
+        string? resourceId) =>
+        Status(
+            "Failed",
+            false,
+            reasonCode,
+            message,
+            new(
+                "Failed",
+                false,
+                reasonCode,
+                message,
+                recommendationTypeId,
+                resourceId,
+                null,
+                [],
+                null,
+                null));
+
+    private static string? GetNextLink(string body)
+    {
+        using var document = JsonDocument.Parse(body);
+        return GetString(document.RootElement, "nextLink");
+    }
+
+    private static JsonElement GetRequiredArray(
+        JsonElement root,
+        string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var value) ||
+            value.ValueKind != JsonValueKind.Array)
+        {
+            throw new JsonException($"{propertyName} must be an array.");
+        }
+
+        return value;
+    }
+
+    private static string GetRequiredString(
+        JsonElement root,
+        string propertyName) =>
+        GetString(root, propertyName) is { Length: > 0 } value
+            ? value
+            : throw new JsonException($"{propertyName} is required.");
+
+    private static bool TryGetProperty(
+        JsonElement root,
+        out JsonElement value,
+        params string[] path)
+    {
+        value = root;
+        foreach (var segment in path)
+        {
+            if (value.ValueKind != JsonValueKind.Object ||
+                !value.TryGetProperty(segment, out value))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string? GetString(JsonElement root, params string[] path)
+    {
+        var current = root;
+        foreach (var segment in path)
+        {
+            if (current.ValueKind != JsonValueKind.Object ||
+                !current.TryGetProperty(segment, out current))
+            {
+                return null;
+            }
+        }
+
+        return current.ValueKind == JsonValueKind.String
+            ? current.GetString()
+            : current.ToString();
+    }
+
+    private static long? GetInt64(JsonElement root, params string[] path)
+    {
+        var current = root;
+        foreach (var segment in path)
+        {
+            if (current.ValueKind != JsonValueKind.Object ||
+                !current.TryGetProperty(segment, out current))
+            {
+                return null;
+            }
+        }
+
+        return current.ValueKind == JsonValueKind.Number &&
+            current.TryGetInt64(out var value)
+            ? value
+            : null;
+    }
+
+    private static IReadOnlyList<string> GetStringArray(
+        JsonElement root,
+        params string[] path)
+    {
+        var current = root;
+        foreach (var segment in path)
+        {
+            if (current.ValueKind != JsonValueKind.Object ||
+                !current.TryGetProperty(segment, out current))
+            {
+                return [];
+            }
+        }
+
+        return current.ValueKind == JsonValueKind.Array
+            ? current.EnumerateArray()
+                .Where(item => item.ValueKind == JsonValueKind.String)
+                .Select(item => item.GetString())
+                .Where(item => !string.IsNullOrWhiteSpace(item))
+                .Select(item => item!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray()
+            : [];
+    }
+
+    private sealed record WorkspaceCandidate(
+        string Id,
+        string Name,
+        string? Location,
+        string? ProvisioningState,
+        string? IdentityType,
+        string? PrincipalId,
+        IReadOnlyList<string> Scopes);
+
+    private sealed record ScenarioCandidate(
+        string Id,
+        string Name,
+        string? RecommendationStatus,
+        IReadOnlyList<string> ActionIds);
+
+    private sealed record ConfigurationCandidate(
+        string Id,
+        string Name,
+        string? ProvisioningState,
+        string? ScenarioId,
+        IReadOnlyList<string> TargetResourceIds,
+        IReadOnlyList<string> Locations,
+        IReadOnlyList<string> Zones,
+        string? Duration,
+        bool HasExactParameterContract,
+        bool HasExactResourceTargetingContract,
+        DateTimeOffset? LastModifiedAt);
+
+    private sealed record RunCandidate(
+        string Id,
+        string Name,
+        string Status,
+        string ConfigurationName,
+        IReadOnlyList<string> ResourceIds,
+        DateTimeOffset? StartTime,
+        DateTimeOffset? EndTime);
+
+    private sealed record ScenarioRunHistory(
+        IReadOnlyList<RunCandidate> Runs,
+        IReadOnlyList<ChaosRunSummary> Candidates,
+        ChaosRemediationStatus? Failure)
+    {
+        public static ScenarioRunHistory Failed(ChaosRemediationStatus failure) =>
+            new([], [], failure);
+    }
+}

--- a/tools/Azure.Mcp.Tools.Advisor/src/Services/AdvisorChaosReviewService.Status.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Services/AdvisorChaosReviewService.Status.cs
@@ -1,0 +1,934 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text.Json;
+using Azure.Mcp.Tools.Advisor.Models.Chaos;
+using Azure.Mcp.Tools.Advisor.Services.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Mcp.Tools.Advisor.Services;
+
+public sealed partial class AdvisorChaosReviewService
+{
+    private async Task<ChaosRemediationStatus> ReviewStatusCoreAsync(
+        ArmRequestContext context,
+        ChaosRemediationTarget target,
+        string? selectedWorkspace,
+        string? selectedScenario,
+        string? selectedConfiguration)
+    {
+        var targetReview = await ReviewTargetAsync(context, target);
+        if (!targetReview.Eligible)
+        {
+            return Status(
+                targetReview.Status,
+                false,
+                targetReview.ReasonCode ?? "TargetNotEligible",
+                targetReview.Message,
+                targetReview,
+                requiredPermission: targetReview.RequiredPermission);
+        }
+
+        PagedResult<WorkspaceCandidate> workspaceResult;
+        try
+        {
+            workspaceResult = await GetAllPagesAsync(
+                context,
+                $"/subscriptions/{target.SubscriptionId:D}/providers/Microsoft.Chaos/workspaces" +
+                    $"?api-version={Uri.EscapeDataString(ChaosApiVersion)}",
+                ParseWorkspaces);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Azure returned an invalid Chaos workspace response.");
+            return Status(
+                "Failed",
+                false,
+                "InvalidWorkspaceResponse",
+                "Azure returned an invalid Chaos workspace response.",
+                targetReview);
+        }
+
+        if (workspaceResult.Failure?.StatusCode == HttpStatusCode.Forbidden)
+        {
+            return Status(
+                "Blocked",
+                false,
+                "WorkspaceReadAccessDenied",
+                "The current identity cannot list Chaos workspaces in this subscription.",
+                targetReview,
+                requiredPermission: WorkspaceReadPermission);
+        }
+
+        if (workspaceResult.Failure is not null)
+        {
+            return Status(
+                "Failed",
+                false,
+                "WorkspaceDiscoveryFailed",
+                $"Azure returned HTTP {(int)workspaceResult.Failure.StatusCode} while listing Chaos workspaces.",
+                targetReview);
+        }
+
+        if (workspaceResult.PageLimitExceeded)
+        {
+            return Status(
+                "Failed",
+                false,
+                "WorkspacePageLimitExceeded",
+                "Chaos workspace discovery exceeded the configured page limit.",
+                targetReview);
+        }
+
+        var coveringWorkspaces = workspaceResult.Items
+            .Where(workspace =>
+                IsExactChaosWorkspaceResourceId(
+                    workspace.Id,
+                    target.SubscriptionId,
+                    workspace.Name,
+                    context.ManagementEndpoint) &&
+                workspace.Scopes.Any(scope =>
+                    DoesWorkspaceScopeCoverTarget(
+                        scope,
+                        target.ResourceId,
+                        context.ManagementEndpoint)))
+            .ToArray();
+
+        if (coveringWorkspaces.Length == 0)
+        {
+            return Status(
+                "SetupRequired",
+                false,
+                "CoveringWorkspaceNotFound",
+                "No Chaos workspace scope covers the selected VMSS.",
+                targetReview);
+        }
+
+        var workspaceCandidates = new List<ChaosWorkspaceCandidate>();
+        foreach (var discoveredWorkspace in coveringWorkspaces)
+        {
+            workspaceCandidates.Add(
+                await HydrateWorkspaceCandidateAsync(
+                    context,
+                    discoveredWorkspace,
+                    target.SubscriptionId,
+                    target.ResourceId));
+        }
+
+        var orderedWorkspaceCandidates = workspaceCandidates
+            .OrderBy(candidate => candidate.Id, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var selectableWorkspaces = orderedWorkspaceCandidates
+            .Where(candidate => candidate.Selectable)
+            .ToArray();
+        if (selectableWorkspaces.Length == 0)
+        {
+            return Status(
+                "Blocked",
+                false,
+                "WorkspaceNotReady",
+                "No covering Chaos workspace could be verified as ready with a supported identity.",
+                targetReview,
+                workspaceCandidates: orderedWorkspaceCandidates);
+        }
+
+        var workspace = SelectById(
+            selectableWorkspaces,
+            selectedWorkspace,
+            candidate => candidate.Id);
+        if (selectedWorkspace is not null && workspace is null)
+        {
+            return Status(
+                "Blocked",
+                false,
+                "WorkspaceSelectionInvalid",
+                "The selected workspace is not a valid candidate for this VMSS.",
+                targetReview,
+                workspaceCandidates: orderedWorkspaceCandidates);
+        }
+
+        if (workspace is null)
+        {
+            return Status(
+                "SelectionRequired",
+                false,
+                "WorkspaceSelectionRequired",
+                "Multiple valid Chaos workspaces cover the selected VMSS.",
+                targetReview,
+                workspaceCandidates: orderedWorkspaceCandidates);
+        }
+
+        return await ReadScenarioStatusAsync(
+            context,
+            target,
+            targetReview,
+            workspace,
+            orderedWorkspaceCandidates,
+            selectedScenario,
+            selectedConfiguration);
+    }
+
+    private async Task<ChaosRemediationStatus> ReadScenarioStatusAsync(
+        ArmRequestContext context,
+        ChaosRemediationTarget target,
+        ChaosTargetReview targetReview,
+        ChaosWorkspaceCandidate workspace,
+        IReadOnlyList<ChaosWorkspaceCandidate> workspaceCandidates,
+        string? selectedScenario,
+        string? selectedConfiguration)
+    {
+        var scenarioResult = await GetAllPagesAsync(
+            context,
+            $"{workspace.Id}/scenarios?api-version={Uri.EscapeDataString(ChaosApiVersion)}",
+            ParseScenarios);
+
+        var scenarioFailure = HandleReadFailure(
+            scenarioResult,
+            "ScenarioReadAccessDenied",
+            "ScenarioDiscoveryFailed",
+            "Chaos scenario discovery exceeded the configured page limit.",
+            targetReview,
+            workspace,
+            workspaceCandidates: workspaceCandidates);
+        if (scenarioFailure is not null)
+        {
+            return scenarioFailure;
+        }
+
+        var matchingScenarios = scenarioResult.Items
+            .Where(scenario =>
+                IsExactChildResourceId(
+                    scenario.Id,
+                    workspace.Id,
+                    "scenarios",
+                    scenario.Name,
+                    context.ManagementEndpoint) &&
+                string.Equals(
+                    scenario.RecommendationStatus,
+                    "Recommended",
+                    StringComparison.OrdinalIgnoreCase) &&
+                scenario.ActionIds.Any(actionId =>
+                    actionId.StartsWith(
+                        RequiredActionIdPrefix,
+                        StringComparison.OrdinalIgnoreCase)))
+            .Select(scenario => new ChaosScenarioCandidate(
+                scenario.Id,
+                scenario.Name,
+                scenario.RecommendationStatus,
+                scenario.ActionIds))
+            .OrderBy(scenario => scenario.Id, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (matchingScenarios.Length == 0)
+        {
+            return Status(
+                "SetupRequired",
+                false,
+                "ComputeZoneDownScenarioNotFound",
+                "The selected workspace does not contain a recommended scenario with the required Compute Zone Down action contract.",
+                targetReview,
+                workspace,
+                workspaceCandidates: workspaceCandidates);
+        }
+
+        var scenario = SelectById(
+            matchingScenarios,
+            selectedScenario,
+            candidate => candidate.Id);
+        if (selectedScenario is not null && scenario is null)
+        {
+            return Status(
+                "Blocked",
+                false,
+                "ScenarioSelectionInvalid",
+                "The selected scenario is not a compatible candidate in the selected workspace.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenarioCandidates: matchingScenarios);
+        }
+
+        if (scenario is null)
+        {
+            return Status(
+                "SelectionRequired",
+                false,
+                "ScenarioSelectionRequired",
+                "Multiple compatible Compute Zone Down scenarios are available.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenarioCandidates: matchingScenarios);
+        }
+
+        var runHistory = await ReadScenarioRunHistoryAsync(
+            context,
+            targetReview,
+            workspace,
+            workspaceCandidates,
+            scenario,
+            matchingScenarios);
+        if (runHistory.Failure is not null)
+        {
+            return runHistory.Failure;
+        }
+
+        var configurationResult = await GetAllPagesAsync(
+            context,
+            $"{scenario.Id}/configurations?api-version={Uri.EscapeDataString(ChaosApiVersion)}",
+            ParseConfigurations);
+
+        var configurationFailure = HandleReadFailure(
+            configurationResult,
+            "ConfigurationReadAccessDenied",
+            "ConfigurationDiscoveryFailed",
+            "Chaos configuration discovery exceeded the configured page limit.",
+            targetReview,
+            workspace,
+            workspaceCandidates: workspaceCandidates,
+            scenario: scenario,
+            scenarioCandidates: matchingScenarios,
+            runCandidates: runHistory.Candidates);
+        if (configurationFailure is not null)
+        {
+            return configurationFailure;
+        }
+
+        var configurations = configurationResult.Items
+            .Where(configuration =>
+                IsExactChildResourceId(
+                    configuration.Id,
+                    scenario.Id,
+                    "configurations",
+                    configuration.Name,
+                    context.ManagementEndpoint) &&
+                string.Equals(
+                    configuration.ScenarioId,
+                    scenario.Id,
+                    StringComparison.OrdinalIgnoreCase) &&
+                configuration.TargetResourceIds.Count > 0 &&
+                configuration.TargetResourceIds.All(resourceId =>
+                    IsResourceAtOrBelowTarget(
+                        resourceId,
+                        target.ResourceId,
+                        context.ManagementEndpoint)) &&
+                configuration.Locations.Count == 1 &&
+                string.Equals(
+                    configuration.Locations[0],
+                    targetReview.Location,
+                    StringComparison.OrdinalIgnoreCase) &&
+                configuration.Zones.Count == 1 &&
+                configuration.HasExactParameterContract &&
+                configuration.HasExactResourceTargetingContract &&
+                configuration.LastModifiedAt is not null &&
+                targetReview.Zones.Contains(
+                    configuration.Zones[0],
+                    StringComparer.OrdinalIgnoreCase) &&
+                IsSupportedDuration(configuration.Duration) &&
+                string.Equals(
+                    configuration.ProvisioningState,
+                    "Succeeded",
+                    StringComparison.OrdinalIgnoreCase))
+            .Select(configuration => new ChaosConfigurationCandidate(
+                configuration.Id,
+                configuration.Name,
+                scenario.Id,
+                scenario.Name,
+                configuration.Zones[0],
+                configuration.Locations[0],
+                configuration.Duration!,
+                configuration.ProvisioningState,
+                configuration.LastModifiedAt!.Value,
+                configuration.TargetResourceIds))
+            .OrderBy(configuration => configuration.Id, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (configurations.Length == 0)
+        {
+            return Status(
+                "SetupRequired",
+                false,
+                "ExactConfigurationNotFound",
+                "No succeeded Compute Zone Down configuration stays within the selected VMSS boundary.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                matchingScenarios,
+                runCandidates: runHistory.Candidates);
+        }
+
+        var configuration = SelectById(
+            configurations,
+            selectedConfiguration,
+            candidate => candidate.Id);
+        if (selectedConfiguration is not null && configuration is null)
+        {
+            return Status(
+                "Blocked",
+                false,
+                "ConfigurationSelectionInvalid",
+                "The selected configuration is not a compatible candidate for the selected VMSS and scenario.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                matchingScenarios,
+                configurationCandidates: configurations,
+                runCandidates: runHistory.Candidates);
+        }
+
+        if (configuration is null)
+        {
+            return Status(
+                "SelectionRequired",
+                false,
+                "ConfigurationSelectionRequired",
+                "Multiple compatible Compute Zone Down configurations are available.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                matchingScenarios,
+                configurationCandidates: configurations,
+                runCandidates: runHistory.Candidates);
+        }
+
+        return await ReadValidationStatusAsync(
+            context,
+            target,
+            targetReview,
+            workspace,
+            workspaceCandidates,
+            scenario,
+            matchingScenarios,
+            configuration,
+            configurations,
+            runHistory);
+    }
+
+    private async Task<ChaosRemediationStatus> ReadValidationStatusAsync(
+        ArmRequestContext context,
+        ChaosRemediationTarget target,
+        ChaosTargetReview targetReview,
+        ChaosWorkspaceCandidate workspace,
+        IReadOnlyList<ChaosWorkspaceCandidate> workspaceCandidates,
+        ChaosScenarioCandidate scenario,
+        IReadOnlyList<ChaosScenarioCandidate> scenarioCandidates,
+        ChaosConfigurationCandidate configuration,
+        IReadOnlyList<ChaosConfigurationCandidate> configurationCandidates,
+        ScenarioRunHistory runHistory)
+    {
+        var runStatus = EvaluateConfigurationRunStatus(
+            context.ManagementEndpoint,
+            target,
+            targetReview,
+            workspace,
+            workspaceCandidates,
+            scenario,
+            scenarioCandidates,
+            configuration,
+            configurationCandidates,
+            runHistory,
+            validation: null);
+        if (runStatus.Status != "Ready")
+        {
+            return runStatus;
+        }
+
+        var runCandidates = runStatus.Runs;
+        var validationId = $"{configuration.Id}/validations/latest";
+        var response = await GetWithThrottleRetryAsync(
+            context,
+            WithChaosApiVersion(validationId));
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return Status(
+                "ValidationRequired",
+                false,
+                "ConfigurationValidationRequired",
+                "The exact Compute Zone Down configuration must be validated before execution.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                scenarioCandidates,
+                configuration,
+                configurationCandidates,
+                runCandidates);
+        }
+
+        if (response.StatusCode == HttpStatusCode.Forbidden)
+        {
+            return Status(
+                "Blocked",
+                false,
+                "ValidationReadAccessDenied",
+                "The current identity cannot read validation for the exact Chaos configuration.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                scenarioCandidates,
+                configuration,
+                configurationCandidates,
+                runCandidates,
+                requiredPermission: ConfigurationReadPermission);
+        }
+
+        if (response.StatusCode is not (HttpStatusCode.OK or HttpStatusCode.Accepted))
+        {
+            return Status(
+                "Failed",
+                false,
+                "ValidationReadFailed",
+                $"Azure returned HTTP {(int)response.StatusCode} while reading configuration validation.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                scenarioCandidates,
+                configuration,
+                configurationCandidates,
+                runCandidates);
+        }
+
+        using var document = JsonDocument.Parse(response.Body);
+        var root = document.RootElement;
+        var validationState = GetString(root, "properties", "status");
+        var startTime = ParseDateTime(GetString(root, "properties", "startTime"));
+        var endTime = ParseDateTime(GetString(root, "properties", "endTime"));
+        if (string.IsNullOrWhiteSpace(validationState) || startTime is null)
+        {
+            throw new JsonException("The latest configuration validation is incomplete.");
+        }
+
+        var (permissionErrorCount, resourceErrorCount) =
+            GetValidationErrorCounts(root);
+        var validation = new ChaosValidationStatus(
+            validationState,
+            startTime.Value,
+            endTime,
+            permissionErrorCount,
+            resourceErrorCount);
+
+        if (startTime.Value < configuration.LastModifiedAt)
+        {
+            return Status(
+                "ValidationRequired",
+                false,
+                "ConfigurationValidationStale",
+                "The exact configuration changed after its latest validation.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                scenarioCandidates,
+                configuration,
+                configurationCandidates,
+                runCandidates,
+                validation: validation);
+        }
+
+        if (IsValidationPending(validationState))
+        {
+            return Status(
+                "Validating",
+                false,
+                "ConfigurationValidationInProgress",
+                "Validation of the exact Compute Zone Down configuration is still in progress.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                scenarioCandidates,
+                configuration,
+                configurationCandidates,
+                runCandidates,
+                validation: validation);
+        }
+
+        if (string.Equals(
+                validationState,
+                "RequiresAttention",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            var permissionsOnly =
+                permissionErrorCount > 0 &&
+                resourceErrorCount == 0;
+            return Status(
+                permissionsOnly ? "PermissionsRequired" : "Blocked",
+                false,
+                permissionsOnly
+                    ? "ScenarioPermissionsRequired"
+                    : "ConfigurationValidationRequiresAttention",
+                permissionsOnly
+                    ? "The exact configuration requires scenario execution permissions."
+                    : "The exact configuration has resource validation errors that permission repair cannot resolve.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                scenarioCandidates,
+                configuration,
+                configurationCandidates,
+                runCandidates,
+                validation: validation);
+        }
+
+        if (string.Equals(
+                validationState,
+                "NoResolvedResources",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return Status(
+                "Blocked",
+                false,
+                "NoResolvedResources",
+                "Validation found no resources for the exact VMSS configuration.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                scenarioCandidates,
+                configuration,
+                configurationCandidates,
+                runCandidates,
+                validation: validation);
+        }
+
+        if (!string.Equals(
+                validationState,
+                "Succeeded",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return Status(
+                "Failed",
+                false,
+                "UnknownValidationState",
+                "Azure returned an unrecognized configuration validation state.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                scenarioCandidates,
+                configuration,
+                configurationCandidates,
+                runCandidates,
+                validation: validation);
+        }
+
+        return Status(
+            "Ready",
+            true,
+            null,
+            "The selected VMSS has a validated Compute Zone Down configuration and no active run.",
+            targetReview,
+            workspace,
+            workspaceCandidates,
+            scenario,
+            scenarioCandidates,
+            configuration,
+            configurationCandidates,
+            runCandidates,
+            validation: validation);
+    }
+
+    private async Task<ScenarioRunHistory> ReadScenarioRunHistoryAsync(
+        ArmRequestContext context,
+        ChaosTargetReview targetReview,
+        ChaosWorkspaceCandidate workspace,
+        IReadOnlyList<ChaosWorkspaceCandidate> workspaceCandidates,
+        ChaosScenarioCandidate scenario,
+        IReadOnlyList<ChaosScenarioCandidate> scenarioCandidates)
+    {
+        PagedResult<RunCandidate> runResult;
+        try
+        {
+            runResult = await GetAllPagesAsync(
+                context,
+                $"{scenario.Id}/runs?api-version={Uri.EscapeDataString(ChaosApiVersion)}",
+                ParseRuns);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Azure returned an invalid Chaos run response.");
+            return ScenarioRunHistory.Failed(
+                Status(
+                    "Failed",
+                    false,
+                    "InvalidRunResponse",
+                    "Azure returned an incomplete Chaos run.",
+                    targetReview,
+                    workspace,
+                    workspaceCandidates,
+                    scenario,
+                    scenarioCandidates));
+        }
+
+        var runFailure = HandleReadFailure(
+            runResult,
+            "RunReadAccessDenied",
+            "RunDiscoveryFailed",
+            "Chaos run discovery exceeded the configured page limit.",
+            targetReview,
+            workspace,
+            workspaceCandidates,
+            scenario,
+            scenarioCandidates);
+        if (runFailure is not null)
+        {
+            return ScenarioRunHistory.Failed(runFailure);
+        }
+
+        var scenarioRuns = runResult.Items
+            .Where(run =>
+                IsExactRunResource(
+                    run.Id,
+                    scenario.Id,
+                    run.Name))
+            .OrderByDescending(run => run.StartTime ?? DateTimeOffset.MinValue)
+            .ThenBy(run => run.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var runCandidates = scenarioRuns
+            .Select(run => ToRunCandidate(workspace, scenario, run))
+            .ToArray();
+
+        return new(scenarioRuns, runCandidates, Failure: null);
+    }
+
+    private static ChaosRemediationStatus EvaluateConfigurationRunStatus(
+        Uri managementEndpoint,
+        ChaosRemediationTarget target,
+        ChaosTargetReview targetReview,
+        ChaosWorkspaceCandidate workspace,
+        IReadOnlyList<ChaosWorkspaceCandidate> workspaceCandidates,
+        ChaosScenarioCandidate scenario,
+        IReadOnlyList<ChaosScenarioCandidate> scenarioCandidates,
+        ChaosConfigurationCandidate configuration,
+        IReadOnlyList<ChaosConfigurationCandidate> configurationCandidates,
+        ScenarioRunHistory runHistory,
+        ChaosValidationStatus? validation)
+    {
+        var matchingRuns = runHistory.Runs
+            .Where(run => string.Equals(
+                run.ConfigurationName,
+                configuration.Name,
+                StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (matchingRuns
+            .Where(run => IsActiveRun(run.Status))
+            .Any(run =>
+                !AreRunResourcesWithinTarget(
+                    run,
+                    target.ResourceId,
+                    managementEndpoint)))
+        {
+            return Status(
+                "Blocked",
+                false,
+                "RunScopeMismatch",
+                "An active Chaos run contains resources outside the selected VMSS.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                scenarioCandidates,
+                configuration,
+                configurationCandidates,
+                runHistory.Candidates,
+                validation: validation);
+        }
+
+        var activeRuns = runHistory.Candidates
+            .Where(run =>
+                string.Equals(
+                    run.ConfigurationResourceId,
+                    configuration.Id,
+                    StringComparison.OrdinalIgnoreCase) &&
+                IsActiveRun(run.Status))
+            .ToArray();
+        if (activeRuns.Length > 0)
+        {
+            return Status(
+                "Running",
+                false,
+                activeRuns.Length == 1
+                    ? "ActiveRunExists"
+                    : "MultipleActiveRunsExist",
+                activeRuns.Length == 1
+                    ? "An active Chaos run already targets the selected configuration and VMSS."
+                    : "Multiple active Chaos runs target the selected configuration and VMSS.",
+                targetReview,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                scenarioCandidates,
+                configuration,
+                configurationCandidates,
+                runHistory.Candidates,
+                validation: validation);
+        }
+
+        return Status(
+            "Ready",
+            true,
+            null,
+            "The selected VMSS has one exact, ready Compute Zone Down configuration and no active run.",
+            targetReview,
+            workspace,
+            workspaceCandidates,
+            scenario,
+            scenarioCandidates,
+            configuration,
+            configurationCandidates,
+            runHistory.Candidates,
+            validation: validation);
+    }
+
+    private static ChaosRemediationStatus? HandleReadFailure<T>(
+        PagedResult<T> result,
+        string forbiddenReasonCode,
+        string failureReasonCode,
+        string pageLimitMessage,
+        ChaosTargetReview target,
+        ChaosWorkspaceCandidate? workspace = null,
+        IReadOnlyList<ChaosWorkspaceCandidate>? workspaceCandidates = null,
+        ChaosScenarioCandidate? scenario = null,
+        IReadOnlyList<ChaosScenarioCandidate>? scenarioCandidates = null,
+        ChaosConfigurationCandidate? configuration = null,
+        IReadOnlyList<ChaosConfigurationCandidate>? configurationCandidates = null,
+        IReadOnlyList<ChaosRunSummary>? runCandidates = null)
+    {
+        if (result.Failure?.StatusCode == HttpStatusCode.Forbidden)
+        {
+            return Status(
+                "Blocked",
+                false,
+                forbiddenReasonCode,
+                "The current identity cannot read the required Chaos resources.",
+                target,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                scenarioCandidates,
+                configuration,
+                configurationCandidates,
+                runCandidates,
+                requiredPermission: ConfigurationReadPermission);
+        }
+
+        if (result.Failure is not null)
+        {
+            return Status(
+                "Failed",
+                false,
+                failureReasonCode,
+                $"Azure returned HTTP {(int)result.Failure.StatusCode} while reading Chaos resources.",
+                target,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                scenarioCandidates,
+                configuration,
+                configurationCandidates,
+                runCandidates);
+        }
+
+        return result.PageLimitExceeded
+            ? Status(
+                "Failed",
+                false,
+                failureReasonCode,
+                pageLimitMessage,
+                target,
+                workspace,
+                workspaceCandidates,
+                scenario,
+                scenarioCandidates,
+                configuration,
+                configurationCandidates,
+                runCandidates)
+            : null;
+    }
+
+    private async Task<ChaosWorkspaceCandidate> HydrateWorkspaceCandidateAsync(
+        ArmRequestContext context,
+        WorkspaceCandidate discoveredWorkspace,
+        Guid subscriptionId,
+        string targetResourceId)
+    {
+        var response = await GetWithThrottleRetryAsync(
+            context,
+            WithChaosApiVersion(discoveredWorkspace.Id));
+        if (response.StatusCode is not (HttpStatusCode.OK or HttpStatusCode.Accepted))
+        {
+            return ToWorkspaceCandidate(
+                discoveredWorkspace,
+                selectable: false,
+                response.StatusCode == HttpStatusCode.Forbidden
+                    ? "WorkspaceExactReadAccessDenied"
+                    : "WorkspaceExactReadFailed");
+        }
+
+        var exactWorkspace = ParseWorkspace(response.Body);
+        if (!string.Equals(
+                exactWorkspace.Id.TrimEnd('/'),
+                discoveredWorkspace.Id.TrimEnd('/'),
+                StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(
+                exactWorkspace.Name,
+                discoveredWorkspace.Name,
+                StringComparison.OrdinalIgnoreCase) ||
+            !IsExactChaosWorkspaceResourceId(
+                exactWorkspace.Id,
+                subscriptionId,
+                exactWorkspace.Name,
+                context.ManagementEndpoint) ||
+            !exactWorkspace.Scopes.Any(scope =>
+                DoesWorkspaceScopeCoverTarget(
+                    scope,
+                    targetResourceId,
+                    context.ManagementEndpoint)))
+        {
+            return ToWorkspaceCandidate(
+                exactWorkspace,
+                selectable: false,
+                "WorkspaceExactReadMismatch");
+        }
+
+        if (!string.Equals(
+                exactWorkspace.ProvisioningState,
+                "Succeeded",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return ToWorkspaceCandidate(
+                exactWorkspace,
+                selectable: false,
+                "WorkspaceProvisioningNotSucceeded");
+        }
+
+        if (string.IsNullOrWhiteSpace(exactWorkspace.IdentityType) ||
+            !exactWorkspace.IdentityType.Contains(
+                "SystemAssigned",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return ToWorkspaceCandidate(
+                exactWorkspace,
+                selectable: false,
+                "UnsupportedWorkspaceIdentity");
+        }
+
+        if (!Guid.TryParse(exactWorkspace.PrincipalId, out var principalId) ||
+            principalId == Guid.Empty)
+        {
+            return ToWorkspaceCandidate(
+                exactWorkspace,
+                selectable: false,
+                "WorkspacePrincipalUnavailable");
+        }
+
+        return ToWorkspaceCandidate(exactWorkspace, selectable: true, null);
+    }
+}

--- a/tools/Azure.Mcp.Tools.Advisor/src/Services/AdvisorChaosReviewService.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Services/AdvisorChaosReviewService.cs
@@ -1,0 +1,485 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Azure.Core;
+using Azure.Mcp.Core.Services.Azure;
+using Azure.Mcp.Tools.Advisor.Models;
+using Azure.Mcp.Tools.Advisor.Models.Chaos;
+using Azure.Mcp.Tools.Advisor.Services.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Mcp.Tools.Advisor.Services;
+
+public sealed partial class AdvisorChaosReviewService(
+    IAzureService azureService,
+    IAdvisorService advisorService,
+    ILogger<AdvisorChaosReviewService> logger)
+    : BaseAzureService(azureService), IAdvisorChaosReviewService
+{
+    private const string ChaosApiVersion = "2026-08-01-preview";
+    private const string ComputeApiVersion = "2024-11-01";
+    private const string RequiredActionIdPrefix =
+        "microsoft-virtualMachineScaleSet-shutdown/";
+    private const string RequiredProvisioningState = "Succeeded";
+    private const string VmssReadPermission =
+        "Microsoft.Compute/virtualMachineScaleSets/read";
+    private const string WorkspaceReadPermission = "Microsoft.Chaos/workspaces/read";
+    private const string ConfigurationReadPermission =
+        "Microsoft.Chaos/workspaces/scenarios/configurations/read";
+    private const int MinimumRequiredZoneCount = 2;
+    private const int MaxAdvisorRecommendationsForVerification = 100;
+    private const int MaxListPages = 10;
+    private const int MaxThrottleRetries = 3;
+
+    private static readonly TimeSpan ThrottleRetryDelay = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan MaxRetryAfter = TimeSpan.FromSeconds(30);
+
+    private readonly IAdvisorService _advisorService =
+        advisorService ?? throw new ArgumentNullException(nameof(advisorService));
+    private readonly ILogger<AdvisorChaosReviewService> _logger = logger;
+
+    public async Task<ChaosRemediationStatus> ReviewChaosRemediationAsync(
+        string subscription,
+        Guid recommendationTypeId,
+        string resource,
+        string? workspace = null,
+        string? scenario = null,
+        string? configuration = null,
+        string? tenant = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters(
+            (nameof(subscription), subscription),
+            (nameof(resource), resource));
+
+        if (!ChaosRemediationTarget.TryCreate(
+                recommendationTypeId,
+                resource,
+                out var target,
+                out var targetError))
+        {
+            return StatusReadFailure(
+                "InvalidVmssResourceId",
+                targetError ?? "The selected resource is not a valid VMSS.",
+                recommendationTypeId.ToString("D"),
+                resource);
+        }
+
+        var subscriptionResource = await AzureService.GetSubscription(
+            subscription,
+            tenant,
+            cancellationToken);
+        if (!Guid.TryParse(subscriptionResource.Id.SubscriptionId, out var subscriptionId) ||
+            subscriptionId != target.SubscriptionId)
+        {
+            return StatusReadFailure(
+                "SubscriptionMismatch",
+                "The VMSS resource ID does not belong to the resolved subscription.",
+                recommendationTypeId.ToString("D"),
+                target.ResourceId);
+        }
+
+        var recommendationFailure = await VerifyAdvisorRecommendationAsync(
+            subscription,
+            target,
+            tenant,
+            cancellationToken);
+        if (recommendationFailure is not null)
+        {
+            return recommendationFailure;
+        }
+
+        var managementEndpoint = AzureService.CloudConfiguration.ArmEnvironment.Endpoint
+            ?? throw new InvalidOperationException("The Azure Resource Manager endpoint is not configured.");
+        var accessToken = await GetArmAccessTokenAsync(tenant, cancellationToken);
+
+        using var client = AzureService.GetClient();
+        var requestContext = new ArmRequestContext(
+            client,
+            managementEndpoint,
+            accessToken.Token,
+            cancellationToken);
+
+        try
+        {
+            return await ReviewStatusCoreAsync(
+                requestContext,
+                target,
+                workspace,
+                scenario,
+                configuration);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException ex)
+        {
+            _logger.LogError(
+                ex,
+                "Chaos review timed out for resource {Resource}.",
+                target.ResourceId);
+            return StatusReadFailure(
+                "ArmRequestFailed",
+                "The Chaos review could not be completed because an Azure request timed out.",
+                recommendationTypeId.ToString("D"),
+                target.ResourceId);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(
+                ex,
+                "Chaos review request failed for resource {Resource}.",
+                target.ResourceId);
+            return StatusReadFailure(
+                "ArmRequestFailed",
+                "The Chaos review could not be completed because an Azure request failed.",
+                recommendationTypeId.ToString("D"),
+                target.ResourceId);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(
+                ex,
+                "Azure returned malformed Chaos review data for resource {Resource}.",
+                target.ResourceId);
+            return StatusReadFailure(
+                "InvalidArmResponse",
+                "Azure returned an invalid response while reviewing Chaos readiness.",
+                recommendationTypeId.ToString("D"),
+                target.ResourceId);
+        }
+    }
+
+    private async Task<ChaosRemediationStatus?> VerifyAdvisorRecommendationAsync(
+        string subscription,
+        ChaosRemediationTarget target,
+        string? tenant,
+        CancellationToken cancellationToken)
+    {
+        var recommendationTypeId = target.RecommendationTypeId.ToString("D");
+        var recommendations = await _advisorService.ListRecommendationsAsync(
+            subscription,
+            target.ResourceGroup,
+            new RecommendationFilters(
+                Status: RecommendationStatus.New,
+                RecommendationTypeId: recommendationTypeId,
+                Resource: target.ResourceId),
+            MaxAdvisorRecommendationsForVerification,
+            tenant,
+            cancellationToken);
+
+        var exactMatch = recommendations.Results.Any(recommendation =>
+            string.Equals(
+                recommendation.Properties.RecommendationTypeId,
+                recommendationTypeId,
+                StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(
+                recommendation.Properties.RecommendationStatus,
+                RecommendationStatus.New.ToString(),
+                StringComparison.OrdinalIgnoreCase) &&
+            IsExactResourceId(
+                recommendation.Properties.ResourceMetadata?.ResourceId,
+                target.ResourceId));
+        if (exactMatch)
+        {
+            return null;
+        }
+
+        return recommendations.AreResultsTruncated
+            ? StatusReadFailure(
+                "AdvisorRecommendationVerificationIncomplete",
+                "Advisor returned a truncated result before the exact active recommendation could be verified.",
+                recommendationTypeId,
+                target.ResourceId)
+            : StatusReadFailure(
+                "AdvisorRecommendationNotFound",
+                "No active Advisor recommendation exactly matches the supplied recommendation type and VMSS resource ID.",
+                recommendationTypeId,
+                target.ResourceId);
+    }
+
+    private static bool IsExactResourceId(
+        string? resourceId,
+        string expectedResourceId) =>
+        !string.IsNullOrWhiteSpace(resourceId) &&
+        string.Equals(
+            resourceId.TrimEnd('/'),
+            expectedResourceId.TrimEnd('/'),
+            StringComparison.OrdinalIgnoreCase);
+
+    private async Task<ChaosTargetReview> ReviewTargetAsync(
+        ArmRequestContext context,
+        ChaosRemediationTarget target)
+    {
+        var response = await GetWithThrottleRetryAsync(
+            context,
+            $"{target.ResourceId}?api-version={Uri.EscapeDataString(ComputeApiVersion)}");
+
+        if (response.StatusCode == HttpStatusCode.Forbidden)
+        {
+            return TargetFailure(
+                "CustomerReadAccessDenied",
+                "The current identity cannot read the selected VMSS.",
+                target,
+                VmssReadPermission);
+        }
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return TargetFailure(
+                "ResourceNotFound",
+                "The selected VMSS no longer exists or is not visible.",
+                target);
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return TargetFailure(
+                "ArmReadFailed",
+                $"Azure returned HTTP {(int)response.StatusCode} while reading the VMSS.",
+                target);
+        }
+
+        using var document = JsonDocument.Parse(response.Body);
+        return BuildTargetReview(target, document.RootElement);
+    }
+
+    private static ChaosTargetReview BuildTargetReview(
+        ChaosRemediationTarget target,
+        JsonElement root)
+    {
+        var resourceType = GetString(root, "type");
+        var location = GetString(root, "location");
+        var zones = GetStringArray(root, "zones");
+        var capacity = GetInt64(root, "sku", "capacity");
+        var provisioningState = GetString(root, "properties", "provisioningState");
+
+        if (!string.Equals(
+                resourceType,
+                "Microsoft.Compute/virtualMachineScaleSets",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return Ineligible("ResourceTypeMismatch", "The selected Azure resource is not a VMSS.");
+        }
+
+        if (string.IsNullOrWhiteSpace(location))
+        {
+            return Ineligible("LocationMissing", "The VMSS response does not contain a location.");
+        }
+
+        if (zones.Count < MinimumRequiredZoneCount)
+        {
+            return Ineligible(
+                "InsufficientAvailabilityZones",
+                $"The VMSS must use at least {MinimumRequiredZoneCount} availability zones.");
+        }
+
+        if (capacity is null or <= 0)
+        {
+            return Ineligible("NoActiveCapacity", "The VMSS currently has no configured capacity.");
+        }
+
+        if (!string.Equals(
+                provisioningState,
+                RequiredProvisioningState,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return Ineligible(
+                "ProvisioningNotSucceeded",
+                $"The VMSS provisioning state must be {RequiredProvisioningState}.");
+        }
+
+        return new(
+            "Eligible",
+            true,
+            null,
+            "The selected VMSS is currently eligible for Compute Zone Down review.",
+            target.RecommendationTypeId.ToString("D"),
+            target.ResourceId,
+            location,
+            zones,
+            capacity,
+            provisioningState);
+
+        ChaosTargetReview Ineligible(string reasonCode, string message) =>
+            new(
+                "Ineligible",
+                false,
+                reasonCode,
+                message,
+                target.RecommendationTypeId.ToString("D"),
+                target.ResourceId,
+                location,
+                zones,
+                capacity,
+                provisioningState);
+    }
+
+    private static ChaosTargetReview TargetFailure(
+        string reasonCode,
+        string message,
+        ChaosRemediationTarget target,
+        string? requiredPermission = null) =>
+        new(
+            "Blocked",
+            false,
+            reasonCode,
+            message,
+            target.RecommendationTypeId.ToString("D"),
+            target.ResourceId,
+            null,
+            [],
+            null,
+            null,
+            requiredPermission);
+
+    private async Task<ArmResponse> GetWithThrottleRetryAsync(
+        ArmRequestContext context,
+        string path)
+    {
+        var response = await SendGetAsync(context, path);
+        for (var retry = 1;
+             response.StatusCode == HttpStatusCode.TooManyRequests &&
+             retry <= MaxThrottleRetries;
+             retry++)
+        {
+            var delay = response.RetryAfter ?? ThrottleRetryDelay;
+            if (delay > MaxRetryAfter)
+            {
+                delay = MaxRetryAfter;
+            }
+
+            _logger.LogWarning(
+                "Chaos ARM read was throttled; retrying attempt {Retry} of {MaxRetries} after {Delay}.",
+                retry,
+                MaxThrottleRetries,
+                delay);
+
+            if (delay > TimeSpan.Zero)
+            {
+                await Task.Delay(delay, context.CancellationToken);
+            }
+
+            response = await SendGetAsync(context, path);
+        }
+
+        return response;
+    }
+
+    private async Task<PagedResult<T>> GetAllPagesAsync<T>(
+        ArmRequestContext context,
+        string initialPath,
+        Func<string, IReadOnlyList<T>> parseItems)
+    {
+        var items = new List<T>();
+        string? nextPath = initialPath;
+        if (!TryGetArmPath(initialPath, context.ManagementEndpoint, out var expectedPath))
+        {
+            throw new ArgumentException("The initial ARM list path is invalid.", nameof(initialPath));
+        }
+
+        for (var page = 1; page <= MaxListPages && nextPath is not null; page++)
+        {
+            if (!TryGetArmPath(nextPath, context.ManagementEndpoint, out var pagePath) ||
+                !string.Equals(
+                    pagePath.TrimEnd('/'),
+                    expectedPath.TrimEnd('/'),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw new JsonException(
+                    "Azure returned a pagination link outside the original ARM collection.");
+            }
+
+            var response = await GetWithThrottleRetryAsync(context, nextPath);
+            if (!response.IsSuccessStatusCode)
+            {
+                return new(items, response, false);
+            }
+
+            items.AddRange(parseItems(response.Body));
+            nextPath = GetNextLink(response.Body);
+        }
+
+        return new(items, null, nextPath is not null);
+    }
+
+    private static async Task<ArmResponse> SendGetAsync(
+        ArmRequestContext context,
+        string path)
+    {
+        var requestUri = BuildArmUri(path, context.ManagementEndpoint);
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            context.AccessToken);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        using var response = await context.Client.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            context.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(context.CancellationToken);
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            throw new RequestFailedException(
+                (int)response.StatusCode,
+                "Azure authentication failed while reading Chaos remediation resources.");
+        }
+
+        return new(
+            response.StatusCode,
+            body,
+            GetRetryAfter(response.Headers.RetryAfter));
+    }
+
+    private static Uri BuildArmUri(string path, Uri managementEndpoint)
+    {
+        if (!TryValidateArmUri(path, managementEndpoint))
+        {
+            throw new ArgumentException("The ARM path or URL is invalid.", nameof(path));
+        }
+
+        return path.StartsWith("/", StringComparison.Ordinal)
+            ? new Uri(managementEndpoint, path)
+            : new Uri(path, UriKind.Absolute);
+    }
+
+    private static TimeSpan? GetRetryAfter(RetryConditionHeaderValue? retryAfter)
+    {
+        if (retryAfter?.Delta is TimeSpan delta)
+        {
+            return delta < TimeSpan.Zero ? TimeSpan.Zero : delta;
+        }
+
+        if (retryAfter?.Date is DateTimeOffset retryDate)
+        {
+            var delay = retryDate - DateTimeOffset.UtcNow;
+            return delay < TimeSpan.Zero ? TimeSpan.Zero : delay;
+        }
+
+        return null;
+    }
+
+    private sealed record ArmRequestContext(
+        HttpClient Client,
+        Uri ManagementEndpoint,
+        string AccessToken,
+        CancellationToken CancellationToken);
+
+    private sealed record ArmResponse(
+        HttpStatusCode StatusCode,
+        string Body,
+        TimeSpan? RetryAfter = null)
+    {
+        public bool IsSuccessStatusCode => (int)StatusCode is >= 200 and <= 299;
+    }
+
+    private sealed record PagedResult<T>(
+        IReadOnlyList<T> Items,
+        ArmResponse? Failure,
+        bool PageLimitExceeded);
+}

--- a/tools/Azure.Mcp.Tools.Advisor/src/Services/IAdvisorChaosReviewService.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Services/IAdvisorChaosReviewService.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Tools.Advisor.Models.Chaos;
+
+namespace Azure.Mcp.Tools.Advisor.Services;
+
+public interface IAdvisorChaosReviewService
+{
+    Task<ChaosRemediationStatus> ReviewChaosRemediationAsync(
+        string subscription,
+        Guid recommendationTypeId,
+        string resource,
+        string? workspace = null,
+        string? scenario = null,
+        string? configuration = null,
+        string? tenant = null,
+        CancellationToken cancellationToken = default);
+}

--- a/tools/Azure.Mcp.Tools.Advisor/src/Services/Models/ChaosRemediationTarget.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Services/Models/ChaosRemediationTarget.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using Azure.Core;
+
+namespace Azure.Mcp.Tools.Advisor.Services.Models;
+
+internal sealed record ChaosRemediationTarget(
+    Guid RecommendationTypeId,
+    string ResourceId,
+    Guid SubscriptionId,
+    string ResourceGroup,
+    string Vmss)
+{
+    private static readonly ResourceType VmssResourceType =
+        new("Microsoft.Compute/virtualMachineScaleSets");
+
+    public static bool TryCreate(
+        Guid recommendationTypeId,
+        string? resource,
+        [NotNullWhen(true)] out ChaosRemediationTarget? target,
+        out string? error)
+    {
+        target = null;
+        error = null;
+
+        if (recommendationTypeId == Guid.Empty)
+        {
+            error = "The recommendation type ID must be a non-empty GUID.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(resource) ||
+            resource.Length > 2048 ||
+            resource.Contains('?', StringComparison.Ordinal) ||
+            resource.Contains('#', StringComparison.Ordinal) ||
+            resource.Contains('\\', StringComparison.Ordinal) ||
+            resource.Contains('%', StringComparison.Ordinal) ||
+            resource.Any(char.IsControl))
+        {
+            error = "The resource must be a valid VMSS ARM resource ID.";
+            return false;
+        }
+
+        ResourceIdentifier identifier;
+        try
+        {
+            identifier = new ResourceIdentifier(resource.Trim());
+        }
+        catch (ArgumentException)
+        {
+            error = "The resource must be a valid ARM resource ID.";
+            return false;
+        }
+
+        if (!identifier.ResourceType.Equals(VmssResourceType) ||
+            !Guid.TryParse(identifier.SubscriptionId, out var subscriptionId) ||
+            !IsValidSegment(identifier.ResourceGroupName) ||
+            !IsValidSegment(identifier.Name))
+        {
+            error = "The resource must identify exactly one Microsoft.Compute/virtualMachineScaleSets resource.";
+            return false;
+        }
+
+        target = new(
+            recommendationTypeId,
+            $"/subscriptions/{subscriptionId:D}/resourceGroups/{identifier.ResourceGroupName}" +
+                $"/providers/Microsoft.Compute/virtualMachineScaleSets/{identifier.Name}",
+            subscriptionId,
+            identifier.ResourceGroupName,
+            identifier.Name);
+        return true;
+    }
+
+    private static bool IsValidSegment([NotNullWhen(true)] string? value) =>
+        !string.IsNullOrWhiteSpace(value) &&
+        value is not "." and not "..";
+}

--- a/tools/Azure.Mcp.Tools.Advisor/src/Validation/ChaosResourceIdValidator.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/src/Validation/ChaosResourceIdValidator.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Advisor.Validation;
+
+internal static class ChaosResourceIdValidator
+{
+    public static bool IsWorkspace(string? value) =>
+        HasExactShape(value, expectedSegmentCount: 8);
+
+    public static bool IsScenario(string? value) =>
+        HasExactShape(value, expectedSegmentCount: 10);
+
+    public static bool IsConfiguration(string? value) =>
+        HasExactShape(value, expectedSegmentCount: 12);
+
+    private static bool HasExactShape(string? value, int expectedSegmentCount)
+    {
+        if (string.IsNullOrWhiteSpace(value) ||
+            value.Length > 2048 ||
+            !value.StartsWith("/", StringComparison.Ordinal) ||
+            value.StartsWith("//", StringComparison.Ordinal) ||
+            value.Contains('?', StringComparison.Ordinal) ||
+            value.Contains('#', StringComparison.Ordinal) ||
+            value.Contains('\\', StringComparison.Ordinal) ||
+            value.Contains('%', StringComparison.Ordinal) ||
+            value.Any(char.IsControl))
+        {
+            return false;
+        }
+
+        var segments = value.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length != expectedSegmentCount ||
+            !string.Equals(segments[0], "subscriptions", StringComparison.OrdinalIgnoreCase) ||
+            !Guid.TryParse(segments[1], out var subscriptionId) ||
+            subscriptionId == Guid.Empty ||
+            !string.Equals(segments[2], "resourceGroups", StringComparison.OrdinalIgnoreCase) ||
+            !IsSafeSegment(segments[3]) ||
+            !string.Equals(segments[4], "providers", StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(segments[5], "Microsoft.Chaos", StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(segments[6], "workspaces", StringComparison.OrdinalIgnoreCase) ||
+            !IsSafeSegment(segments[7]))
+        {
+            return false;
+        }
+
+        if (expectedSegmentCount >= 10 &&
+            (!string.Equals(segments[8], "scenarios", StringComparison.OrdinalIgnoreCase) ||
+             !IsSafeSegment(segments[9])))
+        {
+            return false;
+        }
+
+        return expectedSegmentCount < 12 ||
+            string.Equals(segments[10], "configurations", StringComparison.OrdinalIgnoreCase) &&
+            IsSafeSegment(segments[11]);
+    }
+
+    private static bool IsSafeSegment(string value) =>
+        !string.IsNullOrWhiteSpace(value) &&
+        value.Length <= 260 &&
+        value is not "." and not ".." &&
+        !value.Any(character =>
+            character is '/' or '\\' or '%' or '?' or '#' or '<' or '>' or '&' or ':') &&
+        !value.Any(char.IsControl);
+}

--- a/tools/Azure.Mcp.Tools.Advisor/tests/Azure.Mcp.Tools.Advisor.Tests/Recommendation/RecommendationChaosReviewCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/tests/Azure.Mcp.Tools.Advisor.Tests/Recommendation/RecommendationChaosReviewCommandTests.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Azure.Mcp.Tests.Commands;
+using Azure.Mcp.Tools.Advisor.Commands;
+using Azure.Mcp.Tools.Advisor.Commands.Recommendation;
+using Azure.Mcp.Tools.Advisor.Models.Chaos;
+using Azure.Mcp.Tools.Advisor.Options.Recommendation;
+using Azure.Mcp.Tools.Advisor.Services;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Advisor.Tests.Recommendation;
+
+public class RecommendationChaosReviewCommandTests
+    : SubscriptionCommandUnitTestsBase<RecommendationChaosReviewCommand, IAdvisorChaosReviewService>
+{
+    private const string RecommendationTypeId =
+        "11111111-1111-1111-1111-111111111111";
+    private const string Resource =
+        "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss";
+    private const string Workspace =
+        "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/rg/providers/Microsoft.Chaos/workspaces/workspace";
+    private const string Scenario = Workspace + "/scenarios/ComputeZoneDown";
+    private const string Configuration = Scenario + "/configurations/zone-down";
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = Command.GetCommand();
+
+        Assert.Equal("chaos-review", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+    }
+
+    [Theory]
+    [InlineData(
+        "--subscription sub --recommendation-type-id 11111111-1111-1111-1111-111111111111 --resource /subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss",
+        true)]
+    [InlineData("--subscription sub", false)]
+    [InlineData(
+        "--subscription sub --recommendation-type-id invalid --resource /subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss",
+        false)]
+    [InlineData(
+        "--subscription sub --recommendation-type-id 11111111-1111-1111-1111-111111111111 --resource /subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
+        false)]
+    public async Task ExecuteAsync_ValidatesRequiredInput(
+        string args,
+        bool shouldSucceed)
+    {
+        if (shouldSucceed)
+        {
+            Service.ReviewChaosRemediationAsync(
+                Arg.Any<string>(),
+                Arg.Any<Guid>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+                .Returns(CreateStatus());
+        }
+
+        var response = await ExecuteCommandAsync(args);
+
+        Assert.Equal(
+            shouldSucceed ? HttpStatusCode.OK : HttpStatusCode.BadRequest,
+            response.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RejectsInvalidOptionalResourceId()
+    {
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--recommendation-type-id", RecommendationTypeId,
+            "--resource", Resource,
+            "--workspace", "https://example.com/workspace");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("--workspace", response.Message);
+        await Service.DidNotReceiveWithAnyArgs().ReviewChaosRemediationAsync(
+            default!,
+            default,
+            default!,
+            default,
+            default,
+            default,
+            default,
+            TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RejectsEncodedDotSegmentInResourceId()
+    {
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--recommendation-type-id", RecommendationTypeId,
+            "--resource",
+            "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/%2e%2e");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("--resource", response.Message);
+        await Service.DidNotReceiveWithAnyArgs().ReviewChaosRemediationAsync(
+            default!,
+            default,
+            default!,
+            default,
+            default,
+            default,
+            default,
+            TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RejectsMismatchedSelectionHierarchy()
+    {
+        var otherWorkspace =
+            "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/rg/providers/Microsoft.Chaos/workspaces/other";
+
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--recommendation-type-id", RecommendationTypeId,
+            "--resource", Resource,
+            "--workspace", otherWorkspace,
+            "--scenario", Scenario);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("child of the selected --workspace", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ForwardsSelectionsAndTenant()
+    {
+        Service.ReviewChaosRemediationAsync(
+            "sub",
+            Guid.Parse(RecommendationTypeId),
+            Resource,
+            Workspace,
+            Scenario,
+            Configuration,
+            "tenant",
+            Arg.Any<CancellationToken>())
+            .Returns(CreateStatus());
+
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--tenant", "tenant",
+            "--recommendation-type-id", RecommendationTypeId,
+            "--resource", Resource,
+            "--workspace", Workspace,
+            "--scenario", Scenario,
+            "--configuration", Configuration);
+
+        Assert.Equal(HttpStatusCode.OK, response.Status);
+        await Service.Received(1).ReviewChaosRemediationAsync(
+            "sub",
+            Guid.Parse(RecommendationTypeId),
+            Resource,
+            Workspace,
+            Scenario,
+            Configuration,
+            "tenant",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsTypedReview()
+    {
+        var expected = CreateStatus();
+        Service.ReviewChaosRemediationAsync(
+            Arg.Any<string>(),
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(expected);
+
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--recommendation-type-id", RecommendationTypeId,
+            "--resource", Resource);
+        var result = ValidateAndDeserializeResponse(
+            response,
+            AdvisorJsonContext.Default.RecommendationChaosReviewResult);
+
+        Assert.Equal("Ready", result.Review.Status);
+        Assert.True(result.Review.Ready);
+        Assert.False(result.Review.MutationPerformed);
+        Assert.Equal(Resource, result.Review.Target.ResourceId);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesServiceFailure()
+    {
+        Service.ReviewChaosRemediationAsync(
+            Arg.Any<string>(),
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Test failure"));
+
+        var response = await ExecuteCommandAsync(
+            "--subscription", "sub",
+            "--recommendation-type-id", RecommendationTypeId,
+            "--resource", Resource);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
+        Assert.Contains("Test failure", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PropagatesCallerCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Service.ReviewChaosRemediationAsync(
+            Arg.Any<string>(),
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cancellation.Token));
+
+        var options = new RecommendationChaosReviewOptions
+        {
+            Subscription = "sub",
+            RecommendationTypeId = RecommendationTypeId,
+            Resource = Resource,
+        };
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => Command.ExecuteAsync(Context, options, cancellation.Token));
+    }
+
+    private static ChaosRemediationStatus CreateStatus() =>
+        new()
+        {
+            Status = "Ready",
+            Ready = true,
+            Message = "Ready for review.",
+            Target = new(
+                "Eligible",
+                true,
+                null,
+                "Eligible.",
+                RecommendationTypeId,
+                Resource,
+                "eastus",
+                ["1", "2"],
+                2,
+                "Succeeded"),
+        };
+}

--- a/tools/Azure.Mcp.Tools.Advisor/tests/Azure.Mcp.Tools.Advisor.Tests/Services/AdvisorChaosReviewServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Advisor/tests/Azure.Mcp.Tools.Advisor.Tests/Services/AdvisorChaosReviewServiceTests.cs
@@ -1,0 +1,611 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Azure.Core;
+using Azure.Mcp.Core.Services.Azure;
+using Azure.Mcp.Tools.Advisor.Models;
+using Azure.Mcp.Tools.Advisor.Services;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Mcp.Core.Services.Azure.Authentication;
+using NSubstitute;
+using Xunit;
+using AdvisorRecommendation = Azure.Mcp.Tools.Advisor.Models.Recommendation;
+
+namespace Azure.Mcp.Tools.Advisor.Tests.Services;
+
+public class AdvisorChaosReviewServiceTests
+{
+    private static readonly Guid RecommendationTypeId =
+        Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private const string SubscriptionId =
+        "22222222-2222-2222-2222-222222222222";
+    private const string Resource =
+        "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/vmss";
+    private const string Workspace =
+        "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/rg/providers/Microsoft.Chaos/workspaces/advisor-chaos";
+    private const string Scenario = Workspace + "/scenarios/ComputeZoneDown";
+    private const string Configuration = Scenario + "/configurations/compute-zone-down";
+    private const string PrincipalId =
+        "33333333-3333-3333-3333-333333333333";
+    private const string RunId =
+        "44444444-4444-4444-4444-444444444444";
+
+    [Fact]
+    public async Task ReviewChaosRemediationAsync_ReturnsReadyReview()
+    {
+        var handler = new QueueHttpMessageHandler(
+            VmssResponse(),
+            WorkspaceListResponse(WorkspaceDefinition()),
+            WorkspaceResponse(WorkspaceDefinition()),
+            ScenarioListResponse(),
+            RunListResponse(),
+            ConfigurationListResponse(),
+            ValidationResponse("Succeeded"));
+        var service = CreateService(handler);
+
+        var result = await service.ReviewChaosRemediationAsync(
+            SubscriptionId,
+            RecommendationTypeId,
+            Resource,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("Ready", result.Status);
+        Assert.True(result.Ready);
+        Assert.False(result.MutationPerformed);
+        Assert.Equal(Resource, result.Target.ResourceId);
+        Assert.Equal(Workspace, result.Workspace?.Id);
+        Assert.Equal(Scenario, result.Scenario?.Id);
+        Assert.Equal(Configuration, result.Configuration?.Id);
+        Assert.Equal("Succeeded", result.Validation?.Status);
+        Assert.Equal(7, handler.Requests.Count);
+        Assert.All(handler.Requests, request => Assert.Equal(HttpMethod.Get, request.Method));
+        Assert.All(
+            handler.Requests,
+            request => Assert.Equal("Bearer", request.Authorization?.Scheme));
+        Assert.Contains(
+            handler.Requests,
+            request => request.Uri.AbsolutePath.EndsWith(
+                "/validations/latest",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ReviewChaosRemediationAsync_VerifiesExactActiveAdvisorRecommendation()
+    {
+        RecommendationFilters? capturedFilters = null;
+        var advisorService = CreateAdvisorService();
+        advisorService.ListRecommendationsAsync(
+                SubscriptionId,
+                "rg",
+                Arg.Do<RecommendationFilters?>(filters => capturedFilters = filters),
+                100,
+                null,
+                Arg.Any<CancellationToken>())
+            .Returns(MatchingRecommendationResults());
+        var handler = new QueueHttpMessageHandler(
+            VmssResponse(),
+            WorkspaceListResponse(WorkspaceDefinition()),
+            WorkspaceResponse(WorkspaceDefinition()),
+            ScenarioListResponse(),
+            RunListResponse(),
+            ConfigurationListResponse(),
+            ValidationResponse("Succeeded"));
+        var service = CreateService(handler, advisorService: advisorService);
+
+        var result = await service.ReviewChaosRemediationAsync(
+            SubscriptionId,
+            RecommendationTypeId,
+            Resource,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("Ready", result.Status);
+        Assert.NotNull(capturedFilters);
+        Assert.Equal(RecommendationStatus.New, capturedFilters!.Status);
+        Assert.Equal(
+            RecommendationTypeId.ToString("D"),
+            capturedFilters.RecommendationTypeId);
+        Assert.Equal(Resource, capturedFilters.Resource);
+    }
+
+    [Fact]
+    public async Task ReviewChaosRemediationAsync_BlocksWhenExactAdvisorRecommendationIsMissing()
+    {
+        var advisorService = CreateAdvisorService(new([], false));
+        var handler = new QueueHttpMessageHandler();
+        var service = CreateService(handler, advisorService: advisorService);
+
+        var result = await service.ReviewChaosRemediationAsync(
+            SubscriptionId,
+            RecommendationTypeId,
+            Resource,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("Failed", result.Status);
+        Assert.Equal("AdvisorRecommendationNotFound", result.ReasonCode);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task ReviewChaosRemediationAsync_FailsClosedWhenAdvisorResultsAreTruncated()
+    {
+        var advisorService = CreateAdvisorService(new([], true));
+        var handler = new QueueHttpMessageHandler();
+        var service = CreateService(handler, advisorService: advisorService);
+
+        var result = await service.ReviewChaosRemediationAsync(
+            SubscriptionId,
+            RecommendationTypeId,
+            Resource,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("Failed", result.Status);
+        Assert.Equal(
+            "AdvisorRecommendationVerificationIncomplete",
+            result.ReasonCode);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task ReviewChaosRemediationAsync_ReturnsSetupRequiredWhenNoWorkspaceCoversTarget()
+    {
+        var handler = new QueueHttpMessageHandler(
+            VmssResponse(),
+            JsonResponse(new { value = Array.Empty<object>() }));
+        var service = CreateService(handler);
+
+        var result = await service.ReviewChaosRemediationAsync(
+            SubscriptionId,
+            RecommendationTypeId,
+            Resource,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("SetupRequired", result.Status);
+        Assert.Equal("CoveringWorkspaceNotFound", result.ReasonCode);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task ReviewChaosRemediationAsync_ReturnsSortedWorkspaceCandidatesWhenSelectionIsAmbiguous()
+    {
+        const string secondWorkspace =
+            "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/shared/providers/Microsoft.Chaos/workspaces/advisor-chaos-shared";
+        var second = WorkspaceDefinition(
+            secondWorkspace,
+            "advisor-chaos-shared");
+        var first = WorkspaceDefinition();
+        var handler = new QueueHttpMessageHandler(
+            VmssResponse(),
+            WorkspaceListResponse(second, first),
+            WorkspaceResponse(second),
+            WorkspaceResponse(first));
+        var service = CreateService(handler);
+
+        var result = await service.ReviewChaosRemediationAsync(
+            SubscriptionId,
+            RecommendationTypeId,
+            Resource,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("SelectionRequired", result.Status);
+        Assert.Equal("WorkspaceSelectionRequired", result.ReasonCode);
+        Assert.Equal(2, result.WorkspaceCandidates.Count);
+        Assert.Equal(
+            result.WorkspaceCandidates.OrderBy(
+                candidate => candidate.Id,
+                StringComparer.OrdinalIgnoreCase),
+            result.WorkspaceCandidates);
+    }
+
+    [Fact]
+    public async Task ReviewChaosRemediationAsync_ReturnsPermissionsRequiredFromValidation()
+    {
+        var handler = new QueueHttpMessageHandler(
+            VmssResponse(),
+            WorkspaceListResponse(WorkspaceDefinition()),
+            WorkspaceResponse(WorkspaceDefinition()),
+            ScenarioListResponse(),
+            RunListResponse(),
+            ConfigurationListResponse(),
+            ValidationResponse(
+                "RequiresAttention",
+                permissionErrors: 1,
+                resourceErrors: 0));
+        var service = CreateService(handler);
+
+        var result = await service.ReviewChaosRemediationAsync(
+            SubscriptionId,
+            RecommendationTypeId,
+            Resource,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("PermissionsRequired", result.Status);
+        Assert.Equal("ScenarioPermissionsRequired", result.ReasonCode);
+        Assert.Equal(1, result.Validation?.PermissionErrorCount);
+    }
+
+    [Fact]
+    public async Task ReviewChaosRemediationAsync_ReturnsRunningWhenActiveRunExists()
+    {
+        var handler = new QueueHttpMessageHandler(
+            VmssResponse(),
+            WorkspaceListResponse(WorkspaceDefinition()),
+            WorkspaceResponse(WorkspaceDefinition()),
+            ScenarioListResponse(),
+            RunListResponse(RunDefinition("Running", Resource)),
+            ConfigurationListResponse());
+        var service = CreateService(handler);
+
+        var result = await service.ReviewChaosRemediationAsync(
+            SubscriptionId,
+            RecommendationTypeId,
+            Resource,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("Running", result.Status);
+        Assert.Equal("ActiveRunExists", result.ReasonCode);
+        Assert.Single(result.Runs);
+        Assert.Equal(6, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task ReviewChaosRemediationAsync_FailsClosedWhenActiveRunEscapesTarget()
+    {
+        const string otherResource =
+            "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/other/providers/Microsoft.Compute/virtualMachineScaleSets/other";
+        var handler = new QueueHttpMessageHandler(
+            VmssResponse(),
+            WorkspaceListResponse(WorkspaceDefinition()),
+            WorkspaceResponse(WorkspaceDefinition()),
+            ScenarioListResponse(),
+            RunListResponse(RunDefinition("Running", otherResource)),
+            ConfigurationListResponse());
+        var service = CreateService(handler);
+
+        var result = await service.ReviewChaosRemediationAsync(
+            SubscriptionId,
+            RecommendationTypeId,
+            Resource,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("Blocked", result.Status);
+        Assert.Equal("RunScopeMismatch", result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task ReviewChaosRemediationAsync_RejectsPaginationOutsideArmCollection()
+    {
+        var handler = new QueueHttpMessageHandler(
+            VmssResponse(),
+            JsonResponse(new
+            {
+                value = new[] { WorkspaceDefinition() },
+                nextLink = "https://example.com/subscriptions/steal",
+            }));
+        var service = CreateService(handler);
+
+        var result = await service.ReviewChaosRemediationAsync(
+            SubscriptionId,
+            RecommendationTypeId,
+            Resource,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("Failed", result.Status);
+        Assert.Equal("InvalidWorkspaceResponse", result.ReasonCode);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task ReviewChaosRemediationAsync_ReturnsSubscriptionMismatchWithoutAzureReads()
+    {
+        var handler = new QueueHttpMessageHandler();
+        var service = CreateService(
+            handler,
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+        var result = await service.ReviewChaosRemediationAsync(
+            "other-subscription",
+            RecommendationTypeId,
+            Resource,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("Failed", result.Status);
+        Assert.Equal("SubscriptionMismatch", result.ReasonCode);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task ReviewChaosRemediationAsync_ReturnsRequiredPermissionForVmssForbidden()
+    {
+        var handler = new QueueHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.Forbidden));
+        var service = CreateService(handler);
+
+        var result = await service.ReviewChaosRemediationAsync(
+            SubscriptionId,
+            RecommendationTypeId,
+            Resource,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal("Blocked", result.Status);
+        Assert.Equal("CustomerReadAccessDenied", result.ReasonCode);
+        Assert.Equal(
+            "Microsoft.Compute/virtualMachineScaleSets/read",
+            result.RequiredPermission);
+    }
+
+    private static AdvisorChaosReviewService CreateService(
+        QueueHttpMessageHandler handler,
+        string subscriptionId = SubscriptionId,
+        IAdvisorService? advisorService = null)
+    {
+        var azureService = Substitute.For<IAzureService>();
+        var cloud = Substitute.For<IAzureCloudConfiguration>();
+        cloud.ArmEnvironment.Returns(ArmEnvironment.AzurePublicCloud);
+        azureService.CloudConfiguration.Returns(cloud);
+
+        var credential = Substitute.For<TokenCredential>();
+        credential.GetTokenAsync(
+                Arg.Any<TokenRequestContext>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<AccessToken>(
+                new AccessToken(
+                    "test-token",
+                    DateTimeOffset.UtcNow.AddHours(1))));
+        azureService.GetTokenCredentialAsync(
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(credential));
+
+        var subscription = Substitute.For<SubscriptionResource>();
+        subscription.Id.Returns(
+            SubscriptionResource.CreateResourceIdentifier(subscriptionId));
+        azureService.GetSubscription(
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(subscription));
+        azureService.GetClient(Arg.Any<string?>())
+            .Returns(new HttpClient(handler));
+
+        advisorService ??= CreateAdvisorService();
+        return new(
+            azureService,
+            advisorService,
+            NullLogger<AdvisorChaosReviewService>.Instance);
+    }
+
+    private static IAdvisorService CreateAdvisorService(
+        ResourceQueryResults<AdvisorRecommendation>? recommendations = null)
+    {
+        var advisorService = Substitute.For<IAdvisorService>();
+        advisorService.ListRecommendationsAsync(
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<RecommendationFilters?>(),
+                Arg.Any<int>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(recommendations ?? MatchingRecommendationResults());
+        return advisorService;
+    }
+
+    private static ResourceQueryResults<AdvisorRecommendation>
+        MatchingRecommendationResults() =>
+        new(
+            [
+                new(
+                    new(
+                        Category: "HighAvailability",
+                        RecommendationStatus: RecommendationStatus.New.ToString(),
+                        RecommendationTypeId: RecommendationTypeId.ToString("D"),
+                        ResourceMetadata: new(Resource)),
+                    Id: "/subscriptions/22222222-2222-2222-2222-222222222222/providers/Microsoft.Advisor/recommendations/recommendation"),
+            ],
+            false);
+
+    private static HttpResponseMessage VmssResponse() =>
+        JsonResponse(new
+        {
+            type = "Microsoft.Compute/virtualMachineScaleSets",
+            location = "eastus",
+            zones = new[] { "1", "2" },
+            sku = new { capacity = 3 },
+            properties = new { provisioningState = "Succeeded" },
+        });
+
+    private static object WorkspaceDefinition(
+        string id = Workspace,
+        string name = "advisor-chaos") =>
+        new
+        {
+            id,
+            name,
+            location = "eastus",
+            identity = new
+            {
+                type = "SystemAssigned",
+                principalId = PrincipalId,
+            },
+            properties = new
+            {
+                provisioningState = "Succeeded",
+                scopes = new[] { Resource },
+            },
+        };
+
+    private static HttpResponseMessage WorkspaceListResponse(
+        params object[] workspaces) =>
+        JsonResponse(new { value = workspaces });
+
+    private static HttpResponseMessage WorkspaceResponse(object workspace) =>
+        JsonResponse(workspace);
+
+    private static HttpResponseMessage ScenarioListResponse() =>
+        JsonResponse(new
+        {
+            value = new[]
+            {
+                new
+                {
+                    id = Scenario,
+                    name = "ComputeZoneDown",
+                    properties = new
+                    {
+                        recommendation = new
+                        {
+                            recommendationStatus = "Recommended",
+                        },
+                        actions = new[]
+                        {
+                            new
+                            {
+                                actionId =
+                                    "microsoft-virtualMachineScaleSet-shutdown/1.0",
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+    private static object RunDefinition(
+        string status,
+        params string[] resources) =>
+        new
+        {
+            id = $"{Scenario}/runs/{RunId}",
+            name = RunId,
+            properties = new
+            {
+                status,
+                scenarioConfigurationName = "compute-zone-down",
+                startTime = "2026-09-03T10:00:00Z",
+                resources = resources.Select(id => new { id }).ToArray(),
+            },
+        };
+
+    private static HttpResponseMessage RunListResponse(
+        params object[] runs) =>
+        JsonResponse(new { value = runs });
+
+    private static HttpResponseMessage ConfigurationListResponse() =>
+        JsonResponse(new
+        {
+            value = new[]
+            {
+                new
+                {
+                    id = Configuration,
+                    name = "compute-zone-down",
+                    properties = new
+                    {
+                        provisioningState = "Succeeded",
+                        scenarioId = Scenario,
+                        resourceTargeting = new
+                        {
+                            include = new
+                            {
+                                locations = new[] { "eastus" },
+                                zones = new[] { "1" },
+                            },
+                            exclude = new
+                            {
+                                locations = Array.Empty<string>(),
+                                zones = Array.Empty<string>(),
+                            },
+                        },
+                        parameters = new object[]
+                        {
+                            new
+                            {
+                                key = "duration",
+                                value = "PT10M",
+                            },
+                            new
+                            {
+                                key = "targetResourceIds",
+                                value = JsonSerializer.Serialize(
+                                    new[] { Resource }),
+                            },
+                        },
+                    },
+                    systemData = new
+                    {
+                        lastModifiedAt = "2026-09-03T09:00:00Z",
+                    },
+                },
+            },
+        });
+
+    private static HttpResponseMessage ValidationResponse(
+        string status,
+        int permissionErrors = 0,
+        int resourceErrors = 0) =>
+        JsonResponse(new
+        {
+            properties = new
+            {
+                status,
+                startTime = "2026-09-03T09:30:00Z",
+                endTime = "2026-09-03T09:31:00Z",
+                validationErrors = new
+                {
+                    permission = Enumerable.Range(
+                        0,
+                        permissionErrors).Select(_ => new { }).ToArray(),
+                    resource = Enumerable.Range(
+                        0,
+                        resourceErrors).Select(_ => new { }).ToArray(),
+                },
+            },
+        });
+
+    private static HttpResponseMessage JsonResponse(object value) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(value),
+                Encoding.UTF8,
+                "application/json"),
+        };
+
+    private sealed class QueueHttpMessageHandler(
+        params HttpResponseMessage[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses =
+            new(responses);
+
+        public List<CapturedRequest> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(new(
+                request.Method,
+                request.RequestUri
+                    ?? throw new InvalidOperationException(
+                        "The request URI is missing."),
+                request.Headers.Authorization));
+
+            if (_responses.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    "No queued HTTP response is available.");
+            }
+
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+
+    private sealed record CapturedRequest(
+        HttpMethod Method,
+        Uri Uri,
+        AuthenticationHeaderValue? Authorization);
+}


### PR DESCRIPTION
## What does this PR do?

Adds `advisor recommendation chaos-review`, a read-only Azure Advisor MCP tool that determines whether an active Advisor recommendation for a virtual machine scale set (VMSS) has an existing, reusable Chaos Studio setup for Compute Zone Down remediation.

The tool:

- Accepts `subscription`, the canonical Advisor `recommendation-type-id`, and an exact VMSS `resource` ID, with optional exact workspace, scenario, and configuration IDs.
- Verifies an exact active Advisor recommendation before reading any Chaos resources.
- Reads and validates VMSS location, zones, capacity, and provisioning state.
- Discovers Chaos workspaces whose scopes cover the VMSS and checks workspace provisioning and managed identity.
- Finds recommended scenarios containing the VMSS shutdown action, reviews run history, and validates configuration location, zone, duration, scenario relationship, and target boundaries.
- Reads the latest validation result and classifies missing, stale, active, permission-only, resource-error, no-resource, unknown, and ready states.
- Fails closed for ambiguous resources, truncated recommendation verification, unsafe pagination, unsupported contracts, or an active run that escapes the supplied VMSS boundary.
- Uses only authenticated `GET` requests through the existing Azure MCP credential, cloud endpoint, HTTP pipeline, retry, and AOT-safe serialization infrastructure.
- Is marked `Destructive = false`, `Idempotent = true`, `OpenWorld = false`, and `ReadOnly = true`.

### Functionality moved from Advisor Agent

This PR moves only deterministic review logic: verify the active Advisor recommendation, inspect the VMSS, discover and evaluate existing Chaos workspaces/scenarios/configurations/runs/validation, and return evidence-backed readiness status. It also exposes the capability through the CLI/MCP command, consolidated tool mapping, documentation, changelog, and tests.

### Functionality intentionally not moved

This PR does not create a workspace or configuration, assign roles, repair permissions, trigger validation, start/cancel an experiment, or modify an Azure resource. Immutable remediation plans, customer approval, execution request IDs, and trusted orchestration remain in Advisor Agent. Generic Chaos mutations should remain Chaos-owned rather than being introduced as Advisor-specific MCP operations.

Public API references:

- [Azure Advisor recommendations - List](https://learn.microsoft.com/rest/api/advisor/recommendations/list)
- [Virtual Machine Scale Sets - Get](https://learn.microsoft.com/rest/api/compute/virtual-machine-scale-sets/get)
- [Azure Chaos Studio REST API](https://learn.microsoft.com/rest/api/chaosstudio/)

## Open ownership questions

1. Who owns the authoritative allowlist/configuration for the supported Compute Zone Down Advisor recommendation GUID? The tool currently verifies the exact supplied active recommendation but does not hard-code a centrally approved GUID.
2. Should Chaos own additional generic read tools for listing workspaces, configurations, runs, and latest validation, with Advisor composing those tools later?
3. Until those generic reads exist, should Advisor MCP continue reading the public `Microsoft.Chaos` ARM APIs directly, or should it consume a shared Chaos-owned client/library?
4. Who owns the preview Chaos API version and the Compute Zone Down action/scenario/configuration contract when that contract changes?
5. Can Chaos confirm ownership of generic mutations: workspace/configuration creation, RBAC assignment or repair, validation triggering, and run start/cancel?
6. Which team will provide stable live or recorded-test resources for this preview workflow?

## Validation completed

- 24 focused Chaos review tests passed.
- All 320 Azure Advisor tests passed.
- Azure MCP Server build and trimmed publish completed with zero warnings/errors.
- Compact AOT analysis reported zero trimming/AOT warnings.
- All four new end-to-end prompts resolved to the registered tool among 383 runtime tools.
- Command metadata, consolidated mapping, package README, changelog, and JSON validation passed.
- The generated local npm wrapper successfully launched `azmcp --version` through an isolated `npx` cache.
- Consolidated/server infrastructure tests passed; one localhost W3C test initially timed out while starting its server and then passed in isolation.
- Final read-only code review found no blocking correctness or security defects.

Environment-dependent validation still pending:

- `ToolDescriptionEvaluator` requires evaluator-specific `AOAI_ENDPOINT` and `TEXT_EMBEDDING_API_KEY` configuration that is not present on this machine.
- The repository CSpell wrapper could not install CSpell because the configured npm feed rejects the saved credential and direct npmjs access fails TLS before files are analyzed.

Advisor currently has `HasLiveTests=false`, and a deterministic active Advisor recommendation plus matching preview Chaos resources cannot currently be provisioned by this test project. This PR therefore adds comprehensive mocked command, ARM request, authentication, pagination, retry, parsing, boundary, cancellation, and error-handling coverage. Maintainer agreement or stable recorded resources are needed for live-test coverage.

## GitHub issue number?

N/A - this draft PR is the initial review surface for the implementation and ownership questions above.

## Pre-merge Checklist

- [x] Required for All PRs
    - [x] Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with a descriptive message
    - [x] Added comprehensive tests for new functionality
    - [x] Added a changelog entry
- [x] For MCP tool changes:
    - [x] One tool per PR
    - [x] Updated `servers/Azure.Mcp.Server/README.md`
    - [x] Validated package README changes
    - [ ] Run `ToolDescriptionEvaluator` with a score of `0.4` or more and top-three ranking for related prompts (blocked by local evaluator configuration)
    - [x] Updated `consolidated-tools.json`
    - [x] Added public Azure API documentation URLs
- [x] Extra steps for Azure MCP Server tool changes:
    - [x] Updated `servers/Azure.Mcp.Server/docs/azmcp-commands.md`
    - [x] Synchronized command metadata
    - [x] Updated `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.