### PR TITLE
Removed unused parameters from KeyVault tools

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/alzimmer-keyvault-remove-unused-parameters.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/alzimmer-keyvault-remove-unused-parameters.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Breaking Changes"
+    description: "Removed the unused `subscription` parameter from all Key Vault tools."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3123,8 +3123,7 @@ azmcp iothub query run --subscription <subscription> \
 ```bash
 # Gets Key Vault Managed HSM account settings
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp keyvault admin settings get --subscription <subscription> \
-                                  --vault <vault-name>
+azmcp keyvault admin settings get --vault <vault-name>
 ```
 
 #### Certificates
@@ -3132,20 +3131,17 @@ azmcp keyvault admin settings get --subscription <subscription> \
 ```bash
 # Creates a certificate in a key vault with the default policy
 # ✅ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp keyvault certificate create --subscription <subscription> \
-                                  --vault <vault-name> \
+azmcp keyvault certificate create --vault <vault-name> \
                                   --name <certificate-name>
 
 # Get a specific certificate or list all certificates. If --name is provided, returns a specific certificate; otherwise, lists all certificates in the key vault.
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp keyvault certificate get --subscription <subscription> \
-                               --vault <vault-name> \
+azmcp keyvault certificate get --vault <vault-name> \
                                [--name <certificate-name>]
 
 # Imports an existing certificate (PFX or PEM) into a key vault
 # ✅ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ✅ LocalRequired
-azmcp keyvault certificate import --subscription <subscription> \
-                                  --vault <vault-name> \
+azmcp keyvault certificate import --vault <vault-name> \
                                   --certificate <certificate-name> \
                                   --certificate-data <path-or-base64-or-raw-pem> \
                                   [--password <pfx-password>]
@@ -3156,15 +3152,13 @@ azmcp keyvault certificate import --subscription <subscription> \
 ```bash
 # Creates a key in a key vault
 # ✅ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp keyvault key create --subscription <subscription> \
-                          --vault <vault-name> \
+azmcp keyvault key create --vault <vault-name> \
                           --key <key-name> \
                           --key-type <key-type>
 
 # Get a specific key or list all keys. If --key is provided, returns a specific key; otherwise, lists all keys in the key vault.
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp keyvault key get --subscription <subscription> \
-                       --vault <vault-name> \
+azmcp keyvault key get --vault <vault-name> \
                        [--key <key-name>] \
                        [--include-managed]
 ```
@@ -3186,15 +3180,13 @@ Tools that handle sensitive data such as secrets require user consent before exe
 ```bash
 # Creates a secret in a key vault (will prompt for user consent)
 # ✅ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ✅ Secret | ❌ LocalRequired
-azmcp keyvault secret create --subscription <subscription> \
-                             --vault <vault-name> \
+azmcp keyvault secret create --vault <vault-name> \
                              --name <secret-name> \
                              --value <secret-value>
 
 # Get a specific secret or list all secrets. If --secret is provided, returns a specific secret with its value (requires user consent); otherwise, lists all secrets in the key vault (returns secret names and properties, not values).
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ✅ Secret | ❌ LocalRequired
-azmcp keyvault secret get --subscription <subscription> \
-                          --vault <vault-name> \
+azmcp keyvault secret get --vault <vault-name> \
                           [--secret <secret-name>]
 ```
 

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Admin/AdminSettingsGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Admin/AdminSettingsGetCommand.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.KeyVault.Options;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Microsoft.Extensions.Logging;
@@ -23,8 +21,8 @@ namespace Azure.Mcp.Tools.KeyVault.Commands.Admin;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class AdminSettingsGetCommand(ILogger<AdminSettingsGetCommand> logger, IKeyVaultService keyVaultService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<BaseKeyVaultOptions, AdminSettingsGetCommand.AdminSettingsGetCommandResult>(subscriptionResolver)
+public sealed class AdminSettingsGetCommand(ILogger<AdminSettingsGetCommand> logger, IKeyVaultService keyVaultService)
+    : AuthenticatedCommand<BaseKeyVaultOptions, AdminSettingsGetCommand.AdminSettingsGetCommandResult>
 {
     private readonly ILogger<AdminSettingsGetCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
@@ -33,7 +31,7 @@ public sealed class AdminSettingsGetCommand(ILogger<AdminSettingsGetCommand> log
     {
         try
         {
-            var settingsResult = await _keyVaultService.GetVaultSettings(options.Vault, options.Subscription!, options.Tenant, cancellationToken);
+            var settingsResult = await _keyVaultService.GetVaultSettings(options.Vault, options.Tenant, cancellationToken);
 
             // Convert settings to a dictionary of strings for easier serialization in case the service adds new settings in the future.
             Dictionary<string, string> settings = new(StringComparer.OrdinalIgnoreCase);

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateCreateCommand.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.KeyVault.Models;
 using Azure.Mcp.Tools.KeyVault.Options.Certificate;
 using Azure.Mcp.Tools.KeyVault.Services;
@@ -16,7 +14,7 @@ namespace Azure.Mcp.Tools.KeyVault.Commands.Certificate;
     Id = "a11e024a-62e6-4237-8d7d-4b9b8439f50e",
     Name = "create",
     Title = "Create Key Vault Certificate",
-    Description = "Create/issue/generate a new certificate in an Azure Key Vault using the default certificate policy. Required: --vault, --certificate, --subscription. Optional: --tenant <tenant>. Returns: name, id, keyId, secretId, cer (base64), thumbprint, enabled, notBefore, expiresOn, createdOn, updatedOn, subject, issuerName. Creates a new certificate version if it already exists.",
+    Description = "Create/issue/generate a new certificate in an Azure Key Vault using the default certificate policy. Required: --vault, --certificate. Optional: --tenant <tenant>. Returns: name, id, keyId, secretId, cer (base64), thumbprint, enabled, notBefore, expiresOn, createdOn, updatedOn, subject, issuerName. Creates a new certificate version if it already exists.",
     OperationPlane = ToolOperationPlane.Data,
     Destructive = true,
     Idempotent = false,
@@ -24,8 +22,8 @@ namespace Azure.Mcp.Tools.KeyVault.Commands.Certificate;
     ReadOnly = false,
     Secret = false,
     LocalRequired = false)]
-public sealed class CertificateCreateCommand(ILogger<CertificateCreateCommand> logger, IKeyVaultService keyVaultService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<CertificateCreateOptions, CertificateDetails>(subscriptionResolver)
+public sealed class CertificateCreateCommand(ILogger<CertificateCreateCommand> logger, IKeyVaultService keyVaultService)
+    : AuthenticatedCommand<CertificateCreateOptions, CertificateDetails>
 {
     private readonly ILogger<CertificateCreateCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
@@ -37,7 +35,6 @@ public sealed class CertificateCreateCommand(ILogger<CertificateCreateCommand> l
             var certificate = await _keyVaultService.CreateCertificate(
                 options.Vault,
                 options.Certificate,
-                options.Subscription!,
                 options.Tenant,
                 cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateGetCommand.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.KeyVault.Models;
 using Azure.Mcp.Tools.KeyVault.Options.Certificate;
 using Azure.Mcp.Tools.KeyVault.Services;
@@ -24,8 +22,8 @@ namespace Azure.Mcp.Tools.KeyVault.Commands.Certificate;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class CertificateGetCommand(ILogger<CertificateGetCommand> logger, IKeyVaultService keyVaultService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<CertificateGetOptions, CertificateGetCommand.CertificateGetCommandResult>(subscriptionResolver)
+public sealed class CertificateGetCommand(ILogger<CertificateGetCommand> logger, IKeyVaultService keyVaultService)
+    : AuthenticatedCommand<CertificateGetOptions, CertificateGetCommand.CertificateGetCommandResult>
 {
     private readonly ILogger<CertificateGetCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
@@ -39,7 +37,6 @@ public sealed class CertificateGetCommand(ILogger<CertificateGetCommand> logger,
                 // List all certificates
                 var certificates = await _keyVaultService.ListCertificates(
                     options.Vault,
-                    options.Subscription!,
                     options.Tenant,
                     cancellationToken);
 
@@ -51,7 +48,6 @@ public sealed class CertificateGetCommand(ILogger<CertificateGetCommand> logger,
                 var certificate = await _keyVaultService.GetCertificate(
                     options.Vault,
                     options.Certificate,
-                    options.Subscription!,
                     options.Tenant,
                     cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateImportCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Certificate/CertificateImportCommand.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.KeyVault.Models;
 using Azure.Mcp.Tools.KeyVault.Options.Certificate;
 using Azure.Mcp.Tools.KeyVault.Services;
@@ -16,7 +14,7 @@ namespace Azure.Mcp.Tools.KeyVault.Commands.Certificate;
     Id = "4ae12e3e-dee0-4d8d-ad34-ffeaf70c642b",
     Name = "import",
     Title = "Import Key Vault Certificate",
-    Description = "Imports/uploads an existing certificate (PFX or PEM with private key) into an Azure Key Vault without generating a new certificate or key material. This command accepts either a file path to a PFX/PEM file, a base64 encoded PFX, or raw PEM text starting with -----BEGIN. If the certificate is a password-protected PFX, a password must be provided. Required: --vault <vault>, --certificate <certificate>, --certificate-data <certificate-data>, --subscription <subscription>. Optional: --password <password-for-PFX>, --tenant <tenant>. Returns: name, id, keyId, secretId, cer (base64), thumbprint, enabled, notBefore, expiresOn, createdOn, updatedOn, subject, issuer. Creates a new certificate version if it already exists.",
+    Description = "Imports/uploads an existing certificate (PFX or PEM with private key) into an Azure Key Vault without generating a new certificate or key material. This command accepts either a file path to a PFX/PEM file, a base64 encoded PFX, or raw PEM text starting with -----BEGIN. If the certificate is a password-protected PFX, a password must be provided. Required: --vault <vault>, --certificate <certificate>, --certificate-data <certificate-data>. Optional: --password <password-for-PFX>, --tenant <tenant>. Returns: name, id, keyId, secretId, cer (base64), thumbprint, enabled, notBefore, expiresOn, createdOn, updatedOn, subject, issuer. Creates a new certificate version if it already exists.",
     OperationPlane = ToolOperationPlane.Data,
     Destructive = true,
     Idempotent = false,
@@ -24,8 +22,8 @@ namespace Azure.Mcp.Tools.KeyVault.Commands.Certificate;
     ReadOnly = false,
     Secret = false,
     LocalRequired = true)]
-public sealed class CertificateImportCommand(ILogger<CertificateImportCommand> logger, IKeyVaultService keyVaultService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<CertificateImportOptions, CertificateDetails>(subscriptionResolver)
+public sealed class CertificateImportCommand(ILogger<CertificateImportCommand> logger, IKeyVaultService keyVaultService)
+    : AuthenticatedCommand<CertificateImportOptions, CertificateDetails>
 {
     private readonly ILogger<CertificateImportCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
@@ -39,7 +37,6 @@ public sealed class CertificateImportCommand(ILogger<CertificateImportCommand> l
                 options.Certificate,
                 options.CertificateData,
                 options.Password,
-                options.Subscription!,
                 options.Tenant,
                 cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Key/KeyCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Key/KeyCreateCommand.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.KeyVault.Models;
 using Azure.Mcp.Tools.KeyVault.Options.Key;
 using Azure.Mcp.Tools.KeyVault.Services;
@@ -16,7 +14,7 @@ namespace Azure.Mcp.Tools.KeyVault.Commands.Key;
     Id = "ef27bda9-8a1f-4288-b68b-12308ab8e607",
     Name = "create",
     Title = "Create Key Vault Key",
-    Description = "Create a new key in an Azure Key Vault. This command creates a key with the specified name and type in the given vault. Supports types: RSA, RSA-HSM, EC, EC-HSM (RSA-HSM and EC-HSM require a premium SKU vault). Required: --vault <vault>, --key <key> --key-type <key-type> --subscription <subscription>. Optional: --tenant <tenant>. Returns: name, id, keyId, keyType, enabled, notBefore, expiresOn, createdOn, updatedOn. Creates a new key version if it already exists.",
+    Description = "Create a new key in an Azure Key Vault. This command creates a key with the specified name and type in the given vault. Supports types: RSA, RSA-HSM, EC, EC-HSM (RSA-HSM and EC-HSM require a premium SKU vault). Required: --vault <vault>, --key <key> --key-type <key-type>. Optional: --tenant <tenant>. Returns: name, id, keyId, keyType, enabled, notBefore, expiresOn, createdOn, updatedOn. Creates a new key version if it already exists.",
     OperationPlane = ToolOperationPlane.Data,
     Destructive = true,
     Idempotent = false,
@@ -24,8 +22,8 @@ namespace Azure.Mcp.Tools.KeyVault.Commands.Key;
     ReadOnly = false,
     Secret = false,
     LocalRequired = false)]
-public sealed class KeyCreateCommand(ILogger<KeyCreateCommand> logger, IKeyVaultService keyVaultService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<KeyCreateOptions, KeyDetails>(subscriptionResolver)
+public sealed class KeyCreateCommand(ILogger<KeyCreateCommand> logger, IKeyVaultService keyVaultService)
+    : AuthenticatedCommand<KeyCreateOptions, KeyDetails>
 {
     private readonly ILogger<KeyCreateCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
@@ -38,7 +36,6 @@ public sealed class KeyCreateCommand(ILogger<KeyCreateCommand> logger, IKeyVault
                 options.Vault,
                 options.Key,
                 options.KeyType,
-                options.Subscription!,
                 options.Tenant,
                 cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Key/KeyGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Key/KeyGetCommand.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.KeyVault.Models;
 using Azure.Mcp.Tools.KeyVault.Options.Key;
 using Azure.Mcp.Tools.KeyVault.Services;
@@ -24,8 +22,8 @@ namespace Azure.Mcp.Tools.KeyVault.Commands.Key;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class KeyGetCommand(ILogger<KeyGetCommand> logger, IKeyVaultService keyVaultService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<KeyGetOptions, KeyGetCommand.KeyGetCommandResult>(subscriptionResolver)
+public sealed class KeyGetCommand(ILogger<KeyGetCommand> logger, IKeyVaultService keyVaultService)
+    : AuthenticatedCommand<KeyGetOptions, KeyGetCommand.KeyGetCommandResult>
 {
     private readonly ILogger<KeyGetCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
@@ -40,7 +38,6 @@ public sealed class KeyGetCommand(ILogger<KeyGetCommand> logger, IKeyVaultServic
                 var keys = await _keyVaultService.ListKeys(
                     options.Vault,
                     options.IncludeManaged,
-                    options.Subscription!,
                     options.Tenant,
                     cancellationToken);
 
@@ -52,7 +49,6 @@ public sealed class KeyGetCommand(ILogger<KeyGetCommand> logger, IKeyVaultServic
                 var key = await _keyVaultService.GetKey(
                     options.Vault,
                     options.Key,
-                    options.Subscription!,
                     options.Tenant,
                     cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Secret/SecretCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Secret/SecretCreateCommand.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.KeyVault.Models;
 using Azure.Mcp.Tools.KeyVault.Options.Secret;
 using Azure.Mcp.Tools.KeyVault.Services;
@@ -16,7 +14,7 @@ namespace Azure.Mcp.Tools.KeyVault.Commands.Secret;
     Id = "fb1322cd-05b0-4264-9e96-6a9b3d9291a0",
     Name = "create",
     Title = "Create Key Vault Secret",
-    Description = "Create/set a secret in an Azure Key Vault with the specified name and value. Required: --vault <vault>, --secret <secret>, --subscription <subscription>. Optional: --tenant <tenant>. Creates a new secret version if it already exists.",
+    Description = "Create/set a secret in an Azure Key Vault with the specified name and value. Required: --vault <vault>, --secret <secret>. Optional: --tenant <tenant>. Creates a new secret version if it already exists.",
     OperationPlane = ToolOperationPlane.Data,
     Destructive = true,
     Idempotent = false,
@@ -24,8 +22,8 @@ namespace Azure.Mcp.Tools.KeyVault.Commands.Secret;
     ReadOnly = false,
     Secret = true,
     LocalRequired = false)]
-public sealed class SecretCreateCommand(ILogger<SecretCreateCommand> logger, IKeyVaultService keyVaultService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<SecretCreateOptions, SecretDetails>(subscriptionResolver)
+public sealed class SecretCreateCommand(ILogger<SecretCreateCommand> logger, IKeyVaultService keyVaultService)
+    : AuthenticatedCommand<SecretCreateOptions, SecretDetails>
 {
     private readonly ILogger<SecretCreateCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
@@ -38,7 +36,6 @@ public sealed class SecretCreateCommand(ILogger<SecretCreateCommand> logger, IKe
                 options.Vault!,
                 options.Secret!,
                 options.Value!,
-                options.Subscription!,
                 options.Tenant,
                 cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Secret/SecretGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Commands/Secret/SecretGetCommand.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.KeyVault.Models;
 using Azure.Mcp.Tools.KeyVault.Options.Secret;
 using Azure.Mcp.Tools.KeyVault.Services;
@@ -24,8 +22,8 @@ namespace Azure.Mcp.Tools.KeyVault.Commands.Secret;
     ReadOnly = true,
     Secret = true,
     LocalRequired = false)]
-public sealed class SecretGetCommand(ILogger<SecretGetCommand> logger, IKeyVaultService keyVaultService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<SecretGetOptions, SecretGetCommand.SecretGetCommandResult>(subscriptionResolver)
+public sealed class SecretGetCommand(ILogger<SecretGetCommand> logger, IKeyVaultService keyVaultService)
+    : AuthenticatedCommand<SecretGetOptions, SecretGetCommand.SecretGetCommandResult>
 {
     private readonly ILogger<SecretGetCommand> _logger = logger;
     private readonly IKeyVaultService _keyVaultService = keyVaultService;
@@ -39,7 +37,6 @@ public sealed class SecretGetCommand(ILogger<SecretGetCommand> logger, IKeyVault
                 // List all secrets
                 var secrets = await _keyVaultService.ListSecrets(
                     options.Vault,
-                    options.Subscription!,
                     options.Tenant,
                     cancellationToken);
 
@@ -51,7 +48,6 @@ public sealed class SecretGetCommand(ILogger<SecretGetCommand> logger, IKeyVault
                 var secret = await _keyVaultService.GetSecret(
                     options.Vault,
                     options.Secret,
-                    options.Subscription!,
                     options.Tenant,
                     cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Options/BaseKeyVaultOptions.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Options/BaseKeyVaultOptions.cs
@@ -6,13 +6,10 @@ using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.KeyVault.Options;
 
-public class BaseKeyVaultOptions : ISubscriptionOption
+public class BaseKeyVaultOptions
 {
     [Option(Description = "The name of the Key Vault.")]
     public required string Vault { get; set; }
-
-    [Option(Description = OptionDescriptions.Subscription)]
-    public string? Subscription { get; set; }
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Services/IKeyVaultService.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Services/IKeyVaultService.cs
@@ -15,14 +15,12 @@ public interface IKeyVaultService
     /// </summary>
     /// <param name="vaultName">The name of the Key Vault</param>
     /// <param name="certificateName">The name of the certificate to create</param>
-    /// <param name="subscriptionId">The subscription ID or name</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations</param>
     /// <param name="cancellationToken">A cancellation token</param>
     /// <returns>The created certificate</returns>
     Task<KeyVaultCertificateWithPolicy> CreateCertificate(
         string vaultName,
         string certificateName,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default);
 
@@ -32,14 +30,12 @@ public interface IKeyVaultService
     /// <param name="vaultName">The name of the Key Vault</param>
     /// <param name="keyName">The name of the key to create</param>
     /// <param name="keyType">The type of key to create (e.g., RSA, EC, OCT)</param>
-    /// <param name="subscriptionId">The subscription ID or name</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations</param>
     /// <returns>The created key</returns>
     Task<KeyVaultKey> CreateKey(
         string vaultName,
         string keyName,
         string keyType,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default);
 
@@ -49,14 +45,12 @@ public interface IKeyVaultService
     /// <param name="vaultName">The name of the Key Vault</param>
     /// <param name="secretName">The name of the secret to create</param>
     /// <param name="secretValue">The value of the secret</param>
-    /// <param name="subscriptionId">The subscription ID or name</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations</param>
     /// <returns>The created secret</returns>
     Task<KeyVaultSecret> CreateSecret(
         string vaultName,
         string secretName,
         string secretValue,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default);
 
@@ -65,13 +59,11 @@ public interface IKeyVaultService
     /// </summary>
     /// <param name="vaultName">The name of the Key Vault</param>
     /// <param name="certificateName">The name of the certificate to retrieve</param>
-    /// <param name="subscriptionId">The subscription ID or name</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations</param>
     /// <returns>The certificate</returns>
     Task<KeyVaultCertificateWithPolicy> GetCertificate(
         string vaultName,
         string certificateName,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default);
 
@@ -80,13 +72,11 @@ public interface IKeyVaultService
     /// </summary>
     /// <param name="vaultName">The name of the Key Vault</param>
     /// <param name="keyName">The name of the key to retrieve</param>
-    /// <param name="subscriptionId">The subscription ID or name</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations</param>
     /// <returns>The key</returns>
     Task<KeyVaultKey> GetKey(
         string vaultName,
         string keyName,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default);
 
@@ -95,13 +85,11 @@ public interface IKeyVaultService
     /// </summary>
     /// <param name="vaultName">The name of the Key Vault</param>
     /// <param name="secretName">The name of the secret to retrieve</param>
-    /// <param name="subscriptionId">The subscription ID or name</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations</param>
     /// <returns>The secret value</returns>
     Task<KeyVaultSecret> GetSecret(
         string vaultName,
         string secretName,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default);
 
@@ -109,12 +97,10 @@ public interface IKeyVaultService
     /// List all certificates in a Key Vault.
     /// </summary>
     /// <param name="vaultName">Name of the Key Vault.</param>
-    /// <param name="subscriptionId">Subscription ID containing the Key Vault.</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations.</param>
     /// <returns>List of certificate names in the vault.</returns>
     Task<List<string>> ListCertificates(
         string vaultName,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default);
 
@@ -122,13 +108,11 @@ public interface IKeyVaultService
     /// List all keys in a Key Vault.
     /// </summary>
     /// <param name="vaultName">Name of the Key Vault.</param>
-    /// <param name="subscriptionId">Subscription ID containing the Key Vault.</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations.</param>
     /// <returns>List of key names in the vault.</returns>
     Task<List<string>> ListKeys(
         string vaultName,
         bool includeManagedKeys,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default);
 
@@ -136,12 +120,10 @@ public interface IKeyVaultService
     /// List all secrets in a Key Vault.
     /// </summary>
     /// <param name="vaultName">Name of the Key Vault.</param>
-    /// <param name="subscriptionId">Subscription ID containing the Key Vault.</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations.</param>
     /// <returns>List of secret names in the vault.</returns>
     Task<List<string>> ListSecrets(
         string vaultName,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default);
 
@@ -152,7 +134,6 @@ public interface IKeyVaultService
     /// <param name="certificateName">The target certificate name in Key Vault.</param>
     /// <param name="certificateData">Raw certificate data: bytes base64 encoded (PFX) or raw PEM text.</param>
     /// <param name="password">Optional password if the certificate is a protected PFX.</param>
-    /// <param name="subscriptionId">The subscription ID or name.</param>
     /// <param name="tenantId">Optional tenant ID for cross-tenant operations.</param>
     /// <returns>The imported certificate.</returns>
     Task<KeyVaultCertificateWithPolicy> ImportCertificate(
@@ -160,7 +141,6 @@ public interface IKeyVaultService
         string certificateName,
         string certificateData,
         string? password,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default);
 
@@ -168,12 +148,10 @@ public interface IKeyVaultService
     /// Retrieves account settings for a Key Vault.
     /// </summary>
     /// <param name="vaultName">The name of the Key Vault.</param>
-    /// <param name="subscription">The subscription ID or name.</param>
     /// <param name="tenant">Optional tenant ID for cross-tenant operations.</param>
     /// <returns>Structured vault settings.</returns>
     Task<GetSettingsResult> GetVaultSettings(
         string vaultName,
-        string subscription,
         string? tenant = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.KeyVault/src/Services/KeyVaultService.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/src/Services/KeyVaultService.cs
@@ -16,11 +16,10 @@ public sealed class KeyVaultService(IAzureService azureService)
     public async Task<List<string>> ListKeys(
         string vaultName,
         bool includeManagedKeys,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(subscriptionId), subscriptionId));
+        ValidateRequiredParameters((nameof(vaultName), vaultName));
 
         var credential = await GetCredential(tenantId, cancellationToken);
         var client = CreateKeyClient(vaultName, credential);
@@ -37,11 +36,10 @@ public sealed class KeyVaultService(IAzureService azureService)
     public async Task<KeyVaultKey> GetKey(
         string vaultName,
         string keyName,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(keyName), keyName), (nameof(subscriptionId), subscriptionId));
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(keyName), keyName));
 
         var credential = await GetCredential(tenantId, cancellationToken);
         var client = CreateKeyClient(vaultName, credential);
@@ -53,11 +51,10 @@ public sealed class KeyVaultService(IAzureService azureService)
         string vaultName,
         string keyName,
         string keyType,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(keyName), keyName), (nameof(keyType), keyType), (nameof(subscriptionId), subscriptionId));
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(keyName), keyName), (nameof(keyType), keyType));
 
         var type = new KeyType(keyType);
         var credential = await GetCredential(tenantId, cancellationToken);
@@ -68,11 +65,10 @@ public sealed class KeyVaultService(IAzureService azureService)
 
     public async Task<List<string>> ListSecrets(
         string vaultName,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(subscriptionId), subscriptionId));
+        ValidateRequiredParameters((nameof(vaultName), vaultName));
 
         var credential = await GetCredential(tenantId, cancellationToken);
         var client = CreateSecretClient(vaultName, credential);
@@ -90,11 +86,10 @@ public sealed class KeyVaultService(IAzureService azureService)
         string vaultName,
         string secretName,
         string secretValue,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(secretName), secretName), (nameof(secretValue), secretValue), (nameof(subscriptionId), subscriptionId));
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(secretName), secretName), (nameof(secretValue), secretValue));
 
         var credential = await GetCredential(tenantId, cancellationToken);
         var client = CreateSecretClient(vaultName, credential);
@@ -105,11 +100,10 @@ public sealed class KeyVaultService(IAzureService azureService)
     public async Task<KeyVaultSecret> GetSecret(
         string vaultName,
         string secretName,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(secretName), secretName), (nameof(subscriptionId), subscriptionId));
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(secretName), secretName));
 
         var credential = await GetCredential(tenantId, cancellationToken);
         var client = CreateSecretClient(vaultName, credential);
@@ -119,11 +113,10 @@ public sealed class KeyVaultService(IAzureService azureService)
 
     public async Task<List<string>> ListCertificates(
         string vaultName,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(subscriptionId), subscriptionId));
+        ValidateRequiredParameters((nameof(vaultName), vaultName));
 
         var credential = await GetCredential(tenantId, cancellationToken);
         var client = CreateCertificateClient(vaultName, credential);
@@ -140,11 +133,10 @@ public sealed class KeyVaultService(IAzureService azureService)
     public async Task<KeyVaultCertificateWithPolicy> GetCertificate(
         string vaultName,
         string certificateName,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(certificateName), certificateName), (nameof(subscriptionId), subscriptionId));
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(certificateName), certificateName));
 
         var credential = await GetCredential(tenantId, cancellationToken);
         var client = CreateCertificateClient(vaultName, credential);
@@ -155,11 +147,10 @@ public sealed class KeyVaultService(IAzureService azureService)
     public async Task<KeyVaultCertificateWithPolicy> CreateCertificate(
         string vaultName,
         string certificateName,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(certificateName), certificateName), (nameof(subscriptionId), subscriptionId));
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(certificateName), certificateName));
 
         var credential = await GetCredential(tenantId, cancellationToken);
         var client = CreateCertificateClient(vaultName, credential);
@@ -174,11 +165,10 @@ public sealed class KeyVaultService(IAzureService azureService)
         string certificateName,
         string certificateData,
         string? password,
-        string subscriptionId,
         string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(certificateName), certificateName), (nameof(certificateData), certificateData), (nameof(subscriptionId), subscriptionId));
+        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(certificateName), certificateName), (nameof(certificateData), certificateData));
 
         var credential = await GetCredential(tenantId, cancellationToken);
         var client = CreateCertificateClient(vaultName, credential);
@@ -318,11 +308,10 @@ public sealed class KeyVaultService(IAzureService azureService)
 
     public async Task<GetSettingsResult> GetVaultSettings(
         string vaultName,
-        string subscription,
         string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(vaultName), vaultName), (nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(vaultName), vaultName));
         var credential = await GetCredential(tenantId, cancellationToken);
         var hsmUri = new Uri(GetHsmUri(vaultName));
 

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Admin/AdminSettingsGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Admin/AdminSettingsGetCommandTests.cs
@@ -2,20 +2,19 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Admin;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Administration;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.Tests.Admin;
 
-public class AdminSettingsGetCommandTests : SubscriptionCommandUnitTestsBase<AdminSettingsGetCommand, IKeyVaultService>
+public class AdminSettingsGetCommandTests : CommandUnitTestsBase<AdminSettingsGetCommand, IKeyVaultService>
 {
-    private const string KnownSubscriptionId = "knownSubscription";
     private const string KnownVaultName = "knownVaultName";
 
     [Fact]
@@ -24,12 +23,11 @@ public class AdminSettingsGetCommandTests : SubscriptionCommandUnitTestsBase<Adm
         // We return null from service (simplest stub); command should still succeed with empty dictionary.
         Service.GetVaultSettings(
             Arg.Is(KnownVaultName),
-            Arg.Is(KnownSubscriptionId),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns((GetSettingsResult)null!);
 
-        var response = await ExecuteCommandAsync("--vault", KnownVaultName, "--subscription", KnownSubscriptionId);
+        var response = await ExecuteCommandAsync("--vault", KnownVaultName);
 
         var result = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.AdminSettingsGetCommandResult);
         Assert.Equal(KnownVaultName, result.Name);
@@ -42,29 +40,25 @@ public class AdminSettingsGetCommandTests : SubscriptionCommandUnitTestsBase<Adm
         var expectedError = "Test error";
         Service.GetVaultSettings(
             Arg.Any<string>(),
-            Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
-        var response = await ExecuteCommandAsync("--vault", KnownVaultName, "--subscription", KnownSubscriptionId);
+        var response = await ExecuteCommandAsync("--vault", KnownVaultName);
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.Contains(expectedError, response.Message);
     }
 
     [Theory]
-    [InlineData("--vault knownVaultName --subscription knownSubscription", true)]
-    [InlineData("--subscription knownSubscription --vault knownVaultName", true)]
-    [InlineData("--subscription knownSubscription", false, "Missing required vault")] // Missing required vault
-    [InlineData("", false, "Missing both")] // Missing both
+    [InlineData("--vault knownVaultName", true)]
+    [InlineData("", false, "Missing required vault")]
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed, string expectedFailureReason = "")
     {
         if (shouldSucceed)
         {
             // Service returns null result -> treated as empty settings
             Service.GetVaultSettings(
-                Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
                 Arg.Any<CancellationToken>())
@@ -79,5 +73,7 @@ public class AdminSettingsGetCommandTests : SubscriptionCommandUnitTestsBase<Adm
             Assert.Contains("required", response.Message, StringComparison.OrdinalIgnoreCase);
             Console.WriteLine($"Validation failed as expected: {expectedFailureReason}");
         }
+
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 }

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Certificate/CertificateCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Certificate/CertificateCreateCommandTests.cs
@@ -2,18 +2,17 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Certificate;
 using Azure.Mcp.Tools.KeyVault.Services;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.Tests.Certificate;
 
-public class CertificateCreateCommandTests : SubscriptionCommandUnitTestsBase<CertificateCreateCommand, IKeyVaultService>
+public class CertificateCreateCommandTests : CommandUnitTestsBase<CertificateCreateCommand, IKeyVaultService>
 {
-    private const string _knownSubscriptionId = "knownSubscription";
     private const string _knownVaultName = "knownVaultName";
     private const string _knownCertificateName = "knownCertificateName";
 
@@ -28,7 +27,6 @@ public class CertificateCreateCommandTests : SubscriptionCommandUnitTestsBase<Ce
         Service.CreateCertificate(
             Arg.Is(_knownVaultName),
             Arg.Is(_knownCertificateName),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
@@ -36,14 +34,12 @@ public class CertificateCreateCommandTests : SubscriptionCommandUnitTestsBase<Ce
         // Act
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
-            "--certificate", _knownCertificateName,
-            "--subscription", _knownSubscriptionId);
+            "--certificate", _knownCertificateName);
 
         // Assert - Verify the service was called with correct parameters
         await Service.Received(1).CreateCertificate(
             _knownVaultName,
             _knownCertificateName,
-            _knownSubscriptionId,
             Arg.Any<string>(),
             Arg.Any<CancellationToken>());
 
@@ -57,8 +53,7 @@ public class CertificateCreateCommandTests : SubscriptionCommandUnitTestsBase<Ce
         // Arrange & Act - No need to mock service since validation should fail before service is called
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
-            "--certificate", "",
-            "--subscription", _knownSubscriptionId);
+            "--certificate", "");
 
         // Assert - Should return validation error response
         Assert.NotNull(response);
@@ -74,7 +69,6 @@ public class CertificateCreateCommandTests : SubscriptionCommandUnitTestsBase<Ce
         Service.CreateCertificate(
             Arg.Is(_knownVaultName),
             Arg.Is(_knownCertificateName),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
@@ -82,12 +76,12 @@ public class CertificateCreateCommandTests : SubscriptionCommandUnitTestsBase<Ce
         // Act
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
-            "--certificate", _knownCertificateName,
-            "--subscription", _knownSubscriptionId);
+            "--certificate", _knownCertificateName);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.StartsWith(expectedError, response.Message);
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 }

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Certificate/CertificateGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Certificate/CertificateGetCommandTests.cs
@@ -2,18 +2,17 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Certificate;
 using Azure.Mcp.Tools.KeyVault.Services;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.Tests.Certificate;
 
-public class CertificateGetCommandTests : SubscriptionCommandUnitTestsBase<CertificateGetCommand, IKeyVaultService>
+public class CertificateGetCommandTests : CommandUnitTestsBase<CertificateGetCommand, IKeyVaultService>
 {
-    private const string _knownSubscriptionId = "knownSubscription";
     private const string _knownVaultName = "knownVaultName";
     private const string _knownCertificateName = "knownCertificateName";
 
@@ -28,7 +27,6 @@ public class CertificateGetCommandTests : SubscriptionCommandUnitTestsBase<Certi
         Service.GetCertificate(
             Arg.Is(_knownVaultName),
             Arg.Is(_knownCertificateName),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
@@ -36,14 +34,12 @@ public class CertificateGetCommandTests : SubscriptionCommandUnitTestsBase<Certi
         // Act
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
-            "--certificate", _knownCertificateName,
-            "--subscription", _knownSubscriptionId);
+            "--certificate", _knownCertificateName);
 
         // Assert - Verify the service was called with correct parameters
         await Service.Received(1).GetCertificate(
             Arg.Is(_knownVaultName),
             Arg.Is(_knownCertificateName),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>());
 
@@ -60,7 +56,6 @@ public class CertificateGetCommandTests : SubscriptionCommandUnitTestsBase<Certi
         Service.GetCertificate(
             Arg.Is(_knownVaultName),
             Arg.Is(_knownCertificateName),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
@@ -68,8 +63,7 @@ public class CertificateGetCommandTests : SubscriptionCommandUnitTestsBase<Certi
         // Act
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
-            "--certificate", _knownCertificateName,
-            "--subscription", _knownSubscriptionId);
+            "--certificate", _knownCertificateName);
 
         // Assert
         Assert.NotNull(response);
@@ -85,15 +79,12 @@ public class CertificateGetCommandTests : SubscriptionCommandUnitTestsBase<Certi
 
         Service.ListCertificates(
             Arg.Is(_knownVaultName),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedCertificates);
 
         // Act
-        var response = await ExecuteCommandAsync(
-            "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId);
+        var response = await ExecuteCommandAsync("--vault", _knownVaultName);
 
         // Assert
         var result = ValidateAndDeserializeResponse(response, Commands.KeyVaultJsonContext.Default.CertificateGetCommandResult);
@@ -112,19 +103,17 @@ public class CertificateGetCommandTests : SubscriptionCommandUnitTestsBase<Certi
 
         Service.ListCertificates(
             Arg.Is(_knownVaultName),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         // Act
-        var response = await ExecuteCommandAsync(
-            "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId);
+        var response = await ExecuteCommandAsync("--vault", _knownVaultName);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.StartsWith(expectedError, response.Message);
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 }

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Certificate/CertificateImportCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Certificate/CertificateImportCommandTests.cs
@@ -2,19 +2,17 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Certificate;
 using Azure.Mcp.Tools.KeyVault.Services;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.Tests.Certificate;
 
-public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<CertificateImportCommand, IKeyVaultService>
+public class CertificateImportCommandTests : CommandUnitTestsBase<CertificateImportCommand, IKeyVaultService>
 {
-
-    private const string _knownSubscription = "knownSubscription";
     private const string _knownVault = "knownVault";
     private const string _knownCertName = "knownCertificate";
     // Generate a deterministic base64 string from readable words to avoid cspell warnings on opaque text.
@@ -29,7 +27,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             _knownCertName,
             _fakePfxBase64,
             null,
-            _knownSubscription,
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error")); // force exception to avoid building return object
@@ -38,8 +35,7 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
         var response = await ExecuteCommandAsync(
             "--vault", _knownVault,
             "--certificate", _knownCertName,
-            "--certificate-data", _fakePfxBase64,
-            "--subscription", _knownSubscription);
+            "--certificate-data", _fakePfxBase64);
 
         // Assert
         await Service.Received(1).ImportCertificate(
@@ -47,7 +43,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             _knownCertName,
             _fakePfxBase64,
             null,
-            _knownSubscription,
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status); // due to forced exception
@@ -55,11 +50,10 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
 
     public static IEnumerable<object[]> InvalidArgumentCases()
     {
-        // Build scenarios with missing required parameters (subscription-independent)
+        // Build scenarios with missing required parameters.
         yield return new object[] { "" };
         yield return new object[] { "--vault knownVault" };
         yield return new object[] { "--vault knownVault --certificate knownCertificate" };
-        yield return new object[] { "--vault knownVault --certificate knownCertificate --subscription knownSubscription" };
     }
 
     [Theory]
@@ -74,14 +68,9 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
     }
 
     [Fact]
-    public async Task ExecuteAsync_RejectsArguments_WhenSubscriptionMissing()
+    public void Command_DoesNotExposeSubscription()
     {
-        var response = await ExecuteCommandAsync(
-            "--vault", _knownVault,
-            "--certificate", _knownCertName,
-            "--certificate-data", _fakePfxBase64);
-
-        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 
     [Fact]
@@ -93,7 +82,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string?>(),
-            Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expected));
@@ -101,8 +89,7 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
         var response = await ExecuteCommandAsync(
             "--vault", _knownVault,
             "--certificate", _knownCertName,
-            "--certificate-data", _fakePfxBase64,
-            "--subscription", _knownSubscription);
+            "--certificate-data", _fakePfxBase64);
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.StartsWith(expected, response.Message);
@@ -119,7 +106,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             _knownCertName,
             pem,
             null,
-            _knownSubscription,
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
@@ -128,8 +114,7 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
         var response = await ExecuteCommandAsync(
             "--vault", _knownVault,
             "--certificate", _knownCertName,
-            "--certificate-data", pem,
-            "--subscription", _knownSubscription);
+            "--certificate-data", pem);
 
         // Assert - ensure the PEM (with header) was passed through untouched
         await Service.Received(1).ImportCertificate(
@@ -137,7 +122,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             _knownCertName,
             pem,
             null,
-            _knownSubscription,
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -153,7 +137,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             _knownCertName,
             _fakePfxBase64,
             password,
-            _knownSubscription,
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
@@ -162,15 +145,13 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             "--vault", _knownVault,
             "--certificate", _knownCertName,
             "--certificate-data", _fakePfxBase64,
-            "--password", password,
-            "--subscription", _knownSubscription);
+            "--password", password);
 
         await Service.Received(1).ImportCertificate(
             _knownVault,
             _knownCertName,
             _fakePfxBase64,
             password,
-            _knownSubscription,
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -189,7 +170,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
                 _knownCertName,
                 tempPath,
                 null,
-                _knownSubscription,
                 Arg.Any<string?>(),
                 Arg.Any<CancellationToken>())
                 .ThrowsAsync(new Exception("Test error"));
@@ -198,8 +178,7 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             var response = await ExecuteCommandAsync(
                 "--vault", _knownVault,
                 "--certificate", _knownCertName,
-                "--certificate-data", tempPath,
-                "--subscription", _knownSubscription);
+                "--certificate-data", tempPath);
 
             // Assert - ensure the raw path was passed through
             await Service.Received(1).ImportCertificate(
@@ -207,7 +186,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
                 _knownCertName,
                 tempPath,
                 null,
-                _knownSubscription,
                 Arg.Any<string?>(),
                 Arg.Any<CancellationToken>());
             Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
@@ -234,7 +212,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             _knownCertName,
             invalidData,
             null,
-            _knownSubscription,
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new ArgumentException(errorMessage));
@@ -242,8 +219,7 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
         var response = await ExecuteCommandAsync(
             "--vault", _knownVault,
             "--certificate", _knownCertName,
-            "--certificate-data", invalidData,
-            "--subscription", _knownSubscription);
+            "--certificate-data", invalidData);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.Contains("certificate-data", response.Message, StringComparison.OrdinalIgnoreCase);
@@ -261,7 +237,6 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             _knownCertName,
             _fakePfxBase64,
             password,
-            _knownSubscription,
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(mismatchMessage));
@@ -270,8 +245,7 @@ public class CertificateImportCommandTests : SubscriptionCommandUnitTestsBase<Ce
             "--vault", _knownVault,
             "--certificate", _knownCertName,
             "--certificate-data", _fakePfxBase64,
-            "--password", password,
-            "--subscription", _knownSubscription);
+            "--password", password);
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.StartsWith(mismatchMessage, response.Message);

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Key/KeyCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Key/KeyCreateCommandTests.cs
@@ -2,20 +2,19 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Key;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Keys;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.Tests.Key;
 
-public class KeyCreateCommandTests : SubscriptionCommandUnitTestsBase<KeyCreateCommand, IKeyVaultService>
+public class KeyCreateCommandTests : CommandUnitTestsBase<KeyCreateCommand, IKeyVaultService>
 {
-    private const string _knownSubscriptionId = "knownSubscription";
     private const string _knownVaultName = "knownVaultName";
     private const string _knownKeyName = "knownKeyName";
     private readonly KeyType _knownKeyType = KeyType.Rsa;
@@ -44,7 +43,6 @@ public class KeyCreateCommandTests : SubscriptionCommandUnitTestsBase<KeyCreateC
             Arg.Is(_knownVaultName),
             Arg.Is(_knownKeyName),
             Arg.Is(_knownKeyType.ToString()),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .Returns(_knownKeyVaultKey);
@@ -53,8 +51,7 @@ public class KeyCreateCommandTests : SubscriptionCommandUnitTestsBase<KeyCreateC
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--key", _knownKeyName,
-            "--key-type", _knownKeyType.ToString(),
-            "--subscription", _knownSubscriptionId);
+            "--key-type", _knownKeyType.ToString());
 
         // Assert
         var retrievedKey = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.KeyDetails);
@@ -70,8 +67,7 @@ public class KeyCreateCommandTests : SubscriptionCommandUnitTestsBase<KeyCreateC
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--key", "",
-            "--key-type", _knownKeyType.ToString(),
-            "--subscription", _knownSubscriptionId);
+            "--key-type", _knownKeyType.ToString());
 
         // Assert - Should return validation error response
         Assert.NotNull(response);
@@ -88,7 +84,6 @@ public class KeyCreateCommandTests : SubscriptionCommandUnitTestsBase<KeyCreateC
             Arg.Is(_knownVaultName),
             Arg.Is(_knownKeyName),
             Arg.Is(_knownKeyType.ToString()),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
@@ -97,12 +92,12 @@ public class KeyCreateCommandTests : SubscriptionCommandUnitTestsBase<KeyCreateC
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--key", _knownKeyName,
-            "--key-type", _knownKeyType.ToString(),
-            "--subscription", _knownSubscriptionId);
+            "--key-type", _knownKeyType.ToString());
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.StartsWith(expectedError, response.Message);
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 }

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Key/KeyGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Key/KeyGetCommandTests.cs
@@ -2,20 +2,19 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Key;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Keys;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.Tests.Key;
 
-public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand, IKeyVaultService>
+public class KeyGetCommandTests : CommandUnitTestsBase<KeyGetCommand, IKeyVaultService>
 {
-    private const string _knownSubscriptionId = "knownSubscription";
     private const string _knownVaultName = "knownVaultName";
     private const string _knownKeyName = "knownKeyName";
     private readonly KeyType _knownKeyType = KeyType.Rsa;
@@ -43,7 +42,6 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
         Service.GetKey(
             Arg.Is(_knownVaultName),
             Arg.Is(_knownKeyName),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .Returns(_knownKeyVaultKey);
@@ -51,8 +49,7 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
         // Act
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
-            "--key", _knownKeyName,
-            "--subscription", _knownSubscriptionId);
+            "--key", _knownKeyName);
 
         // Assert
         var retrievedKey = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.KeyGetCommandResult);
@@ -72,7 +69,6 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
         Service.GetKey(
             Arg.Is(_knownVaultName),
             Arg.Is(_knownKeyName),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
@@ -80,8 +76,7 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
         // Act
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
-            "--key", _knownKeyName,
-            "--subscription", _knownSubscriptionId);
+            "--key", _knownKeyName);
 
         // Assert
         Assert.NotNull(response);
@@ -98,15 +93,12 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
         Service.ListKeys(
             Arg.Is(_knownVaultName),
             Arg.Is(false),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedKeys);
 
         // Act
-        var response = await ExecuteCommandAsync(
-            "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId);
+        var response = await ExecuteCommandAsync("--vault", _knownVaultName);
 
         // Assert
         var result = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.KeyGetCommandResult);
@@ -126,7 +118,6 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
         Service.ListKeys(
             Arg.Is(_knownVaultName),
             Arg.Is(true),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedKeys);
@@ -134,7 +125,6 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
         // Act
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId,
             "--include-managed", "true");
 
         // Assert
@@ -155,15 +145,12 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
         Service.ListKeys(
             Arg.Is(_knownVaultName),
             Arg.Any<bool>(),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         // Act
-        var response = await ExecuteCommandAsync(
-            "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId);
+        var response = await ExecuteCommandAsync("--vault", _knownVaultName);
 
         // Assert
         Assert.NotNull(response);
@@ -182,19 +169,17 @@ public class KeyGetCommandTests : SubscriptionCommandUnitTestsBase<KeyGetCommand
         Service.ListKeys(
             Arg.Is(_knownVaultName),
             Arg.Is(false),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedKeys);
 
-        var response = await ExecuteCommandAsync(
-            "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId);
+        var response = await ExecuteCommandAsync("--vault", _knownVaultName);
 
         var result = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.KeyGetCommandResult);
 
         Assert.NotNull(result.Keys);
         Assert.Equal(expectedKeys.Count, result.Keys.Count);
         Assert.Contains("null-managed-key", result.Keys);
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 }

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/KeyVaultCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/KeyVaultCommandTests.cs
@@ -55,7 +55,6 @@ public class KeyVaultCommandTests(ITestOutputHelper output, TestProxyFixture fix
             "keyvault_key_get",
             new()
             {
-                { "subscription", Settings.SubscriptionId },
                 { "vault", Settings.ResourceBaseName }
             });
 
@@ -73,7 +72,6 @@ public class KeyVaultCommandTests(ITestOutputHelper output, TestProxyFixture fix
             "keyvault_key_get",
             new()
             {
-                { "subscription", Settings.SubscriptionId },
                 { "vault", Settings.ResourceBaseName },
                 { "key", knownKeyName}
             });
@@ -97,7 +95,6 @@ public class KeyVaultCommandTests(ITestOutputHelper output, TestProxyFixture fix
             "keyvault_key_create",
             new()
             {
-                { "subscription", Settings.SubscriptionId },
                 { "vault", Settings.ResourceBaseName },
                 { "key", keyName},
                 { "key-type", KeyType.Rsa.ToString() }
@@ -119,7 +116,6 @@ public class KeyVaultCommandTests(ITestOutputHelper output, TestProxyFixture fix
             "keyvault_secret_get",
             new()
             {
-                { "subscription", Settings.SubscriptionId },
                 { "vault", Settings.ResourceBaseName }
             });
 
@@ -137,7 +133,6 @@ public class KeyVaultCommandTests(ITestOutputHelper output, TestProxyFixture fix
             "keyvault_secret_get",
             new()
             {
-                { "subscription", Settings.SubscriptionId },
                 { "vault", Settings.ResourceBaseName },
                 { "secret", secretName }
             });
@@ -159,7 +154,6 @@ public class KeyVaultCommandTests(ITestOutputHelper output, TestProxyFixture fix
             "keyvault_certificate_get",
             new()
             {
-                { "subscription", Settings.SubscriptionId },
                 { "vault", Settings.ResourceBaseName }
             });
 
@@ -177,7 +171,6 @@ public class KeyVaultCommandTests(ITestOutputHelper output, TestProxyFixture fix
             "keyvault_certificate_get",
             new()
             {
-                { "subscription", Settings.SubscriptionId },
                 { "vault", Settings.ResourceBaseName },
                 { "certificate", certificateName }
             });
@@ -200,7 +193,6 @@ public class KeyVaultCommandTests(ITestOutputHelper output, TestProxyFixture fix
             "keyvault_certificate_create",
             new()
             {
-                { "subscription", Settings.SubscriptionId },
                 { "vault", Settings.ResourceBaseName },
                 { "certificate", certificateName}
             });
@@ -233,7 +225,6 @@ public class KeyVaultCommandTests(ITestOutputHelper output, TestProxyFixture fix
                 "keyvault_certificate_import",
                 new()
                 {
-                    { "subscription", Settings.SubscriptionId },
                     { "vault", Settings.ResourceBaseName },
                     { "certificate", certificateName },
                     { "certificate-data", tempPath },
@@ -261,7 +252,6 @@ public class KeyVaultCommandTests(ITestOutputHelper output, TestProxyFixture fix
             "keyvault_admin_settings_get",
             new()
             {
-                { "subscription", Settings.SubscriptionId },
                 { "vault", Settings.ResourceBaseName }
             });
 

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Secret/SecretCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Secret/SecretCreateCommandTests.cs
@@ -2,20 +2,19 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Secret;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Secrets;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.Tests.Secret;
 
-public class SecretCreateCommandTests : SubscriptionCommandUnitTestsBase<SecretCreateCommand, IKeyVaultService>
+public class SecretCreateCommandTests : CommandUnitTestsBase<SecretCreateCommand, IKeyVaultService>
 {
-    private const string _knownSubscriptionId = "knownSubscription";
     private const string _knownVaultName = "knownVaultName";
     private const string _knownSecretName = "knownSecretName";
     private const string _knownSecretValue = "knownSecretValue";
@@ -29,7 +28,6 @@ public class SecretCreateCommandTests : SubscriptionCommandUnitTestsBase<SecretC
             Arg.Is(_knownVaultName),
             Arg.Is(_knownSecretName),
             Arg.Is(_knownSecretValue),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .Returns(_knownKeyVaultSecret);
@@ -38,8 +36,7 @@ public class SecretCreateCommandTests : SubscriptionCommandUnitTestsBase<SecretC
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--secret", _knownSecretName,
-            "--value", _knownSecretValue,
-            "--subscription", _knownSubscriptionId);
+            "--value", _knownSecretValue);
 
         // Assert
         var retrievedSecret = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.SecretDetails);
@@ -54,8 +51,7 @@ public class SecretCreateCommandTests : SubscriptionCommandUnitTestsBase<SecretC
         // Arrange & Act - No need to mock service since validation should fail before service is called
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
-            "--secret", "",
-            "--subscription", _knownSubscriptionId);
+            "--secret", "");
 
         // Assert - Should return validation error response
         Assert.NotNull(response);
@@ -73,7 +69,6 @@ public class SecretCreateCommandTests : SubscriptionCommandUnitTestsBase<SecretC
             Arg.Is(_knownVaultName),
             Arg.Is(_knownSecretName),
             Arg.Is(_knownSecretValue),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
@@ -82,12 +77,12 @@ public class SecretCreateCommandTests : SubscriptionCommandUnitTestsBase<SecretC
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
             "--secret", _knownSecretName,
-            "--value", _knownSecretValue,
-            "--subscription", _knownSubscriptionId);
+            "--value", _knownSecretValue);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.StartsWith(expectedError, response.Message);
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 }

--- a/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Secret/SecretGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.KeyVault/tests/Azure.Mcp.Tools.KeyVault.Tests/Secret/SecretGetCommandTests.cs
@@ -2,20 +2,19 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands;
 using Azure.Mcp.Tools.KeyVault.Commands.Secret;
 using Azure.Mcp.Tools.KeyVault.Services;
 using Azure.Security.KeyVault.Secrets;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.KeyVault.Tests.Secret;
 
-public class SecretGetCommandTests : SubscriptionCommandUnitTestsBase<SecretGetCommand, IKeyVaultService>
+public class SecretGetCommandTests : CommandUnitTestsBase<SecretGetCommand, IKeyVaultService>
 {
-    private const string _knownSubscriptionId = "knownSubscription";
     private const string _knownVaultName = "knownVaultName";
     private const string _knownSecretName = "knownSecretName";
     private const string _knownSecretValue = "knownSecretValue";
@@ -28,7 +27,6 @@ public class SecretGetCommandTests : SubscriptionCommandUnitTestsBase<SecretGetC
         Service.GetSecret(
             Arg.Is(_knownVaultName),
             Arg.Is(_knownSecretName),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .Returns(_knownKeyVaultSecret);
@@ -36,8 +34,7 @@ public class SecretGetCommandTests : SubscriptionCommandUnitTestsBase<SecretGetC
         // Act
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
-            "--secret", _knownSecretName,
-            "--subscription", _knownSubscriptionId);
+            "--secret", _knownSecretName);
 
         // Assert
         var retrievedSecret = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.SecretGetCommandResult);
@@ -58,15 +55,13 @@ public class SecretGetCommandTests : SubscriptionCommandUnitTestsBase<SecretGetC
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         // Act
         var response = await ExecuteCommandAsync(
             "--vault", _knownVaultName,
-            "--secret", _knownSecretName,
-            "--subscription", _knownSubscriptionId);
+            "--secret", _knownSecretName);
 
         // Assert
         Assert.NotNull(response);
@@ -82,15 +77,12 @@ public class SecretGetCommandTests : SubscriptionCommandUnitTestsBase<SecretGetC
 
         Service.ListSecrets(
             Arg.Is(_knownVaultName),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedSecrets);
 
         // Act
-        var response = await ExecuteCommandAsync(
-            "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId);
+        var response = await ExecuteCommandAsync("--vault", _knownVaultName);
 
         // Assert
         var result = ValidateAndDeserializeResponse(response, KeyVaultJsonContext.Default.SecretGetCommandResult);
@@ -109,19 +101,17 @@ public class SecretGetCommandTests : SubscriptionCommandUnitTestsBase<SecretGetC
 
         Service.ListSecrets(
             Arg.Is(_knownVaultName),
-            Arg.Is(_knownSubscriptionId),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         // Act
-        var response = await ExecuteCommandAsync(
-            "--vault", _knownVaultName,
-            "--subscription", _knownSubscriptionId);
+        var response = await ExecuteCommandAsync("--vault", _knownVaultName);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.Contains(expectedError, response.Message);
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 }


### PR DESCRIPTION
## What does this PR do?

Removed the unused `subscription` parameter from all Key Vault tools.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
