### PR TITLE
Removed unused parameters from OneLake tools

### DIFF
--- a/servers/Fabric.Mcp.Server/changelog-entries/alzimmer-onelake-remove-unused-parameters.yaml
+++ b/servers/Fabric.Mcp.Server/changelog-entries/alzimmer-onelake-remove-unused-parameters.yaml
@@ -1,0 +1,3 @@
+changes:
+  - section: "Breaking Changes"
+    description: "Removed the unused `target-table-name` parameter from the `onelake create-shortcut-dataverse` tool."

--- a/tools/Fabric.Mcp.Tools.OneLake/README.md
+++ b/tools/Fabric.Mcp.Tools.OneLake/README.md
@@ -749,7 +749,6 @@ Eight per-target tools provide flat, typed options instead of requiring a JSON b
 - `--target-environment-domain`: Dataverse environment URI
 - `--target-connection-id`: Connection ID
 - `--target-deltalake-folder`: Delta Lake folder path
-- `--target-table-name`: (Optional) Table name
 
 **OneDrive/SharePoint target parameters:**
 - `--target-location`: Storage URL

--- a/tools/Fabric.Mcp.Tools.OneLake/src/Options/ShortcutCreateDataverseOptions.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/src/Options/ShortcutCreateDataverseOptions.cs
@@ -31,8 +31,4 @@ public sealed class ShortcutCreateDataverseOptions
 
     [Option(Description = "The Delta Lake folder path in Dataverse.")]
     public required string TargetDeltalakeFolder { get; set; }
-
-    // TODO (alzimmer): Option isn't used, command probably needs to be updated.
-    [Option(Description = "The Dataverse table name.")]
-    public string? TargetTableName { get; set; }
 }

--- a/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Shortcut/ShortcutCreateCommandVariantsTests.cs
+++ b/tools/Fabric.Mcp.Tools.OneLake/tests/Fabric.Mcp.Tools.OneLake.Tests/Commands/Shortcut/ShortcutCreateCommandVariantsTests.cs
@@ -200,6 +200,7 @@ public class ShortcutCreateCommandVariantsTests
     {
         var service = CreateShortcutService();
         var command = new ShortcutCreateDataverseCommand(Substitute.For<ILogger<ShortcutCreateDataverseCommand>>(), service);
+        Assert.DoesNotContain("--target-table-name", command.GetCommand().Options.Select(option => option.Name));
 
         var response = await ExecuteAsync(command,
             "--workspace-id", "ws1",
@@ -208,8 +209,7 @@ public class ShortcutCreateCommandVariantsTests
             "--shortcut-name", "shortcut1",
             "--target-environment-domain", "https://org.crm.dynamics.com",
             "--target-connection-id", "connection-1",
-            "--target-deltalake-folder", "Tables/account",
-            "--target-table-name", "account");
+            "--target-deltalake-folder", "Tables/account");
 
         Assert.Equal(HttpStatusCode.OK, response.Status);
         var result = DeserializeResponse(response, OneLakeJsonContext.Default.ShortcutCreateDataverseCommandResult);


### PR DESCRIPTION
## What does this PR do?

Removed the unused `target-table-name` parameter from the `onelake create-shortcut-dataverse` tool.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist
- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [x] Created a changelog entry if the change falls among the following: new feature, bug fix, UI/UX update, breaking change, or updated dependencies. Follow [the changelog entry guide](https://github.com/microsoft/mcp/blob/main/docs/changelog-entries.md)
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `servers/Azure.Mcp.Server/README.md` and/or `servers/Fabric.Mcp.Server/README.md` documentation
    - [ ] Validate `README.md` changes running the script `./eng/scripts/Process-PackageReadMe.ps1`. See [Package README](https://github.com/microsoft/mcp/blob/main/CONTRIBUTING.md#package-readme)
    - [ ] For new or modified tool descriptions, ran [`ToolDescriptionEvaluator`](https://github.com/microsoft/mcp/blob/main/eng/tools/ToolDescriptionEvaluator/Quickstart.md) and obtained a score of `0.4` or more and a top 3 ranking for all related test prompts
    - [ ] For tools with new names, including new tools or renamed tools, update [`consolidated-tools.json`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/src/Resources/consolidated-tools.json)
    - [ ] For **renamed** tools, follow the [Tool Rename Checklist](https://github.com/microsoft/mcp/blob/main/docs/tool-rename-checklist.md) and tag the PR with the `breaking-change` label
    - [ ] For new tools associated with Azure services or publicly available tools/APIs/products, add URL to documentation in the PR description
- [ ] Extra steps for **Azure MCP Server** tool changes:
    - [ ] Updated command list in [`servers/Azure.Mcp.Server/docs/azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md)
    - [ ] Ran `./eng/scripts/Update-AzCommandsMetadata.ps1` to update tool metadata in [`azmcp-commands.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/azmcp-commands.md) (required for CI)
    - [ ] Updated test prompts in [`servers/Azure.Mcp.Server/docs/e2eTestPrompts.md`](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/docs/e2eTestPrompts.md)
    - [ ] 👉 For Community (non-Microsoft team member) PRs:
        - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
        - [ ] **Manual tests run**: added comment `/azp run mcp - pullrequest - live` to run *Live Test Pipeline*
    
