### PR TITLE
docs(virtualdesktop): document unsupported auth-method option (#2943)

### DIFF
--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -5176,6 +5176,9 @@ azmcp azureterraform conftest plan --plan-folder <plan-folder> \
 
 ### Azure Virtual Desktop Operations
 
+> [!NOTE]
+> The `virtualdesktop hostpool list`, `virtualdesktop hostpool host list`, and `virtualdesktop hostpool host user-list` commands do not support the `--auth-method` global option. Authentication always uses the default credential flow.
+
 ```bash
 # List Azure Virtual Desktop host pools in a subscription
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired


### PR DESCRIPTION
## Summary
- Fixes #2943
- Adds note to Azure Virtual Desktop Operations in `servers/Azure.Mcp.Server/docs/azmcp-commands.md` clarifying that `--auth-method` is not supported following the options migration in PR #2941.