### PR TITLE
docs(commands): update AKS command notes for retry options removal (#3408)

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3075,7 +3075,7 @@ azmcp keyvault secret get --subscription <subscription> \
 ### Azure Kubernetes Service (AKS) Operations
 
 > [!NOTE]
-> The `aks cluster get` and `aks nodepool get` commands do not support `--auth-method` (the `--retry-*` options are still supported).
+> The `aks cluster get` and `aks nodepool get` commands do not support `--auth-method` or any `--retry-*` options.
 
 ```bash
 # Gets Azure Kubernetes Service (AKS) cluster details


### PR DESCRIPTION
## Summary

Closes #3408

Fixes documentation gap in `servers/Azure.Mcp.Server/docs/azmcp-commands.md` where the AKS notes incorrectly stated that `--retry-*` options were still supported following PR #3404 which removed `RetryPolicyOptions`.

### Changes:
- Updated the note under the AKS section to state that `aks cluster get` and `aks nodepool get` do not support `--auth-method` or any `--retry-*` options.
