### PR TITLE
Removed unused parameters from Communication tools

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/alzimmer-communication-remove-unused-parameters.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/alzimmer-communication-remove-unused-parameters.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Breaking Changes"
+    description: "Removed the unused `sender-name` parameter from the `communication email send` tool."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -1444,7 +1444,6 @@ azmcp communication email send --endpoint <endpoint> \
                                --subject <email-subject> \
                                --message <email-content> \
                                [--is-html] \
-                               [--sender-name <sender-display-name>] \
                                [--cc <cc-recipient-email>] \
                                [--bcc <bcc-recipient-email>] \
                                [--reply-to <reply-to-email>]
@@ -1458,11 +1457,10 @@ azmcp communication email send --endpoint "https://mycomms.communication.azure.c
                                --subject "Important message" \
                                --message "Hello from Azure Communication Services!"
 
-# Send HTML-formatted email with CC and sender name
+# Send HTML-formatted email with CC
 # ❌ Destructive | ❌ Idempotent | ✅ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp communication email send --endpoint "https://mycomms.communication.azure.com" \
                                --from "sender@verified-domain.com" \
-                               --sender-name "Support Team" \
                                --to "recipient@example.com" \
                                --cc "manager@example.com" \
                                --subject "Monthly Report" \
@@ -1487,7 +1485,6 @@ azmcp communication email send --endpoint "https://mycomms.communication.azure.c
 -   `--subject`: Email subject line (required)
 -   `--message`: Email content body (required)
 -   `--is-html`: Flag indicating the message content is HTML format (optional)
--   `--sender-name`: Display name of the sender (optional)
 -   `--cc`: Carbon copy recipient email address(es), comma-separated for multiple recipients (optional)
 -   `--bcc`: Blind carbon copy recipient email address(es), comma-separated for multiple recipients (optional)
 -   `--reply-to`: Reply-to email address(es), comma-separated for multiple addresses (optional)

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -388,7 +388,6 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | communication_email_send | Send email with CC to <email-address-1> and <email-address-2> | clarification-required |
 | communication_email_send | Send email to multiple recipients: <email-address-1>, <email-address-2> | clarification-required |
 | communication_email_send | Send email with reply-to address set to <email-address> | clarification-required |
-| communication_email_send | Send email with custom sender name <sender-name> | clarification-required |
 | communication_email_send | Send an email with BCC recipients | clarification-required |
 | communication_sms_send | Send an SMS message to <phone-number> saying "Hello" | clarification-required |
 | communication_sms_send | Send SMS to <phone-number-2> from <phone-number-1> with message "Test message" | clarification-required |

--- a/tools/Azure.Mcp.Tools.Communication/src/Commands/Email/EmailSendCommand.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Commands/Email/EmailSendCommand.cs
@@ -67,7 +67,6 @@ public sealed class EmailSendCommand(ILogger<EmailSendCommand> logger, ICommunic
             var result = await _communicationService.SendEmailAsync(
                 options.Endpoint,
                 options.From,
-                options.SenderName,
                 options.To,
                 options.Subject,
                 options.Message,

--- a/tools/Azure.Mcp.Tools.Communication/src/Options/Email/EmailSendOptions.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Options/Email/EmailSendOptions.cs
@@ -17,12 +17,6 @@ public sealed class EmailSendOptions : BaseCommunicationOptions
     public required string From { get; set; }
 
     /// <summary>
-    /// The display name of the sender.
-    /// </summary>
-    [Option(Description = "The display name of the sender")]
-    public string? SenderName { get; set; }
-
-    /// <summary>
     /// The recipient email addresses.
     /// </summary>
     [Option(Description = "The recipient email address(es) to send the email to.")]

--- a/tools/Azure.Mcp.Tools.Communication/src/Services/CommunicationService.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Services/CommunicationService.cs
@@ -92,7 +92,6 @@ public class CommunicationService(IAzureService azureService, ILogger<Communicat
     public async Task<Models.EmailSendResult> SendEmailAsync(
         string endpoint,
         string from,
-        string? senderName,
         string[] to,
         string subject,
         string message,

--- a/tools/Azure.Mcp.Tools.Communication/src/Services/ICommunicationService.cs
+++ b/tools/Azure.Mcp.Tools.Communication/src/Services/ICommunicationService.cs
@@ -22,7 +22,6 @@ public interface ICommunicationService
     /// </summary>
     /// <param name="endpoint">The Azure Communication Services endpoint.</param>
     /// <param name="from">The email address to send from (must be from a verified domain).</param>
-    /// <param name="senderName">The display name of the sender.</param>
     /// <param name="to">The recipient email addresses.</param>
     /// <param name="subject">The email subject.</param>
     /// <param name="message">The email body content.</param>
@@ -34,7 +33,6 @@ public interface ICommunicationService
     Task<EmailSendResult> SendEmailAsync(
         string endpoint,
         string from,
-        string? senderName,
         string[] to,
         string subject,
         string message,

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/Email/EmailSendCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/Email/EmailSendCommandTests.cs
@@ -55,7 +55,6 @@ public class EmailSendCommandTests : CommandUnitTestsBase<EmailSendCommand, ICom
             Service.SendEmailAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<string>(),
                 Arg.Any<string[]>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -111,7 +110,6 @@ public class EmailSendCommandTests : CommandUnitTestsBase<EmailSendCommand, ICom
         Service.SendEmailAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<string>(),
             Arg.Any<string[]>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
@@ -133,7 +131,6 @@ public class EmailSendCommandTests : CommandUnitTestsBase<EmailSendCommand, ICom
         await Service.Received(1).SendEmailAsync(
             "https://example.communication.azure.com",
             "sender@example.com",
-            null,
             Arg.Is<string[]>(arr => arr.Length == 1 && arr[0] == "recipient@example.com"),
             "Test Subject",
             "Test Message",
@@ -168,7 +165,6 @@ public class EmailSendCommandTests : CommandUnitTestsBase<EmailSendCommand, ICom
 
         var expectedException = new RequestFailedException("Test error message");
         Service.SendEmailAsync(
-            Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string[]>(),

--- a/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/Services/CommunicationServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Communication/tests/Azure.Mcp.Tools.Communication.Tests/Services/CommunicationServiceTests.cs
@@ -28,7 +28,6 @@ public class CommunicationServiceTests
         // Arrange
         string endpoint = string.Empty;
         string sender = "sender@example.com";
-        string? senderName = string.Empty;
         string[] to = ["recipient@example.com"];
         string subject = "Test Subject";
         string message = "Test Message";
@@ -36,7 +35,7 @@ public class CommunicationServiceTests
         // Act & Assert
         // Updated to use Assert.ThrowsAsync for async methods
         var exception = await Assert.ThrowsAsync<ArgumentException>(
-            () => _service.SendEmailAsync(endpoint, sender, senderName, to, subject, message, false, null, null, null, null, TestContext.Current.CancellationToken));
+            () => _service.SendEmailAsync(endpoint, sender, to, subject, message, false, null, null, null, null, TestContext.Current.CancellationToken));
 
         Assert.Contains("endpoint", exception.Message, StringComparison.OrdinalIgnoreCase);
     }


### PR DESCRIPTION
## What does this PR do?

Removed the unused `sender-name` parameter from the `communication email send` tool.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
