### PR TITLE
revert: restore Azure VSIX dependency updates

### DIFF
--- a/servers/Azure.Mcp.Server/vscode/package-lock.json
+++ b/servers/Azure.Mcp.Server/vscode/package-lock.json
@@ -4754,9 +4754,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
## What does this PR do?

Reverts the temporary Azure VSIX dependency rollbacks from #3497 and #3508, applied during the Azure Artifacts quarantine, now that the release has completed.

The reverts were applied in reverse chronological order (`f31aa8664`, then `acbedd13d`) so later `main` dependency updates remain intact. Those later updates already supersede all temporarily rolled-back packages except `js-yaml`, leaving this exact final version change:

| Package | Temporary version | Restored version |
| --- | --- | --- |
| `js-yaml` | `4.3.1` | `4.3.2` |

The final diff modifies only `servers/Azure.Mcp.Server/vscode/package-lock.json`; `package.json` is unchanged.

### Validation

- `npm ci --omit=optional` against the exact Azure Artifacts registry was attempted with isolated temporary configuration, but returned `E401` because no feed credentials are available locally; the temporary configuration was removed.
- `npm ci --omit=optional --registry=https://registry.npmjs.org/` passed (npm reported one existing moderate-severity audit finding).
- `npm run build` passed for `servers/Azure.Mcp.Server/vscode`.
- `dotnet build servers/Azure.Mcp.Server/src/Azure.Mcp.Server.csproj` passed.
- `./eng/scripts/Build-Local.ps1 -VerifyNpx` passed.
- `.\eng\common\spelling\Invoke-Cspell.ps1` passed.

## GitHub issue number?

N/A

## Pre-merge Checklist

- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality (existing lockfile/build validation applies)
    - [x] Created a changelog entry if required (not required for reverting a temporary release workaround)
- [x] For MCP tool changes: N/A; no MCP tool changes
- [x] Extra steps for Azure MCP Server tool changes: N/A; no tool changes

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.
