### PR TITLE
docs(advisor): document valid resource values for recommendation apply (#2762)

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -406,6 +406,15 @@ azmcp advisor recommendation summary --subscription <subscription> \
 
 # Apply Advisor recommendation to create or modify IaaC files (like ARM, Terraform) for Azure resources
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
+# Supported --resource values:
+#   aad_domainservices, apimanagement_service, cognitiveservices_accounts,
+#   compute_virtualmachines, compute_virtualmachinescalesets,
+#   containerregistry_registries, containerservice_managedclusters,
+#   dbforpostgresql_flexibleservers, documentdb_databaseaccounts,
+#   keyvault_vaults, kubernetes_connectedclusters, kubernetesconfiguration_extensions,
+#   netapp_volumes, network_applicationgatewaywebapplicationfirewallpolicies,
+#   network_expressrouteports, network_frontdoorwebapplicationfirewallpolicies,
+#   sql_managedinstances, storage_storageaccounts, web_serverfarms, web_staticsites
 azmcp advisor recommendation apply --resource <resource>
 
 # List the global Azure Advisor recommendation metadata catalog (also called recommendation types) from Azure Resource


### PR DESCRIPTION
## Summary
- Fixes #2762
- Expands `azmcp advisor recommendation apply` command docs in `servers/Azure.Mcp.Server/docs/azmcp-commands.md` to list all 20 valid `--resource` values.