### PR TITLE
docs(resilience): add example prompts for resilience_drill_start and resilience_drill_end (#3446)

### DIFF
--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -1278,6 +1278,10 @@ Example prompts that generate Azure CLI commands:
 * "Update resilience drill 'my-drill' in service group 'my-service-group' to use manual RBAC setup"
 * "Create a zonal resilience drill 'my-drill' in service group 'my-service-group'"
 * "Get the resilience drill 'my-drill' in service group 'my-service-group'"
+* "Start resilience drill 'my-drill' in service group 'my-service-group' in Failover mode"
+* "Run a TestFailover for resilience drill 'my-drill' in service group 'my-service-group'"
+* "End resilience drill 'my-drill' in service group 'my-service-group' and attest it as Success with notes 'Validation completed'"
+* "Stop the running resilience drill 'my-drill' in service group 'my-service-group' and attest it as Failed"
 * "Create a Basic resilience usage plan 'my-plan' in resource group 'my-rg'"
 * "Enroll service group 'my-service-group' into usage plan 'my-plan' in resource group 'my-rg'"
 


### PR DESCRIPTION
## Summary
- Fixes #3446
- Bổ sung các example prompts bị thiếu cho `resilience_drill_start` và `resilience_drill_end` vào mục **Azure Resilience Management** trong `servers/Azure.Mcp.Server/README.md`.
- Đảm bảo đồng bộ 100% với tài liệu lệnh `azmcp-commands.md` và `e2eTestPrompts.md`.