### PR TITLE
Removed unused parameters from Storage tools

### DIFF
--- a/servers/Azure.Mcp.Server/changelog-entries/alzimmer-storage-remove-unused-parameters.yaml
+++ b/servers/Azure.Mcp.Server/changelog-entries/alzimmer-storage-remove-unused-parameters.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Breaking Changes"
+    description: "Removed the unused `subscription` parameter from the `storage blob get`, `storage blob upload`, `storage blob container create`, `storage blob container get`, and `storage table list` tools."

--- a/servers/Azure.Mcp.Server/docs/azmcp-commands.md
+++ b/servers/Azure.Mcp.Server/docs/azmcp-commands.md
@@ -5016,29 +5016,25 @@ azmcp storage account get --subscription <subscription> \
 ```bash
 # Create a blob container with optional public access
 # ✅ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp storage blob container create --subscription <subscription> \
-                                    --account <account> \
+azmcp storage blob container create --account <account> \
                                     --container <container>
 
 # Get detailed properties of Storage containers
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp storage blob container get --subscription <subscription> \
-                                 --account <account> \
+azmcp storage blob container get --account <account> \
                                  [--container <container>] \
                                  [--prefix <prefix>]
 
 # Get detailed properties of Storage blobs
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp storage blob get --subscription <subscription> \
-                           --account <account> \
+azmcp storage blob get --account <account> \
                            --container <container> \
                            [--blob <blob>] \
                            [--prefix <prefix>]
 
 # Upload a file to a Storage blob
 # ❌ Destructive | ❌ Idempotent | ❌ OpenWorld | ❌ ReadOnly | ❌ Secret | ✅ LocalRequired
-azmcp storage blob upload --subscription <subscription> \
-                          --account <account> \
+azmcp storage blob upload --account <account> \
                           --container <container> \
                           --blob <blob> \
                           --local-file-path <path-to-local-file>
@@ -5049,8 +5045,7 @@ azmcp storage blob upload --subscription <subscription> \
 ```bash
 # List tables in an Azure Storage account
 # ❌ Destructive | ✅ Idempotent | ❌ OpenWorld | ✅ ReadOnly | ❌ Secret | ❌ LocalRequired
-azmcp storage table list --subscription <subscription> \
-                         --account <account>
+azmcp storage table list --account <account>
 ```
 
 ### Azure Storage Sync Operations

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobGetCommand.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Options.Blob;
 using Azure.Mcp.Tools.Storage.Services;
@@ -21,7 +19,7 @@ namespace Azure.Mcp.Tools.Storage.Commands.Blob;
         get details for a specific blob. If no blob specified, lists all blobs present in the container, optionally
         filtering on a prefix. The prefix is ignored if a blob is specified.
 
-        Required: --account, --container, --subscription
+        Required: --account, --container
         Optional: --blob, --tenant, --prefix
 
         Returns: blob name, size, lastModified, contentType, contentHash, metadata, and blob properties.
@@ -34,8 +32,8 @@ namespace Azure.Mcp.Tools.Storage.Commands.Blob;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class BlobGetCommand(ILogger<BlobGetCommand> logger, IStorageService storageService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<BlobGetOptions, BlobGetCommand.BlobGetCommandResult>(subscriptionResolver)
+public sealed class BlobGetCommand(ILogger<BlobGetCommand> logger, IStorageService storageService)
+    : AuthenticatedCommand<BlobGetOptions, BlobGetCommand.BlobGetCommandResult>
 {
     private readonly ILogger<BlobGetCommand> _logger = logger;
     private readonly IStorageService _storageService = storageService;
@@ -48,7 +46,6 @@ public sealed class BlobGetCommand(ILogger<BlobGetCommand> logger, IStorageServi
                 options.Account,
                 options.Container,
                 options.Blob,
-                options.Subscription!,
                 options.Prefix,
                 options.Tenant,
                 cancellationToken

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobUploadCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/BlobUploadCommand.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Options.Blob;
 using Azure.Mcp.Tools.Storage.Services;
@@ -27,8 +25,8 @@ namespace Azure.Mcp.Tools.Storage.Commands.Blob;
     ReadOnly = false,
     Secret = false,
     LocalRequired = true)]
-public sealed class BlobUploadCommand(ILogger<BlobUploadCommand> logger, IStorageService storageService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<BlobUploadOptions, BlobUploadResult>(subscriptionResolver)
+public sealed class BlobUploadCommand(ILogger<BlobUploadCommand> logger, IStorageService storageService)
+    : AuthenticatedCommand<BlobUploadOptions, BlobUploadResult>
 {
     private readonly ILogger<BlobUploadCommand> _logger = logger;
     private readonly IStorageService _storageService = storageService;
@@ -42,7 +40,6 @@ public sealed class BlobUploadCommand(ILogger<BlobUploadCommand> logger, IStorag
                 options.Container,
                 options.Blob,
                 options.LocalFilePath,
-                options.Subscription!,
                 options.Tenant,
                 cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerCreateCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerCreateCommand.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Options.Blob.Container;
 using Azure.Mcp.Tools.Storage.Services;
@@ -19,7 +17,7 @@ namespace Azure.Mcp.Tools.Storage.Commands.Blob.Container;
     Description = """
         Create/provision a new Azure Storage blob container in a storage account.
 
-        Required: --account, --container, --subscription
+        Required: --account, --container
         Optional: --tenant
 
         Returns: container name, lastModified, eTag, leaseStatus, publicAccessLevel, hasImmutabilityPolicy, hasLegalHold.
@@ -32,8 +30,8 @@ namespace Azure.Mcp.Tools.Storage.Commands.Blob.Container;
     ReadOnly = false,
     Secret = false,
     LocalRequired = false)]
-public sealed class ContainerCreateCommand(ILogger<ContainerCreateCommand> logger, IStorageService storageService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<ContainerCreateOptions, ContainerCreateCommand.ContainerCreateCommandResult>(subscriptionResolver)
+public sealed class ContainerCreateCommand(ILogger<ContainerCreateCommand> logger, IStorageService storageService)
+    : AuthenticatedCommand<ContainerCreateOptions, ContainerCreateCommand.ContainerCreateCommandResult>
 {
     private readonly ILogger<ContainerCreateCommand> _logger = logger;
     private readonly IStorageService _storageService = storageService;
@@ -45,7 +43,6 @@ public sealed class ContainerCreateCommand(ILogger<ContainerCreateCommand> logge
             var containerInfo = await _storageService.CreateContainer(
                 options.Account,
                 options.Container,
-                options.Subscription!,
                 options.Tenant,
                 cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerGetCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Blob/Container/ContainerGetCommand.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Options.Blob.Container;
 using Azure.Mcp.Tools.Storage.Services;
@@ -21,7 +19,7 @@ namespace Azure.Mcp.Tools.Storage.Commands.Blob.Container;
         show details for a specific Storage container. If no container specified, shows all containers in the storage
         account, optionally filtering on a prefix. The prefix is ignored if a container is specified.
 
-        Required: --account, --subscription
+        Required: --account
         Optional: --container, --tenant, --prefix
 
         Returns: container name, lastModified, leaseStatus, publicAccess, metadata, and container properties.
@@ -34,8 +32,8 @@ namespace Azure.Mcp.Tools.Storage.Commands.Blob.Container;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class ContainerGetCommand(ILogger<ContainerGetCommand> logger, IStorageService storageService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<ContainerGetOptions, ContainerGetCommand.ContainerGetCommandResult>(subscriptionResolver)
+public sealed class ContainerGetCommand(ILogger<ContainerGetCommand> logger, IStorageService storageService)
+    : AuthenticatedCommand<ContainerGetOptions, ContainerGetCommand.ContainerGetCommandResult>
 {
     private readonly ILogger<ContainerGetCommand> _logger = logger;
     private readonly IStorageService _storageService = storageService;
@@ -47,7 +45,6 @@ public sealed class ContainerGetCommand(ILogger<ContainerGetCommand> logger, ISt
             var containers = await _storageService.GetContainerDetails(
                 options.Account,
                 options.Container,
-                options.Subscription!,
                 options.Prefix,
                 options.Tenant,
                 cancellationToken

--- a/tools/Azure.Mcp.Tools.Storage/src/Commands/Table/TableListCommand.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Commands/Table/TableListCommand.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Mcp.Core.Commands.Subscription;
-using Azure.Mcp.Core.Services.Azure.Subscription;
 using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Options.Table;
 using Azure.Mcp.Tools.Storage.Services;
@@ -16,7 +14,7 @@ namespace Azure.Mcp.Tools.Storage.Table.Commands;
     Id = "1236ad1d-baf1-4b95-8c1d-420637ce08da",
     Name = "list",
     Title = "List Tables in Azure Storage",
-    Description = "List all tables in an Azure Storage account. Shows table names for the specified storage account. Required: account, subscription. Optional: tenant. Returns: table names. Do not use this tool for Cosmos DB tables or Kusto/Data Explorer tables.",
+    Description = "List all tables in an Azure Storage account. Shows table names for the specified storage account. Required: account. Optional: tenant. Returns: table names. Do not use this tool for Cosmos DB tables or Kusto/Data Explorer tables.",
     OperationPlane = ToolOperationPlane.Data,
     Destructive = false,
     Idempotent = true,
@@ -24,8 +22,8 @@ namespace Azure.Mcp.Tools.Storage.Table.Commands;
     ReadOnly = true,
     Secret = false,
     LocalRequired = false)]
-public sealed class TableListCommand(ILogger<TableListCommand> logger, IStorageService storageService, ISubscriptionResolver subscriptionResolver)
-    : SubscriptionCommand<TableListOptions, TableListCommand.TableListCommandResult>(subscriptionResolver)
+public sealed class TableListCommand(ILogger<TableListCommand> logger, IStorageService storageService)
+    : AuthenticatedCommand<TableListOptions, TableListCommand.TableListCommandResult>
 {
     private readonly ILogger<TableListCommand> _logger = logger;
     private readonly IStorageService _storageService = storageService;
@@ -36,7 +34,6 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger, IStorageS
         {
             var tables = await _storageService.ListTables(
                 options.Account,
-                options.Subscription!,
                 options.Tenant,
                 cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/BlobGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/BlobGetOptions.cs
@@ -6,7 +6,7 @@ using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Storage.Options.Blob;
 
-public class BlobGetOptions : ISubscriptionOption
+public class BlobGetOptions
 {
     [Option(Description = "The name of the blob to access within the container. This should be the full path within the container (e.g., 'file.txt' or 'folder/file.txt').")]
     public string? Blob { get; set; }
@@ -19,9 +19,6 @@ public class BlobGetOptions : ISubscriptionOption
 
     [Option(Description = "The name of the container to access within the storage account.")]
     public required string Container { get; set; }
-
-    [Option(Description = OptionDescriptions.Subscription)]
-    public string? Subscription { get; set; }
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }

--- a/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/BlobUploadOptions.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/BlobUploadOptions.cs
@@ -6,7 +6,7 @@ using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Storage.Options.Blob;
 
-public class BlobUploadOptions : ISubscriptionOption
+public class BlobUploadOptions
 {
     [Option(Description = "The local file path to read content from or to write content to. This should be the full path to the file on your local system.")]
     public required string LocalFilePath { get; set; }
@@ -19,9 +19,6 @@ public class BlobUploadOptions : ISubscriptionOption
 
     [Option(Description = "The name of the blob to access within the container. This should be the full path within the container (e.g., 'file.txt' or 'folder/file.txt').")]
     public required string Blob { get; set; }
-
-    [Option(Description = OptionDescriptions.Subscription)]
-    public string? Subscription { get; set; }
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }

--- a/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/Container/ContainerCreateOptions.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/Container/ContainerCreateOptions.cs
@@ -6,16 +6,13 @@ using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Storage.Options.Blob.Container;
 
-public class ContainerCreateOptions : ISubscriptionOption
+public class ContainerCreateOptions
 {
     [Option(Description = "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').")]
     public required string Account { get; set; }
 
     [Option(Description = "The name of the container to access within the storage account.")]
     public required string Container { get; set; }
-
-    [Option(Description = OptionDescriptions.Subscription)]
-    public string? Subscription { get; set; }
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }

--- a/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/Container/ContainerGetOptions.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Options/Blob/Container/ContainerGetOptions.cs
@@ -6,7 +6,7 @@ using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Storage.Options.Blob.Container;
 
-public class ContainerGetOptions : ISubscriptionOption
+public class ContainerGetOptions
 {
     [Option(Description = "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').")]
     public required string Account { get; set; }
@@ -16,9 +16,6 @@ public class ContainerGetOptions : ISubscriptionOption
 
     [Option(Description = "The prefix to filter containers when listing containers in a storage account. Only containers whose names start with the specified prefix will be listed.")]
     public string? Prefix { get; set; }
-
-    [Option(Description = OptionDescriptions.Subscription)]
-    public string? Subscription { get; set; }
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }

--- a/tools/Azure.Mcp.Tools.Storage/src/Options/Table/TableListOptions.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Options/Table/TableListOptions.cs
@@ -6,13 +6,10 @@ using Microsoft.Mcp.Core.Options;
 
 namespace Azure.Mcp.Tools.Storage.Options.Table;
 
-public class TableListOptions : ISubscriptionOption
+public class TableListOptions
 {
     [Option(Description = "The name of the Azure Storage account. This is the unique name you chose for your storage account (e.g., 'mystorageaccount').")]
     public required string Account { get; set; }
-
-    [Option(Description = OptionDescriptions.Subscription)]
-    public string? Subscription { get; set; }
 
     [Option(Description = OptionDescriptions.Tenant)]
     public string? Tenant { get; set; }

--- a/tools/Azure.Mcp.Tools.Storage/src/Services/IStorageService.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Services/IStorageService.cs
@@ -30,7 +30,6 @@ public interface IStorageService
         string account,
         string container,
         string? blob,
-        string subscription,
         string? prefix = null,
         string? tenant = null,
         CancellationToken cancellationToken = default);
@@ -38,7 +37,6 @@ public interface IStorageService
     Task<List<ContainerInfo>> GetContainerDetails(
         string account,
         string? container,
-        string subscription,
         string? prefix = null,
         string? tenant = null,
         CancellationToken cancellationToken = default);
@@ -46,7 +44,6 @@ public interface IStorageService
     Task<ContainerInfo> CreateContainer(
         string account,
         string container,
-        string subscription,
         string? tenant = null,
         CancellationToken cancellationToken = default);
 
@@ -55,13 +52,11 @@ public interface IStorageService
         string container,
         string blob,
         string localFilePath,
-        string subscription,
         string? tenant = null,
         CancellationToken cancellationToken = default);
 
     Task<List<string>> ListTables(
         string account,
-        string subscription,
         string? tenant = null,
         CancellationToken cancellationToken = default);
 }

--- a/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
+++ b/tools/Azure.Mcp.Tools.Storage/src/Services/StorageService.cs
@@ -154,15 +154,13 @@ public sealed class StorageService(IAzureService azureService)
         string account,
         string container,
         string? blob,
-        string subscription,
         string? prefix = null,
         string? tenant = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
             (nameof(account), account),
-            (nameof(container), container),
-            (nameof(subscription), subscription));
+            (nameof(container), container));
 
         var blobServiceClient = await CreateBlobServiceClient(account, tenant, cancellationToken);
         var containerClient = blobServiceClient.GetBlobContainerClient(container);
@@ -233,12 +231,11 @@ public sealed class StorageService(IAzureService azureService)
     public async Task<List<ContainerInfo>> GetContainerDetails(
         string account,
         string? container,
-        string subscription,
         string? prefix = null,
         string? tenant = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(account), account), (nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(account), account));
 
         var blobServiceClient = await CreateBlobServiceClient(account, tenant, cancellationToken);
         var containers = new List<ContainerInfo>();
@@ -292,14 +289,12 @@ public sealed class StorageService(IAzureService azureService)
     public async Task<ContainerInfo> CreateContainer(
         string account,
         string container,
-        string subscription,
         string? tenant = null,
         CancellationToken cancellationToken = default)
     {
         ValidateRequiredParameters(
             (nameof(account), account),
-            (nameof(container), container),
-            (nameof(subscription), subscription));
+            (nameof(container), container));
 
         var blobServiceClient = await CreateBlobServiceClient(account, tenant, cancellationToken);
         var containerClient = blobServiceClient.GetBlobContainerClient(container);
@@ -364,7 +359,6 @@ public sealed class StorageService(IAzureService azureService)
         string container,
         string blob,
         string localFilePath,
-        string subscription,
         string? tenant = null,
         CancellationToken cancellationToken = default)
     {
@@ -372,8 +366,7 @@ public sealed class StorageService(IAzureService azureService)
             (nameof(account), account),
             (nameof(container), container),
             (nameof(blob), blob),
-            (nameof(localFilePath), localFilePath),
-            (nameof(subscription), subscription));
+            (nameof(localFilePath), localFilePath));
 
         if (!File.Exists(localFilePath))
         {
@@ -418,7 +411,6 @@ public sealed class StorageService(IAzureService azureService)
 
     private async Task<TableServiceClient> CreateTableServiceClient(
         string account,
-        string subscription,
         string? tenant = null,
         CancellationToken cancellationToken = default)
     {
@@ -430,18 +422,16 @@ public sealed class StorageService(IAzureService azureService)
 
     public async Task<List<string>> ListTables(
         string account,
-        string subscription,
         string? tenant = null,
         CancellationToken cancellationToken = default)
     {
-        ValidateRequiredParameters((nameof(account), account), (nameof(subscription), subscription));
+        ValidateRequiredParameters((nameof(account), account));
 
         var tables = new List<string>();
 
         // First attempt with requested auth method
         var tableServiceClient = await CreateTableServiceClient(
             account,
-            subscription,
             tenant,
             cancellationToken);
 

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/BlobGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/BlobGetCommandTests.cs
@@ -2,24 +2,23 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Commands.Blob;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Services;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Storage.Tests.Blob;
 
-public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetCommand, IStorageService>
+public class BlobGetCommandTests : CommandUnitTestsBase<BlobGetCommand, IStorageService>
 {
     [Fact]
     public async Task ExecuteAsync_NoParameters_ReturnsBlobs()
     {
         // Arrange
-        var subscription = "sub123";
         var account = "testaccount";
         var container = "container123";
         var expectedBlobs = new List<BlobInfo>(
@@ -32,17 +31,13 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(account),
             Arg.Is(container),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedBlobs);
 
         // Act
-        var response = await ExecuteCommandAsync(
-            "--subscription", subscription,
-            "--account", account,
-            "--container", container);
+        var response = await ExecuteCommandAsync("--account", account, "--container", container);
 
         // Assert
         var result = ValidateAndDeserializeResponse(response, StorageJsonContext.Default.BlobGetCommandResult);
@@ -56,7 +51,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoBlobs()
     {
         // Arrange
-        var subscription = "sub123";
         var account = "testaccount";
         var container = "container123";
 
@@ -64,17 +58,13 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(account),
             Arg.Is(container),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act
-        var response = await ExecuteCommandAsync(
-            "--subscription", subscription,
-            "--account", account,
-            "--container", container);
+        var response = await ExecuteCommandAsync("--account", account, "--container", container);
 
         // Assert
         var result = ValidateAndDeserializeResponse(response, StorageJsonContext.Default.BlobGetCommandResult);
@@ -87,7 +77,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
     {
         // Arrange
         var expectedError = "Test error";
-        var subscription = "sub123";
         var account = "testaccount";
         var container = "container123";
 
@@ -95,17 +84,13 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(account),
             Arg.Is(container),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         // Act
-        var response = await ExecuteCommandAsync(
-            "--subscription", subscription,
-            "--account", account,
-            "--container", container);
+        var response = await ExecuteCommandAsync("--account", account, "--container", container);
 
         // Assert
         Assert.NotNull(response);
@@ -119,20 +104,17 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
         Assert.Equal("get", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Description);
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 
     [Theory]
-    [InlineData("--account mystorageaccount --subscription sub123 --container container", true)]
-    [InlineData("--subscription sub123 --account mystorageaccount --container container", true)]
-    [InlineData("--subscription sub123 --account mystorageaccount --container container --blob blob", true)]
-    [InlineData("--subscription sub123 --account mystorageaccount --container container --blob blob --prefix prefix", true)]
-    [InlineData("--subscription sub123", false)] // Missing account and container
-    [InlineData("--account mystorageaccount", false)] // Missing subscription and container
-    [InlineData("--container container", false)] // Missing subscription and account
-    [InlineData("--subscription sub123 --account mystorageaccount", false)] // Missing container
-    [InlineData("--subscription sub123 --container container", false)] // Missing account
-    [InlineData("--account mystorageaccount --container container", false)] // Missing subscription
-    [InlineData("--blob blob", false)] // Missing subscription, account, and container
+    [InlineData("--account mystorageaccount --container container", true)]
+    [InlineData("--container container --account mystorageaccount", true)]
+    [InlineData("--account mystorageaccount --container container --blob blob", true)]
+    [InlineData("--account mystorageaccount --container container --blob blob --prefix prefix", true)]
+    [InlineData("--account mystorageaccount", false)] // Missing container
+    [InlineData("--container container", false)] // Missing account
+    [InlineData("--blob blob", false)] // Missing account and container
     [InlineData("", false)] // No parameters
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
     {
@@ -147,7 +129,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<string>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
                 Arg.Any<CancellationToken>())
@@ -175,7 +156,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
     {
         // Arrange
         var account = "mystorageaccount";
-        var subscription = "sub123";
         var container = "container123";
         var blob = "blob123";
         var expected = new BlobInfo(blob, DateTimeOffset.UtcNow, null, null, "application/octet-stream", null, null,
@@ -185,7 +165,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(account),
             Arg.Is(container),
             Arg.Is(blob),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
@@ -194,7 +173,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
         // Act
         var response = await ExecuteCommandAsync(
             "--account", account,
-            "--subscription", subscription,
             "--container", container,
             "--blob", blob);
 
@@ -213,7 +191,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
     {
         // Arrange
         var account = "mystorageaccount";
-        var subscription = "sub123";
         var container = "container123";
         var blob = "blob123";
 
@@ -221,7 +198,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(account),
             Arg.Is(container),
             Arg.Is(blob),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
@@ -230,7 +206,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
         // Act
         var response = await ExecuteCommandAsync(
             "--account", account,
-            "--subscription", subscription,
             "--container", container,
             "--blob", blob);
 
@@ -245,7 +220,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
     {
         // Arrange
         var account = "mystorageaccount";
-        var subscription = "sub123";
         var container = "container123";
         var blob = "notfound";
 
@@ -253,7 +227,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(account),
             Arg.Is(container),
             Arg.Is(blob),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
@@ -262,7 +235,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
         // Act
         var response = await ExecuteCommandAsync(
             "--account", account,
-            "--subscription", subscription,
             "--container", container,
             "--blob", blob);
 
@@ -276,7 +248,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
     {
         // Arrange
         var account = "mystorageaccount";
-        var subscription = "sub123";
         var container = "container123";
         var blob = "blob123";
 
@@ -284,7 +255,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
             Arg.Is(account),
             Arg.Is(container),
             Arg.Is(blob),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
@@ -293,7 +263,6 @@ public class BlobGetCommandTests : SubscriptionCommandUnitTestsBase<BlobGetComma
         // Act
         var response = await ExecuteCommandAsync(
             "--account", account,
-            "--subscription", subscription,
             "--container", container,
             "--blob", blob);
 

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/BlobUploadCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/BlobUploadCommandTests.cs
@@ -2,18 +2,18 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Commands.Blob;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Services;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Storage.Tests.Blob;
 
-public class BlobUploadCommandTests : SubscriptionCommandUnitTestsBase<BlobUploadCommand, IStorageService>
+public class BlobUploadCommandTests : CommandUnitTestsBase<BlobUploadCommand, IStorageService>
 {
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
@@ -21,13 +21,13 @@ public class BlobUploadCommandTests : SubscriptionCommandUnitTestsBase<BlobUploa
         Assert.Equal("upload", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Description);
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 
     [Fact]
     public async Task ExecuteAsync_UploadsBlob_WhenValidParametersProvided()
     {
         // Arrange
-        var subscription = "sub123";
         var account = "testaccount";
         var container = "testcontainer";
         var blob = "testblob.txt";
@@ -40,14 +40,12 @@ public class BlobUploadCommandTests : SubscriptionCommandUnitTestsBase<BlobUploa
             Arg.Is(container),
             Arg.Is(blob),
             Arg.Is(localFilePath),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedResult);
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", subscription,
             "--account", account,
             "--container", container,
             "--blob", blob,
@@ -71,14 +69,12 @@ public class BlobUploadCommandTests : SubscriptionCommandUnitTestsBase<BlobUploa
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         // Act
         var response = await ExecuteCommandAsync(
-            "--subscription", "sub123",
             "--account", "testaccount",
             "--container", "testcontainer",
             "--blob", "testblob",
@@ -91,12 +87,11 @@ public class BlobUploadCommandTests : SubscriptionCommandUnitTestsBase<BlobUploa
     }
 
     [Theory]
-    [InlineData("--subscription sub123 --account acct --container cont --blob b --local-file-path /f", true)]
-    [InlineData("--account acct --container cont --blob b --local-file-path /f", false)] // Missing subscription
-    [InlineData("--subscription sub123 --container cont --blob b --local-file-path /f", false)] // Missing account
-    [InlineData("--subscription sub123 --account acct --blob b --local-file-path /f", false)] // Missing container
-    [InlineData("--subscription sub123 --account acct --container cont --local-file-path /f", false)] // Missing blob
-    [InlineData("--subscription sub123 --account acct --container cont --blob b", false)] // Missing local-file-path
+    [InlineData("--account acct --container cont --blob b --local-file-path /f", true)]
+    [InlineData("--container cont --blob b --local-file-path /f", false)] // Missing account
+    [InlineData("--account acct --blob b --local-file-path /f", false)] // Missing container
+    [InlineData("--account acct --container cont --local-file-path /f", false)] // Missing blob
+    [InlineData("--account acct --container cont --blob b", false)] // Missing local-file-path
     [InlineData("", false)] // No parameters
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
     {
@@ -106,7 +101,6 @@ public class BlobUploadCommandTests : SubscriptionCommandUnitTestsBase<BlobUploa
                 DateTimeOffset.UtcNow, "\"etag\"", "md5hash");
 
             Service.UploadBlob(
-                Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/Container/ContainerCreateCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/Container/ContainerCreateCommandTests.cs
@@ -2,18 +2,18 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Commands.Blob.Container;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Services;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Storage.Tests.Blob.Container;
 
-public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<ContainerCreateCommand, IStorageService>
+public class ContainerCreateCommandTests : CommandUnitTestsBase<ContainerCreateCommand, IStorageService>
 {
     [Fact]
     public void Constructor_InitializesCommandCorrectly()
@@ -21,17 +21,14 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
         Assert.Equal("create", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Description);
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 
     [Theory]
-    [InlineData("--account testaccount --subscription sub123 --container container123", true)]
-    [InlineData("--account testaccount --tenant tenant123 --subscription sub123 --container container123 ", true)]
-    [InlineData("--account testaccount", false)] // Missing subscription and container name
-    [InlineData("--container container123", false)] // Missing subscription and account name
-    [InlineData("--subscription sub123", false)] // Missing account name and container name
-    [InlineData("--account testaccount --subscription sub123", false)] // Missing container name
-    [InlineData("--container container123 --subscription sub123", false)] // Missing account name
-    [InlineData("--account testaccount --container container123", false)] // Missing subscription
+    [InlineData("--account testaccount --container container123", true)]
+    [InlineData("--account testaccount --tenant tenant123 --container container123 ", true)]
+    [InlineData("--account testaccount", false)] // Missing container name
+    [InlineData("--container container123", false)] // Missing account name
     [InlineData("", false)] // No parameters
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
     {
@@ -42,7 +39,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
                 "unlocked", "available", null, "private", false, false, null, null, false);
 
             Service.CreateContainer(
-                Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
@@ -75,7 +71,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
         Service.CreateContainer(
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.Conflict, "Container already exists"));
@@ -83,7 +78,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
         // Act
         var response = await ExecuteCommandAsync(
             "--account", "testaccount",
-            "--subscription", "sub123",
              "--container", "existingcontainer");
 
         // Assert
@@ -98,7 +92,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
         Service.CreateContainer(
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.Forbidden, "Authorization failed"));
@@ -106,7 +99,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
         // Act
         var response = await ExecuteCommandAsync(
             "--account", "testaccount",
-            "--subscription", "sub123",
             "--container", "invalidaccess");
 
         // Assert
@@ -121,7 +113,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
         Service.CreateContainer(
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.NotFound, "Storage account not found"));
@@ -129,7 +120,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
         // Act
         var response = await ExecuteCommandAsync(
             "--account", "nonexistentaccount",
-            "--subscription", "sub123",
             "--container", "container123");
 
         // Assert
@@ -144,7 +134,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
         Service.CreateContainer(
             Arg.Any<string>(),
             Arg.Any<string>(),
-            Arg.Any<string>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("Test error"));
@@ -152,7 +141,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
         // Act
         var response = await ExecuteCommandAsync(
             "--account", "testaccount",
-            "--subscription", "sub123",
             "--container", "container123");
 
         // Assert
@@ -165,7 +153,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
     public async Task ExecuteAsync_CallsServiceWithCorrectParameters()
     {
         // Arrange
-        var subscription = "sub123";
         var account = "testaccount";
         var container = "container123";
 
@@ -175,7 +162,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
         Service.CreateContainer(
             account,
             container,
-            subscription,
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expected);
@@ -183,7 +169,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
         // Act
         var response = await ExecuteCommandAsync(
             "--account", account,
-            "--subscription", subscription,
             "--container", container);
 
         // Assert
@@ -191,7 +176,6 @@ public class ContainerCreateCommandTests : SubscriptionCommandUnitTestsBase<Cont
         await Service.Received(1).CreateContainer(
             account,
             container,
-            subscription,
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/Container/ContainerGetCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Blob/Container/ContainerGetCommandTests.cs
@@ -2,24 +2,23 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Commands.Blob.Container;
 using Azure.Mcp.Tools.Storage.Models;
 using Azure.Mcp.Tools.Storage.Services;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Storage.Tests.Blob.Container;
 
-public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<ContainerGetCommand, IStorageService>
+public class ContainerGetCommandTests : CommandUnitTestsBase<ContainerGetCommand, IStorageService>
 {
     [Fact]
     public async Task ExecuteAsync_NoParameters_ReturnsContainers()
     {
         // Arrange
-        var subscription = "sub123";
         var account = "testaccount";
         var expectedContainers = new List<ContainerInfo>(
         [
@@ -30,14 +29,13 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
         Service.GetContainerDetails(
             Arg.Is(account),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedContainers);
 
         // Act
-        var response = await ExecuteCommandAsync("--subscription", subscription, "--account", account);
+        var response = await ExecuteCommandAsync("--account", account);
 
         // Assert
         var result = ValidateAndDeserializeResponse(response, StorageJsonContext.Default.ContainerGetCommandResult);
@@ -51,20 +49,18 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
     public async Task ExecuteAsync_ReturnsEmpty_WhenNoContainers()
     {
         // Arrange
-        var subscription = "sub123";
         var account = "testaccount";
 
         Service.GetContainerDetails(
             Arg.Is(account),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act
-        var response = await ExecuteCommandAsync("--subscription", subscription, "--account", account);
+        var response = await ExecuteCommandAsync("--account", account);
 
         // Assert
         var result = ValidateAndDeserializeResponse(response, StorageJsonContext.Default.ContainerGetCommandResult);
@@ -77,20 +73,18 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
     {
         // Arrange
         var expectedError = "Test error";
-        var subscription = "sub123";
         var account = "testaccount";
 
         Service.GetContainerDetails(
             Arg.Is(account),
             Arg.Is<string?>(s => string.IsNullOrEmpty(s)),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         // Act
-        var response = await ExecuteCommandAsync("--subscription", subscription, "--account", account);
+        var response = await ExecuteCommandAsync("--account", account);
 
         // Assert
         Assert.NotNull(response);
@@ -104,15 +98,14 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
         Assert.Equal("get", CommandDefinition.Name);
         Assert.NotNull(CommandDefinition.Description);
         Assert.NotEmpty(CommandDefinition.Description);
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 
     [Theory]
-    [InlineData("--account mystorageaccount --subscription sub123", true)]
-    [InlineData("--subscription sub123 --account mystorageaccount", true)]
-    [InlineData("--subscription sub123 --account mystorageaccount --container container", true)]
-    [InlineData("--subscription sub123 --account mystorageaccount --container container --prefix prefix", true)]
-    [InlineData("--subscription sub123", false)] // Missing account
-    [InlineData("--account mystorageaccount", false)] // Missing subscription
+    [InlineData("--account mystorageaccount", true)]
+    [InlineData("--account mystorageaccount --container container", true)]
+    [InlineData("--account mystorageaccount --container container --prefix prefix", true)]
+    [InlineData("", false)] // Missing account
     public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
     {
         if (shouldSucceed)
@@ -125,7 +118,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
             Service.GetContainerDetails(
                 Arg.Any<string>(),
                 Arg.Any<string?>(),
-                Arg.Any<string>(),
                 Arg.Any<string?>(),
                 Arg.Any<string?>(),
                 Arg.Any<CancellationToken>())
@@ -153,7 +145,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
     {
         // Arrange
         var account = "mystorageaccount";
-        var subscription = "sub123";
         var container = "container123";
         var expected = new ContainerInfo(container, DateTimeOffset.UtcNow, "etag123", new Dictionary<string, string>(),
             "unlocked", "available", null, "private", false, false, null, null, false);
@@ -161,7 +152,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
         Service.GetContainerDetails(
             Arg.Is(account),
             Arg.Is(container),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
@@ -170,7 +160,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
         // Act
         var response = await ExecuteCommandAsync(
             "--account", account,
-            "--subscription", subscription,
             "--container", container);
 
         // Assert
@@ -188,13 +177,11 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
     {
         // Arrange
         var account = "mystorageaccount";
-        var subscription = "sub123";
         var container = "container123";
 
         Service.GetContainerDetails(
             Arg.Is(account),
             Arg.Is(container),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
@@ -203,7 +190,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
         // Act
         var response = await ExecuteCommandAsync(
             "--account", account,
-            "--subscription", subscription,
             "--container", container);
 
         // Assert
@@ -217,13 +203,11 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
     {
         // Arrange
         var account = "mystorageaccount";
-        var subscription = "sub123";
         var container = "notfound";
 
         Service.GetContainerDetails(
             Arg.Is(account),
             Arg.Is(container),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
@@ -232,7 +216,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
         // Act
         var response = await ExecuteCommandAsync(
             "--account", account,
-            "--subscription", subscription,
             "--container", container);
 
         // Assert
@@ -245,13 +228,11 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
     {
         // Arrange
         var account = "mystorageaccount";
-        var subscription = "sub123";
         var container = "container123";
 
         Service.GetContainerDetails(
             Arg.Is(account),
             Arg.Is(container),
-            Arg.Is(subscription),
             Arg.Any<string?>(),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
@@ -260,7 +241,6 @@ public class ContainerGetCommandTests : SubscriptionCommandUnitTestsBase<Contain
         // Act
         var response = await ExecuteCommandAsync(
             "--account", account,
-            "--subscription", subscription,
             "--container", container);
 
         // Assert

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/StorageCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/StorageCommandTests.cs
@@ -199,7 +199,6 @@ public class StorageCommandTests(ITestOutputHelper output, TestProxyFixture fixt
             "storage_blob_get",
             new()
             {
-            { "subscription", Settings.SubscriptionName },
             { "tenant", Settings.TenantId },
             { "account", Settings.ResourceBaseName },
             { "container", "bar" },
@@ -217,7 +216,6 @@ public class StorageCommandTests(ITestOutputHelper output, TestProxyFixture fixt
             "storage_blob_get",
             new()
             {
-            { "subscription", Settings.SubscriptionName },
             { "tenant", Settings.TenantId },
             { "account", Settings.ResourceBaseName },
             { "container", "bar" },
@@ -236,7 +234,6 @@ public class StorageCommandTests(ITestOutputHelper output, TestProxyFixture fixt
             "storage_blob_get",
             new()
             {
-            { "subscription", Settings.SubscriptionName },
             { "tenant", Settings.TenantId },
             { "account", Settings.ResourceBaseName },
             { "container", "bar" },
@@ -282,7 +279,6 @@ public class StorageCommandTests(ITestOutputHelper output, TestProxyFixture fixt
                 "storage_blob_upload",
                 new()
                 {
-                    { "subscription", Settings.SubscriptionName },
                     { "tenant", Settings.TenantId },
                     { "account", Settings.ResourceBaseName },
                     { "container", "bar" },
@@ -321,7 +317,6 @@ public class StorageCommandTests(ITestOutputHelper output, TestProxyFixture fixt
             "storage_blob_container_get",
             new()
             {
-            { "subscription", Settings.SubscriptionName },
             { "tenant", Settings.TenantId },
             { "account", Settings.ResourceBaseName }
             });
@@ -338,7 +333,6 @@ public class StorageCommandTests(ITestOutputHelper output, TestProxyFixture fixt
             "storage_blob_container_get",
             new()
             {
-            { "subscription", Settings.SubscriptionName },
             { "tenant", Settings.TenantId },
             { "account", Settings.ResourceBaseName },
             { "prefix", "ba" }
@@ -356,7 +350,6 @@ public class StorageCommandTests(ITestOutputHelper output, TestProxyFixture fixt
             "storage_blob_container_get",
             new()
             {
-            { "subscription", Settings.SubscriptionName },
             { "account", Settings.ResourceBaseName },
             { "container", "bar" }
             });
@@ -378,7 +371,6 @@ public class StorageCommandTests(ITestOutputHelper output, TestProxyFixture fixt
             "storage_blob_container_create",
             new()
             {
-            { "subscription", Settings.SubscriptionName },
             { "account", Settings.ResourceBaseName },
             { "container", containerName }
             });
@@ -433,7 +425,6 @@ public class StorageCommandTests(ITestOutputHelper output, TestProxyFixture fixt
             "storage_table_list",
             new()
             {
-            { "subscription", Settings.SubscriptionName },
             { "tenant", Settings.TenantId },
             { "account", Settings.ResourceBaseName },
             });
@@ -452,7 +443,6 @@ public class StorageCommandTests(ITestOutputHelper output, TestProxyFixture fixt
             "storage_table_list",
             new()
             {
-            { "subscription", Settings.SubscriptionName },
             { "tenant", Settings.TenantName },
             { "account", Settings.ResourceBaseName },
             });

--- a/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Table/TableListCommandTests.cs
+++ b/tools/Azure.Mcp.Tools.Storage/tests/Azure.Mcp.Tools.Storage.Tests/Table/TableListCommandTests.cs
@@ -2,20 +2,19 @@
 // Licensed under the MIT License.
 
 using System.Net;
-using Azure.Mcp.Tests.Commands;
 using Azure.Mcp.Tools.Storage.Commands;
 using Azure.Mcp.Tools.Storage.Services;
 using Azure.Mcp.Tools.Storage.Table.Commands;
+using Microsoft.Mcp.Tests.Client;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Azure.Mcp.Tools.Storage.Tests.Table;
 
-public class TableListCommandTests : SubscriptionCommandUnitTestsBase<TableListCommand, IStorageService>
+public class TableListCommandTests : CommandUnitTestsBase<TableListCommand, IStorageService>
 {
     private readonly string _knownStorageAccount = "storage123";
-    private readonly string _knownSubscription = "sub123";
 
     [Fact]
     public async Task ExecuteAsync_ReturnsStorageTables()
@@ -25,15 +24,12 @@ public class TableListCommandTests : SubscriptionCommandUnitTestsBase<TableListC
 
         Service.ListTables(
             Arg.Is(_knownStorageAccount),
-            Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns(expectedTables);
 
         // Act
-        var response = await ExecuteCommandAsync(
-            "--account", _knownStorageAccount,
-            "--subscription", _knownSubscription);
+        var response = await ExecuteCommandAsync("--account", _knownStorageAccount);
 
         // Assert
         var result = ValidateAndDeserializeResponse(response, StorageJsonContext.Default.TableListCommandResult);
@@ -47,15 +43,12 @@ public class TableListCommandTests : SubscriptionCommandUnitTestsBase<TableListC
         // Arrange
         Service.ListTables(
             Arg.Is(_knownStorageAccount),
-            Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .Returns([]);
 
         // Act
-        var response = await ExecuteCommandAsync(
-            "--account", _knownStorageAccount,
-            "--subscription", _knownSubscription);
+        var response = await ExecuteCommandAsync("--account", _knownStorageAccount);
 
         // Assert
         var result = ValidateAndDeserializeResponse(response, StorageJsonContext.Default.TableListCommandResult);
@@ -64,10 +57,8 @@ public class TableListCommandTests : SubscriptionCommandUnitTestsBase<TableListC
     }
 
     [Theory]
-    [InlineData("--subscription sub123")] // Missing Storage account
-    [InlineData("--account mystorageaccount")] // Missing subscription
     [InlineData("")] // No arguments
-    public async Task ExecuteAsync_ValidatesMissingSubscriptionCorrectly(string args)
+    public async Task ExecuteAsync_ValidatesMissingAccount(string args)
     {
         // Arrange & Act
         var response = await ExecuteCommandAsync(args);
@@ -84,19 +75,17 @@ public class TableListCommandTests : SubscriptionCommandUnitTestsBase<TableListC
 
         Service.ListTables(
             Arg.Is(_knownStorageAccount),
-            Arg.Is(_knownSubscription),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception(expectedError));
 
         // Act
-        var response = await ExecuteCommandAsync(
-            "--account", _knownStorageAccount,
-            "--subscription", _knownSubscription);
+        var response = await ExecuteCommandAsync("--account", _knownStorageAccount);
 
         // Assert
         Assert.NotNull(response);
         Assert.Equal(HttpStatusCode.InternalServerError, response.Status);
         Assert.StartsWith(expectedError, response.Message);
+        Assert.DoesNotContain("--subscription", CommandDefinition.Options.Select(option => option.Name));
     }
 }


### PR DESCRIPTION
## What does this PR do?

Removed the unused `subscription` parameter from the `storage blob get`, `storage blob upload`, `storage blob container create`, `storage blob container get`, and `storage table list` tools.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
