### PR TITLE
docs(communication): document retry options removal (#3416)

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -1315,6 +1315,7 @@ azmcp extension cli install --cli-type <cli-type>
 
 ### Azure Communication Services Operations
 
+> The `communication email send` and `communication sms send` commands do not support `--retry-*` options.
 #### Email
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #3416

Fixes documentation gap in `servers/Azure.Mcp.Server/docs/azmcp-commands.md` by noting that `communication email send` and `communication sms send` do not support `--retry-*` options following the removal of RetryPolicyOptions in PR #3406.
