### PR TITLE
docs(monitor): add e2e test prompts for monitor_webtests_get (#3212)

### DIFF
--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -955,6 +955,8 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | monitor_table_type_list | Show me the available table types in the Log Analytics workspace <workspace_name> | none |
 | monitor_webtests_createorupdate | Create a new Standard Web Test with name <webtest_resource_name> in my subscription in <resource_group> in a given <appinsights_component> | none |
 | monitor_webtests_createorupdate | Update an existing Standard Web Test with name <webtest_resource_name> in my subscription in <resource_group> in a given <appinsights_component> | none |
+| monitor_webtests_get | Get details for the web test named <webtest_resource_name> in <resource_group> | none |
+| monitor_webtests_get | List all web tests in my subscription | none |
 | monitor_workspace_list | List all Log Analytics workspaces in my subscription | none |
 | monitor_workspace_list | Show me my Log Analytics workspaces | none |
 | monitor_workspace_list | Show me the Log Analytics workspaces in my subscription | none |


### PR DESCRIPTION
## Summary
- Fixes #3212
- Adds missing `monitor_webtests_get` prompt entries to `servers/Azure.Mcp.Server/docs/e2eTestPrompts.md` under Azure Monitor section.
- Maintains alphabetical ordering following `monitor_webtests_createorupdate`.