### PR TITLE
docs(iothub): consolidate duplicate Azure IoT Hub Operations sections (#3367)

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -2961,6 +2961,15 @@ azmcp iothub device show --subscription <subscription> \
                          --hub-name <iot-hub-name> \
                          --device-id <device-id>
 
+# List devices in an IoT Hub
+# Returns one page of device identities. --max-count sets the page size (default 100, maximum 100); values less than 1 or greater than 100 are rejected.
+# When the hub has more devices than were returned, the response sets truncated=true with an explanatory message.
+# ❌ Destructive | ❌ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
+azmcp iothub device list --subscription <subscription> \
+                         --resource-group <resource-group> \
+                         --hub-name <iot-hub-name> \
+                         [--max-count <max-count>]
+
 # Get device statistics for an IoT Hub identity registry
 # ❌ Destructive | ❌ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp iothub device stats --subscription <subscription> \
@@ -3178,20 +3187,6 @@ azmcp loadtesting testrun createorupdate --subscription <subscription> \
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp grafana list --subscription <subscription> \
                   [--resource-group <resource-group>]
-```
-### Azure IoT Hub Operations
-
-#### Device Registry Operations
-
-```bash
-# List devices in an IoT Hub
-# Returns one page of device identities. --max-count sets the page size (default 100, maximum 100); values less than 1 or greater than 100 are rejected.
-# When the hub has more devices than were returned, the response sets truncated=true with an explanatory message.
-# ❌ Destructive | ❌ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp iothub device list --subscription <subscription> \
-                         --resource-group <resource-group> \
-                         --hub-name <iot-hub-name> \
-                         [--max-count <max-count>]
 ```
 
 ### Azure Marketplace Operations


### PR DESCRIPTION
## Summary

Closes #3367

Consolidates the disjointed `### Azure IoT Hub Operations` sections in `servers/Azure.Mcp.Server/docs/azmcp-commands.md`.
- Merged the isolated `azmcp iothub device list` command into the primary IoT Hub Operations section alongside `device show` and `device stats`.
- Removed the redundant duplicate section header, keeping tool documentation in the same namespace unified and cohesive.
