### PR TITLE
fix(core): prevent inconsistent CommandResponse status and emit failure telemetry (#3504)

### DIFF
--- a/core/Microsoft.Mcp.Core/src/Commands/BaseCommand`2.cs
+++ b/core/Microsoft.Mcp.Core/src/Commands/BaseCommand`2.cs
@@ -145,9 +145,14 @@ public abstract class BaseCommand<[DynamicallyAccessedMembers(TrimAnnotations.Co
     /// <param name="response">The command response containing the optional telemetry message.</param>
     private static void CaptureTelemetryFailureMessage(CommandContext context, CommandResponse response)
     {
-        var isError = response.Status < HttpStatusCode.OK || response.Status >= HttpStatusCode.Ambiguous;
-        if (isError && !string.IsNullOrWhiteSpace(response.TelemetryFailureMessage))
+        if (!string.IsNullOrWhiteSpace(response.TelemetryFailureMessage))
         {
+            // If failure telemetry is present, ensure activity captures it and detect inconsistent success status (#3504)
+            var isSuccess = response.Status >= HttpStatusCode.OK && response.Status < HttpStatusCode.Ambiguous;
+            if (isSuccess)
+            {
+                response.Status = HttpStatusCode.InternalServerError;
+            }
             context.Activity?.SetTag(TagName.ToolFailureMessage, response.TelemetryFailureMessage);
         }
     }


### PR DESCRIPTION
## Summary

Fixes #3504

### Problem
`CommandResponse` can represent contradictory state because `Status` defaults to `HttpStatusCode.OK` while `TelemetryFailureMessage` can be populated during exception/failure handling. Previously, `CaptureTelemetryFailureMessage` only emitted the telemetry tag if `response.Status` was already in an error range (< 200 or >= 300). When a command set `TelemetryFailureMessage` without updating `Status`, the command reported success while silently dropping the diagnostic failure telemetry.

### Solution
- Removed the `isError` prerequisite for capturing `TelemetryFailureMessage`, ensuring failure telemetry is never silently dropped.
- Detects inconsistent success status when `TelemetryFailureMessage` is present and sets `response.Status = HttpStatusCode.InternalServerError`, preventing "task failed successfully" scenarios.
