### PR TITLE
Fix MySQL parameter updates to use user-override source

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/ramnov-mysql-parameter-source.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/ramnov-mysql-parameter-source.yaml
@@ -1,0 +1,4 @@
+pr: 3621
+changes:
+  - section: "Bugs Fixed"
+    description: "Fixed MySQL server parameter updates failing when changing a system-default value by setting the configuration source to user-override."

--- a/tools/Azure.Mcp.Tools.MySql/src/Services/MySqlService.cs
+++ b/tools/Azure.Mcp.Tools.MySql/src/Services/MySqlService.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.MySql.Commands;
 using Azure.ResourceManager.MySql.FlexibleServers;
+using Azure.ResourceManager.MySql.FlexibleServers.Models;
 using Microsoft.Mcp.Core.Helpers;
 using Microsoft.Mcp.Core.Services.Azure.Authentication;
 using MySqlConnector;
@@ -412,6 +413,7 @@ public sealed class MySqlService(IAzureService azureService)
 
         var configData = configuration.Value.Data;
         configData.Value = value;
+        configData.Source = MySqlFlexibleServerConfigurationSource.UserOverride;
 
         var updateOperation = await mysqlServer.Value.GetMySqlFlexibleServerConfigurations().CreateOrUpdateAsync(WaitUntil.Started, param, configData, cancellationToken);
         await WaitForLroCompletionAsync(updateOperation, cancellationToken);

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Services/MySqlServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Services/MySqlServiceTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure;
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.MySql.Services;
 using Azure.ResourceManager;

--- a/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Services/MySqlServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.MySql/tests/Azure.Mcp.Tools.MySql.Tests/Services/MySqlServiceTests.cs
@@ -3,6 +3,11 @@
 
 using Azure.Mcp.Core.Services.Azure;
 using Azure.Mcp.Tools.MySql.Services;
+using Azure.ResourceManager;
+using Azure.ResourceManager.MySql.FlexibleServers;
+using Azure.ResourceManager.MySql.FlexibleServers.Mocking;
+using Azure.ResourceManager.MySql.FlexibleServers.Models;
+using Azure.ResourceManager.Resources;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -92,6 +97,56 @@ public class MySqlServiceTests
             _mysqlService.GetServerParameterAsync("sub123", "missing-rg", "some-server", "some-param", TestContext.Current.CancellationToken));
 
         Assert.Contains("missing-rg", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("system-default", "10")]
+    [InlineData("user-override", "30")]
+    public async Task SetServerParameterAsync_SetsValueAndUserOverrideSource(string source, string currentValue)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var resourceGroup = Substitute.For<ResourceGroupResource>();
+        var mysqlResourceGroup = Substitute.For<MockableMySqlFlexibleServersResourceGroupResource>();
+        var server = Substitute.For<MySqlFlexibleServerResource>();
+        var configuration = Substitute.For<MySqlFlexibleServerConfigurationResource>();
+        var configurations = Substitute.For<MySqlFlexibleServerConfigurationCollection>();
+        var updatedConfiguration = Substitute.For<MySqlFlexibleServerConfigurationResource>();
+        var operation = Substitute.For<ArmOperation<MySqlFlexibleServerConfigurationResource>>();
+        var response = Substitute.For<Response>();
+
+        _azureService.GetResourceGroupResource("sub123", "rg1", null, cancellationToken)
+            .Returns(resourceGroup);
+        resourceGroup.GetCachedClient(Arg.Any<Func<ArmClient, MockableMySqlFlexibleServersResourceGroupResource>>())
+            .Returns(mysqlResourceGroup);
+        mysqlResourceGroup.GetMySqlFlexibleServerAsync("test-server", cancellationToken)
+            .Returns(Response.FromValue(server, response));
+        configuration.Data.Returns(new MySqlFlexibleServerConfigurationData
+        {
+            Value = currentValue,
+            Source = new MySqlFlexibleServerConfigurationSource(source)
+        });
+        server.GetMySqlFlexibleServerConfigurationAsync("connect_timeout", cancellationToken)
+            .Returns(Response.FromValue(configuration, response));
+        server.GetMySqlFlexibleServerConfigurations().Returns(configurations);
+        updatedConfiguration.Data.Returns(new MySqlFlexibleServerConfigurationData
+        {
+            Value = "20",
+            Source = MySqlFlexibleServerConfigurationSource.UserOverride
+        });
+        operation.Value.Returns(updatedConfiguration);
+        operation.HasCompleted.Returns(true);
+        configurations.CreateOrUpdateAsync(WaitUntil.Started, "connect_timeout",
+            Arg.Any<MySqlFlexibleServerConfigurationData>(), cancellationToken)
+            .Returns(operation);
+
+        var result = await _mysqlService.SetServerParameterAsync(
+            "sub123", "rg1", "test-server", "connect_timeout", "20", cancellationToken);
+
+        Assert.Equal("20", result);
+        await configurations.Received(1).CreateOrUpdateAsync(WaitUntil.Started, "connect_timeout",
+            Arg.Is<MySqlFlexibleServerConfigurationData>(data =>
+                data.Value == "20" && data.Source == MySqlFlexibleServerConfigurationSource.UserOverride),
+            cancellationToken);
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?
Fixes `mysql_server_param_set` failing to update parameters that still use their system-default value.

`SetServerParameterAsync` previously changed only `Value` on the configuration returned by Azure, retaining `Source = system-default`. This caused Azure to reject updates such as changing `connect_timeout` from `10` to `20`.

The service now sets `Source` to `MySqlFlexibleServerConfigurationSource.UserOverride` before submitting the update. Regression tests cover both system-default and previously overridden parameters and verify the submitted value, source, and returned result.

## GitHub issue number?
https://github.com/microsoft/mcp/issues/3546

## Pre-merge Checklist
- [x] Required for All PRs
    - [x ] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
