### PR TITLE
Removed unused parameters from Postgres tools

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/alzimmer-postgres-remove-unused-parameters.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/alzimmer-postgres-remove-unused-parameters.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Breaking Changes"
+    description: "Removed the unused `user` parameter from the `postgres server config get`, `postgres server param get`, and `postgres server param set` tools."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -2662,14 +2662,12 @@ azmcp postgres table schema get --user <user> \
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp postgres server config get --subscription <subscription> \
                                  --resource-group <resource-group> \
-                                 --user <user> \
                                  --server <server>
 
 # Retrieve a specific parameter of a PostgreSQL server
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp postgres server param get --subscription <subscription> \
                                 --resource-group <resource-group> \
-                                --user <user> \
                                 --server <server> \
                                 --param <parameter>
 
@@ -2677,7 +2675,6 @@ azmcp postgres server param get --subscription <subscription> \
 # ✅ Destructive | ✅ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
 azmcp postgres server param set --subscription <subscription> \
                                 --resource-group <resource-group> \
-                                --user <user> \
                                 --server <server> \
                                 --param <parameter> \
                                 --value <value>

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerConfigGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerConfigGetCommand.cs
@@ -33,7 +33,7 @@ public sealed class ServerConfigGetCommand(IPostgresService postgresService, ILo
     {
         try
         {
-            var config = await _postgresService.GetServerConfigAsync(options.Subscription!, options.ResourceGroup, options.User, options.Server, options.Tenant, cancellationToken);
+            var config = await _postgresService.GetServerConfigAsync(options.Subscription!, options.ResourceGroup, options.Server, options.Tenant, cancellationToken);
             context.Response.Results = config?.Length > 0 ?
                 ResponseResult.Create(new(config), PostgresJsonContext.Default.ServerConfigGetCommandResult) :
                 null;

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamGetCommand.cs
@@ -33,7 +33,7 @@ public sealed class ServerParamGetCommand(IPostgresService postgresService, ILog
     {
         try
         {
-            var parameterValue = await _postgresService.GetServerParameterAsync(options.Subscription!, options.ResourceGroup, options.User, options.Server, options.Param, options.Tenant, cancellationToken);
+            var parameterValue = await _postgresService.GetServerParameterAsync(options.Subscription!, options.ResourceGroup, options.Server, options.Param, options.Tenant, cancellationToken);
             context.Response.Results = parameterValue?.Length > 0 ?
                 ResponseResult.Create(new(parameterValue), PostgresJsonContext.Default.ServerParamGetCommandResult) :
                 null;

--- a/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamSetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Commands/Server/ServerParamSetCommand.cs
@@ -36,7 +36,7 @@ public sealed class ServerParamSetCommand(IPostgresService postgresService, ILog
         {
             ServerParameterValidator.EnsureParameterAllowed(options.Param);
 
-            var result = await _postgresService.SetServerParameterAsync(options.Subscription!, options.ResourceGroup, options.User, options.Server, options.Param, options.Value, options.Tenant, cancellationToken);
+            var result = await _postgresService.SetServerParameterAsync(options.Subscription!, options.ResourceGroup, options.Server, options.Param, options.Value, options.Tenant, cancellationToken);
             context.Response.Results = !string.IsNullOrEmpty(result) ?
                 ResponseResult.Create(new(result, options.Param!, options.Value!), PostgresJsonContext.Default.ServerParamSetCommandResult) :
                 null;

--- a/tools/Azure.Mcp.Tools.Postgres/src/Options/Server/BaseServerOptions.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Options/Server/BaseServerOptions.cs
@@ -8,9 +8,6 @@ namespace Azure.Mcp.Tools.Postgres.Options.Server;
 
 public class BaseServerOptions : ISubscriptionOption
 {
-    [Option(Description = PostgresOptionDefinitions.UserDescription)]
-    public required string User { get; set; }
-
     [Option(Description = PostgresOptionDefinitions.ServerDescription)]
     public required string Server { get; set; }
 

--- a/tools/Azure.Mcp.Tools.Postgres/src/Services/IPostgresService.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Services/IPostgresService.cs
@@ -49,7 +49,6 @@ public interface IPostgresService
     Task<string> GetServerConfigAsync(
         string subscriptionId,
         string resourceGroup,
-        string user,
         string server,
         string? tenant = null,
         CancellationToken cancellationToken = default);
@@ -57,7 +56,6 @@ public interface IPostgresService
     Task<string> GetServerParameterAsync(
         string subscriptionId,
         string resourceGroup,
-        string user,
         string server,
         string param,
         string? tenant = null,
@@ -66,7 +64,6 @@ public interface IPostgresService
     Task<string> SetServerParameterAsync(
         string subscription,
         string resourceGroup,
-        string user,
         string server,
         string param,
         string value,

--- a/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/src/Services/PostgresService.cs
@@ -264,7 +264,6 @@ public class PostgresService(IAzureService azureService, IEntraTokenProvider ent
     public async Task<string> GetServerConfigAsync(
         string subscriptionId,
         string resourceGroup,
-        string user,
         string server,
         string? tenant = null,
         CancellationToken cancellationToken = default)
@@ -287,7 +286,6 @@ public class PostgresService(IAzureService azureService, IEntraTokenProvider ent
     public async Task<string> GetServerParameterAsync(
         string subscriptionId,
         string resourceGroup,
-        string user,
         string server,
         string param,
         string? tenant = null,
@@ -309,7 +307,6 @@ public class PostgresService(IAzureService azureService, IEntraTokenProvider ent
     public async Task<string> SetServerParameterAsync(
         string subscriptionId,
         string resourceGroup,
-        string user,
         string server,
         string param,
         string value,

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/PostgresCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/PostgresCommandTests.cs
@@ -329,7 +329,6 @@ public class PostgresCommandTests(ITestOutputHelper output, LiveServerFixture li
                 { "subscription", Settings.SubscriptionId },
                 { "resource-group", Settings.ResourceGroupName },
                 { "server", ServerName },
-                { "user", AdminUsername },
             });
 
         // Should successfully retrieve server configurations
@@ -372,7 +371,6 @@ public class PostgresCommandTests(ITestOutputHelper output, LiveServerFixture li
                 { "subscription", Settings.SubscriptionId },
                 { "resource-group", Settings.ResourceGroupName },
                 { "server", ServerName },
-                { "user", AdminUsername },
                 { "param", "max_connections" }
             });
 

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Server/ServerConfigGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Server/ServerConfigGetCommandTests.cs
@@ -18,12 +18,11 @@ public class ServerConfigGetCommandTests : SubscriptionCommandUnitTestsBase<Serv
     public async Task ExecuteAsync_ReturnsConfig_WhenConfigExists()
     {
         var expectedConfig = "config123";
-        Service.GetServerConfigAsync("sub123", "rg1", "user1", "server123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedConfig);
+        Service.GetServerConfigAsync("sub123", "rg1", "server123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedConfig);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1",
             "--server", "server123");
 
         var result = ValidateAndDeserializeResponse(response, PostgresJsonContext.Default.ServerConfigGetCommandResult);
@@ -33,12 +32,11 @@ public class ServerConfigGetCommandTests : SubscriptionCommandUnitTestsBase<Serv
     [Fact]
     public async Task ExecuteAsync_ReturnsNull_WhenConfigDoesNotExist()
     {
-        Service.GetServerConfigAsync("sub123", "rg1", "user1", "server123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns("");
+        Service.GetServerConfigAsync("sub123", "rg1", "server123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns("");
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1",
             "--server", "server123");
 
         Assert.NotNull(response);
@@ -50,14 +48,12 @@ public class ServerConfigGetCommandTests : SubscriptionCommandUnitTestsBase<Serv
     [Theory]
     [InlineData("--subscription")]
     [InlineData("--resource-group")]
-    [InlineData("--user")]
     [InlineData("--server")]
     public async Task ExecuteAsync_ReturnsError_WhenParameterIsMissing(string missingParameter)
     {
         var response = await ExecuteCommandAsync(ArgBuilder.BuildArgs(missingParameter,
             ("--subscription", "sub123"),
             ("--resource-group", "rg1"),
-            ("--user", "user1"),
             ("--server", "server123")
         ));
 
@@ -69,15 +65,15 @@ public class ServerConfigGetCommandTests : SubscriptionCommandUnitTestsBase<Serv
     [Fact]
     public async Task ExecuteAsync_ForwardsTenant()
     {
-        Service.GetServerConfigAsync("sub123", "rg1", "user1", "server123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns("config123");
+        Service.GetServerConfigAsync("sub123", "rg1", "server123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns("config123");
 
         await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1",
             "--server", "server123",
             "--tenant", "tenant123");
 
-        await Service.Received(1).GetServerConfigAsync("sub123", "rg1", "user1", "server123", "tenant123", Arg.Any<CancellationToken>());
+        await Service.Received(1).GetServerConfigAsync("sub123", "rg1", "server123", "tenant123", Arg.Any<CancellationToken>());
+        Assert.DoesNotContain("--user", CommandDefinition.Options.Select(option => option.Name));
     }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Server/ServerParamGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Server/ServerParamGetCommandTests.cs
@@ -18,12 +18,11 @@ public class ServerParamGetCommandTests : SubscriptionCommandUnitTestsBase<Serve
     public async Task ExecuteAsync_ReturnsParamValue_WhenParamExists()
     {
         var expectedValue = "value123";
-        Service.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedValue);
+        Service.GetServerParameterAsync("sub123", "rg1", "server123", "param123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedValue);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1",
             "--server", "server123",
             "--param", "param123");
 
@@ -34,11 +33,10 @@ public class ServerParamGetCommandTests : SubscriptionCommandUnitTestsBase<Serve
     [Fact]
     public async Task ExecuteAsync_ReturnsNull_WhenParamDoesNotExist()
     {
-        Service.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns("");
+        Service.GetServerParameterAsync("sub123", "rg1", "server123", "param123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns("");
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1",
             "--server", "server123",
             "--param", "param123");
 
@@ -51,7 +49,6 @@ public class ServerParamGetCommandTests : SubscriptionCommandUnitTestsBase<Serve
     [Theory]
     [InlineData("--subscription")]
     [InlineData("--resource-group")]
-    [InlineData("--user")]
     [InlineData("--server")]
     [InlineData("--param")]
     public async Task ExecuteAsync_ReturnsError_WhenParameterIsMissing(string missingParameter)
@@ -59,7 +56,6 @@ public class ServerParamGetCommandTests : SubscriptionCommandUnitTestsBase<Serve
         var response = await ExecuteCommandAsync(ArgBuilder.BuildArgs(missingParameter,
             ("--subscription", "sub123"),
             ("--resource-group", "rg1"),
-            ("--user", "user1"),
             ("--server", "server123"),
             ("--param", "param123")
         ));
@@ -72,16 +68,16 @@ public class ServerParamGetCommandTests : SubscriptionCommandUnitTestsBase<Serve
     [Fact]
     public async Task ExecuteAsync_ForwardsTenant()
     {
-        Service.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns("value123");
+        Service.GetServerParameterAsync("sub123", "rg1", "server123", "param123", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns("value123");
 
         await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1",
             "--server", "server123",
             "--param", "param123",
             "--tenant", "tenant123");
 
-        await Service.Received(1).GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123", "tenant123", Arg.Any<CancellationToken>());
+        await Service.Received(1).GetServerParameterAsync("sub123", "rg1", "server123", "param123", "tenant123", Arg.Any<CancellationToken>());
+        Assert.DoesNotContain("--user", CommandDefinition.Options.Select(option => option.Name));
     }
 }

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Server/ServerParamSetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Server/ServerParamSetCommandTests.cs
@@ -20,12 +20,11 @@ public class ServerParamSetCommandTests : SubscriptionCommandUnitTestsBase<Serve
     public async Task ExecuteAsync_ReturnsSuccessMessage_WhenParamIsSet()
     {
         var expectedMessage = "Parameter 'work_mem' updated successfully to '256MB'.";
-        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "work_mem", "256MB", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedMessage);
+        Service.SetServerParameterAsync("sub123", "rg1", "server123", "work_mem", "256MB", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedMessage);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1",
             "--server", "server123",
             "--param", "work_mem",
             "--value", "256MB");
@@ -40,12 +39,11 @@ public class ServerParamSetCommandTests : SubscriptionCommandUnitTestsBase<Serve
     [Fact]
     public async Task ExecuteAsync_ReturnsNull_WhenParamDoesNotExist()
     {
-        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "shared_buffers", "512MB", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns("");
+        Service.SetServerParameterAsync("sub123", "rg1", "server123", "shared_buffers", "512MB", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns("");
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1",
             "--server", "server123",
             "--param", "shared_buffers",
             "--value", "512MB");
@@ -59,7 +57,6 @@ public class ServerParamSetCommandTests : SubscriptionCommandUnitTestsBase<Serve
     [Theory]
     [InlineData("--subscription")]
     [InlineData("--resource-group")]
-    [InlineData("--user")]
     [InlineData("--server")]
     [InlineData("--param")]
     [InlineData("--value")]
@@ -68,7 +65,6 @@ public class ServerParamSetCommandTests : SubscriptionCommandUnitTestsBase<Serve
         var response = await ExecuteCommandAsync(ArgBuilder.BuildArgs(missingParameter,
             ("--subscription", "sub123"),
             ("--resource-group", "rg1"),
-            ("--user", "user1"),
             ("--server", "server123"),
             ("--param", "max_connections"),
             ("--value", "200")
@@ -83,34 +79,33 @@ public class ServerParamSetCommandTests : SubscriptionCommandUnitTestsBase<Serve
     public async Task ExecuteAsync_CallsServiceWithCorrectParameters()
     {
         var expectedMessage = "Parameter updated successfully.";
-        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedMessage);
+        Service.SetServerParameterAsync("sub123", "rg1", "server123", "max_connections", "200", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedMessage);
 
         await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1",
             "--server", "server123",
             "--param", "max_connections",
             "--value", "200");
 
-        await Service.Received(1).SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200", Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await Service.Received(1).SetServerParameterAsync("sub123", "rg1", "server123", "max_connections", "200", Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ExecuteAsync_ForwardsTenant()
     {
-        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns("ok");
+        Service.SetServerParameterAsync("sub123", "rg1", "server123", "max_connections", "200", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns("ok");
 
         await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1",
             "--server", "server123",
             "--param", "max_connections",
             "--value", "200",
             "--tenant", "tenant123");
 
-        await Service.Received(1).SetServerParameterAsync("sub123", "rg1", "user1", "server123", "max_connections", "200", "tenant123", Arg.Any<CancellationToken>());
+        await Service.Received(1).SetServerParameterAsync("sub123", "rg1", "server123", "max_connections", "200", "tenant123", Arg.Any<CancellationToken>());
+        Assert.DoesNotContain("--user", CommandDefinition.Options.Select(option => option.Name));
     }
 
     [Theory]
@@ -127,7 +122,6 @@ public class ServerParamSetCommandTests : SubscriptionCommandUnitTestsBase<Serve
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1",
             "--server", "server123",
             "--param", blockedParam,
             "--value", "off");
@@ -135,19 +129,18 @@ public class ServerParamSetCommandTests : SubscriptionCommandUnitTestsBase<Serve
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.Forbidden, response.Status);
         Assert.Contains("security-sensitive", response.Message);
-        await Service.DidNotReceiveWithAnyArgs().SetServerParameterAsync("", "", "", "", "", "", null, TestContext.Current.CancellationToken);
+        await Service.DidNotReceiveWithAnyArgs().SetServerParameterAsync("", "", "", "", "", null, TestContext.Current.CancellationToken);
     }
 
     [Fact]
     public async Task ExecuteAsync_AllowsNonBlockedParameters()
     {
         var expectedMessage = "Parameter 'custom_setting' updated successfully.";
-        Service.SetServerParameterAsync("sub123", "rg1", "user1", "server123", "custom_setting", "42", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedMessage);
+        Service.SetServerParameterAsync("sub123", "rg1", "server123", "custom_setting", "42", Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(expectedMessage);
 
         var response = await ExecuteCommandAsync(
             "--subscription", "sub123",
             "--resource-group", "rg1",
-            "--user", "user1",
             "--server", "server123",
             "--param", "custom_setting",
             "--value", "42");

--- a/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceTests.cs
+++ b/tools/Azure.Mcp.Tools.Postgres/tests/Azure.Mcp.Tools.Postgres.Tests/Services/PostgresServiceTests.cs
@@ -231,7 +231,7 @@ public class PostgresServiceTests
 
         // Act & Assert — resource group lookup happens first; null triggers the exception
         await Assert.ThrowsAsync<Exception>(() =>
-            _postgresService.GetServerConfigAsync(subscriptionId, resourceGroup, user, server, tenant, TestContext.Current.CancellationToken));
+            _postgresService.GetServerConfigAsync(subscriptionId, resourceGroup, server, tenant, TestContext.Current.CancellationToken));
 
         await _azureService.Received(1)
             .GetResourceGroupResource(subscriptionId, resourceGroup, tenant, Arg.Any<CancellationToken>());
@@ -248,7 +248,7 @@ public class PostgresServiceTests
 
         // Act & Assert
         await Assert.ThrowsAsync<Exception>(() =>
-            _postgresService.GetServerParameterAsync(subscriptionId, resourceGroup, user, server, "param123", tenant, TestContext.Current.CancellationToken));
+            _postgresService.GetServerParameterAsync(subscriptionId, resourceGroup, server, "param123", tenant, TestContext.Current.CancellationToken));
 
         await _azureService.Received(1)
             .GetResourceGroupResource(subscriptionId, resourceGroup, tenant, Arg.Any<CancellationToken>());
@@ -265,7 +265,7 @@ public class PostgresServiceTests
 
         // Act & Assert
         await Assert.ThrowsAsync<Exception>(() =>
-            _postgresService.SetServerParameterAsync(subscriptionId, resourceGroup, user, server, "param123", "value123", tenant, TestContext.Current.CancellationToken));
+            _postgresService.SetServerParameterAsync(subscriptionId, resourceGroup, server, "param123", "value123", tenant, TestContext.Current.CancellationToken));
 
         await _azureService.Received(1)
             .GetResourceGroupResource(subscriptionId, resourceGroup, tenant, Arg.Any<CancellationToken>());


### PR DESCRIPTION
## What does this PR do?

Removed the unused `user` parameter from the `postgres server config get`, `postgres server param get`, and `postgres server param set` tools.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
