### PR TITLE
fix(authorization): return role assignments for management group scopes

### DIFF
--- a/core/Azure.Mcp.Core/src/Commands/Subscription/SubscriptionCommand`2.cs
+++ b/core/Azure.Mcp.Core/src/Commands/Subscription/SubscriptionCommand`2.cs
@@ -14,11 +14,17 @@ public abstract class SubscriptionCommand<
 {
     private readonly ISubscriptionResolver _subscriptionResolver = subscriptionResolver;
 
+    /// <summary>
+    /// Determines whether subscription resolution and validation apply to the bound options.
+    /// </summary>
+    /// <remarks>This method is evaluated during post-binding and must only inspect already-bound option values.</remarks>
+    protected virtual bool IsSubscriptionApplicable(TOptions options) => true;
+
     public override void ValidateOptions(TOptions options, ValidationResult validationResult)
     {
         base.ValidateOptions(options, validationResult);
 
-        if (string.IsNullOrEmpty(options.Subscription))
+        if (IsSubscriptionApplicable(options) && string.IsNullOrEmpty(options.Subscription))
         {
             validationResult.Errors.Add("Missing Required options: --subscription");
         }
@@ -26,6 +32,13 @@ public abstract class SubscriptionCommand<
 
     public override void PostBindOptions(TOptions options)
     {
+        base.PostBindOptions(options);
+
+        if (!IsSubscriptionApplicable(options))
+        {
+            return;
+        }
+
         // Always post-process subscription via resolver (env var / CLI profile fallback)
         options.Subscription = _subscriptionResolver.ResolveSubscription(options.Subscription);
         if (!string.IsNullOrEmpty(options.Subscription))

--- a/core/Azure.Mcp.Core/src/Commands/Subscription/SubscriptionCommand`2.cs
+++ b/core/Azure.Mcp.Core/src/Commands/Subscription/SubscriptionCommand`2.cs
@@ -14,17 +14,11 @@ public abstract class SubscriptionCommand<
 {
     private readonly ISubscriptionResolver _subscriptionResolver = subscriptionResolver;
 
-    /// <summary>
-    /// Determines whether subscription resolution and validation apply to the bound options.
-    /// </summary>
-    /// <remarks>This method is evaluated during post-binding and must only inspect already-bound option values.</remarks>
-    protected virtual bool IsSubscriptionApplicable(TOptions options) => true;
-
     public override void ValidateOptions(TOptions options, ValidationResult validationResult)
     {
         base.ValidateOptions(options, validationResult);
 
-        if (IsSubscriptionApplicable(options) && string.IsNullOrEmpty(options.Subscription))
+        if (string.IsNullOrEmpty(options.Subscription))
         {
             validationResult.Errors.Add("Missing Required options: --subscription");
         }
@@ -32,13 +26,6 @@ public abstract class SubscriptionCommand<
 
     public override void PostBindOptions(TOptions options)
     {
-        base.PostBindOptions(options);
-
-        if (!IsSubscriptionApplicable(options))
-        {
-            return;
-        }
-
         // Always post-process subscription via resolver (env var / CLI profile fallback)
         options.Subscription = _subscriptionResolver.ResolveSubscription(options.Subscription);
         if (!string.IsNullOrEmpty(options.Subscription))

--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureResourceService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureResourceService.cs
@@ -88,29 +88,12 @@ public abstract class BaseAzureResourceService(IAzureService azureService)
     {
         ValidateRequiredParameters((nameof(resourceType), resourceType), (nameof(subscription), subscription));
         ArgumentNullException.ThrowIfNull(converter);
-
-        if (!string.IsNullOrEmpty(additionalFilter) && additionalFilter.Contains('|'))
-        {
-            throw new ArgumentException(
-                "additionalFilter must not contain the pipe operator '|' to prevent KQL injection.",
-                nameof(additionalFilter));
-        }
-
-        var results = new List<T>();
+        ValidateAdditionalFilter(additionalFilter);
 
         var subscriptionResource = await AzureService.GetSubscription(subscription, tenant, cancellationToken);
         var tenantResource = await GetTenantResourceAsync(subscriptionResource!.Data.TenantId, cancellationToken);
 
-        var queryFilter = $"{tableName} | where type =~ '{EscapeKqlString(resourceType)}'";
-        if (!string.IsNullOrEmpty(resourceGroup))
-        {
-            queryFilter += $" and resourceGroup =~ '{EscapeKqlString(resourceGroup)}'";
-        }
-        if (!string.IsNullOrEmpty(additionalFilter))
-        {
-            queryFilter += $" and {additionalFilter}";
-        }
-        queryFilter += $" | limit {limit}";
+        var queryFilter = BuildResourceQuery(tableName, resourceType, resourceGroup, additionalFilter, limit);
 
         var queryContent = new ResourceQueryContent(queryFilter)
         {
@@ -118,19 +101,9 @@ public abstract class BaseAzureResourceService(IAzureService azureService)
         };
 
         ResourceQueryResult result = await tenantResource.GetResourcesAsync(queryContent, cancellationToken);
-        if (result != null && result.Count > 0)
-        {
-            using var jsonDocument = JsonDocument.Parse(result.Data);
-            var dataArray = jsonDocument.RootElement;
-            if (dataArray.ValueKind == JsonValueKind.Array)
-            {
-                foreach (var item in dataArray.EnumerateArray())
-                {
-                    results.Add(converter(item));
-                }
-            }
-        }
-        else if (!string.IsNullOrEmpty(resourceGroup))
+        var results = MaterializeResults(result, converter);
+
+        if ((result == null || result.Count == 0) && !string.IsNullOrEmpty(resourceGroup))
         {
             // If the query returned no results and a resource group filter was applied, validate that the resource group exists to provide better error handling
             if (!await ValidateResourceGroupExistsAsync(subscriptionResource, resourceGroup, cancellationToken))
@@ -140,6 +113,131 @@ public abstract class BaseAzureResourceService(IAzureService azureService)
         }
 
         return new ResourceQueryResults<T>(results, result?.ResultTruncated == ResultTruncated.True);
+    }
+
+    /// <summary>
+    /// Executes a Resource Graph query scoped to a management group and returns a list of resources of the specified type.
+    /// </summary>
+    /// <remarks>
+    /// Resource Graph evaluates a query only within the scopes it is given. A subscription-scoped query therefore
+    /// cannot see resources whose IDs live outside any subscription, such as role assignments made directly on a
+    /// management group. Use this overload when the caller asked about a management group scope.
+    /// </remarks>
+    /// <typeparam name="T">The type to convert each resource to</typeparam>
+    /// <param name="resourceType">The Azure resource type to query for</param>
+    /// <param name="managementGroup">The management group ID to scope the query to</param>
+    /// <param name="converter">Function to convert JsonElement to the target type</param>
+    /// <param name="tableName">Optional table name to query (default: "resources")</param>
+    /// <param name="additionalFilter">Optional additional KQL filter condition</param>
+    /// <param name="limit">Maximum number of results to return (default: 50)</param>
+    /// <param name="tenant">Optional tenant to use for the query</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of resources converted to the specified type</returns>
+    protected async Task<ResourceQueryResults<T>> ExecuteManagementGroupResourceQueryAsync<T>(
+        string resourceType,
+        string managementGroup,
+        Func<JsonElement, T> converter,
+        string? tableName = "resources",
+        string? additionalFilter = null,
+        int limit = 50,
+        string? tenant = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredParameters((nameof(resourceType), resourceType), (nameof(managementGroup), managementGroup));
+        ArgumentNullException.ThrowIfNull(converter);
+        ValidateAdditionalFilter(additionalFilter);
+
+        var tenantResource = await ResolveTenantResourceAsync(tenant, cancellationToken);
+
+        var queryFilter = BuildResourceQuery(tableName, resourceType, resourceGroup: null, additionalFilter, limit);
+
+        var queryContent = new ResourceQueryContent(queryFilter)
+        {
+            ManagementGroups = { managementGroup }
+        };
+
+        ResourceQueryResult result = await tenantResource.GetResourcesAsync(queryContent, cancellationToken);
+        var results = MaterializeResults(result, converter);
+
+        return new ResourceQueryResults<T>(results, result?.ResultTruncated == ResultTruncated.True);
+    }
+
+    private static void ValidateAdditionalFilter(string? additionalFilter)
+    {
+        if (!string.IsNullOrEmpty(additionalFilter) && additionalFilter.Contains('|'))
+        {
+            throw new ArgumentException(
+                "additionalFilter must not contain the pipe operator '|' to prevent KQL injection.",
+                nameof(additionalFilter));
+        }
+    }
+
+    private static string BuildResourceQuery(
+        string? tableName,
+        string resourceType,
+        string? resourceGroup,
+        string? additionalFilter,
+        int limit)
+    {
+        var queryFilter = $"{tableName} | where type =~ '{EscapeKqlString(resourceType)}'";
+        if (!string.IsNullOrEmpty(resourceGroup))
+        {
+            queryFilter += $" and resourceGroup =~ '{EscapeKqlString(resourceGroup)}'";
+        }
+        if (!string.IsNullOrEmpty(additionalFilter))
+        {
+            queryFilter += $" and {additionalFilter}";
+        }
+
+        return queryFilter + $" | limit {limit}";
+    }
+
+    private static List<T> MaterializeResults<T>(ResourceQueryResult? result, Func<JsonElement, T> converter)
+    {
+        var results = new List<T>();
+        if (result == null || result.Count == 0)
+        {
+            return results;
+        }
+
+        using var jsonDocument = JsonDocument.Parse(result.Data);
+        var dataArray = jsonDocument.RootElement;
+        if (dataArray.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in dataArray.EnumerateArray())
+            {
+                results.Add(converter(item));
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Resolves the tenant to run a query against when no subscription is available to derive it from.
+    /// </summary>
+    private async Task<TenantResource> ResolveTenantResourceAsync(string? tenant, CancellationToken cancellationToken)
+    {
+        var tenantId = await AzureService.ResolveTenantIdAsync(tenant, cancellationToken);
+        if (!string.IsNullOrEmpty(tenantId))
+        {
+            return await GetTenantResourceAsync(Guid.Parse(tenantId), cancellationToken);
+        }
+
+        var tenants = await AzureService.GetTenants(cancellationToken);
+        if (tenants.Count == 1)
+        {
+            return tenants[0];
+        }
+
+        if (tenants.Count == 0)
+        {
+            throw new InvalidOperationException("No accessible Azure tenants were found for the current credential.");
+        }
+
+        throw new ArgumentException(
+            "Multiple tenants are accessible, so the tenant to query cannot be inferred. Specify the tenant explicitly.",
+            nameof(tenant));
     }
 
     /// <summary>

--- a/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/BaseAzureService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using Azure.Core;
 using Azure.Mcp.Core.Services.Azure.Helpers;
 using Azure.ResourceManager;
@@ -111,6 +112,15 @@ public abstract class BaseAzureService(IAzureService azureService)
         ArmClientOptions? armClientOptions = null,
         CancellationToken cancellationToken = default) =>
         await AzureHelper.CreateArmClientAsync(AzureService, tenantIdOrName, armClientOptions: armClientOptions, cancellationToken: cancellationToken);
+
+    /// <summary>
+    /// Validates that the provided parameter is not null or empty.
+    /// </summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="value">The parameter value.</param>
+    /// <exception cref="ArgumentException">Thrown when the parameter is null or empty.</exception>
+    public static void ValidateRequiredParameter(string name, [NotNull] string? value) =>
+        AzureHelper.ValidateRequiredParameter(name, value);
 
     /// <summary>
     /// Validates that the provided named parameters are not null or empty

--- a/core/Azure.Mcp.Core/src/Services/Azure/Helpers/AzureHelper.cs
+++ b/core/Azure.Mcp.Core/src/Services/Azure/Helpers/AzureHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Versioning;
 using Azure.Core;
@@ -44,6 +45,20 @@ public static class AzureHelper
         // Initialize the default user agent policy without transport type
         s_defaultUserAgent = $"azmcp/{s_version} ({s_framework}; {s_platform})";
         s_sharedUserAgentPolicy = new UserAgentPolicy(s_defaultUserAgent);
+    }
+
+    /// <summary>
+    /// Validates that the provided parameter is not null or empty.
+    /// </summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="value">The parameter value.</param>
+    /// <exception cref="ArgumentException">Thrown when the parameter is null or empty.</exception>
+    internal static void ValidateRequiredParameter(string name, [NotNull] string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            throw new ArgumentException($"Required parameter is null or empty: {name}");
+        }
     }
 
     /// <summary>

--- a/servers/Azure.Mcp.Server/changelog-entries/kaghiya-role-assignment-management-group-scope.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/kaghiya-role-assignment-management-group-scope.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed `role_assignment_list` returning an empty result for management group scopes. The Resource Graph query was always scoped to a subscription, so assignments made directly on a management group were never visible. Scope matching is also anchored now, so a scope ending in `rg1` no longer matches `rg10`, and the queried scope is echoed in the response."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -4039,7 +4039,7 @@ azmcp pricing get [--sku <sku>] \
 ```bash
 # List Azure RBAC role assignments at a scope and any scope nested beneath it
 # Assignments inherited from a parent scope are not included.
-# --subscription is not required when --scope is a management group.
+# --subscription must not be specified when --scope is a management group.
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp role assignment list --scope <scope> \
                            [--subscription <subscription>]

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -4037,10 +4037,12 @@ azmcp pricing get [--sku <sku>] \
 ### Azure RBAC Operations
 
 ```bash
-# List Azure RBAC role assignments
+# List Azure RBAC role assignments at a scope and any scope nested beneath it
+# Assignments inherited from a parent scope are not included.
+# --subscription is not required when --scope is a management group.
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp role assignment list --subscription <subscription> \
-                           --scope <scope>
+azmcp role assignment list --scope <scope> \
+                           [--subscription <subscription>]
 ```
 
 ### Azure Redis Operations

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -1024,8 +1024,8 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 |:----------|:------------|:------------|
 | role_assignment_list | List all available role assignments in my subscription | none |
 | role_assignment_list | Show me the available role assignments in my subscription | none |
-| role_assignment_list | List the role assignments on management group <management_group_name> | none |
-| role_assignment_list | List the role assignments on resource group <resource_group_name> | none |
+| role_assignment_list | List the role assignments at scope /providers/Microsoft.Management/managementGroups/<management-group> | none |
+| role_assignment_list | List the role assignments at scope <scope> | none |
 
 ## Azure Redis
 

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -1025,7 +1025,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | role_assignment_list | List all available role assignments in my subscription | none |
 | role_assignment_list | Show me the available role assignments in my subscription | none |
 | role_assignment_list | List the role assignments at scope /providers/Microsoft.Management/managementGroups/<management-group> | none |
-| role_assignment_list | List the role assignments at scope <scope> | none |
+| role_assignment_list | List the role assignments at scope /subscriptions/<subscription>/resourceGroups/<resource-group> | none |
 
 ## Azure Redis
 

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -1025,7 +1025,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | role_assignment_list | List all available role assignments in my subscription | none |
 | role_assignment_list | Show me the available role assignments in my subscription | none |
 | role_assignment_list | List the role assignments on management group <management_group_name> | none |
-| role_assignment_list | Who has access to resource group <resource_group_name>? | none |
+| role_assignment_list | List the role assignments on resource group <resource_group_name> | none |
 
 ## Azure Redis
 

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -1024,6 +1024,8 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 |:----------|:------------|:------------|
 | role_assignment_list | List all available role assignments in my subscription | none |
 | role_assignment_list | Show me the available role assignments in my subscription | none |
+| role_assignment_list | List the role assignments on management group <management_group_name> | none |
+| role_assignment_list | Who has access to resource group <resource_group_name>? | none |
 
 ## Azure Redis
 

--- a/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordFetchCommand.cs
+++ b/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordFetchCommand.cs
@@ -33,6 +33,7 @@ namespace Azure.Mcp.Tools.Adme.Commands.Storage;
         server, and reports per-record outcomes in conversionStatuses (empty for records without
         measured or spatial fields). It cannot be combined with --attributes.
         """,
+    OperationPlane = ToolOperationPlane.Data,
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,

--- a/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordGetCommand.cs
@@ -31,6 +31,7 @@ namespace Azure.Mcp.Tools.Adme.Commands.Storage;
 
         For several records in one call use 'azmcp adme storage record fetch'.
         """,
+    OperationPlane = ToolOperationPlane.Data,
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,

--- a/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordListCommand.cs
@@ -28,6 +28,7 @@ namespace Azure.Mcp.Tools.Adme.Commands.Storage;
         response. A null cursor means there are no more pages. A kind can hold thousands of records,
         so confirm how many the user wants before paging through the whole set.
         """,
+    OperationPlane = ToolOperationPlane.Data,
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,

--- a/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordVersionListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordVersionListCommand.cs
@@ -26,6 +26,7 @@ namespace Azure.Mcp.Tools.Adme.Commands.Storage;
         Pass one of the returned versions to 'azmcp adme storage record get --version' to read that
         version of the record.
         """,
+    OperationPlane = ToolOperationPlane.Data,
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,

--- a/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
@@ -17,8 +17,11 @@ namespace Azure.Mcp.Tools.Authorization.Commands;
     Name = "list",
     Title = "List Role Assignments",
     Description = """
-        List role assignments. This command retrieves and displays all Azure RBAC role assignments
-        in the specified scope. Results include role definition IDs and principal IDs, returned as a JSON array.
+        List role assignments. This command retrieves and displays the Azure RBAC role assignments
+        at the specified scope and at any scope nested beneath it. Assignments inherited from a parent
+        scope are not included. The scope may be a subscription, resource group, resource, or management
+        group; a subscription is not required when the scope is a management group. Results include role
+        definition IDs and principal IDs, returned as a JSON array.
         """,
     OperationPlane = ToolOperationPlane.Control,
     Destructive = false,
@@ -33,26 +36,38 @@ public sealed class RoleAssignmentListCommand(ILogger<RoleAssignmentListCommand>
     private readonly ILogger<RoleAssignmentListCommand> _logger = logger;
     private readonly IAuthorizationService _authorizationService = authorizationService;
 
+    public override void ValidateOptions(RoleAssignmentListOptions options, ValidationResult validationResult)
+    {
+        // A management group scope sits outside every subscription, so the inherited --subscription
+        // requirement would reject a valid request. Skipping the base call skips only that check.
+        if (ManagementGroupScope.TryParse(options.Scope, out _))
+        {
+            return;
+        }
+
+        base.ValidateOptions(options, validationResult);
+    }
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, RoleAssignmentListOptions options, CancellationToken cancellationToken)
     {
         try
         {
             var assignments = await _authorizationService.ListRoleAssignmentsAsync(
-                options.Subscription!,
+                options.Subscription,
                 options.Scope,
                 options.Tenant,
                 cancellationToken);
 
-            context.Response.Results = ResponseResult.Create(new(assignments?.Results ?? [], assignments?.AreResultsTruncated ?? false), AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);
+            context.Response.Results = ResponseResult.Create(new(options.Scope, assignments?.Results ?? [], assignments?.AreResultsTruncated ?? false), AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "An exception occurred listing role assignments.");
+            _logger.LogError(ex, "An exception occurred listing role assignments for scope {Scope}.", options.Scope);
             HandleException(context, ex);
         }
 
         return context.Response;
     }
 
-    public sealed record RoleAssignmentListCommandResult(List<RoleAssignment> Assignments, bool AreResultsTruncated);
+    public sealed record RoleAssignmentListCommandResult(string Scope, List<RoleAssignment> Assignments, bool AreResultsTruncated);
 }

--- a/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.Authorization.Models;
 using Azure.Mcp.Tools.Authorization.Options;
@@ -31,22 +30,50 @@ namespace Azure.Mcp.Tools.Authorization.Commands;
     Secret = false,
     LocalRequired = false)]
 public sealed class RoleAssignmentListCommand(ILogger<RoleAssignmentListCommand> logger, IAuthorizationService authorizationService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<RoleAssignmentListOptions, RoleAssignmentListCommand.RoleAssignmentListCommandResult>(subscriptionResolver)
+    : AuthenticatedCommand<RoleAssignmentListOptions, RoleAssignmentListCommand.RoleAssignmentListCommandResult>
 {
     private readonly ILogger<RoleAssignmentListCommand> _logger = logger;
     private readonly IAuthorizationService _authorizationService = authorizationService;
+    private readonly ISubscriptionResolver _subscriptionResolver = subscriptionResolver;
 
-    protected override bool IsSubscriptionApplicable(RoleAssignmentListOptions options) =>
-        !ManagementGroupScope.TryParse(options.Scope, out _);
+    // Management groups are outside every subscription, so this command binds and validates
+    // --subscription itself rather than inheriting SubscriptionCommand's unconditional handling.
+    private static bool IsManagementGroupScope(RoleAssignmentListOptions options) =>
+        ManagementGroupScope.TryParse(options.Scope, out _);
+
+    public override void PostBindOptions(RoleAssignmentListOptions options)
+    {
+        base.PostBindOptions(options);
+
+        if (IsManagementGroupScope(options))
+        {
+            return;
+        }
+
+        // Always post-process subscription via resolver (env var / CLI profile fallback)
+        options.Subscription = _subscriptionResolver.ResolveSubscription(options.Subscription);
+        if (!string.IsNullOrEmpty(options.Subscription))
+        {
+            // Trim any surrounding quotes that may have been included in the input
+            options.Subscription = options.Subscription.Trim('"', '\'');
+        }
+    }
 
     public override void ValidateOptions(RoleAssignmentListOptions options, ValidationResult validationResult)
     {
         base.ValidateOptions(options, validationResult);
 
-        if (!IsSubscriptionApplicable(options) && !string.IsNullOrEmpty(options.Subscription))
+        if (IsManagementGroupScope(options))
         {
-            validationResult.Errors.Add(
-                "Omit --subscription when --scope is a management group because management groups are outside subscriptions.");
+            if (!string.IsNullOrEmpty(options.Subscription))
+            {
+                validationResult.Errors.Add(
+                    "Omit --subscription when --scope is a management group because management groups are outside subscriptions.");
+            }
+        }
+        else if (string.IsNullOrEmpty(options.Subscription))
+        {
+            validationResult.Errors.Add("Missing Required options: --subscription");
         }
     }
 
@@ -64,21 +91,33 @@ public sealed class RoleAssignmentListCommand(ILogger<RoleAssignmentListCommand>
         }
         catch (Exception ex)
         {
-            _logger.LogError(
-                ex,
-                "An exception occurred listing role assignments for scope '{Scope}'.",
-                FormatScopeForLogging(options.Scope));
+            if (IsManagementGroupScope(options))
+            {
+                _logger.LogError(
+                    ex,
+                    "An exception occurred listing role assignments for scope '{Scope}'.",
+                    FormatForLogging(options.Scope));
+            }
+            else
+            {
+                _logger.LogError(
+                    ex,
+                    "An exception occurred listing role assignments for scope '{Scope}' in subscription '{Subscription}'.",
+                    FormatForLogging(options.Scope),
+                    FormatForLogging(options.Subscription));
+            }
+
             HandleException(context, ex);
         }
 
         return context.Response;
     }
 
-    private static string FormatScopeForLogging(string? scope) => scope switch
+    private static string FormatForLogging(string? value) => value switch
     {
         null => "<null>",
         "" => "<empty>",
-        _ => scope
+        _ => value
     };
 
     public sealed record RoleAssignmentListCommandResult(string Scope, List<RoleAssignment> Assignments, bool AreResultsTruncated);

--- a/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
@@ -20,7 +20,7 @@ namespace Azure.Mcp.Tools.Authorization.Commands;
         List role assignments. This command retrieves and displays the Azure RBAC role assignments
         at the specified scope and at any scope nested beneath it. Assignments inherited from a parent
         scope are not included. The scope may be a subscription, resource group, resource, or management
-        group; a subscription is not required when the scope is a management group. Results include role
+        group; a subscription must not be specified when the scope is a management group. Results include role
         definition IDs and principal IDs.
         """,
     OperationPlane = ToolOperationPlane.Control,
@@ -36,16 +36,18 @@ public sealed class RoleAssignmentListCommand(ILogger<RoleAssignmentListCommand>
     private readonly ILogger<RoleAssignmentListCommand> _logger = logger;
     private readonly IAuthorizationService _authorizationService = authorizationService;
 
+    protected override bool IsSubscriptionApplicable(RoleAssignmentListOptions options) =>
+        !ManagementGroupScope.TryParse(options.Scope, out _);
+
     public override void ValidateOptions(RoleAssignmentListOptions options, ValidationResult validationResult)
     {
-        // A management group scope sits outside every subscription, so the inherited --subscription
-        // requirement would reject a valid request. Skipping the base call skips only that check.
-        if (ManagementGroupScope.TryParse(options.Scope, out _))
-        {
-            return;
-        }
-
         base.ValidateOptions(options, validationResult);
+
+        if (!IsSubscriptionApplicable(options) && !string.IsNullOrEmpty(options.Subscription))
+        {
+            validationResult.Errors.Add(
+                "Omit --subscription when --scope is a management group because management groups are outside subscriptions.");
+        }
     }
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, RoleAssignmentListOptions options, CancellationToken cancellationToken)
@@ -62,12 +64,22 @@ public sealed class RoleAssignmentListCommand(ILogger<RoleAssignmentListCommand>
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "An exception occurred listing role assignments for scope {Scope}.", options.Scope);
+            _logger.LogError(
+                ex,
+                "An exception occurred listing role assignments for scope '{Scope}'.",
+                FormatScopeForLogging(options.Scope));
             HandleException(context, ex);
         }
 
         return context.Response;
     }
+
+    private static string FormatScopeForLogging(string? scope) => scope switch
+    {
+        null => "<null>",
+        "" => "<empty>",
+        _ => scope
+    };
 
     public sealed record RoleAssignmentListCommandResult(string Scope, List<RoleAssignment> Assignments, bool AreResultsTruncated);
 }

--- a/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
@@ -20,8 +20,8 @@ namespace Azure.Mcp.Tools.Authorization.Commands;
         List role assignments. This command retrieves and displays the Azure RBAC role assignments
         at the specified scope and at any scope nested beneath it. Assignments inherited from a parent
         scope are not included. The scope may be a subscription, resource group, resource, or management
-        group; a subscription is not required when the scope is a management group. Returns the queried
-        scope and the matching role assignments, including their role definition IDs and principal IDs.
+        group; a subscription is not required when the scope is a management group. Results include role
+        definition IDs and principal IDs.
         """,
     OperationPlane = ToolOperationPlane.Control,
     Destructive = false,

--- a/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
@@ -20,8 +20,8 @@ namespace Azure.Mcp.Tools.Authorization.Commands;
         List role assignments. This command retrieves and displays the Azure RBAC role assignments
         at the specified scope and at any scope nested beneath it. Assignments inherited from a parent
         scope are not included. The scope may be a subscription, resource group, resource, or management
-        group; a subscription is not required when the scope is a management group. Results include role
-        definition IDs and principal IDs, returned as a JSON array.
+        group; a subscription is not required when the scope is a management group. Returns the queried
+        scope and the matching role assignments, including their role definition IDs and principal IDs.
         """,
     OperationPlane = ToolOperationPlane.Control,
     Destructive = false,

--- a/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Commands/RoleAssignmentListCommand.cs
@@ -20,7 +20,7 @@ namespace Azure.Mcp.Tools.Authorization.Commands;
         List role assignments. This command retrieves and displays the Azure RBAC role assignments
         at the specified scope and at any scope nested beneath it. Assignments inherited from a parent
         scope are not included. The scope may be a subscription, resource group, resource, or management
-        group; a subscription must not be specified when the scope is a management group. Results include role
+        group; a subscription is not required when the scope is a management group. Results include role
         definition IDs and principal IDs.
         """,
     OperationPlane = ToolOperationPlane.Control,

--- a/tools/Azure.Mcp.Tools.Authorization/src/ManagementGroupScope.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/ManagementGroupScope.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.Mcp.Tools.Authorization;
+
+/// <summary>
+/// Helpers for recognizing management group scopes.
+/// </summary>
+/// <remarks>
+/// Management group scopes are not part of any subscription, so they need different handling from
+/// subscription, resource group, and resource scopes.
+/// </remarks>
+internal static class ManagementGroupScope
+{
+    private const string Prefix = "/providers/Microsoft.Management/managementGroups/";
+
+    /// <summary>
+    /// Extracts the management group ID when the scope refers to a management group itself.
+    /// </summary>
+    /// <param name="scope">The requested scope.</param>
+    /// <param name="managementGroup">The management group ID, when the scope is a management group scope.</param>
+    /// <returns><c>true</c> when the scope is a management group scope; otherwise <c>false</c>.</returns>
+    public static bool TryParse(string? scope, out string managementGroup)
+    {
+        managementGroup = string.Empty;
+        if (string.IsNullOrEmpty(scope) || !scope.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var remainder = scope[Prefix.Length..].Trim('/');
+        if (remainder.Length == 0 || remainder.Contains('/'))
+        {
+            // A nested provider path below a management group is a resource scope, not a management group scope.
+            return false;
+        }
+
+        managementGroup = remainder;
+        return true;
+    }
+}

--- a/tools/Azure.Mcp.Tools.Authorization/src/Options/RoleAssignmentListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Options/RoleAssignmentListOptions.cs
@@ -8,12 +8,12 @@ namespace Azure.Mcp.Tools.Authorization.Options;
 
 public sealed class RoleAssignmentListOptions : ISubscriptionOption
 {
-    [Option(Description = "Scope at which the role assignment or definition applies to, e.g., /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333, /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup, or /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM.")]
+    [Option(Description = "Scope at which the role assignment applies, e.g., /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333, /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup, /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM, or /providers/Microsoft.Management/managementGroups/myManagementGroup.")]
     public required string Scope { get; set; }
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [Option(Description = OptionDescriptions.Subscription)]
+    [Option(Description = OptionDescriptions.Subscription + " Not required when the scope is a management group.")]
     public string? Subscription { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Authorization/src/Options/RoleAssignmentListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Options/RoleAssignmentListOptions.cs
@@ -14,6 +14,6 @@ public sealed class RoleAssignmentListOptions : ISubscriptionOption
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
 
-    [Option(Description = OptionDescriptions.Subscription + " Not required when the scope is a management group.")]
+    [Option(Description = OptionDescriptions.Subscription + " Must not be specified when the scope is a management group.")]
     public string? Subscription { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Authorization/src/Services/AuthorizationService.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Services/AuthorizationService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using Azure.Core;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.Authorization.Models;
 using Azure.Mcp.Tools.Authorization.Services.Models;
@@ -12,22 +11,45 @@ namespace Azure.Mcp.Tools.Authorization.Services;
 public class AuthorizationService(IAzureService azureService)
     : BaseAzureResourceService(azureService), IAuthorizationService
 {
+    private const string RoleAssignmentsTable = "authorizationresources";
+    private const string RoleAssignmentResourceType = "Microsoft.Authorization/roleAssignments";
+
     public async Task<ResourceQueryResults<RoleAssignment>> ListRoleAssignmentsAsync(
-        string subscription,
+        string? subscription,
         string scope,
         string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters((nameof(scope), scope));
 
-        var scopeId = new ResourceIdentifier(scope!);
+        // Match the scope itself, plus anything nested beneath it. The trailing separator keeps a scope
+        // ending in "rg1" from also matching "rg10".
+        var escapedScope = EscapeKqlString(scope.TrimEnd('/'));
+        var scopeFilter = $"(properties.scope =~ '{escapedScope}' or properties.scope startswith '{escapedScope}/')";
+
+        if (ManagementGroupScope.TryParse(scope, out var managementGroup))
+        {
+            // Role assignments on a management group are not part of any subscription, so a
+            // subscription-scoped Resource Graph query can never return them.
+            return await ExecuteManagementGroupResourceQueryAsync(
+                RoleAssignmentResourceType,
+                managementGroup,
+                ConvertToRoleAssignmentModel,
+                RoleAssignmentsTable,
+                additionalFilter: scopeFilter,
+                tenant: tenantId,
+                cancellationToken: cancellationToken);
+        }
+
+        ValidateRequiredParameters((nameof(subscription), subscription));
+
         return await ExecuteResourceQueryAsync(
-            "Microsoft.Authorization/roleAssignments",
+            RoleAssignmentResourceType,
             null, // all resource groups
-            subscription,
+            subscription!,
             ConvertToRoleAssignmentModel,
-            "authorizationresources",
-            additionalFilter: $"id contains '{EscapeKqlString(scope)}'",
+            RoleAssignmentsTable,
+            additionalFilter: scopeFilter,
             tenant: tenantId,
             cancellationToken: cancellationToken);
     }

--- a/tools/Azure.Mcp.Tools.Authorization/src/Services/AuthorizationService.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Services/AuthorizationService.cs
@@ -20,7 +20,7 @@ public class AuthorizationService(IAzureService azureService)
         string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(scope), scope));
+        ValidateRequiredParameter(nameof(scope), scope);
 
         // Match the scope itself, plus anything nested beneath it. The trailing separator keeps a scope
         // ending in "rg1" from also matching "rg10".
@@ -29,6 +29,13 @@ public class AuthorizationService(IAzureService azureService)
 
         if (ManagementGroupScope.TryParse(scope, out var managementGroup))
         {
+            if (!string.IsNullOrEmpty(subscription))
+            {
+                throw new ArgumentException(
+                    "Subscription must not be specified for a management group scope.",
+                    nameof(subscription));
+            }
+
             // Role assignments on a management group are not part of any subscription, so a
             // subscription-scoped Resource Graph query can never return them.
             return await ExecuteManagementGroupResourceQueryAsync(
@@ -41,12 +48,12 @@ public class AuthorizationService(IAzureService azureService)
                 cancellationToken: cancellationToken);
         }
 
-        ValidateRequiredParameters((nameof(subscription), subscription));
+        ValidateRequiredParameter(nameof(subscription), subscription);
 
         return await ExecuteResourceQueryAsync(
             RoleAssignmentResourceType,
             null, // all resource groups
-            subscription!,
+            subscription,
             ConvertToRoleAssignmentModel,
             RoleAssignmentsTable,
             additionalFilter: scopeFilter,

--- a/tools/Azure.Mcp.Tools.Authorization/src/Services/IAuthorizationService.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Services/IAuthorizationService.cs
@@ -9,15 +9,18 @@ namespace Azure.Mcp.Tools.Authorization.Services;
 public interface IAuthorizationService
 {
     /// <summary>
-    /// Lists all role assignments in the subscription.
+    /// Lists the role assignments at or below the requested scope.
     /// </summary>
-    /// <param name="subscription">The subscription ID to query.</param>
-    /// <param name="scope">The scope that the resource will apply against.</param>
+    /// <param name="subscription">
+    /// The subscription ID to query. Not required when <paramref name="scope"/> is a management group scope,
+    /// because those assignments live outside any subscription.
+    /// </param>
+    /// <param name="scope">The scope that the role assignments apply against.</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations.</param>
     /// <param name="cancellationToken">Optional cancellation token for the operation.</param>
-    /// <returns>List of role assignments in the format "Role Definition ID: Principal ID"</returns>
+    /// <returns>The role assignments found at or below the scope.</returns>
     Task<ResourceQueryResults<RoleAssignment>> ListRoleAssignmentsAsync(
-        string subscription,
+        string? subscription,
         string scope,
         string? tenantId = null,
         CancellationToken cancellationToken = default);

--- a/tools/Azure.Mcp.Tools.Authorization/src/Services/IAuthorizationService.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Services/IAuthorizationService.cs
@@ -12,7 +12,7 @@ public interface IAuthorizationService
     /// Lists the role assignments at or below the requested scope.
     /// </summary>
     /// <param name="subscription">
-    /// The subscription ID to query. Not required when <paramref name="scope"/> is a management group scope,
+    /// The subscription ID or name to query. Not required when <paramref name="scope"/> is a management group scope,
     /// because those assignments live outside any subscription.
     /// </param>
     /// <param name="scope">The scope that the role assignments apply against.</param>

--- a/tools/Azure.Mcp.Tools.Authorization/src/Services/IAuthorizationService.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/src/Services/IAuthorizationService.cs
@@ -12,8 +12,8 @@ public interface IAuthorizationService
     /// Lists the role assignments at or below the requested scope.
     /// </summary>
     /// <param name="subscription">
-    /// The subscription ID or name to query. Not required when <paramref name="scope"/> is a management group scope,
-    /// because those assignments live outside any subscription.
+    /// The subscription ID or name to query. Must be <see langword="null"/> when <paramref name="scope"/> is a
+    /// management group scope because those assignments live outside any subscription.
     /// </param>
     /// <param name="scope">The scope that the role assignments apply against.</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations.</param>

--- a/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/AuthorizationServiceManagementGroupTransportTests.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/AuthorizationServiceManagementGroupTransportTests.cs
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Mcp.Core.Services.Azure;
+using Azure.Mcp.Tools.Authorization.Services;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Authorization.Tests;
+
+/// <summary>
+/// Exercises <see cref="AuthorizationService.ListRoleAssignmentsAsync"/> against a real
+/// <see cref="ArmClient"/> whose transport is a fake <see cref="HttpMessageHandler"/>, rather than
+/// mocking <see cref="IAuthorizationService"/> or <see cref="Azure.ResourceManager.ResourceGraph.Models.ResourceQueryContent"/>
+/// directly. This is what actually regresses if the management-group scoping fix is undone: it asserts
+/// the outgoing Resource Graph request body scopes to <c>managementGroups</c> (never <c>subscriptions</c>)
+/// and that the response is mapped back into a <see cref="Azure.Mcp.Tools.Authorization.Models.RoleAssignment"/>.
+/// </summary>
+public sealed class AuthorizationServiceManagementGroupTransportTests
+{
+    [Fact]
+    public async Task ListRoleAssignmentsAsync_ManagementGroupScope_QueriesManagementGroupsAndMapsResponse()
+    {
+        // Arrange
+        const string managementGroup = "mg-contoso";
+        var scope = $"/providers/Microsoft.Management/managementGroups/{managementGroup}";
+        var assignmentId = Guid.NewGuid();
+        var principalId = Guid.NewGuid();
+        var roleDefinitionId = $"/providers/Microsoft.Authorization/roleDefinitions/{Guid.NewGuid()}";
+
+        var tenantId = Guid.NewGuid();
+        var armHandler = new CapturingHttpMessageHandler((request, _) => Task.FromResult(
+            request.Method == HttpMethod.Get
+                ? CreateTenantListResponse(tenantId)
+                : CreateResourceGraphResponse(scope, assignmentId, principalId, roleDefinitionId)));
+
+        var credential = Substitute.For<TokenCredential>();
+        credential.GetTokenAsync(Arg.Any<TokenRequestContext>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<AccessToken>(new AccessToken("fake-arm-token", DateTimeOffset.UtcNow.AddHours(1))));
+
+        var armOptions = new ArmClientOptions
+        {
+            Transport = new HttpClientTransport(new HttpClient(armHandler))
+        };
+        armOptions.Retry.MaxRetries = 0;
+
+        var armClient = new ArmClient(credential, defaultSubscriptionId: null, armOptions);
+
+        // TenantResource has no accessible public constructor for tests, so obtain a real instance
+        // the same way production code does: list tenants through the ArmClient (backed by the fake
+        // transport above) rather than constructing one directly.
+        var tenants = new List<TenantResource>();
+        await foreach (var tenant in armClient.GetTenants().GetAllAsync(TestContext.Current.CancellationToken))
+        {
+            tenants.Add(tenant);
+        }
+
+        var azureService = Substitute.For<IAzureService>();
+        azureService.GetTenants(Arg.Any<CancellationToken>()).Returns(tenants);
+
+        var service = new AuthorizationService(azureService);
+
+        // Act: no subscription and no explicit tenant, matching how the command invokes a management-group scope.
+        var result = await service.ListRoleAssignmentsAsync(
+            subscription: null,
+            scope: scope,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert: one call to list tenants, one Resource Graph call scoped to the management group
+        // (never to a subscription).
+        Assert.Equal(2, armHandler.CallCount);
+        Assert.NotNull(armHandler.LastRequestBody);
+
+        using var requestBody = JsonDocument.Parse(armHandler.LastRequestBody);
+        var root = requestBody.RootElement;
+        Assert.Equal(managementGroup, root.GetProperty("managementGroups")[0].GetString());
+        Assert.True(
+            !root.TryGetProperty("subscriptions", out var subscriptions) || subscriptions.GetArrayLength() == 0,
+            "The management-group query must not scope the request to any subscription.");
+
+        // Assert: the Resource Graph response was mapped back into a RoleAssignment.
+        var assignment = Assert.Single(result.Results);
+        Assert.Equal($"{scope}/providers/Microsoft.Authorization/roleAssignments/{assignmentId}", assignment.Id);
+        Assert.Equal(scope, assignment.Scope);
+        Assert.Equal(principalId, assignment.PrincipalId);
+        Assert.Equal("ServicePrincipal", assignment.PrincipalType);
+        Assert.Equal(roleDefinitionId, assignment.RoleDefinitionId);
+        Assert.False(result.AreResultsTruncated);
+    }
+
+    private static HttpResponseMessage CreateTenantListResponse(Guid tenantId)
+    {
+        var payload = new
+        {
+            value = new[]
+            {
+                new
+                {
+                    id = $"/tenants/{tenantId}",
+                    tenantId = tenantId.ToString()
+                }
+            }
+        };
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
+        };
+    }
+
+    private static HttpResponseMessage CreateResourceGraphResponse(
+        string scope,
+        Guid assignmentId,
+        Guid principalId,
+        string roleDefinitionId)
+    {
+        var payload = new
+        {
+            totalRecords = 1,
+            count = 1,
+            resultTruncated = "false",
+            data = new[]
+            {
+                new
+                {
+                    id = $"{scope}/providers/Microsoft.Authorization/roleAssignments/{assignmentId}",
+                    name = assignmentId.ToString(),
+                    type = "Microsoft.Authorization/roleAssignments",
+                    properties = new
+                    {
+                        scope,
+                        principalId,
+                        principalType = "ServicePrincipal",
+                        roleDefinitionId
+                    }
+                }
+            }
+        };
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class CapturingHttpMessageHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responseFactory)
+        : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+        public string? LastRequestBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            LastRequestBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            return await responseFactory(request, cancellationToken);
+        }
+    }
+}

--- a/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/AuthorizationServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/AuthorizationServiceTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Mcp.Core.Services.Azure;
+using Azure.Mcp.Tools.Authorization.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Azure.Mcp.Tools.Authorization.Tests;
+
+public sealed class AuthorizationServiceTests
+{
+    [Fact]
+    public async Task ListRoleAssignmentsAsync_RejectsSubscription_ForManagementGroupScope()
+    {
+        var service = new AuthorizationService(Substitute.For<IAzureService>());
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.ListRoleAssignmentsAsync(
+                "00000000-0000-0000-0000-000000000001",
+                "/providers/Microsoft.Management/managementGroups/mg-contoso",
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal("subscription", exception.ParamName);
+    }
+}

--- a/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/RoleAssignmentListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/RoleAssignmentListCommandTests.cs
@@ -83,6 +83,84 @@ public class RoleAssignmentListCommandTests : SubscriptionCommandUnitTestsBase<R
     }
 
     [Fact]
+    public async Task ExecuteAsync_QueriesManagementGroupScope_WithoutSubscription()
+    {
+        // Arrange
+        var scope = "/providers/Microsoft.Management/managementGroups/mg-contoso";
+        var assignmentId = "00000000-0000-0000-0000-000000000003";
+        var expected = new ResourceQueryResults<RoleAssignment>(
+        [
+            new() {
+                Id = $"{scope}/providers/Microsoft.Authorization/roleAssignments/{assignmentId}",
+                Name = "Reader",
+                PrincipalId = new Guid(assignmentId),
+                PrincipalType = "ServicePrincipal",
+                Scope = scope
+            }
+        ], false);
+
+        Service.ListRoleAssignmentsAsync(null, scope, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(expected);
+
+        // Act: a management group scope is outside every subscription, so --subscription is not supplied.
+        var response = await ExecuteCommandAsync("--scope", scope);
+
+        // Assert
+        var result = ValidateAndDeserializeResponse(response, AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);
+
+        Assert.Equal(expected.Results, result.Assignments);
+        await Service.Received(1).ListRoleAssignmentsAsync(null, scope, Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EchoesQueriedScope()
+    {
+        // Arrange
+        var subscriptionId = "00000000-0000-0000-0000-000000000001";
+        var scope = $"/subscriptions/{subscriptionId}/resourceGroups/rg1";
+        Service.ListRoleAssignmentsAsync(subscriptionId, scope, null, TestContext.Current.CancellationToken)
+            .Returns(new ResourceQueryResults<RoleAssignment>([], false));
+
+        // Act
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId, "--scope", scope);
+
+        // Assert: an empty result must still say which scope produced it.
+        var result = ValidateAndDeserializeResponse(response, AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);
+
+        Assert.Equal(scope, result.Scope);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RequiresSubscription_ForNonManagementGroupScope()
+    {
+        // Arrange
+        var scope = "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1";
+
+        // Act
+        var response = await ExecuteCommandAsync("--scope", scope);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("--subscription", response.Message);
+    }
+
+    [Theory]
+    [InlineData("/providers/Microsoft.Management/managementGroups/mg-contoso", true, "mg-contoso")]
+    [InlineData("/PROVIDERS/MICROSOFT.MANAGEMENT/MANAGEMENTGROUPS/mg-contoso", true, "mg-contoso")]
+    [InlineData("/providers/Microsoft.Management/managementGroups/mg-contoso/", true, "mg-contoso")]
+    [InlineData("/subscriptions/00000000-0000-0000-0000-000000000001", false, "")]
+    [InlineData("/providers/Microsoft.Management/managementGroups/", false, "")]
+    // A resource nested under a management group is a resource scope, not a management group scope.
+    [InlineData("/providers/Microsoft.Management/managementGroups/mg-contoso/providers/Microsoft.Authorization/roleAssignments/abc", false, "")]
+    public void TryParse_RecognizesManagementGroupScopes(string scope, bool expectedResult, string expectedManagementGroup)
+    {
+        var actualResult = ManagementGroupScope.TryParse(scope, out var actualManagementGroup);
+
+        Assert.Equal(expectedResult, actualResult);
+        Assert.Equal(expectedManagementGroup, actualManagementGroup);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_HandlesException()
     {
         // Arrange

--- a/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/RoleAssignmentListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/RoleAssignmentListCommandTests.cs
@@ -146,7 +146,7 @@ public class RoleAssignmentListCommandTests : SubscriptionCommandUnitTestsBase<R
 
     [Theory]
     [InlineData("/providers/Microsoft.Management/managementGroups/mg-contoso", true, "mg-contoso")]
-    [InlineData("/PROVIDERS/MICROSOFT.MANAGEMENT/MANAGEMENTGROUPS/mg-contoso", true, "mg-contoso")]
+    [InlineData("/PROVIDERS/Microsoft.Management/ManagementGroups/mg-contoso", true, "mg-contoso")]
     [InlineData("/providers/Microsoft.Management/managementGroups/mg-contoso/", true, "mg-contoso")]
     [InlineData("/subscriptions/00000000-0000-0000-0000-000000000001", false, "")]
     [InlineData("/providers/Microsoft.Management/managementGroups/", false, "")]

--- a/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/RoleAssignmentListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/RoleAssignmentListCommandTests.cs
@@ -87,6 +87,7 @@ public class RoleAssignmentListCommandTests : SubscriptionCommandUnitTestsBase<R
     {
         // Arrange
         var scope = "/providers/Microsoft.Management/managementGroups/mg-contoso";
+        SubscriptionResolver.ResolveSubscription(null).Returns("default-subscription");
         var assignmentId = "00000000-0000-0000-0000-000000000003";
         var expected = new ResourceQueryResults<RoleAssignment>(
         [
@@ -110,6 +111,26 @@ public class RoleAssignmentListCommandTests : SubscriptionCommandUnitTestsBase<R
 
         Assert.Equal(expected.Results, result.Assignments);
         await Service.Received(1).ListRoleAssignmentsAsync(null, scope, Arg.Any<string>(), Arg.Any<CancellationToken>());
+        SubscriptionResolver.DidNotReceive().ResolveSubscription(Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RejectsSubscription_ForManagementGroupScope()
+    {
+        // Arrange
+        var scope = "/providers/Microsoft.Management/managementGroups/mg-contoso";
+
+        // Act
+        var response = await ExecuteCommandAsync(
+            "--subscription",
+            "00000000-0000-0000-0000-000000000001",
+            "--scope",
+            scope);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.Contains("--subscription", response.Message);
+        Assert.Empty(Service.ReceivedCalls());
     }
 
     [Fact]

--- a/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/assets.json
+++ b/tools/Azure.Mcp.Tools.Authorization/tests/Azure.Mcp.Tools.Authorization.Tests/assets.json
@@ -2,5 +2,5 @@
     "AssetsRepo": "Azure/azure-sdk-assets",
     "AssetsRepoPrefixPath": "",
     "TagPrefix": "Azure.Mcp.Tools.Authorization.Tests",
-    "Tag": "Azure.Mcp.Tools.Authorization.Tests_65ebb9af0a"
+    "Tag": "Azure.Mcp.Tools.Authorization.Tests_a8cd50f9a5"
 }


### PR DESCRIPTION
## Description

`role_assignment_list` returned an empty array with a `200` success response for any management group scope, so callers could not tell "no assignments" from "not queried".

### Root cause

`BaseAzureResourceService.ExecuteResourceQueryAsync` built every Resource Graph query with only `Subscriptions` populated on `ResourceQueryContent`, never `ManagementGroups` (`core/Azure.Mcp.Core/src/Services/Azure/BaseAzureResourceService.cs:115-118` before this change). Management group role assignments have IDs of the form:

```
/providers/Microsoft.Management/managementGroups/<mg>/providers/Microsoft.Authorization/roleAssignments/<guid>
```

They live outside any subscription, so Resource Graph excluded them from the result set before the scope filter was ever applied. The query itself succeeded, which is why the tool reported success with zero rows.

### Changes

1. **Management group scoping.** Added `ExecuteManagementGroupResourceQueryAsync<T>` to `BaseAzureResourceService`, which populates `ManagementGroups` instead of `Subscriptions`. `AuthorizationService` routes management group scopes to it. A private `ResolveTenantResourceAsync` obtains the `TenantResource` without needing a subscription.
2. **Anchored scope filter.** The previous filter was `id contains '<scope>'`, an unanchored substring match, so requesting `.../resourceGroups/rg1` also returned assignments from `rg10`. It is now `(properties.scope =~ '<scope>' or properties.scope startswith '<scope>/')`. Both KQL operators are case-insensitive, which matters because Resource Graph returns `resourcegroups` in lowercase.
3. **Subscription handling is scope-aware.** Management groups sit outside subscriptions, so the shared `SubscriptionCommand` now has an explicit applicability hook used by both subscription resolution and validation. Management group scopes skip ambient subscription resolution and reject an explicitly supplied `--subscription`; every other supported scope still requires one.
4. **The requested scope is echoed in the result**, so an empty list is attributable to a specific scope. This was explicitly requested in the issue.

### Semantics

Results remain **at and below** the requested scope. Assignments inherited from a parent scope are **not** included, and this PR does not add an `--include-inherited` option. This is now stated in the tool description, in `azmcp-commands.md`, and in the option help so the behavior is no longer implicit.

### Not addressed

The issue also notes that an insufficient-permissions result should surface an error rather than an empty success. Resource Graph returns zero rows for both "nothing there" and "you cannot see it", so the two are not distinguishable at this layer. Left as a separate concern.

## Testing

- `Azure.Mcp.Tools.Authorization.Tests` — 15/15 pass, including the recorded `Should_list_role_assignments` integration test.
- Six new unit tests cover: a management group scope with no subscription or ambient subscription resolution, rejection of an explicit subscription for management group scopes at both command and service layers, the scope being echoed on an empty result, `--subscription` still being required for non-management-group scopes, and a six-case theory over `ManagementGroupScope.TryParse` (casing, trailing slash, empty remainder, nested provider path).
- The existing recording was re-pushed (`Azure.Mcp.Tools.Authorization.Tests_a8cd50f9a5`) because the anchored filter changes the request body the test proxy matches on. The recorded response contains a single assignment whose scope is exactly the test resource group, so both the old and new queries select the identical row — the response payload is unchanged.
- Full `dotnet build` succeeds; `dotnet format --verify-no-changes` and `Invoke-Cspell.ps1` are clean.

**Known limitation:** there is no recorded or live test for the management group path. Recording one requires a real management group, which the tenant-level permissions in the existing `test-resources.bicep` cannot provision.

## Pre-merge checklist

- [x] Unit tests added for the new behavior
- [x] `servers/Azure.Mcp.Server/docs/azmcp-commands.md` updated
- [x] `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md` updated with two new prompts
- [x] Changelog entry added under `servers/Azure.Mcp.Server/changelog-entries/`
- [x] Spell check clean
- [x] `dotnet format` clean
- [x] Recordings updated and pushed; `assets.json` `Tag` bumped
- [n/a] `consolidated-tools.json` — no tool is added, renamed, or removed
- [x] **ToolDescriptionEvaluator score** — the tool description changed, so a score is required. 

Evaluator results ( text-embedding-3-large ) — new description beats the original on every prompt that routes:

┌───────────────────────────────────────────────┬────────────┬────────────┐
│ Prompt                                        │ Original   │ New        │
├───────────────────────────────────────────────┼────────────┼────────────┤
│ list role assignments for my management group │ #2, 0.5477 │ #1, 0.6406 │
├───────────────────────────────────────────────┼────────────┼────────────┤
│ show rbac role assignments at this scope      │ #1, 0.5920 │ #1, 0.6068 │
└───────────────────────────────────────────────┴────────────┴────────────┘

Both rank #1, comfortably above the 0.4 threshold. Checkbox ticked in the PR body with the numbers.

One incidental finding: `Who has access to resource group X?` does not surface `role_assignment_list` in the top 10 — for the old description and the new one alike, so it is a pre-existing discovery gap rather than something this PR caused.

**Update following review feedback.** `role_assignment_list` exposes only `--scope`, `--subscription` and `--tenant`, so the two prompts originally added to `e2eTestPrompts.md` wrongly implied `management-group` and `resource-group` parameters. Both now name `--scope` and give the value as an explicit ARM scope path:

- `List the role assignments at scope /providers/Microsoft.Management/managementGroups/<management-group>`
- `List the role assignments at scope /subscriptions/<subscription>/resourceGroups/<resource-group>`

The tool description has also had the inaccurate `, returned as a JSON array` clause removed. That is a pure deletion, so the text measured in the table above still stands and no re-score was required.

A later review also led to an explicit subscription-applicability hook in `SubscriptionCommand`, clearer `<null>`/`<empty>` scope logging, and a `[NotNull]` single-parameter validation helper that removes the null-forgiveness operator. Azure Resource Graph supports tenant-wide queries by omitting both subscription and management-group scopes, but `/` is not added in this focused management-group fix because tenant-wide semantics, permissions, and testing need separate design work.

Fixes #3285

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.