### PR TITLE
ci(pipelines): exclude changelog files from pull request build trigger (#3421)

### DIFF
--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -5,6 +5,12 @@ pr:
       - feature/*
       - hotfix/*
       - release/*
+  paths:
+    exclude:
+      - '**/CHANGELOG.md'
+      - '**/changelog-entries/**'
+      - 'docs/changelog-entries.md'
+      - 'docs/design/changelog-management-system.md'
 
 trigger: none
 


### PR DESCRIPTION
## Summary

Closes #3421

### Problem
Azure Pipelines runs full build and test suites on every pull request, even when a PR only touches changelog updates prior to release. This significantly delays release workflows.

### Solution
- Added `paths.exclude` in `eng/pipelines/pullrequest.yml` to ignore updates to `**/CHANGELOG.md`, `**/changelog-entries/**`, and changelog docs from triggering PR build/test runs.
