### PR TITLE
docs(cli): refresh global options table descriptions and option names (#3224)

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -9,9 +9,14 @@ The following options are available for most commands:
 
 | Option | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `--subscription` | No | Environment variable `AZURE_SUBSCRIPTION_ID` | Azure subscription ID for target resources |
-| `--tenant-id` | No | - | Azure tenant ID for authentication |
+| `--subscription` | No | Azure CLI profile default or `AZURE_SUBSCRIPTION_ID` env var | The Azure subscription GUID identifier or display name. If not specified, the Azure CLI profile default subscription or `AZURE_SUBSCRIPTION_ID` environment variable will be used. |
+| `--tenant` | No | - | The Microsoft Entra ID tenant GUID identifier or display name. |
 | `--auth-method` | No | 'credential' | Authentication method ('credential', 'key', 'connectionString') |
+| `--retry-max-retries` | No | 3 | Maximum number of retry attempts. |
+| `--retry-delay` | No | 2 | Initial delay in seconds. For exponential backoff, this value is used as the base. |
+| `--retry-max-delay` | No | 10 | Maximum delay in seconds, regardless of the retry strategy. |
+| `--retry-mode` | No | 'exponential' | Retry strategy to use. 'fixed' uses consistent delays, 'exponential' increases delay between attempts. |
+| `--retry-network-timeout` | No | 100 | Network operation timeout in seconds. |
 | `--learn` | No | false | Discover available sub-commands and their parameters without executing any Azure operation. Use on a command group to list commands in that group, or on a specific command to see its options. |
 
 ### Discovery with `--learn`


### PR DESCRIPTION
## Summary
- Fixes #3224
- Refreshes global options table in `servers/Azure.Mcp.Server/docs/azmcp-commands.md` to align parameter names (`--tenant` instead of `--tenant-id`) and descriptions with centralized `OptionDescriptions` and `RetryPolicyOptions`.