### PR TITLE
docs(aks): clarify retry options are not supported for aks commands (#3408)

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3111,7 +3111,7 @@ azmcp keyvault secret get --subscription <subscription> \
 ### Azure Kubernetes Service (AKS) Operations
 
 > [!NOTE]
-> The `aks cluster get` and `aks nodepool get` commands do not support `--auth-method` (the `--retry-*` options are still supported).
+> The `aks cluster get` and `aks nodepool get` commands do not support `--auth-method` or any `--retry-*` options.
 
 ```bash
 # Gets Azure Kubernetes Service (AKS) cluster details


### PR DESCRIPTION
## Summary
- Fixes #3408
- Updates note in `servers/Azure.Mcp.Server/docs/azmcp-commands.md` under Azure Kubernetes Service (AKS) Operations to state that `--auth-method` and `--retry-*` options are not supported, reflecting removal in PR #3404.