### PR TITLE
docs(redis): update redis create parameters to use --resource and add missing options (#3073)

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3968,9 +3968,11 @@ azmcp role assignment list --subscription <subscription> \
 # ✅ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp redis create --subscription <subscription> \
                    --resource-group <resource-group> \
-                   --name <name> \
-                   --sku <sku> \
+                   --resource <resource> \
                    --location <location> \
+                   [--sku <sku>] \
+                   [--access-keys-authentication <true|false>] \
+                   [--public-network-access <true|false>] \
                    [--modules <modules>]
 ```
 


### PR DESCRIPTION
## Summary
- Fixes #3073
- Updates `azmcp redis create` in `servers/Azure.Mcp.Server/docs/azmcp-commands.md` to use `--resource` instead of `--name`, and adds missing `--access-keys-authentication` and `--public-network-access` options reflecting changes from PR #3065.