### PR TITLE
docs(functions): add Go prompts to e2eTestPrompts.md (#3243)

### DIFF
--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -675,7 +675,9 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | functions_project_get | Set up a new Azure Functions project in Python | none |
 | functions_project_get | Generate the project files for a TypeScript Azure Functions app | none |
 | functions_project_get | Use an Azure Functions project template to create boilerplate for a Java app using JDK 21 | none |
+| functions_project_get | Set up a new Azure Functions project in Go | none |
 | functions_template_get | Get the available triggers and bindings for C# Azure Functions. | none |
+| functions_template_get | Show me all the Go Azure Function templates | none |
 | functions_template_get | Show me all the Python Azure Function templates | none |
 | functions_template_get | Create a Timer trigger function in C# that runs every 5 minutes | none |
 | functions_template_get | Show me a Cosmos DB trigger with an output binding in Java | none |


### PR DESCRIPTION
## Summary

Closes #3243

Addresses documentation gap in `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`:
- Added Go test prompt for `functions_project_get`.
- Added Go test prompt for `functions_template_get`.
