### PR TITLE
docs(cli): document unsupported retry options for communication and compute commands (#3416)

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -1351,6 +1351,9 @@ azmcp extension cli install --cli-type <cli-type>
 
 ### Azure Communication Services Operations
 
+> [!NOTE]
+> The `communication email send` and `communication sms send` commands do not support `--auth-method` or any `--retry-*` options.
+
 #### Email
 
 ```bash
@@ -1450,6 +1453,9 @@ azmcp communication sms send --endpoint "https://mycomms.communication.azure.com
 
 
 ### Azure Compute Operations
+
+> [!NOTE]
+> The `compute disk`, `compute vm`, and `compute vmss` commands do not support `--auth-method` or any `--retry-*` options.
 
 #### Virtual Machines
 


### PR DESCRIPTION
## Summary
- Fixes #3416
- Adds notes to Azure Communication Services and Azure Compute sections in `servers/Azure.Mcp.Server/docs/azmcp-commands.md` clarifying that `--auth-method` and `--retry-*` options are not supported after PRs #3406 and #3407.