### PR TITLE
fix(compute): include timeCreated in VM listings

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/shasailucidity-compute-vm-timecreated.yml
+++ b/servers/Azure.Mcp.Server/changelog-entries/shasailucidity-compute-vm-timecreated.yml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bug Fixes"
+    description: "`compute vm get` now includes `timeCreated` for each VM, so questions like \"which VMs were created in the last N days\" can be answered from the listing."

--- a/servers/Azure.Mcp.Server/changelog-entries/shasailucidity-compute-vm-timecreated.yml
+++ b/servers/Azure.Mcp.Server/changelog-entries/shasailucidity-compute-vm-timecreated.yml
@@ -1,3 +1,3 @@
 changes:
-  - section: "Bug Fixes"
+  - section: "Bugs Fixed"
     description: "`compute vm get` now includes `timeCreated` for each VM, so questions like \"which VMs were created in the last N days\" can be answered from the listing."

--- a/tools/Azure.Mcp.Tools.Compute/src/Models/VmInfo.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Models/VmInfo.cs
@@ -14,4 +14,5 @@ public sealed record VmInfo(
     [property: JsonPropertyName("osType")] string? OsType,
     [property: JsonPropertyName("licenseType")] string? LicenseType,
     [property: JsonPropertyName("zones")] IReadOnlyList<string>? Zones,
-    [property: JsonPropertyName("tags")] IReadOnlyDictionary<string, string>? Tags);
+    [property: JsonPropertyName("tags")] IReadOnlyDictionary<string, string>? Tags,
+    [property: JsonPropertyName("timeCreated")] DateTimeOffset? TimeCreated = null);

--- a/tools/Azure.Mcp.Tools.Compute/src/Services/ComputeService.cs
+++ b/tools/Azure.Mcp.Tools.Compute/src/Services/ComputeService.cs
@@ -1349,7 +1349,8 @@ public class ComputeService(
             OsType: data.StorageProfile?.OSDisk?.OSType?.ToString(),
             LicenseType: data.LicenseType,
             Zones: data.Zones?.ToList(),
-            Tags: data.Tags as IReadOnlyDictionary<string, string>);
+            Tags: data.Tags as IReadOnlyDictionary<string, string>,
+            TimeCreated: data.TimeCreated);
     }
 
     private static VmInstanceView MapToVmInstanceView(string vmName, VirtualMachineInstanceView instanceView)


### PR DESCRIPTION
## What does this PR do?

`compute vm get` lists VMs without `timeCreated`, even though ARM returns `properties.timeCreated` and the SDK surfaces it as `VirtualMachineData.TimeCreated`. The disk model in the same tool already maps it; the VM model never did. So an agent asked "which VMs were created in the last 10 days" has nothing to go on.

Adds `timeCreated` to `VmInfo` as a trailing optional record parameter, so existing positional callers (tests included) compile unchanged, and maps it in `MapToVmInfo`.

Verified against a subscription with 21 VMs: the field is populated for each and matches `az vm list --query '[].timeCreated'`.

## GitHub issue number?

None filed.

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages
    - [x] Added comprehensive tests for new/modified functionality: the existing `VmGetCommandTests` cover the mapping path; this adds one field, no new behaviour
    - [x] Created a changelog entry
- [ ] For MCP tool changes: output-only addition, no name, description or parameter changes, so the README/metadata/e2e prompt steps do not apply
- [ ] Extra steps for **Azure MCP Server** tool changes: n/a for the same reason
    - [x] Community PR: reviewed for security concerns; one read-only field added to an existing response
