### PR TITLE
Classify the two usage plan delete tools as control plane

### DIFF
--- a/tools/Azure.Mcp.Tools.ResilienceManagement/src/Commands/UsagePlans/Enrollments/UsagePlanEnrollmentDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.ResilienceManagement/src/Commands/UsagePlans/Enrollments/UsagePlanEnrollmentDeleteCommand.cs
@@ -19,6 +19,7 @@ namespace Azure.Mcp.Tools.ResilienceManagement.Commands.UsagePlans.Enrollments;
     Name = "delete",
     Title = "Delete Resilience Usage Plan Enrollment",
     Description = "Deletes a named enrollment from a resilience usage plan to remove a service group association while keeping the parent plan. Deletes only the enrollment and reports whether it existed. Use this to unenroll a service group, not to delete the entire usage plan resource.",
+    OperationPlane = ToolOperationPlane.Control,
     Destructive = true,
     Idempotent = true,
     OpenWorld = false,

--- a/tools/Azure.Mcp.Tools.ResilienceManagement/src/Commands/UsagePlans/UsagePlanDeleteCommand.cs
+++ b/tools/Azure.Mcp.Tools.ResilienceManagement/src/Commands/UsagePlans/UsagePlanDeleteCommand.cs
@@ -18,6 +18,7 @@ namespace Azure.Mcp.Tools.ResilienceManagement.Commands.UsagePlans;
     Name = "delete",
     Title = "Delete Resilience Usage Plan",
     Description = "Deletes a named resilience usage plan from an Azure resource group or removes the usage plan of a service group. Deletes the entire parent plan and reports whether it existed; do not use this to remove only an enrollment or association. Dependent enrollments block plan deletion and are not deleted automatically; list the exact enrollments and obtain explicit confirmation before deleting each separately.",
+    OperationPlane = ToolOperationPlane.Control,
     Destructive = true,
     Idempotent = true,
     OpenWorld = false,


### PR DESCRIPTION
## Description

`AllCommands_DeclareAnOperationPlane` currently fails on `main`:

```
2 tool(s) do not declare an OperationPlane.
  resilience_usageplan_delete (UsagePlanDeleteCommand)
  resilience_usageplan_enrollment_delete (UsagePlanEnrollmentDeleteCommand)
```

Both tools were authored on a branch that predated #3368, so they were never annotated. #3368 merged, the two tools merged, and neither PR could see the other's requirement. Nothing is wrong with either change on its own; the break is purely an artifact of them landing concurrently.

## Change

Both commands are now `OperationPlane = ToolOperationPlane.Control`.

Per `docs/design/operation-plane-metadata.md`, a tool is classified by the API it acts against to produce the result the user asked for. Both delete `Microsoft.AzureResilienceManagement` resources through `ArmClient`:

- `DeleteUsagePlanAsync` resolves a `UsagePlanResource` and calls `DeleteAsync`.
- `DeleteUsagePlanEnrollmentAsync` resolves a `UsagePlanEnrollmentResource` and calls `DeleteAsync`.

The ARM call is the requested work, not setup used to locate a target, so `Control` is correct. This also matches every sibling in the toolset: `UsagePlanCreateCommand`, `UsagePlanGetCommand`, `UsagePlanEnrollmentCreateCommand` and `UsagePlanEnrollmentGetCommand` are all `Control`, as are the other 36 commands in `Azure.Mcp.Tools.ResilienceManagement`.

## Testing

- `CommandOperationPlaneTests` — 3/3 pass, so no unclassified tools remain on `main`.
- `dotnet format --verify-no-changes` clean.
- `Invoke-Cspell.ps1` clean over both changed files.

## No changelog entry

The operation-plane feature was already announced in `kaghiya-operation-plane-metadata.yaml` from #3368, which describes the metadata being applied across the tool surface. This PR only completes that same rollout for two tools that raced the merge; it introduces no behavior or feature beyond what that entry already covers. Happy to add one if reviewers prefer.

## Note for maintainers

This is the fifth time a concurrently-merged tool has tripped this test, and the first time it has reached `main`. The check runs at test time with no allowlist, so any tool merged from a branch that predates its introduction breaks the build. If that churn becomes a nuisance, moving the check into a Roslyn analyzer (so the requirement surfaces at compile time in the authoring PR) would catch it before merge rather than after. Out of scope here.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.