### PR TITLE
Update Analyze-Dependencies Script

### DIFF
--- a/eng/scripts/Analyze-Dependencies.ps1
+++ b/eng/scripts/Analyze-Dependencies.ps1
@@ -1,4 +1,4 @@
-#!/bin/env pwsh
+#!/usr/bin/env pwsh
 #Requires -Version 7
 
 <#

--- a/eng/scripts/Analyze-Dependencies.ps1
+++ b/eng/scripts/Analyze-Dependencies.ps1
@@ -1,3 +1,6 @@
+#!/bin/env pwsh
+#Requires -Version 7
+
 <#
 .SYNOPSIS
     Analyzes project.assets.json and writes a dependency report to .work/.
@@ -29,19 +32,15 @@ param(
     [string]$Server
 )
 
+. "$PSScriptRoot/../common/scripts/common.ps1"
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-
-$repoRoot = & git -C $PSScriptRoot rev-parse --show-toplevel 2>$null
-if (-not $repoRoot) {
-    Write-Error "Could not determine repository root"
-    return
-}
 
 # ── Parse Directory.Packages.props ────────────────────────────────────────────
 
 $cpmVersions = @{}
-$propsPath = Join-Path $repoRoot 'Directory.Packages.props'
+$propsPath = Join-Path $RepoRoot 'Directory.Packages.props'
 if (Test-Path $propsPath) {
     $propsXml = [xml](Get-Content $propsPath -Raw)
     foreach ($pv in $propsXml.SelectNodes('//PackageVersion')) {
@@ -321,7 +320,7 @@ function BuildReverseGraph([hashtable]$forwardEdges, [string[]]$serverRoots) {
 $serverExplicit = $PSBoundParameters.ContainsKey('Server')
 
 if ($serverExplicit) {
-    $assetsPath = Join-Path $repoRoot "servers/$Server/src/obj/project.assets.json"
+    $assetsPath = Join-Path $RepoRoot "servers/$Server/src/obj/project.assets.json"
     if (-not (Test-Path $assetsPath)) {
         Write-Error "Assets file not found: $assetsPath`nRun 'dotnet restore' on the $Server project first."
         return
@@ -349,7 +348,7 @@ if ($serverExplicit) {
     }
 }
 else {
-    $serverDirs = Get-ChildItem (Join-Path $repoRoot 'servers') -Directory
+    $serverDirs = Get-ChildItem (Join-Path $RepoRoot 'servers') -Directory
     $results = @()
     foreach ($dir in $serverDirs) {
         $assetsPath = Join-Path $dir.FullName 'src/obj/project.assets.json'
@@ -377,7 +376,7 @@ else {
 }
 
 # Write output
-$workDir = Join-Path $repoRoot '.work'
+$workDir = Join-Path $RepoRoot '.work'
 if (-not (Test-Path $workDir)) { New-Item -ItemType Directory -Path $workDir -Force | Out-Null }
 
 $outPath = Join-Path $workDir 'dependencies.json'


### PR DESCRIPTION
This pull request updates the `Analyze-Dependencies.ps1` script to standardize how the repository root is determined and referenced. The main change is to source common utility functions and consistently use the `$RepoRoot` variable (from the sourced script) instead of locally computing `$repoRoot`. This improves maintainability and consistency across engineering scripts.

**Refactoring for repository root handling:**

* Sources the common script `common.ps1` to set `$RepoRoot`, replacing the previous local computation of `$repoRoot`. (`eng/scripts/Analyze-Dependencies.ps1`) [[1]](diffhunk://#diff-56f883b775441ecdc2e709556280218285a521f9a1b59d74cc0ce66173d17dfeR1-R3) [[2]](diffhunk://#diff-56f883b775441ecdc2e709556280218285a521f9a1b59d74cc0ce66173d17dfeR35-R43)
* Updates all references from `$repoRoot` to `$RepoRoot` for paths such as `Directory.Packages.props`, server directories, and the `.work` output directory. (`eng/scripts/Analyze-Dependencies.ps1`) [[1]](diffhunk://#diff-56f883b775441ecdc2e709556280218285a521f9a1b59d74cc0ce66173d17dfeR35-R43) [[2]](diffhunk://#diff-56f883b775441ecdc2e709556280218285a521f9a1b59d74cc0ce66173d17dfeL324-R323) [[3]](diffhunk://#diff-56f883b775441ecdc2e709556280218285a521f9a1b59d74cc0ce66173d17dfeL352-R351) [[4]](diffhunk://#diff-56f883b775441ecdc2e709556280218285a521f9a1b59d74cc0ce66173d17dfeL380-R379)

**General improvements:**

* Adds a shebang and PowerShell version requirement at the top of the script for better portability and clarity. (`eng/scripts/Analyze-Dependencies.ps1`)