### PR TITLE
Classify ADME record commands as data plane

### DIFF
--- a/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordFetchCommand.cs
+++ b/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordFetchCommand.cs
@@ -33,6 +33,7 @@ namespace Azure.Mcp.Tools.Adme.Commands.Storage;
         server, and reports per-record outcomes in conversionStatuses (empty for records without
         measured or spatial fields). It cannot be combined with --attributes.
         """,
+    OperationPlane = ToolOperationPlane.Data,
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,

--- a/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordGetCommand.cs
@@ -31,6 +31,7 @@ namespace Azure.Mcp.Tools.Adme.Commands.Storage;
 
         For several records in one call use 'azmcp adme storage record fetch'.
         """,
+    OperationPlane = ToolOperationPlane.Data,
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,

--- a/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordListCommand.cs
@@ -28,6 +28,7 @@ namespace Azure.Mcp.Tools.Adme.Commands.Storage;
         response. A null cursor means there are no more pages. A kind can hold thousands of records,
         so confirm how many the user wants before paging through the whole set.
         """,
+    OperationPlane = ToolOperationPlane.Data,
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,

--- a/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordVersionListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Adme/src/Commands/Storage/RecordVersionListCommand.cs
@@ -26,6 +26,7 @@ namespace Azure.Mcp.Tools.Adme.Commands.Storage;
         Pass one of the returned versions to 'azmcp adme storage record get --version' to read that
         version of the record.
         """,
+    OperationPlane = ToolOperationPlane.Data,
     Destructive = false,
     Idempotent = true,
     OpenWorld = false,


### PR DESCRIPTION
## Description

Adds `OperationPlane = ToolOperationPlane.Data` to the four ADME storage record commands introduced by #3611:

- `adme_storage_record_fetch`
- `adme_storage_record_get`
- `adme_storage_record_list`
- `adme_storage_record_version_list`

These commands operate on OSDU record data APIs. Without the metadata, `CommandOperationPlaneTests.AllCommands_DeclareAnOperationPlane` fails across PR validation builds.

## Testing

- `dotnet build tools/Azure.Mcp.Tools.Adme/src/Azure.Mcp.Tools.Adme.csproj` — succeeds with 0 warnings and 0 errors.
- `CommandOperationPlaneTests` — 3/3 pass.