### PR TITLE
docs(resilience): document drill runs and resources capabilities in README (#3369)

### DIFF
--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -1280,6 +1280,10 @@ Example prompts that generate Azure CLI commands:
 * "Get the resilience drill 'my-drill' in service group 'my-service-group'"
 * "Create a Basic resilience usage plan 'my-plan' in resource group 'my-rg'"
 * "Enroll service group 'my-service-group' into usage plan 'my-plan' in resource group 'my-rg'"
+* "List all runs of drill 'my-drill' in service group 'my-service-group'"
+* "Get drill run 'my-drill-run' for drill 'my-drill' in service group 'my-service-group'"
+* "List all resources of drill run 'my-drill-run' for drill 'my-drill' in service group 'my-service-group'"
+* "Get resource 'my-resource' from drill run 'my-drill-run' for drill 'my-drill' in service group 'my-service-group'"
 
 ### Azure Resource Manager
 
@@ -1350,7 +1354,7 @@ The Azure MCP Server provides tools for interacting with **44+ Azure service are
 - 📊 **Azure Quota** - Resource quota and usage management
 - 🎭 **Azure RBAC** - Access control management
 - 🔴 **Azure Redis Cache** - In-memory data store
-- 🛡️ **Azure Resilience Management** - Resilience goal templates, goal assignments, goal resources, usage plans, usage plan enrollments, recovery plans, recovery plan resources, recovery jobs, recovery job resources, and drills
+- 🛡️ **Azure Resilience Management** - Resilience goal templates, goal assignments, goal resources, usage plans, usage plan enrollments, recovery plans, recovery plan resources, recovery jobs, recovery job resources, drills, drill resources, drill runs, and drill run resources
 - 🏗️ **Azure Resource Groups** - Resource organization
 - 🚌 **Azure Service Bus** - Message queuing
 - 🧵 **Azure Service Fabric** - Managed cluster node operations


### PR DESCRIPTION
## Summary

Closes #3369

Addresses documentation gap in `servers/Azure.Mcp.Server/README.md`:
- Added example prompts for `resilience_drill_run_get` and `resilience_drill_run_resource_get` tools under `### 🛡️ Azure Resilience Management`.
- Updated service description in `## Complete List of Supported Azure Services` to include drill resources, drill runs, and drill run resources.
