### PR TITLE
docs(advisor): add summary example prompts to README (#2913)

### DIFF
--- a/servers/Azure.Mcp.Server/README.md
+++ b/servers/Azure.Mcp.Server/README.md
@@ -954,6 +954,8 @@ For full configuration options, see the [Sovereign Clouds documentation](https:/
 ### 📊 Azure Advisor
 
 * "List my Advisor recommendations"
+* "Summarize my Advisor recommendations by category"
+* "Which resource types have the most high-impact Advisor recommendations?"
 * "Mark an Advisor recommendation as completed"
 * "Dismiss an Advisor recommendation because the risk is acceptable"
 * "Postpone an Advisor recommendation until December 31, 2026"


### PR DESCRIPTION
## Summary
- Fixes #2913
- Adds missing `recommendation summary` example prompts to the Azure Advisor section in `servers/Azure.Mcp.Server/README.md`, covering category summarization and high-impact resource query patterns.