### PR TITLE
docs(resilience): add drill run and drill run resource prompts to README (#3369)

### DIFF
--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -1275,6 +1275,10 @@ Example prompts that generate Azure CLI commands:
 * "Remove recovery resource 'my-resource' from recovery plan 'my-recovery-plan' in service group 'my-service-group'"
 * "Delete recovery plan 'my-recovery-plan' from service group 'my-service-group' and report whether it existed"
 * "List the recovery jobs of recovery plan 'my-recovery-plan' in service group 'my-service-group'"
+* "List all runs of drill 'my-drill' in service group 'my-service-group'"
+* "Get drill run 'my-drill-run' for drill 'my-drill' in service group 'my-service-group'"
+* "List all resources of drill run 'my-drill-run' for drill 'my-drill' in service group 'my-service-group'"
+* "Get resource 'my-resource' from drill run 'my-drill-run' for drill 'my-drill' in service group 'my-service-group'"
 * "Update resilience drill 'my-drill' in service group 'my-service-group' to use manual RBAC setup"
 * "Create a zonal resilience drill 'my-drill' in service group 'my-service-group'"
 * "Get the resilience drill 'my-drill' in service group 'my-service-group'"
@@ -1350,7 +1354,7 @@ The Azure MCP Server provides tools for interacting with **44+ Azure service are
 - 📊 **Azure Quota** - Resource quota and usage management
 - 🎭 **Azure RBAC** - Access control management
 - 🔴 **Azure Redis Cache** - In-memory data store
-- 🛡️ **Azure Resilience Management** - Resilience goal templates, goal assignments, goal resources, usage plans, usage plan enrollments, recovery plans, recovery plan resources, recovery jobs, recovery job resources, and drills
+- 🛡️ **Azure Resilience Management** - Resilience goal templates, goal assignments, goal resources, usage plans, usage plan enrollments, recovery plans, recovery plan resources, recovery jobs, recovery job resources, drills, drill resources, drill runs, and drill run resources
 - 🏗️ **Azure Resource Groups** - Resource organization
 - 🚌 **Azure Service Bus** - Message queuing
 - 🧵 **Azure Service Fabric** - Managed cluster node operations


### PR DESCRIPTION
## Summary
- Fixes #3369
- Adds missing example prompts for `resilience_drill_run_get` and `resilience_drill_run_resource_get` to the **Azure Resilience Management** section in `servers/Azure.Mcp.Server/README.md`.
- Updates **Complete List of Supported Azure Services** description to include drill runs and drill run resources.