### PR TITLE
docs(azurebackup): document valid workload-type values for protectableitem list (#2745)

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -1165,12 +1165,13 @@ azmcp azurebackup protecteditem undelete --subscription <subscription> \
 
 ```bash
 # Lists protectable items (SQL databases, SAP HANA databases) discovered in the Recovery Services vault.
+# --workload-type values are case-insensitive
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp azurebackup protectableitem list --subscription <subscription> \
                                        --resource-group <resource-group> \
                                        --vault <vault> \
                                        [--vault-type <vault-type>] \
-                                       [--workload-type <workload-type>] \
+                                       [--workload-type <SQL|SQLDatabase|SQLInstance|SAPHana|SAPHanaDatabase|SAPHanaSystem|SAPHanaDBInstance|SAPHanaDBI|VM|IaaSVM|VirtualMachine|FileShare|AzureFileShare|AFS|SAPAse|SAPAseDatabase|ASE|Sybase>] \
                                        [--container <container>]
 ```
 


### PR DESCRIPTION
## Summary
- Fixes #2745
- Enumerates all accepted `--workload-type` values and aliases for `azmcp azurebackup protectableitem list` in `servers/Azure.Mcp.Server/docs/azmcp-commands.md`.
- Adds comment clarifying case-insensitivity according to `WorkloadTypeNormalizer`.