### PR TITLE
Handle Cloud Not Supported Scenario for FileShare Tool

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/1788973074981.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/1788973074981.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed unclear error when using Azure File Shares tools in clouds where the Microsoft.FileShares resource provider is not yet available."

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/BaseFileSharesCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/BaseFileSharesCommand.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using Azure.Mcp.Core.Commands.Subscription;
+using Azure.Mcp.Core.Options;
+using Azure.Mcp.Core.Services.Azure.Subscription;
+using Microsoft.Mcp.Core.Commands;
+
+namespace Azure.Mcp.Tools.FileShares.Commands;
+
+/// <summary>
+/// Base command for Azure File Shares operations. The Microsoft.FileShares resource provider is a new
+/// ARM resource provider that is not registered in all clouds. This base class handles scenario where tool is called in a non supported cloud to ensure there is a clear error message.
+/// </summary>
+public abstract class BaseFileSharesCommand<[DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions, TResult>(ISubscriptionResolver subscriptionResolver)
+    : SubscriptionCommand<TOptions, TResult>(subscriptionResolver) where TOptions : class, ISubscriptionOption
+{
+    protected override string GetErrorMessage(Exception ex) => ex switch
+    {
+        RequestFailedException reqEx when IsResourceProviderUnavailable(reqEx) =>
+            $"Azure File Shares (the Microsoft.FileShares resource provider) is not available in this cloud. Details: {reqEx.Message}",
+        _ => base.GetErrorMessage(ex)
+    };
+
+    protected override HttpStatusCode GetStatusCode(Exception ex) => ex switch
+    {
+        RequestFailedException reqEx when IsResourceProviderUnavailable(reqEx) => HttpStatusCode.NotImplemented,
+        _ => base.GetStatusCode(ex)
+    };
+
+    private static bool IsResourceProviderUnavailable(RequestFailedException ex) =>
+        string.Equals(ex.ErrorCode, "InvalidResourceNamespace", StringComparison.OrdinalIgnoreCase);
+}

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/BaseFileSharesCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/BaseFileSharesCommand.cs
@@ -20,7 +20,7 @@ public abstract class BaseFileSharesCommand<[DynamicallyAccessedMembers(TrimAnno
     protected override string GetErrorMessage(Exception ex) => ex switch
     {
         RequestFailedException reqEx when IsResourceProviderUnavailable(reqEx) =>
-            "Azure File Shares (the Microsoft.FileShares resource provider) is not available in this cloud.",
+            "Azure File Shares (the Microsoft.FileShares resource provider) is not available in this cloud",
         _ => base.GetErrorMessage(ex)
     };
 

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/BaseFileSharesCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/BaseFileSharesCommand.cs
@@ -20,7 +20,7 @@ public abstract class BaseFileSharesCommand<[DynamicallyAccessedMembers(TrimAnno
     protected override string GetErrorMessage(Exception ex) => ex switch
     {
         RequestFailedException reqEx when IsResourceProviderUnavailable(reqEx) =>
-            $"Azure File Shares (the Microsoft.FileShares resource provider) is not available in this cloud. Details: {reqEx.Message}",
+            "Azure File Shares (the Microsoft.FileShares resource provider) is not available in this cloud.",
         _ => base.GetErrorMessage(ex)
     };
 

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCheckNameAvailabilityCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCheckNameAvailabilityCommand.cs
@@ -26,7 +26,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.FileShare;
     Secret = false,
     LocalRequired = false)]
 public sealed class FileShareCheckNameAvailabilityCommand(ILogger<FileShareCheckNameAvailabilityCommand> logger, IFileSharesService fileSharesService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<FileShareCheckNameAvailabilityOptions, FileShareCheckNameAvailabilityCommand.FileShareCheckNameAvailabilityCommandResult>(subscriptionResolver)
+    : BaseFileSharesCommand<FileShareCheckNameAvailabilityOptions, FileShareCheckNameAvailabilityCommand.FileShareCheckNameAvailabilityCommandResult>(subscriptionResolver)
 {
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, FileShareCheckNameAvailabilityOptions options, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCheckNameAvailabilityCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCheckNameAvailabilityCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Options.FileShare;
 using Azure.Mcp.Tools.FileShares.Services;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCreateCommand.cs
@@ -25,7 +25,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.FileShare;
     Secret = false,
     LocalRequired = false)]
 public sealed class FileShareCreateCommand(ILogger<FileShareCreateCommand> logger, IFileSharesService fileSharesService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<FileShareCreateOptions, FileShareCreateCommand.FileShareCreateCommandResult>(subscriptionResolver)
+    : BaseFileSharesCommand<FileShareCreateOptions, FileShareCreateCommand.FileShareCreateCommandResult>(subscriptionResolver)
 {
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, FileShareCreateOptions options, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareCreateCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Models;
 using Azure.Mcp.Tools.FileShares.Options.FileShare;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareDeleteCommand.cs
@@ -26,7 +26,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.FileShare;
     Secret = false,
     LocalRequired = false)]
 public sealed class FileShareDeleteCommand(ILogger<FileShareDeleteCommand> logger, IFileSharesService fileSharesService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<FileShareDeleteOptions, FileShareDeleteCommand.FileShareDeleteCommandResult>(subscriptionResolver)
+    : BaseFileSharesCommand<FileShareDeleteOptions, FileShareDeleteCommand.FileShareDeleteCommandResult>(subscriptionResolver)
 {
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, FileShareDeleteOptions options, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareDeleteCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Options.FileShare;
 using Azure.Mcp.Tools.FileShares.Services;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareGetCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Models;
 using Azure.Mcp.Tools.FileShares.Options.FileShare;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareGetCommand.cs
@@ -24,7 +24,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.FileShare;
     Secret = false,
     LocalRequired = false)]
 public sealed class FileShareGetCommand(ILogger<FileShareGetCommand> logger, IFileSharesService fileSharesService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<FileShareGetOptions, FileShareGetCommand.FileShareGetCommandResult>(subscriptionResolver)
+    : BaseFileSharesCommand<FileShareGetOptions, FileShareGetCommand.FileShareGetCommandResult>(subscriptionResolver)
 {
     public override void ValidateOptions(FileShareGetOptions options, ValidationResult validationResult)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareUpdateCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Models;
 using Azure.Mcp.Tools.FileShares.Options.FileShare;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/FileShare/FileShareUpdateCommand.cs
@@ -25,7 +25,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.FileShare;
     Secret = false,
     LocalRequired = false)]
 public sealed class FileShareUpdateCommand(ILogger<FileShareUpdateCommand> logger, IFileSharesService fileSharesService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<FileShareUpdateOptions, FileShareUpdateCommand.FileShareUpdateCommandResult>(subscriptionResolver)
+    : BaseFileSharesCommand<FileShareUpdateOptions, FileShareUpdateCommand.FileShareUpdateCommandResult>(subscriptionResolver)
 {
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, FileShareUpdateOptions options, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetLimitsCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetLimitsCommand.cs
@@ -24,7 +24,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.Informational;
     Secret = false,
     LocalRequired = false)]
 public sealed class FileShareGetLimitsCommand(ILogger<FileShareGetLimitsCommand> logger, IFileSharesService service, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<FileShareGetLimitsOptions, FileShareLimitsResult>(subscriptionResolver)
+    : BaseFileSharesCommand<FileShareGetLimitsOptions, FileShareLimitsResult>(subscriptionResolver)
 {
     private readonly ILogger<FileShareGetLimitsCommand> _logger = logger;
     private readonly IFileSharesService _service = service;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetLimitsCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetLimitsCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Models;
 using Azure.Mcp.Tools.FileShares.Options.Informational;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetProvisioningRecommendationCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetProvisioningRecommendationCommand.cs
@@ -24,7 +24,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.Informational;
     Secret = false,
     LocalRequired = false)]
 public sealed class FileShareGetProvisioningRecommendationCommand(ILogger<FileShareGetProvisioningRecommendationCommand> logger, IFileSharesService service, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<FileShareGetProvisioningRecommendationOptions, FileShareProvisioningRecommendationResult>(subscriptionResolver)
+    : BaseFileSharesCommand<FileShareGetProvisioningRecommendationOptions, FileShareProvisioningRecommendationResult>(subscriptionResolver)
 {
     private readonly ILogger<FileShareGetProvisioningRecommendationCommand> _logger = logger;
     private readonly IFileSharesService _service = service;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetProvisioningRecommendationCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetProvisioningRecommendationCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Models;
 using Azure.Mcp.Tools.FileShares.Options.Informational;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetUsageDataCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetUsageDataCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Models;
 using Azure.Mcp.Tools.FileShares.Options.Informational;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetUsageDataCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Informational/FileShareGetUsageDataCommand.cs
@@ -24,7 +24,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.Informational;
     Secret = false,
     LocalRequired = false)]
 public sealed class FileShareGetUsageDataCommand(ILogger<FileShareGetUsageDataCommand> logger, IFileSharesService service, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<FileShareGetUsageDataOptions, FileShareUsageDataResult>(subscriptionResolver)
+    : BaseFileSharesCommand<FileShareGetUsageDataOptions, FileShareUsageDataResult>(subscriptionResolver)
 {
     private readonly ILogger<FileShareGetUsageDataCommand> _logger = logger;
     private readonly IFileSharesService _service = service;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/PrivateEndpointConnection/PrivateEndpointConnectionGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/PrivateEndpointConnection/PrivateEndpointConnectionGetCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Models;
 using Azure.Mcp.Tools.FileShares.Options.PrivateEndpointConnection;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/PrivateEndpointConnection/PrivateEndpointConnectionGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/PrivateEndpointConnection/PrivateEndpointConnectionGetCommand.cs
@@ -25,7 +25,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.PrivateEndpointConnection;
     Secret = false,
     LocalRequired = false)]
 public sealed class PrivateEndpointConnectionGetCommand(ILogger<PrivateEndpointConnectionGetCommand> logger, IFileSharesService fileSharesService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<PrivateEndpointConnectionGetOptions, PrivateEndpointConnectionGetCommand.PrivateEndpointConnectionGetCommandResult>(subscriptionResolver)
+    : BaseFileSharesCommand<PrivateEndpointConnectionGetOptions, PrivateEndpointConnectionGetCommand.PrivateEndpointConnectionGetCommandResult>(subscriptionResolver)
 {
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, PrivateEndpointConnectionGetOptions options, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/PrivateEndpointConnection/PrivateEndpointConnectionUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/PrivateEndpointConnection/PrivateEndpointConnectionUpdateCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Models;
 using Azure.Mcp.Tools.FileShares.Options.PrivateEndpointConnection;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/PrivateEndpointConnection/PrivateEndpointConnectionUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/PrivateEndpointConnection/PrivateEndpointConnectionUpdateCommand.cs
@@ -24,7 +24,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.PrivateEndpointConnection;
     Secret = false,
     LocalRequired = false)]
 public sealed class PrivateEndpointConnectionUpdateCommand(ILogger<PrivateEndpointConnectionUpdateCommand> logger, IFileSharesService fileSharesService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<PrivateEndpointConnectionUpdateOptions, PrivateEndpointConnectionUpdateCommand.PrivateEndpointConnectionUpdateCommandResult>(subscriptionResolver)
+    : BaseFileSharesCommand<PrivateEndpointConnectionUpdateOptions, PrivateEndpointConnectionUpdateCommand.PrivateEndpointConnectionUpdateCommandResult>(subscriptionResolver)
 {
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, PrivateEndpointConnectionUpdateOptions options, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotCreateCommand.cs
@@ -25,7 +25,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.Snapshot;
     Secret = false,
     LocalRequired = false)]
 public sealed class SnapshotCreateCommand(ILogger<SnapshotCreateCommand> logger, IFileSharesService fileSharesService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<SnapshotCreateOptions, SnapshotCreateCommand.SnapshotCreateCommandResult>(subscriptionResolver)
+    : BaseFileSharesCommand<SnapshotCreateOptions, SnapshotCreateCommand.SnapshotCreateCommandResult>(subscriptionResolver)
 {
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, SnapshotCreateOptions options, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotCreateCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Models;
 using Azure.Mcp.Tools.FileShares.Options.Snapshot;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotDeleteCommand.cs
@@ -26,7 +26,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.Snapshot;
     Secret = false,
     LocalRequired = false)]
 public sealed class SnapshotDeleteCommand(ILogger<SnapshotDeleteCommand> logger, IFileSharesService fileSharesService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<SnapshotDeleteOptions, SnapshotDeleteCommand.SnapshotDeleteCommandResult>(subscriptionResolver)
+    : BaseFileSharesCommand<SnapshotDeleteOptions, SnapshotDeleteCommand.SnapshotDeleteCommandResult>(subscriptionResolver)
 {
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, SnapshotDeleteOptions options, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotDeleteCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Options.Snapshot;
 using Azure.Mcp.Tools.FileShares.Services;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotGetCommand.cs
@@ -24,7 +24,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.Snapshot;
     Secret = false,
     LocalRequired = false)]
 public sealed class SnapshotGetCommand(ILogger<SnapshotGetCommand> logger, IFileSharesService fileSharesService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<SnapshotGetOptions, SnapshotGetCommand.SnapshotGetCommandResult>(subscriptionResolver)
+    : BaseFileSharesCommand<SnapshotGetOptions, SnapshotGetCommand.SnapshotGetCommandResult>(subscriptionResolver)
 {
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, SnapshotGetOptions options, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotGetCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Models;
 using Azure.Mcp.Tools.FileShares.Options.Snapshot;

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotUpdateCommand.cs
@@ -25,7 +25,7 @@ namespace Azure.Mcp.Tools.FileShares.Commands.Snapshot;
     Secret = false,
     LocalRequired = false)]
 public sealed class SnapshotUpdateCommand(ILogger<SnapshotUpdateCommand> logger, IFileSharesService fileSharesService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<SnapshotUpdateOptions, SnapshotUpdateCommand.SnapshotUpdateCommandResult>(subscriptionResolver)
+    : BaseFileSharesCommand<SnapshotUpdateOptions, SnapshotUpdateCommand.SnapshotUpdateCommandResult>(subscriptionResolver)
 {
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, SnapshotUpdateOptions options, CancellationToken cancellationToken)
     {

--- a/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotUpdateCommand.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/src/Commands/Snapshot/SnapshotUpdateCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using Azure.Mcp.Core.Commands.Subscription;
 using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.FileShares.Models;
 using Azure.Mcp.Tools.FileShares.Options.Snapshot;

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.Tests/FileShare/FileShareGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.Tests/FileShare/FileShareGetCommandTests.cs
@@ -6,6 +6,7 @@ using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.FileShares.Commands.FileShare;
 using Azure.Mcp.Tools.FileShares.Services;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.FileShares.Tests.FileShare;

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.Tests/FileShare/FileShareGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.Tests/FileShare/FileShareGetCommandTests.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net;
 using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.FileShares.Commands.FileShare;
 using Azure.Mcp.Tools.FileShares.Services;
+using NSubstitute;
 using Xunit;
 
 namespace Azure.Mcp.Tools.FileShares.Tests.FileShare;
@@ -19,5 +21,22 @@ public class FileShareGetCommandTests : SubscriptionCommandUnitTestsBase<FileSha
         Assert.Equal("get", Command.Name);
         Assert.Equal("Get File Share", Command.Title);
         Assert.Equal("get", CommandDefinition.Name);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsFriendlyError_WhenResourceProviderUnavailableInCloud()
+    {
+        var subscriptionId = "12345678-1234-1234-1234-123456789012";
+        var errorMessage = "The resource namespace 'Microsoft.FileShares' is invalid.";
+        var expectedError = $"Azure File Shares (the Microsoft.FileShares resource provider) is not available. This resource provider is currently only registered in Azure Public Cloud and is not yet available in sovereign clouds such as Azure China or Azure US Government. Details: {errorMessage}. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
+
+        Service.ListFileSharesAsync(subscriptionId, null, Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new RequestFailedException(404, errorMessage, "InvalidResourceNamespace", null));
+
+        var response = await ExecuteCommandAsync("--subscription", subscriptionId);
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.NotImplemented, response.Status);
+        Assert.Equal(expectedError, response.Message);
     }
 }

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.Tests/FileShare/FileShareGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.Tests/FileShare/FileShareGetCommandTests.cs
@@ -28,7 +28,7 @@ public class FileShareGetCommandTests : SubscriptionCommandUnitTestsBase<FileSha
     {
         var subscriptionId = "12345678-1234-1234-1234-123456789012";
         var errorMessage = "The resource namespace 'Microsoft.FileShares' is invalid.";
-        var expectedError = $"Azure File Shares (the Microsoft.FileShares resource provider) is not available. This resource provider is currently only registered in Azure Public Cloud and is not yet available in sovereign clouds such as Azure China or Azure US Government. Details: {errorMessage}. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
+        var expectedError = $"Azure File Shares (the Microsoft.FileShares resource provider) is not available in this cloud. Details: {errorMessage}. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
 
         Service.ListFileSharesAsync(subscriptionId, null, Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, errorMessage, "InvalidResourceNamespace", null));

--- a/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.Tests/FileShare/FileShareGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.FileShares/tests/Azure.Mcp.Tools.FileShares.Tests/FileShare/FileShareGetCommandTests.cs
@@ -29,7 +29,7 @@ public class FileShareGetCommandTests : SubscriptionCommandUnitTestsBase<FileSha
     {
         var subscriptionId = "12345678-1234-1234-1234-123456789012";
         var errorMessage = "The resource namespace 'Microsoft.FileShares' is invalid.";
-        var expectedError = $"Azure File Shares (the Microsoft.FileShares resource provider) is not available in this cloud. Details: {errorMessage}. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
+        var expectedError = $"Azure File Shares (the Microsoft.FileShares resource provider) is not available in this cloud. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
 
         Service.ListFileSharesAsync(subscriptionId, null, Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException(404, errorMessage, "InvalidResourceNamespace", null));


### PR DESCRIPTION
## What does this PR do?
Adds proper error message for scenario where cloud is not supported in FileShare Tool. Existing error message is confusing for users 

## GitHub issue number?
#2274

## Pre-merge Checklist
- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
