### PR TITLE
Removed unused parameters from Monitor tools

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/alzimmer-monitor-remove-unused-parameters.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/alzimmer-monitor-remove-unused-parameters.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Breaking Changes"
+    description: "Removed the unused `completion-note` parameter from `monitor instrumentation orchestrator-next`, `subscription` from `monitor resource log query`, and `max-buckets` from `monitor metrics batchquery`."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -3447,8 +3447,7 @@ azmcp monitor workspace list --subscription <subscription> \
 # .delete, .set, .append, .set-or-append, .set-or-replace, .ingest, .purge, .execute)
 # are rejected.
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp monitor resource log query --subscription <subscription> \
-                                 --resource-id <resource-id> \
+azmcp monitor resource log query --resource-id <resource-id> \
                                  --table <table> \
                                  --query <kql-query> \
                                  [--hours <hours>] \
@@ -3588,8 +3587,7 @@ azmcp monitor metrics batchquery --subscription <subscription> \
                                  [--aggregation <aggregation>] \
                                  [--filter <filter>] \
                                  [--order-by <order-by>] \
-                                 [--top <top>] \
-                                 [--max-buckets <max-buckets>]
+                                 [--top <top>]
 
 # Query CPU metrics across multiple storage accounts at once
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
@@ -3657,8 +3655,7 @@ azmcp monitor instrumentation orchestrator-start --workspace-path <absolute-work
 
 # Continue orchestration after completing the previous action
 # ❌ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ✅ LocalRequired
-azmcp monitor instrumentation orchestrator-next --session-id <session-id> \
-                                                --completion-note <what-was-completed>
+azmcp monitor instrumentation orchestrator-next --session-id <session-id>
 
 # Send brownfield analysis findings JSON to continue migration flow
 # ❌ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ✅ LocalRequired

--- a/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
+++ b/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md
@@ -980,9 +980,9 @@ The `Interaction` column describes whether a prompt can invoke its tool immediat
 | monitor_instrumentation_get-learning-resource | List all available Azure Monitor onboarding learning resources | none |
 | monitor_instrumentation_get-learning-resource | Show me all learning resource paths for Azure Monitor instrumentation | none |
 | monitor_instrumentation_get-learning-resource | What learning resources are available for Azure Monitor instrumentation onboarding? | none |
-| monitor_instrumentation_orchestrator-next | After completing the previous Azure Monitor instrumentation step, get the next action for session <session_id> with completion note <completion_note> | none |
-| monitor_instrumentation_orchestrator-next | Get the next Azure Monitor instrumentation onboarding action for session <session_id> after I completed <completion_note> | none |
-| monitor_instrumentation_orchestrator-next | I finished the previous instrumentation step; return the next step for session <session_id> with note <completion_note> | none |
+| monitor_instrumentation_orchestrator-next | After completing the previous Azure Monitor instrumentation step, get the next action for session <session_id> | none |
+| monitor_instrumentation_orchestrator-next | Get the next Azure Monitor instrumentation onboarding action for session <session_id> | none |
+| monitor_instrumentation_orchestrator-next | I finished the previous instrumentation step; return the next step for session <session_id> | none |
 | monitor_instrumentation_orchestrator-start | Start Azure Monitor instrumentation orchestration for workspace <workspace_path> | none |
 | monitor_instrumentation_orchestrator-start | Analyze workspace <workspace_path> and return the first Azure Monitor instrumentation step | none |
 | monitor_instrumentation_orchestrator-start | Begin guided Azure Monitor onboarding for project at <workspace_path> and give me step one | none |

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/OrchestratorNextCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Instrumentation/OrchestratorNextCommand.cs
@@ -43,7 +43,7 @@ public sealed class OrchestratorNextCommand(ILogger<OrchestratorNextCommand> log
     {
         try
         {
-            var result = _orchestratorTool.Next(options.SessionId, options.CompletionNote);
+            var result = _orchestratorTool.Next(options.SessionId);
 
             context.Response.Status = HttpStatusCode.OK;
             context.Response.Results = ResponseResult.Create(

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Log/ResourceLogQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Log/ResourceLogQueryCommand.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Nodes;
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.Monitor.Options;
 using Azure.Mcp.Tools.Monitor.Services;
 using Microsoft.Extensions.Logging;
@@ -31,8 +29,8 @@ namespace Azure.Mcp.Tools.Monitor.Commands.Log;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class ResourceLogQueryCommand(ILogger<ResourceLogQueryCommand> logger, IMonitorService monitorService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<ResourceLogQueryOptions, ResourceLogQueryCommand.ResourceLogQueryCommandResult>(subscriptionResolver)
+public sealed class ResourceLogQueryCommand(ILogger<ResourceLogQueryCommand> logger, IMonitorService monitorService)
+    : AuthenticatedCommand<ResourceLogQueryOptions, ResourceLogQueryCommand.ResourceLogQueryCommandResult>
 {
     private readonly ILogger<ResourceLogQueryCommand> _logger = logger;
     private readonly IMonitorService _monitorService = monitorService;
@@ -42,7 +40,6 @@ public sealed class ResourceLogQueryCommand(ILogger<ResourceLogQueryCommand> log
         try
         {
             var results = await _monitorService.QueryResourceLogs(
-                options.Subscription!,
                 options.ResourceId,
                 options.Query,
                 options.Table,

--- a/tools/Azure.Mcp.Tools.Monitor/src/Commands/Metrics/MetricsBatchQueryCommand.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Commands/Metrics/MetricsBatchQueryCommand.cs
@@ -32,11 +32,6 @@ public sealed class MetricsBatchQueryCommand(ILogger<MetricsBatchQueryCommand> l
 {
     private const int MaxBatchResources = 50;
 
-    // Assumed granularity used only to estimate the expected bucket count up front when '--interval' isn't
-    // specified. It is never sent to the service -- when '--interval' is omitted, Azure Monitor still selects
-    // the actual granularity automatically.
-    private const string DefaultValidationInterval = "PT1H";
-
     private readonly ILogger<MetricsBatchQueryCommand> _logger = logger;
     private readonly IMonitorMetricsService _metricsService = metricsService;
 
@@ -65,49 +60,20 @@ public sealed class MetricsBatchQueryCommand(ILogger<MetricsBatchQueryCommand> l
 
         // Validate the start/end time formats up front instead of letting the service throw once the request
         // is already in flight (PostBindOptions guarantees these are always populated by the time this runs).
-        bool validStartTime = DateTimeOffset.TryParse(options.StartTime, out var startTime);
-        if (!validStartTime)
+        if (!DateTimeOffset.TryParse(options.StartTime, out _))
         {
             validationResult.Errors.Add($"Invalid format for '--start-time': '{options.StartTime}'. Provide a valid date/time (e.g. 2023-01-01T00:00:00Z).");
         }
 
-        bool validEndTime = DateTimeOffset.TryParse(options.EndTime, out var endTime);
-        if (!validEndTime)
+        if (!DateTimeOffset.TryParse(options.EndTime, out _))
         {
             validationResult.Errors.Add($"Invalid format for '--end-time': '{options.EndTime}'. Provide a valid date/time (e.g. 2023-01-01T00:00:00Z).");
         }
 
-        // The expected number of time buckets is always derived from the start/end time range up front, so an
-        // oversized request is rejected before calling the service -- there's no need to fall back to validating
-        // the actual results after the query executes. When '--interval' isn't specified, Azure Monitor selects
-        // the granularity automatically, so a representative default is assumed for this estimate only; it is not
-        // sent to the service, so the actual query behavior is unaffected.
-        bool intervalProvided = !string.IsNullOrWhiteSpace(options.Interval);
-        string intervalToValidate = intervalProvided ? options.Interval! : DefaultValidationInterval;
-
-        if (!TryParseIsoDuration(intervalToValidate, out var interval) || interval <= TimeSpan.Zero)
+        if (!string.IsNullOrWhiteSpace(options.Interval) &&
+            (!TryParseIsoDuration(options.Interval, out var interval) || interval <= TimeSpan.Zero))
         {
-            // The internal default is always a valid duration, so a parse failure here only happens when the
-            // user explicitly supplied an invalid '--interval' value.
             validationResult.Errors.Add($"Invalid format for '--interval': '{options.Interval}'. Provide an ISO 8601 duration (e.g. PT1H, PT5M).");
-        }
-        else if (validStartTime && validEndTime)
-        {
-            int maxBuckets = options.MaxBuckets ?? 50;
-            int expectedBucketCount = (int)Math.Ceiling((endTime - startTime) / interval);
-
-            if (expectedBucketCount > maxBuckets)
-            {
-                string intervalDescription = intervalProvided
-                    ? $"'--interval' of '{options.Interval}'"
-                    : $"an assumed default interval of '{DefaultValidationInterval}' (since '--interval' was not specified)";
-
-                validationResult.Errors.Add(
-                    $"The requested time range ('--start-time' to '--end-time') combined with {intervalDescription} would produce " +
-                    $"approximately {expectedBucketCount} time buckets, which exceeds the maximum allowed limit of {maxBuckets}. " +
-                    $"To resolve this issue, either query a smaller time range, specify a larger '--interval' (e.g., PT1H), " +
-                    $"or increase the '--max-buckets' parameter.");
-            }
         }
     }
 

--- a/tools/Azure.Mcp.Tools.Monitor/src/Options/Instrumentation/CommandOptions.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Options/Instrumentation/CommandOptions.cs
@@ -21,9 +21,6 @@ public sealed class OrchestratorNextOptions
 {
     [Option(Description = MonitorOptionDescriptions.SessionId)]
     public required string SessionId { get; set; }
-
-    [Option(Description = "One sentence describing what you executed, e.g., 'Ran dotnet add package command' or 'Added UseAzureMonitor() to Program.cs'")]
-    public required string CompletionNote { get; set; }
 }
 
 public sealed class SendBrownfieldAnalysisOptions

--- a/tools/Azure.Mcp.Tools.Monitor/src/Options/Metrics/MetricsBatchQueryOptions.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Options/Metrics/MetricsBatchQueryOptions.cs
@@ -84,9 +84,4 @@ public sealed class MetricsBatchQueryOptions : ISubscriptionOption
     [Option(Description = "The maximum number of time series to retrieve per resource per metric. Only valid when '--filter' is specified. Defaults to 10.")]
     public int? Top { get; set; }
 
-    /// <summary>
-    /// The maximum number of time buckets to return per metric time series. Defaults to 50.
-    /// </summary>
-    [Option(Description = "The maximum number of time buckets to return per metric time series. Defaults to 50.", DefaultValue = 50)]
-    public int? MaxBuckets { get; set; }
 }

--- a/tools/Azure.Mcp.Tools.Monitor/src/Options/ResourceLogQueryOptions.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Options/ResourceLogQueryOptions.cs
@@ -6,7 +6,7 @@ using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Monitor.Options;
 
-public sealed class ResourceLogQueryOptions : ISubscriptionOption
+public sealed class ResourceLogQueryOptions
 {
     [Option(Description = MonitorOptionDescriptions.Query)]
     public required string Query { get; set; }
@@ -25,8 +25,5 @@ public sealed class ResourceLogQueryOptions : ISubscriptionOption
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }
-
-    [Option(Description = OptionDescriptions.Subscription)]
-    public string? Subscription { get; set; }
 
 }

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/IMonitorService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/IMonitorService.cs
@@ -10,7 +10,6 @@ namespace Azure.Mcp.Tools.Monitor.Services;
 public interface IMonitorService
 {
     Task<List<JsonNode>> QueryResourceLogs(
-        string subscription,
         string resourceId,
         string query,
         string table,

--- a/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorService.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Services/MonitorService.cs
@@ -26,7 +26,6 @@ public class MonitorService(IAzureService azureService, IResourceResolverService
     private readonly ILogger<MonitorService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     public async Task<List<JsonNode>> QueryResourceLogs(
-        string subscription,
         string resourceId,
         string query,
         string table,
@@ -35,7 +34,7 @@ public class MonitorService(IAzureService azureService, IResourceResolverService
         string? tenant,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(subscription), subscription), (nameof(resourceId), resourceId), (nameof(table), table));
+        ValidateRequiredParameters((nameof(resourceId), resourceId), (nameof(table), table));
 
         query = BuildQuery(query, table, limit);
         KqlQueryValidator.ValidateQuerySafety(query);

--- a/tools/Azure.Mcp.Tools.Monitor/src/Tools/Instrumentation/OrchestratorTool.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/src/Tools/Instrumentation/OrchestratorTool.cs
@@ -130,7 +130,7 @@ public class OrchestratorTool(WorkspaceAnalyzer analyzer)
         });
     }
 
-    public string Next(string sessionId, string completionNote)
+    public string Next(string sessionId)
     {
         CleanupExpiredSessions();
 

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/Instrumentation/Commands/InstrumentationCommandResultTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/Instrumentation/Commands/InstrumentationCommandResultTests.cs
@@ -51,8 +51,7 @@ public sealed class InstrumentationCommandResultTests
             tool);
         var options = new OrchestratorNextOptions
         {
-            SessionId = $"missing-{Guid.NewGuid():N}",
-            CompletionNote = "done"
+            SessionId = $"missing-{Guid.NewGuid():N}"
         };
 
         var response = await command.ExecuteAsync(

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/Instrumentation/Tools/OrchestratorToolTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/Instrumentation/Tools/OrchestratorToolTests.cs
@@ -32,8 +32,8 @@ public sealed class OrchestratorToolTests
             var startResponse = ParseJson(tool.Start(workspacePath));
             var sessionId = startResponse.GetProperty("sessionId").GetString();
 
-            var nextResponse = ParseJson(tool.Next(sessionId!, "Completed step 1"));
-            var finalResponse = ParseJson(tool.Next(sessionId!, "Completed step 2"));
+            var nextResponse = ParseJson(tool.Next(sessionId!));
+            var finalResponse = ParseJson(tool.Next(sessionId!));
 
             // Assert
             Assert.Equal("in_progress", startResponse.GetProperty("status").GetString());
@@ -63,7 +63,7 @@ public sealed class OrchestratorToolTests
         var tool = new OrchestratorTool(analyzer);
 
         // Act
-        var response = ParseJson(tool.Next($"missing-{Guid.NewGuid():N}", "done"));
+        var response = ParseJson(tool.Next($"missing-{Guid.NewGuid():N}"));
 
         // Assert
         Assert.Equal("error", response.GetProperty("status").GetString());

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/Log/ResourceLogQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/Log/ResourceLogQueryCommandTests.cs
@@ -3,19 +3,18 @@
 
 using System.Net;
 using System.Text.Json.Nodes;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Monitor.Commands;
 using Azure.Mcp.Tools.Monitor.Commands.Log;
 using Azure.Mcp.Tools.Monitor.Services;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Monitor.Tests.Log;
 
-public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsBase<ResourceLogQueryCommand, IMonitorService>
+public sealed class ResourceLogQueryCommandTests : CommandUnitTestsBase<ResourceLogQueryCommand, IMonitorService>
 {
-    private const string _knownSubscription = "knownSubscription";
     private const string _knownResourceId = "/subscriptions/sub123/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/storage1";
     private const string _knownTable = "StorageEvents";
     private const string _knownQuery = "| limit 10";
@@ -24,10 +23,9 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
     private const string _knownLimit = "100";
 
     [Theory]
-    [InlineData($"--subscription {_knownSubscription} --resource-id {_knownResourceId} --table {_knownTable} --query \"{_knownQuery}\"", true)]
-    [InlineData($"--subscription {_knownSubscription} --resource-id {_knownResourceId} --table {_knownTable} --query \"{_knownQuery}\" --hours {_knownHours} --limit {_knownLimit}", true)]
-    [InlineData($"--subscription {_knownSubscription} --table {_knownTable} --query \"{_knownQuery}\"", false)] // missing resource-id
-    [InlineData($"--subscription {_knownSubscription}", false)]
+    [InlineData($"--resource-id {_knownResourceId} --table {_knownTable} --query \"{_knownQuery}\"", true)]
+    [InlineData($"--resource-id {_knownResourceId} --table {_knownTable} --query \"{_knownQuery}\" --hours {_knownHours} --limit {_knownLimit}", true)]
+    [InlineData($"--table {_knownTable} --query \"{_knownQuery}\"", false)] // missing resource-id
     [InlineData("", false)]
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
     {
@@ -40,7 +38,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
                 new JsonObject([new("TimeGenerated", "2023-01-01T12:01:00Z"), new("Message", "Another resource log entry")])
             };
             Service.QueryResourceLogs(
-                _knownSubscription,
                 _knownResourceId,
                 _knownQuery,
                 _knownTable,
@@ -78,7 +75,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
             new JsonObject([new("TimeGenerated", "2023-01-01T12:02:00Z"), new("ResourceId", _knownResourceId), new("Level", "Error")])
         };
         Service.QueryResourceLogs(
-            _knownSubscription,
             _knownResourceId,
             _knownQuery,
             _knownTable,
@@ -90,7 +86,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", _knownSubscription,
             "--resource-id", _knownResourceId,
             "--table", _knownTable,
             "--query", _knownQuery);
@@ -103,7 +98,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
 
         // Verify the mock was called
         await Service.Received(1).QueryResourceLogs(
-            _knownSubscription,
             _knownResourceId,
             _knownQuery,
             _knownTable,
@@ -119,7 +113,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
         // Arrange
         var mockResults = new List<JsonNode> { new JsonObject([new("result", "data")]) };
         Service.QueryResourceLogs(
-            _knownSubscription,
             _knownResourceId,
             _knownQuery,
             _knownTable,
@@ -131,7 +124,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", _knownSubscription,
             "--resource-id", _knownResourceId,
             "--table", _knownTable,
             "--query", _knownQuery,
@@ -142,7 +134,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         await Service.Received(1).QueryResourceLogs(
-            _knownSubscription,
             _knownResourceId,
             _knownQuery,
             _knownTable,
@@ -158,7 +149,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
         // Arrange
         var mockResults = new List<JsonNode> { new JsonObject([new("result", "data")]) };
         Service.QueryResourceLogs(
-            _knownSubscription,
             _knownResourceId,
             _knownQuery,
             _knownTable,
@@ -170,7 +160,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", _knownSubscription,
             "--resource-id", _knownResourceId,
             "--table", _knownTable,
             "--query", _knownQuery);
@@ -178,7 +167,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         await Service.Received(1).QueryResourceLogs(
-            _knownSubscription,
             _knownResourceId,
             _knownQuery,
             _knownTable,
@@ -193,7 +181,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
     {
         // Arrange
         Service.QueryResourceLogs(
-            _knownSubscription,
             _knownResourceId,
             _knownQuery,
             _knownTable,
@@ -205,7 +192,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", _knownSubscription,
             "--resource-id", _knownResourceId,
             "--table", _knownTable,
             "--query", _knownQuery);
@@ -225,7 +211,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
         var table = "VMEvents";
         var mockResults = new List<JsonNode> { new JsonObject([new("result", "vm data")]) };
         Service.QueryResourceLogs(
-            _knownSubscription,
             complexResourceId,
             query,
             table,
@@ -237,7 +222,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", _knownSubscription,
             "--resource-id", complexResourceId,
             "--table", table,
             "--query", query);
@@ -245,7 +229,6 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.Status);
         await Service.Received(1).QueryResourceLogs(
-            _knownSubscription,
             complexResourceId,
             query,
             table,
@@ -253,5 +236,7 @@ public sealed class ResourceLogQueryCommandTests : SubscriptionCommandUnitTestsB
             Arg.Any<int?>(),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>());
+
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 }

--- a/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/Metrics/MetricsBatchQueryCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Monitor/tests/Azure.Mcp.Tools.Monitor.Tests/Metrics/MetricsBatchQueryCommandTests.cs
@@ -54,7 +54,7 @@ public class MetricsBatchQueryCommandTests : SubscriptionCommandUnitTestsBase<Me
         Assert.Contains("--filter", options);
         Assert.Contains("--order-by", options);
         Assert.Contains("--top", options);
-        Assert.Contains("--max-buckets", options);
+        Assert.DoesNotContain("--max-buckets", options);
 
         var requiredOptions = CommandDefinition.Options.Where(o => o.Required).Select(o => o.Name).ToList();
         Assert.Contains("--resources", requiredOptions);
@@ -102,8 +102,7 @@ public class MetricsBatchQueryCommandTests : SubscriptionCommandUnitTestsBase<Me
             "--aggregation", "Average",
             "--filter", "dimension eq 'value'",
             "--order-by", "total asc",
-            "--top", "5",
-            "--max-buckets", "2000");
+            "--top", "5");
 
         // Assert
         await Service.Received(1).QueryMetricsBatchAsync(
@@ -355,173 +354,6 @@ public class MetricsBatchQueryCommandTests : SubscriptionCommandUnitTestsBase<Me
         Assert.Equal(HttpStatusCode.BadRequest, response.Status);
         Assert.NotEmpty(response.Message);
         Assert.Null(response.Results);
-    }
-
-    #endregion
-
-    #region ExecuteAsync Tests - Bucket Limit Validation
-
-    [Fact]
-    public async Task ExecuteAsync_IntervalWouldExceedBucketLimit_ReturnsBadRequestWithoutCallingService()
-    {
-        // Act
-        // 24 hours at PT1M granularity is 1440 buckets, which exceeds the default limit of 50.
-        var response = await ExecuteCommandAsync(
-            "--subscription", "sub1",
-            "--resources", "sa1",
-            "--metric-names", "CPU",
-            "--metric-namespace", "microsoft.compute/virtualmachines",
-            "--start-time", "2023-01-01T00:00:00Z",
-            "--end-time", "2023-01-02T00:00:00Z",
-            "--interval", "PT1M");
-
-        // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
-        Assert.Contains("exceeds the maximum allowed limit of 50", response.Message);
-        await Service.DidNotReceive().QueryMetricsBatchAsync(
-            Arg.Any<string>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<IEnumerable<string>>(),
-            Arg.Any<string>(),
-            Arg.Any<IEnumerable<string>>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<int?>(),
-            Arg.Any<string?>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_IntervalWithinBucketLimit_CallsService()
-    {
-        // Arrange
-        // 2 hours at PT1H granularity is 2 buckets, well within the default limit of 50.
-        Service.QueryMetricsBatchAsync(
-            Arg.Any<string>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<IEnumerable<string>>(),
-            Arg.Any<string>(),
-            Arg.Any<IEnumerable<string>>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<int?>(),
-            Arg.Any<string?>(),
-            Arg.Any<CancellationToken>())
-            .Returns([]);
-
-        // Act
-        var response = await ExecuteCommandAsync(
-            "--subscription", "sub1",
-            "--resources", "sa1",
-            "--metric-names", "CPU",
-            "--metric-namespace", "microsoft.compute/virtualmachines",
-            "--start-time", "2023-01-01T00:00:00Z",
-            "--end-time", "2023-01-01T02:00:00Z",
-            "--interval", "PT1H");
-
-        // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_NoIntervalSpecified_UsesDefaultIntervalForBucketValidation()
-    {
-        // Arrange
-        // When '--interval' isn't specified, the up-front bucket estimate assumes PT1H (this is only used for
-        // validation and is not sent to the service): 30 days at PT1H granularity is 720 buckets, which exceeds
-        // the default limit of 50 -- the service must not be called.
-
-        // Act
-        var response = await ExecuteCommandAsync(
-            "--subscription", "sub1",
-            "--resources", "sa1",
-            "--metric-names", "CPU",
-            "--metric-namespace", "microsoft.compute/virtualmachines",
-            "--start-time", "2023-01-01T00:00:00Z",
-            "--end-time", "2023-01-31T00:00:00Z");
-
-        // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, response.Status);
-        Assert.Contains("exceeds the maximum allowed limit of 50", response.Message);
-        await Service.DidNotReceive().QueryMetricsBatchAsync(
-            Arg.Any<string>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<IEnumerable<string>>(),
-            Arg.Any<string>(),
-            Arg.Any<IEnumerable<string>>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<int?>(),
-            Arg.Any<string?>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_NoIntervalSpecified_WithinBucketLimit_CallsService()
-    {
-        // Arrange
-        // When '--interval' isn't specified, the up-front bucket estimate assumes PT1H: 2 hours at PT1H
-        // granularity is 2 buckets, well within the default limit of 50.
-        Service.QueryMetricsBatchAsync(
-            Arg.Any<string>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<IEnumerable<string>>(),
-            Arg.Any<string>(),
-            Arg.Any<IEnumerable<string>>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<int?>(),
-            Arg.Any<string?>(),
-            Arg.Any<CancellationToken>())
-            .Returns([]);
-
-        // Act
-        var response = await ExecuteCommandAsync(
-            "--subscription", "sub1",
-            "--resources", "sa1",
-            "--metric-names", "CPU",
-            "--metric-namespace", "microsoft.compute/virtualmachines",
-            "--start-time", "2023-01-01T00:00:00Z",
-            "--end-time", "2023-01-01T02:00:00Z");
-
-        // Assert
-        Assert.Equal(HttpStatusCode.OK, response.Status);
-        await Service.Received(1).QueryMetricsBatchAsync(
-            Arg.Any<string>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<IEnumerable<string>>(),
-            Arg.Any<string>(),
-            Arg.Any<IEnumerable<string>>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Is<string?>(t => t == null),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<string?>(),
-            Arg.Any<int?>(),
-            Arg.Any<string?>(),
-            Arg.Any<CancellationToken>());
     }
 
     #endregion


### PR DESCRIPTION
## What does this PR do?

Removed the unused `completion-note` parameter from `monitor instrumentation orchestrator-next`, `subscription` from `monitor resource log query`, and `max-buckets` from `monitor metrics batchquery`.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
