### PR TITLE
Return concise errors for invalid command names

### DIFF
--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/BaseToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/BaseToolLoaderTests.cs
@@ -4,6 +4,7 @@
 
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Microsoft.Mcp.Core.Areas.Server;
 using Microsoft.Mcp.Core.Areas.Server.Commands.ToolLoading;
 using Microsoft.Mcp.Core.Commands;
 using Microsoft.Mcp.Tests.Client.Helpers;
@@ -16,6 +17,123 @@ namespace Azure.Mcp.Core.Tests.Areas.Server.Commands.ToolLoading;
 
 public class BaseToolLoaderTests
 {
+    [Fact]
+    public void CreateUnknownCommandResult_ReturnsSortedDistinctNamesOnly()
+    {
+        var result = BaseToolLoader.CreateUnknownCommandResult(
+            "storage", "invalid_command", ["storage_zeta", "storage_alpha", "storage_zeta", "storage_middle"]);
+
+        AssertUnknownCommandResult(result, "storage", "invalid_command",
+            "storage_alpha", "storage_middle", "storage_zeta");
+    }
+
+    [Fact]
+    public void CreateUnknownCommandResult_WithEmptyCatalog_ExplainsNoCommandsAreAvailable()
+    {
+        var result = BaseToolLoader.CreateUnknownCommandResult("storage", "invalid_command", []);
+
+        AssertUnknownCommandResult(result, "storage", "invalid_command");
+    }
+
+    [Fact]
+    public void CreateUnknownCommandResult_IncludesAllNamesWithoutTruncation()
+    {
+        var names = Enumerable.Range(0, 150).Select(index => $"storage_command_{index:D3}").ToArray();
+
+        var result = BaseToolLoader.CreateUnknownCommandResult("storage", "invalid_command", names.Reverse());
+
+        AssertUnknownCommandResult(result, "storage", "invalid_command", names);
+    }
+
+    internal static string AssertUnknownCommandResult(
+        CallToolResult result, string toolName, string commandName, params string[] availableNames)
+    {
+        Assert.True(result.IsError);
+        Assert.False(result.StructuredContent.HasValue);
+        Assert.Null(result.Meta);
+        var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
+        Assert.Contains($"'{commandName}'", text, StringComparison.Ordinal);
+        Assert.Contains($"'{toolName}'", text, StringComparison.Ordinal);
+        Assert.Contains("not available", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("learn=true", text, StringComparison.Ordinal);
+        if (availableNames.Length == 0)
+        {
+            Assert.Contains("No commands are available for this tool in the current server configuration.", text);
+            Assert.DoesNotContain("Available commands:", text);
+        }
+        else
+        {
+            var namesLine = Assert.Single(text.Split('\n'), line => line.StartsWith("Available commands:", StringComparison.Ordinal));
+            Assert.Equal($"Available commands: {string.Join(", ", availableNames)}", namesLine.TrimEnd('\r'));
+        }
+
+        Assert.DoesNotContain("\"description\"", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"inputSchema\"", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"outputSchema\"", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"annotations\"", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"_meta\"", text, StringComparison.Ordinal);
+        return text;
+    }
+
+    internal static McpServer CreateSamplingServer(bool supportsSampling, string? samplingText = null, bool failSampling = false)
+    {
+        var server = Substitute.For<McpServer>();
+        server.ClientCapabilities.Returns(new ClientCapabilities
+        {
+            Sampling = supportsSampling ? new SamplingCapability() : null
+        });
+        var response = new JsonRpcResponse
+        {
+            Id = new RequestId(1),
+            Result = JsonSerializer.SerializeToNode(new CreateMessageResult
+            {
+                Role = Role.Assistant,
+                Content = samplingText == null ? [] : [new TextContentBlock { Text = samplingText }],
+                Model = "test-model"
+            })
+        };
+        // Bound a buggy correction loop so it fails the call-count assertion instead of hanging the test.
+        var samplingRequests = 0;
+        server.SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<CancellationToken>())
+            .Returns(_ => failSampling || ++samplingRequests > 1
+                ? throw new InvalidOperationException("Sampling failed.")
+                : response);
+        return server;
+    }
+
+    internal static RequestContext<CallToolRequestParams> CreateCommandRequest(
+        McpServer server,
+        string? command = "invalid_command",
+        string? intent = "list resources",
+        bool learn = false,
+        string parametersJson = "{}",
+        string toolName = "storage")
+    {
+        using var parameters = JsonDocument.Parse(parametersJson);
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["parameters"] = parameters.RootElement.Clone()
+        };
+        if (command != null)
+        {
+            arguments["command"] = JsonSerializer.SerializeToElement(command, ServerJsonContext.Default.String);
+        }
+        if (intent != null)
+        {
+            arguments["intent"] = JsonSerializer.SerializeToElement(intent, ServerJsonContext.Default.String);
+        }
+        if (learn)
+        {
+            arguments["learn"] = JsonSerializer.SerializeToElement(true, ServerJsonContext.Default.Boolean);
+        }
+
+        return McpTestUtilities.CreateToolCallRequest(new CallToolRequestParams
+        {
+            Name = toolName,
+            Arguments = arguments
+        }, server);
+    }
+
     [Fact]
     public void CreateClientOptions_WithNoCapabilities_ReturnsOptionsWithNoCapabilities()
     {

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/NamespaceToolLoaderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.CommandLine;
 using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
@@ -595,11 +596,8 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
         // Act
         var result = await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
 
-        // Assert
-        Assert.NotNull(result);
-        // Should fallback to learn mode or return error
-        var textContent = result.Content[0] as TextContentBlock;
-        Assert.NotNull(textContent);
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, toolName, "nonexistent-command",
+            loader.GetChildToolList(request, toolName).Select(tool => tool.Name).Order(StringComparer.Ordinal).ToArray());
     }
 
     [Fact]
@@ -721,17 +719,293 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
         // Act
         var result = await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
 
-        // Assert - Should provide helpful error guidance
-        Assert.NotNull(result);
-        Assert.NotNull(result.Content);
-        Assert.NotEmpty(result.Content);
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, toolName, "nonexistent_invalid_command_xyz",
+            loader.GetChildToolList(request, toolName).Select(tool => tool.Name).Order(StringComparer.Ordinal).ToArray());
+    }
 
-        var textContent = result.Content[0] as TextContentBlock;
-        Assert.NotNull(textContent);
+    [Theory]
+    [InlineData(ModeTypes.NamespaceProxy, null)]
+    [InlineData(ModeTypes.NamespaceProxy, StructuredOutputMode.Duplicated)]
+    [InlineData(ModeTypes.NamespaceProxy, StructuredOutputMode.Compact)]
+    [InlineData(ModeTypes.ConsolidatedProxy, null)]
+    [InlineData(ModeTypes.ConsolidatedProxy, StructuredOutputMode.Duplicated)]
+    [InlineData(ModeTypes.ConsolidatedProxy, StructuredOutputMode.Compact)]
+    public async Task CallToolHandler_UnknownCommandWithoutUsableSampling_ReturnsNamesOnly(
+        string executionMode, StructuredOutputMode? outputMode)
+    {
+        var commands = new Dictionary<string, IBaseCommand>
+        {
+            ["storage_zeta"] = CreateRoutingCommand("storage_zeta"),
+            ["storage_alpha"] = CreateRoutingCommand("storage_alpha")
+        };
+        await using var loader = CreateRoutingLoader(commands, new ServerRuntimeConfiguration
+        {
+            Mode = executionMode,
+            StructuredOutputMode = outputMode
+        });
 
-        // When command doesn't exist or encounters issues, should provide guidance
-        // This validates the error handling path preserves informative messages
-        Assert.True(textContent.Text.Length > 0);
+        (string? Intent, bool SupportsSampling)[] scenarios =
+        [
+            (null, false), (null, true), ("", true), (" \t ", true), ("list resources", false)
+        ];
+        foreach (var (intent, supportsSampling) in scenarios)
+        {
+            var server = BaseToolLoaderTests.CreateSamplingServer(supportsSampling,
+                """{"command":"storage_alpha","parameters":{}}""");
+            var request = BaseToolLoaderTests.CreateCommandRequest(server, intent: intent);
+
+            var result = await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+            var text = BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "invalid_command",
+                "storage_alpha", "storage_zeta");
+            Assert.DoesNotContain("Catalog detail.", text);
+            await server.DidNotReceive().SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<CancellationToken>());
+        }
+
+        foreach (var command in commands.Values)
+        {
+            await command.DidNotReceiveWithAnyArgs().ExecuteAsync(default!, default!, TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Theory]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, true)]
+    public async Task CallToolHandler_UnknownCommand_ListsOnlyCommandsAllowedByConfiguration(
+        bool readOnly, bool isHttpMode, bool emptyCatalog)
+    {
+        var commands = new Dictionary<string, IBaseCommand>
+        {
+            ["storage_blocked"] = CreateRoutingCommand("storage_blocked", readOnly: false, localRequired: true)
+        };
+        if (!emptyCatalog)
+        {
+            commands["storage_allowed"] = CreateRoutingCommand("storage_allowed");
+        }
+        await using var loader = CreateRoutingLoader(commands, new ServerRuntimeConfiguration
+        {
+            ReadOnly = readOnly,
+            Transport = isHttpMode ? TransportTypes.Http : TransportTypes.StdIo
+        });
+        var server = BaseToolLoaderTests.CreateSamplingServer(false);
+        var request = BaseToolLoaderTests.CreateCommandRequest(server, command: "storage_blocked");
+
+        var result = await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "storage_blocked",
+            emptyCatalog ? [] : ["storage_allowed"]);
+        foreach (var command in commands.Values)
+        {
+            await command.DidNotReceiveWithAnyArgs().ExecuteAsync(default!, default!, TestContext.Current.CancellationToken);
+        }
+        await server.DidNotReceive().SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CallToolHandler_UnknownCommandWithEmptyCatalog_DoesNotSample(bool supportsSampling)
+    {
+        await using var loader = CreateRoutingLoader([]);
+        var server = BaseToolLoaderTests.CreateSamplingServer(supportsSampling);
+
+        var result = await loader.CallToolHandler(
+            BaseToolLoaderTests.CreateCommandRequest(server), TestContext.Current.CancellationToken);
+
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "invalid_command");
+        await server.DidNotReceive().SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("storage_alpha")]
+    [InlineData("STORAGE_ALPHA")]
+    public async Task CallToolHandler_SamplingCorrection_ExecutesCanonicalCommandOnceWithSampledParameters(string sampledName)
+    {
+        var command = CreateRoutingCommand("storage_alpha");
+        await using var loader = CreateRoutingLoader(new Dictionary<string, IBaseCommand>
+        {
+            ["storage_alpha"] = command
+        });
+        var server = BaseToolLoaderTests.CreateSamplingServer(true,
+            $$$"""{"command":"{{{sampledName}}}","parameters":{"subscription":"sampled-subscription","limit":3}}""");
+        var request = BaseToolLoaderTests.CreateCommandRequest(server,
+            parametersJson: """{"subscription":"original-subscription","limit":1}""");
+
+        var result = await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError);
+        await command.Received(1).ExecuteAsync(
+            Arg.Any<CommandContext>(),
+            Arg.Is<ParseResult>(parsed => parsed.GetValue<string>("--subscription") == "sampled-subscription"
+                && parsed.GetValue<int>("--limit") == 3),
+            TestContext.Current.CancellationToken);
+        await command.ReceivedWithAnyArgs(1).ExecuteAsync(default!, default!, TestContext.Current.CancellationToken);
+        await server.Received(1).SendRequestAsync(
+            Arg.Is<JsonRpcRequest>(rpc => rpc.Method == "sampling/createMessage"), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData(" \t ", false)]
+    [InlineData("not JSON", false)]
+    [InlineData("null", false)]
+    [InlineData("[]", false)]
+    [InlineData("{}", false)]
+    [InlineData("""{"command":null}""", false)]
+    [InlineData("""{"command":17}""", false)]
+    [InlineData("""{"command":""}""", false)]
+    [InlineData("""{"command":" "}""", false)]
+    [InlineData("""{"command":"Unknown","parameters":{}}""", false)]
+    [InlineData("""{"command":"nonexistent","parameters":{}}""", false)]
+    [InlineData(null, true)]
+    public async Task CallToolHandler_UnusableSamplingCorrection_ReturnsErrorWithoutExecutionOrRetry(
+        string? samplingText, bool failSampling)
+    {
+        var command = CreateRoutingCommand("storage_alpha");
+        await using var loader = CreateRoutingLoader(new Dictionary<string, IBaseCommand>
+        {
+            ["storage_alpha"] = command
+        });
+        var server = BaseToolLoaderTests.CreateSamplingServer(true, samplingText, failSampling);
+
+        var result = await loader.CallToolHandler(
+            BaseToolLoaderTests.CreateCommandRequest(server), TestContext.Current.CancellationToken);
+
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "invalid_command", "storage_alpha");
+        await command.DidNotReceiveWithAnyArgs().ExecuteAsync(default!, default!, TestContext.Current.CancellationToken);
+        await server.Received(1).SendRequestAsync(
+            Arg.Is<JsonRpcRequest>(rpc => rpc.Method == "sampling/createMessage"), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task CallToolHandler_FilteredSamplingCorrection_DoesNotExecuteOrRetry(bool readOnly, bool isHttpMode)
+    {
+        var commands = new Dictionary<string, IBaseCommand>
+        {
+            ["storage_alpha"] = CreateRoutingCommand("storage_alpha"),
+            ["storage_blocked"] = CreateRoutingCommand("storage_blocked", readOnly: !readOnly, localRequired: isHttpMode)
+        };
+        await using var loader = CreateRoutingLoader(commands, new ServerRuntimeConfiguration
+        {
+            ReadOnly = readOnly,
+            Transport = isHttpMode ? TransportTypes.Http : TransportTypes.StdIo
+        });
+        var server = BaseToolLoaderTests.CreateSamplingServer(true,
+            """{"command":"STORAGE_BLOCKED","parameters":{}}""");
+
+        var result = await loader.CallToolHandler(
+            BaseToolLoaderTests.CreateCommandRequest(server), TestContext.Current.CancellationToken);
+
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "invalid_command", "storage_alpha");
+        foreach (var command in commands.Values)
+        {
+            await command.DidNotReceiveWithAnyArgs().ExecuteAsync(default!, default!, TestContext.Current.CancellationToken);
+        }
+        await server.Received(1).SendRequestAsync(
+            Arg.Is<JsonRpcRequest>(rpc => rpc.Method == "sampling/createMessage"), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CallToolHandler_LearnOrIntentOnlyWithoutSampling_PreservesFullCatalog(bool explicitLearn)
+    {
+        var command = CreateRoutingCommand("storage_alpha");
+        await using var loader = CreateRoutingLoader(new Dictionary<string, IBaseCommand>
+        {
+            ["storage_alpha"] = command
+        });
+        var server = BaseToolLoaderTests.CreateSamplingServer(false);
+        var request = BaseToolLoaderTests.CreateCommandRequest(server,
+            command: explicitLearn ? "invalid_command" : null, learn: explicitLearn);
+
+        var result = await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError);
+        var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
+        Assert.Contains("storage_alpha", text);
+        Assert.Contains("Catalog detail.", text);
+        Assert.Contains("\"inputSchema\"", text);
+        await command.DidNotReceiveWithAnyArgs().ExecuteAsync(default!, default!, TestContext.Current.CancellationToken);
+        await server.DidNotReceive().SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CallToolHandler_LearnOrIntentOnlyWithInvalidSample_DoesNotReenterCorrection(bool explicitLearn)
+    {
+        var command = CreateRoutingCommand("storage_alpha");
+        await using var loader = CreateRoutingLoader(new Dictionary<string, IBaseCommand>
+        {
+            ["storage_alpha"] = command
+        });
+        var server = BaseToolLoaderTests.CreateSamplingServer(true,
+            """{"command":"nonexistent","parameters":{}}""");
+        var request = BaseToolLoaderTests.CreateCommandRequest(server,
+            command: explicitLearn ? "invalid_command" : null, learn: explicitLearn);
+
+        var result = await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError);
+        var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
+        Assert.Contains("storage_alpha", text);
+        Assert.Contains("\"inputSchema\"", text);
+        await command.DidNotReceiveWithAnyArgs().ExecuteAsync(default!, default!, TestContext.Current.CancellationToken);
+        await server.Received(1).SendRequestAsync(
+            Arg.Is<JsonRpcRequest>(rpc => rpc.Method == "sampling/createMessage"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CallToolHandler_InvalidAppServiceCommand_IsMuchSmallerThanLearnAndIndependentOfCatalogDetails()
+    {
+        await using var loader = new NamespaceToolLoader(_commandFactory, _configuration, _logger);
+        var server = BaseToolLoaderTests.CreateSamplingServer(false);
+        var request = BaseToolLoaderTests.CreateCommandRequest(server, command: "appservice_webapp_list", toolName: "appservice");
+        var availableNames = _commandFactory.GroupCommands(["appservice"]).Keys.Order(StringComparer.Ordinal).ToArray();
+        Assert.Contains("appservice_webapp_get", availableNames);
+        Assert.DoesNotContain("appservice_webapp_list", availableNames);
+
+        var result = await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
+        var learn = await loader.CallToolHandler(
+            BaseToolLoaderTests.CreateCommandRequest(server, learn: true, toolName: "appservice"),
+            TestContext.Current.CancellationToken);
+
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "appservice", "appservice_webapp_list", availableNames);
+        Assert.False(learn.IsError);
+        Assert.Contains("\"inputSchema\"", Assert.IsType<TextContentBlock>(Assert.Single(learn.Content)).Text);
+        var errorBytes = JsonSerializer.SerializeToUtf8Bytes(result, ServerJsonContext.Default.CallToolResult);
+        var learnBytes = JsonSerializer.SerializeToUtf8Bytes(learn, ServerJsonContext.Default.CallToolResult);
+        TestContext.Current.TestOutputHelper?.WriteLine($"App Service error: {errorBytes.Length} bytes; learn: {learnBytes.Length} bytes.");
+        Assert.True(errorBytes.Length < learnBytes.Length / 4,
+            $"Names-only error ({errorBytes.Length} bytes) should be much smaller than learn ({learnBytes.Length} bytes).");
+
+        var previousCatalogSize = 0;
+        foreach (var descriptionRepeats in new[] { 1, 200 })
+        {
+            var syntheticCommands = availableNames.ToDictionary(
+                name => name, name => CreateRoutingCommand(name, descriptionRepeats: descriptionRepeats));
+            await using var syntheticLoader = CreateRoutingLoader(syntheticCommands, namespaceName: "appservice");
+            var syntheticResult = await syntheticLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
+            var catalogSize = JsonSerializer.SerializeToUtf8Bytes(
+                syntheticLoader.GetChildToolList(request, "appservice"), ServerJsonContext.Default.IEnumerableTool).Length;
+
+            Assert.True(catalogSize > previousCatalogSize);
+            previousCatalogSize = catalogSize;
+            Assert.Equal(errorBytes, JsonSerializer.SerializeToUtf8Bytes(syntheticResult, ServerJsonContext.Default.CallToolResult));
+            foreach (var command in syntheticCommands.Values)
+            {
+                await command.DidNotReceiveWithAnyArgs().ExecuteAsync(default!, default!, TestContext.Current.CancellationToken);
+            }
+        }
+        await server.DidNotReceive().SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -768,10 +1042,11 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
         });
 
         // Act
-        await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
+        var result = await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
 
         // Assert - non-read-only command should not have been executed
         Assert.False(executed, "Non-read-only command should not be executed in read-only mode");
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "write-cmd");
     }
 
     [Fact]
@@ -888,10 +1163,11 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
         });
 
         // Act
-        await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
+        var result = await loader.CallToolHandler(request, TestContext.Current.CancellationToken);
 
         // Assert - local-required command should not have been executed in HTTP mode
         Assert.False(executed, "Local-required command should not be executed in HTTP mode");
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "local-cmd");
     }
 
     [Fact]
@@ -1002,9 +1278,8 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
 
         // Assert
         Assert.NotNull(result);
-        // Should fallback to learn mode or return error
-        var textContent = result.Content[0] as TextContentBlock;
-        Assert.NotNull(textContent);
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, toolName, "nonexistent-command",
+            loader.GetChildToolList(request, toolName).Select(tool => tool.Name).Order(StringComparer.Ordinal).ToArray());
         activity.AssertTagEquals(TagName.ToolParameters, toolParameters =>
         {
             var parametersList = JsonSerializer.Deserialize(toolParameters.ToString()!, ModelsJsonContext.Default.ListString);
@@ -1078,6 +1353,40 @@ public sealed class NamespaceToolLoaderTests : IAsyncDisposable
     }
 
     // Helper methods
+
+    private NamespaceToolLoader CreateRoutingLoader(
+        Dictionary<string, IBaseCommand> commands,
+        ServerRuntimeConfiguration? configuration = null,
+        string namespaceName = "storage")
+    {
+        var group = new CommandGroup(namespaceName, "Namespace commands");
+        foreach (var (name, command) in commands)
+        {
+            group.AddCommand(name, command);
+        }
+        var root = new CommandGroup("root", "Root command group");
+        root.SubGroup.Add(group);
+        var factory = Substitute.For<ICommandFactory>();
+        factory.RootGroup.Returns(root);
+        factory.GroupCommands(Arg.Any<string[]>()).Returns(commands);
+        configuration ??= new ServerRuntimeConfiguration();
+        return new NamespaceToolLoader(factory, Microsoft.Extensions.Options.Options.Create(configuration), _logger,
+            applyFilter: configuration.Mode != ModeTypes.ConsolidatedProxy);
+    }
+
+    private static IBaseCommand CreateRoutingCommand(
+        string name, bool readOnly = true, bool localRequired = false, int descriptionRepeats = 1)
+    {
+        var description = string.Concat(Enumerable.Repeat("Catalog detail. ", descriptionRepeats));
+        var underlyingCommand = new Command(name, description);
+        underlyingCommand.Options.Add(new Option<string>("--subscription") { Description = description });
+        underlyingCommand.Options.Add(new Option<int>("--limit") { Description = description });
+        var command = Substitute.For<IBaseCommand>();
+        command.Metadata.Returns(new ToolMetadata { ReadOnly = readOnly, LocalRequired = localRequired, Destructive = false });
+        command.GetCommand().Returns(underlyingCommand);
+        command.ExecuteAsync(default!, default!, default!).ReturnsForAnyArgs(CreateSuccessfulCommandResponse());
+        return command;
+    }
 
     private NamespaceToolLoader CreateLoaderWithCommand(
         string executionMode,

--- a/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/ServerToolLoaderTests.cs
+++ b/core/Azure.Mcp.Core/tests/Azure.Mcp.Core.Tests/Areas/Server/Commands/ToolLoading/ServerToolLoaderTests.cs
@@ -343,11 +343,7 @@ public class ServerToolLoaderTests
 
         // Assert - The non-read-only tool must NOT be executed
         Assert.False(writeToolExecuted, "Non-read-only tool should not be executed in read-only mode");
-        Assert.NotNull(result);
-        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
-        Assert.NotNull(textContent);
-        // Should not contain the write tool's success response
-        Assert.DoesNotContain("Created account", textContent.Text);
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "account_create", "account_list");
     }
 
     [Fact]
@@ -429,11 +425,7 @@ public class ServerToolLoaderTests
 
         // Assert - The local-required tool must NOT be executed in HTTP mode
         Assert.False(localToolExecuted, "Local-required tool should not be executed in HTTP mode");
-        Assert.NotNull(result);
-        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
-        Assert.NotNull(textContent);
-        // Should not contain the local tool's success response
-        Assert.DoesNotContain("Local result", textContent.Text);
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "local_command", "remote_command");
     }
 
     [Fact]
@@ -506,11 +498,7 @@ public class ServerToolLoaderTests
 
         // Assert - Tool without read-only annotation must NOT be executed in read-only mode
         Assert.False(toolExecuted, "Tool without ReadOnlyHint should not be executed in read-only mode");
-        Assert.NotNull(result);
-        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
-        Assert.NotNull(textContent);
-        // Should not contain the tool's success response
-        Assert.DoesNotContain("Result", textContent.Text);
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "unknown_command");
     }
 
     [Fact]
@@ -544,11 +532,8 @@ public class ServerToolLoaderTests
     }
 
     [Fact]
-    public async Task CallToolHandler_WithReadOnlyAndSamplingFallback_RejectsNonReadOnlyResolvedCommand()
+    public async Task CallToolHandler_WithReadOnlyAndNoSampling_UnknownCommandReturnsFilteredNames()
     {
-        // Arrange - Set up a server where the direct command name doesn't match,
-        // forcing the code path through sampling. With no sampling support on the mock server,
-        // this should fall back to learn mode or reject.
         var readOnlyTool = new Tool
         {
             Name = "account_list",
@@ -571,25 +556,276 @@ public class ServerToolLoaderTests
 
         var toolLoader = CreateToolLoaderWithMockClient(new ServerRuntimeConfiguration { ReadOnly = true }, clientBuilder, "storage");
 
-        // Use a command name that doesn't exist in the filtered available tools list.
-        // "account_create" exists in the backend but is filtered out by ReadOnly.
-        // The non-existent command "bad_command" will fail the availableTools check
-        // and without sampling support, it should fall back to learn mode.
         var request = CreateCallToolRequestWithCommand("storage", "bad_command");
 
         // Act
         var result = await toolLoader.CallToolHandler(request, TestContext.Current.CancellationToken);
 
-        // Assert - Should NOT succeed with a write operation.
-        // The command doesn't match any filtered tool, so it should trigger learn mode or rejection.
-        Assert.NotNull(result);
-        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
-        Assert.NotNull(textContent);
-        // Should not contain the write tool's response
-        Assert.DoesNotContain("Created account", textContent.Text);
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "bad_command", "account_list");
     }
 
     #endregion
+
+    [Theory]
+    [InlineData(ModeTypes.NamespaceProxy, null)]
+    [InlineData(ModeTypes.NamespaceProxy, StructuredOutputMode.Duplicated)]
+    [InlineData(ModeTypes.NamespaceProxy, StructuredOutputMode.Compact)]
+    [InlineData(ModeTypes.ConsolidatedProxy, null)]
+    [InlineData(ModeTypes.ConsolidatedProxy, StructuredOutputMode.Duplicated)]
+    [InlineData(ModeTypes.ConsolidatedProxy, StructuredOutputMode.Compact)]
+    public async Task CallToolHandler_UnknownCommandWithoutUsableSampling_ReturnsNamesOnly(
+        string executionMode, StructuredOutputMode? outputMode)
+    {
+        var executions = 0;
+        var clientBuilder = new MockMcpClientBuilder();
+        foreach (var name in new[] { "storage_zeta", "storage_alpha" })
+        {
+            clientBuilder.AddTool(CreateRoutingTool(name), _ =>
+            {
+                executions++;
+                return new CallToolResult { Content = [new TextContentBlock { Text = "Executed" }] };
+            });
+        }
+        await using var loader = CreateToolLoaderWithMockClient(new ServerRuntimeConfiguration
+        {
+            Mode = executionMode,
+            StructuredOutputMode = outputMode
+        }, clientBuilder, "storage");
+
+        (string? Intent, bool SupportsSampling)[] scenarios =
+        [
+            (null, false), (null, true), ("", true), (" \t ", true), ("list resources", false)
+        ];
+        foreach (var (intent, supportsSampling) in scenarios)
+        {
+            var server = BaseToolLoaderTests.CreateSamplingServer(supportsSampling,
+                """{"command":"storage_alpha","parameters":{}}""");
+
+            var result = await loader.CallToolHandler(
+                BaseToolLoaderTests.CreateCommandRequest(server, intent: intent),
+                TestContext.Current.CancellationToken);
+
+            var text = BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "invalid_command",
+                "storage_alpha", "storage_zeta");
+            Assert.DoesNotContain("Catalog detail.", text);
+            await server.DidNotReceive().SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<CancellationToken>());
+        }
+        Assert.Equal(0, executions);
+    }
+
+    [Theory]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, true)]
+    public async Task CallToolHandler_UnknownCommand_ListsOnlyCommandsAllowedByConfiguration(
+        bool readOnly, bool isHttpMode, bool emptyCatalog)
+    {
+        var executions = 0;
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(CreateRoutingTool("storage_blocked", readOnly: false, localRequired: true), _ =>
+            {
+                executions++;
+                return new CallToolResult { Content = [] };
+            });
+        if (!emptyCatalog)
+        {
+            clientBuilder.AddTool(CreateRoutingTool("storage_allowed"), _ =>
+            {
+                executions++;
+                return new CallToolResult { Content = [] };
+            });
+        }
+        await using var loader = CreateToolLoaderWithMockClient(new ServerRuntimeConfiguration
+        {
+            ReadOnly = readOnly,
+            Transport = isHttpMode ? TransportTypes.Http : TransportTypes.StdIo
+        }, clientBuilder, "storage");
+        var server = BaseToolLoaderTests.CreateSamplingServer(false);
+
+        var result = await loader.CallToolHandler(
+            BaseToolLoaderTests.CreateCommandRequest(server, command: "storage_blocked"),
+            TestContext.Current.CancellationToken);
+
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "storage_blocked",
+            emptyCatalog ? [] : ["storage_allowed"]);
+        Assert.Equal(0, executions);
+        await server.DidNotReceive().SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CallToolHandler_UnknownCommandWithEmptyCatalog_DoesNotSample(bool supportsSampling)
+    {
+        await using var loader = CreateToolLoaderWithMockClient(
+            new ServerRuntimeConfiguration(), new MockMcpClientBuilder(), "storage");
+        var server = BaseToolLoaderTests.CreateSamplingServer(supportsSampling);
+
+        var result = await loader.CallToolHandler(
+            BaseToolLoaderTests.CreateCommandRequest(server), TestContext.Current.CancellationToken);
+
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "invalid_command");
+        await server.DidNotReceive().SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("storage_alpha")]
+    [InlineData("STORAGE_ALPHA")]
+    public async Task CallToolHandler_SamplingCorrection_ExecutesCanonicalCommandOnceWithSampledParameters(string sampledName)
+    {
+        var executions = 0;
+        IReadOnlyDictionary<string, object?>? executedParameters = null;
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(CreateRoutingTool("storage_alpha"), parameters =>
+            {
+                executions++;
+                executedParameters = parameters;
+                return new CallToolResult { Content = [new TextContentBlock { Text = "Corrected execution" }], IsError = false };
+            });
+        await using var loader = CreateToolLoaderWithMockClient(new ServerRuntimeConfiguration(), clientBuilder, "storage");
+        var server = BaseToolLoaderTests.CreateSamplingServer(true,
+            $$$"""{"command":"{{{sampledName}}}","parameters":{"subscription":"sampled-subscription","limit":3}}""");
+
+        var result = await loader.CallToolHandler(
+            BaseToolLoaderTests.CreateCommandRequest(server,
+                parametersJson: """{"subscription":"original-subscription","limit":1}"""),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError);
+        Assert.Equal("Corrected execution", Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text);
+        Assert.Equal(1, executions);
+        Assert.NotNull(executedParameters);
+        Assert.Equal(2, executedParameters.Count);
+        Assert.Equal("sampled-subscription", executedParameters["subscription"]);
+        Assert.Equal(3, executedParameters["limit"]);
+        await server.Received(1).SendRequestAsync(
+            Arg.Is<JsonRpcRequest>(rpc => rpc.Method == "sampling/createMessage"), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData(" \t ", false)]
+    [InlineData("not JSON", false)]
+    [InlineData("null", false)]
+    [InlineData("[]", false)]
+    [InlineData("{}", false)]
+    [InlineData("""{"command":null}""", false)]
+    [InlineData("""{"command":17}""", false)]
+    [InlineData("""{"command":""}""", false)]
+    [InlineData("""{"command":" "}""", false)]
+    [InlineData("""{"command":"Unknown","parameters":{}}""", false)]
+    [InlineData("""{"command":"nonexistent","parameters":{}}""", false)]
+    [InlineData(null, true)]
+    public async Task CallToolHandler_UnusableSamplingCorrection_ReturnsErrorWithoutExecutionOrRetry(
+        string? samplingText, bool failSampling)
+    {
+        var executions = 0;
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(CreateRoutingTool("storage_alpha"), _ =>
+            {
+                executions++;
+                return new CallToolResult { Content = [] };
+            });
+        await using var loader = CreateToolLoaderWithMockClient(new ServerRuntimeConfiguration(), clientBuilder, "storage");
+        var server = BaseToolLoaderTests.CreateSamplingServer(true, samplingText, failSampling);
+
+        var result = await loader.CallToolHandler(
+            BaseToolLoaderTests.CreateCommandRequest(server), TestContext.Current.CancellationToken);
+
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "invalid_command", "storage_alpha");
+        Assert.Equal(0, executions);
+        await server.Received(1).SendRequestAsync(
+            Arg.Is<JsonRpcRequest>(rpc => rpc.Method == "sampling/createMessage"), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task CallToolHandler_FilteredSamplingCorrection_DoesNotExecuteOrRetry(bool readOnly, bool isHttpMode)
+    {
+        var executions = 0;
+        var clientBuilder = new MockMcpClientBuilder();
+        foreach (var tool in new[]
+        {
+            CreateRoutingTool("storage_alpha"),
+            CreateRoutingTool("storage_blocked", readOnly: !readOnly, localRequired: isHttpMode)
+        })
+        {
+            clientBuilder.AddTool(tool, _ =>
+            {
+                executions++;
+                return new CallToolResult { Content = [] };
+            });
+        }
+        await using var loader = CreateToolLoaderWithMockClient(new ServerRuntimeConfiguration
+        {
+            ReadOnly = readOnly,
+            Transport = isHttpMode ? TransportTypes.Http : TransportTypes.StdIo
+        }, clientBuilder, "storage");
+        var server = BaseToolLoaderTests.CreateSamplingServer(true,
+            """{"command":"STORAGE_BLOCKED","parameters":{}}""");
+
+        var result = await loader.CallToolHandler(
+            BaseToolLoaderTests.CreateCommandRequest(server), TestContext.Current.CancellationToken);
+
+        BaseToolLoaderTests.AssertUnknownCommandResult(result, "storage", "invalid_command", "storage_alpha");
+        Assert.Equal(0, executions);
+        await server.Received(1).SendRequestAsync(
+            Arg.Is<JsonRpcRequest>(rpc => rpc.Method == "sampling/createMessage"), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    public async Task CallToolHandler_LearnOrIntentOnly_PreservesCatalogWithoutCorrectionLoop(
+        bool explicitLearn, bool supportsSampling)
+    {
+        var executions = 0;
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(CreateRoutingTool("storage_alpha"), _ =>
+            {
+                executions++;
+                return new CallToolResult { Content = [] };
+            });
+        await using var loader = CreateToolLoaderWithMockClient(new ServerRuntimeConfiguration(), clientBuilder, "storage");
+        var server = BaseToolLoaderTests.CreateSamplingServer(supportsSampling,
+            """{"command":"nonexistent","parameters":{}}""");
+
+        var result = await loader.CallToolHandler(
+            BaseToolLoaderTests.CreateCommandRequest(server,
+                command: explicitLearn ? "invalid_command" : null, learn: explicitLearn),
+            TestContext.Current.CancellationToken);
+
+        Assert.NotEqual(true, result.IsError);
+        var text = Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text;
+        Assert.Contains("storage_alpha", text);
+        Assert.Contains("Catalog detail.", text);
+        Assert.Contains("\"inputSchema\"", text);
+        Assert.Equal(0, executions);
+        await server.Received(supportsSampling ? 1 : 0).SendRequestAsync(
+            Arg.Is<JsonRpcRequest>(rpc => rpc.Method == "sampling/createMessage"), Arg.Any<CancellationToken>());
+    }
+
+    private static Tool CreateRoutingTool(string name, bool readOnly = true, bool localRequired = false)
+    {
+        using var schema = JsonDocument.Parse("""
+            {"type":"object","properties":{"subscription":{"type":"string","description":"Catalog detail."},"limit":{"type":"integer"}}}
+            """);
+        return new Tool
+        {
+            Name = name,
+            Description = "Catalog detail.",
+            InputSchema = schema.RootElement.Clone(),
+            Annotations = new ToolAnnotations { ReadOnlyHint = readOnly },
+            Meta = [new(McpHelper.LocalRequiredHintMetaKey, localRequired)]
+        };
+    }
 
     #region Telemetry tests
 

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/BaseToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/BaseToolLoader.cs
@@ -92,6 +92,30 @@ public abstract class BaseToolLoader(ILogger logger) : IToolLoader
         return parametersElem.EnumerateObject().ToDictionary(prop => prop.Name, prop => (object?)prop.Value);
     }
 
+    internal static CallToolResult CreateUnknownCommandResult(string toolName, string commandName, IEnumerable<string> availableCommandNames)
+    {
+        var names = availableCommandNames.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
+        var availableCommands = names.Length == 0
+            ? "No commands are available for this tool in the current server configuration."
+            : $"Available commands: {string.Join(", ", names)}";
+
+        return new CallToolResult
+        {
+            Content =
+            [
+                new TextContentBlock
+                {
+                    Text = $"""
+                        The command '{commandName}' is not available for the '{toolName}' tool.
+                        {availableCommands}
+                        Use "learn=true" to get command descriptions and parameter schemas.
+                        """
+                }
+            ],
+            IsError = true
+        };
+    }
+
     /// <summary>
     /// The name of the option used to pass raw MCP tool input directly to a command.
     /// </summary>

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/NamespaceToolLoader.cs
@@ -328,7 +328,7 @@ public sealed class NamespaceToolLoader(
         try
         {
             namespaceCommands = _commandFactory.GroupCommands([namespaceName]);
-            if (namespaceCommands == null || namespaceCommands.Count == 0)
+            if (namespaceCommands == null)
             {
                 _logger.LogError("Failed to get commands for namespace: {Namespace}", namespaceName);
                 return await InvokeToolLearn(request, intent, namespaceName, cancellationToken);
@@ -343,26 +343,29 @@ public sealed class NamespaceToolLoader(
         try
         {
             var availableTools = GetChildToolList(request, namespaceName);
+            var requestedCommand = command;
+            var resolvedTool = availableTools.FirstOrDefault(t => string.Equals(t.Name, command, StringComparison.OrdinalIgnoreCase));
 
-            // When the specified command is not available, we try to learn about the tool's capabilities
-            // and infer the command and parameters from the users intent.
-            if (!availableTools.Any(t => string.Equals(t.Name, command, StringComparison.OrdinalIgnoreCase)))
+            // Try one supported sampling correction without falling back to the full learn response.
+            if (resolvedTool == null)
             {
                 _logger.LogWarning("Namespace {Namespace} does not have a command {Command}.", namespaceName, command);
-                if (string.IsNullOrWhiteSpace(intent))
+                if (availableTools.Count == 0 || !SupportsSampling(request.Server) || string.IsNullOrWhiteSpace(intent))
                 {
-                    return await InvokeToolLearn(request, intent, namespaceName, cancellationToken);
+                    return CreateUnknownCommandResult(namespaceName, requestedCommand, availableTools.Select(t => t.Name));
                 }
 
                 var samplingResult = await GetCommandAndParametersFromIntentAsync(request, intent, namespaceName, availableTools, cancellationToken);
-                if (string.IsNullOrWhiteSpace(samplingResult.commandName))
+                resolvedTool = availableTools.FirstOrDefault(t => string.Equals(t.Name, samplingResult.commandName, StringComparison.OrdinalIgnoreCase));
+                if (resolvedTool == null)
                 {
-                    return await InvokeToolLearn(request, intent ?? "", namespaceName, cancellationToken);
+                    return CreateUnknownCommandResult(namespaceName, requestedCommand, availableTools.Select(t => t.Name));
                 }
 
-                command = samplingResult.commandName;
                 parameters = samplingResult.parameters;
             }
+
+            command = resolvedTool.Name;
 
             // Here the parameters are now those for the tool call, instead of being the namespace parameters.
             Activity.Current?.SetTag(TagName.ToolParameters, McpHelper.CreateToolParametersTelemetry(parameters.Keys));
@@ -372,7 +375,7 @@ public sealed class NamespaceToolLoader(
             if (!namespaceCommands.TryGetValue(command, out var cmd))
             {
                 _logger.LogError("Command {Command} found in tools but missing from namespace {Namespace} commands.", command, namespaceName);
-                return await InvokeToolLearn(request, intent, namespaceName, cancellationToken);
+                return CreateUnknownCommandResult(namespaceName, requestedCommand, availableTools.Select(t => t.Name));
             }
 
             Activity.Current?.SetTag(TagName.ToolAnnotations, McpHelper.CreateToolAnnotationTelemetry(cmd));
@@ -786,10 +789,15 @@ public sealed class NamespaceToolLoader(
                 }
             }
 
-            if (commandName != null && commandName != "Unknown")
+            var resolvedTool = !string.IsNullOrWhiteSpace(commandName) && commandName != "Unknown"
+                ? availableTools.FirstOrDefault(t => string.Equals(t.Name, commandName, StringComparison.OrdinalIgnoreCase))
+                : null;
+            if (resolvedTool != null)
             {
-                return (commandName, parameters);
+                return (resolvedTool.Name, parameters);
             }
+
+            _logger.LogWarning("Sampling did not resolve to an available command for namespace: {Namespace}.", namespaceName);
         }
         catch
         {

--- a/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
+++ b/core/Microsoft.Mcp.Core/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
@@ -244,40 +244,31 @@ public sealed class ServerToolLoader(
         {
             Activity.Current?.SetTag(TagName.ToolSource, "external." + client.ServerInfo.Name);
             var availableTools = await GetChildToolListAsync(request, tool, cancellationToken);
+            var resolvedTool = availableTools.FirstOrDefault(t => string.Equals(t.Name, command, StringComparison.OrdinalIgnoreCase));
 
-            // When the specified command is not available, we try to learn about the tool's capabilities
-            // and infer the command and parameters from the users intent.
-            if (!availableTools.Any(t => string.Equals(t.Name, command, StringComparison.OrdinalIgnoreCase)))
+            // Try one supported sampling correction without falling back to the full learn response.
+            if (resolvedTool == null)
             {
                 _logger.LogWarning("Tool {Tool} does not have a command {Command}.", tool, command);
-                if (string.IsNullOrWhiteSpace(intent))
+                if (availableTools.Count == 0 || !SupportsSampling(request.Server) || string.IsNullOrWhiteSpace(intent))
                 {
-                    return await InvokeToolLearn(request, intent, tool, cancellationToken);
+                    return CreateUnknownCommandResult(tool, command, availableTools.Select(t => t.Name));
                 }
 
                 var samplingResult = await GetCommandAndParametersFromIntentAsync(request, intent, tool, availableTools, cancellationToken);
-                if (string.IsNullOrWhiteSpace(samplingResult.commandName))
+                resolvedTool = availableTools.FirstOrDefault(t => string.Equals(t.Name, samplingResult.commandName, StringComparison.OrdinalIgnoreCase));
+                if (resolvedTool == null)
                 {
-                    return await InvokeToolLearn(request, intent ?? "", tool, cancellationToken);
+                    return CreateUnknownCommandResult(tool, command, availableTools.Select(t => t.Name));
                 }
 
-                command = samplingResult.commandName;
                 parameters = samplingResult.parameters;
             }
 
+            command = resolvedTool.Name;
+
             // Here the parameters are now those for the tool call, instead of being the server parameters.
             Activity.Current?.SetTag(TagName.ToolParameters, McpHelper.CreateToolParametersTelemetry(parameters.Keys));
-
-            // Verify the resolved command (which may have been updated by sampling)
-            // exists and is permitted under current mode restrictions.
-            var allTools = await GetAllChildToolsAsync(request, tool, cancellationToken);
-            var resolvedTool = allTools.FirstOrDefault(t => string.Equals(t.Name, command, StringComparison.OrdinalIgnoreCase));
-
-            if (resolvedTool == null)
-            {
-                // Sampling resolved to a command that doesn't exist at all.
-                return await InvokeToolLearn(request, intent, tool, cancellationToken);
-            }
 
             var toolId = McpHelper.GetToolIdFromMeta(resolvedTool.Meta);
             Activity.Current?.SetTag(TagName.ToolId, toolId)
@@ -561,10 +552,15 @@ public sealed class ServerToolLoader(
                     parameters = parametersElem.EnumerateObject().ToDictionary(prop => prop.Name, prop => (object?)prop.Value.Clone()) ?? [];
                 }
             }
-            if (commandName != null && commandName != "Unknown")
+            var resolvedTool = !string.IsNullOrWhiteSpace(commandName) && commandName != "Unknown"
+                ? availableTools.FirstOrDefault(t => string.Equals(t.Name, commandName, StringComparison.OrdinalIgnoreCase))
+                : null;
+            if (resolvedTool != null)
             {
-                return (commandName, parameters);
+                return (resolvedTool.Name, parameters);
             }
+
+            _logger.LogWarning("Sampling did not resolve to an available command for tool: {Tool}.", tool);
         }
         catch
         {

--- a/servers/Azure.Mcp.Server/changelog-entries/rickwinter-concise-command-errors.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/rickwinter-concise-command-errors.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Bugs Fixed"
+    description: "Return concise errors listing available command names instead of full help when namespace or consolidated tool routing cannot resolve a command, including external-server routing."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -103,6 +103,8 @@ the CLI and the container image entrypoint.
 
 Exposes Azure tools grouped by service namespace. Each Azure service appears as a single namespace-level tool that routes to individual operations internally. This is the default mode to reduce tool count and prevent VS Code from hitting the 128 tool limit.
 
+If a tool call specifies an unavailable `command`, the router can make one correction attempt using the supplied `intent` when the MCP client supports sampling. If it cannot resolve the command, it returns a tool error listing only the command names available to that tool under the current server configuration, without descriptions or parameter schemas. Set `learn=true` to request the full command catalog. This behavior also applies to consolidated mode and external-server routing in these modes; CLI help is unchanged.
+
 ```bash
 # Start MCP Server with namespace-level tools (default behavior)
 azmcp server start \

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -231,6 +231,7 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | appservice_webapp_get | List the web apps in my subscription | none |
 | appservice_webapp_get | Show me the web apps in my <resource_group> resource group | investigation-required |
 | appservice_webapp_get | Get the details for web app <webapp> in <resource_group> | none |
+| appservice_webapp_get | Get app service details for <app-service-resource-id> | none |
 | appservice_webapp_deployment_get | List the deployments for web app <webapp> in <resource_group> | none |
 | appservice_webapp_deployment_get | Get the deployment <deployment-id> for web app <webapp> in <resource_group> | none |
 | appservice_webapp_settings_get-appsettings | List the application settings for web app <webapp> in <resource_group> | none |


### PR DESCRIPTION
## What does this PR do?

Return an error with available command names instead of full help when namespace or consolidated routing cannot resolve a command, including external-server routing. Preserve one supported sampling correction attempt and leave explicit learning unchanged.

## GitHub issue number?

Fixes #2624.

## Invoking Livetests

Copilot submitted PRs are not trustworthy by default. Users with `write` access to the repo need to validate the contents of this PR before leaving a comment with the text `/azp run mcp - pullrequest - live`. This will trigger the necessary livetest workflows to complete required validation.